### PR TITLE
Post-MVP UX polish round 4: eye-icon password toggle + filename auto-…

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -664,6 +664,24 @@ Repo root: `f:\_coding\ai_drive`.
      startup crash sweep); without a cipher an `.enc` copy is refused. Deliberately TEXT-only
      (never `shell.openPath`): the original bytes must never reach an external viewer in
      plaintext. Tested: ingestion + encrypted-leak tests + renderer modal tests.
+- **Post-MVP UX polish round 4 (2026-06-11) — two frontend issues:**
+  1. **Unlock "Show" toggle → eye icon:** the password-reveal control in `WorkspaceGate`'s
+     shared `PasswordField` (Unlock + first-run create) was a text "Show"/"Hide" Button; now an
+     inline eye / eye-off SVG (`currentColor`, muted→full on hover, decorative `aria-hidden`).
+     A11y preserved/improved: the Button keeps `aria-pressed` and carries a descriptive
+     `aria-label`/`title` ("Show password"/"Hide password"). Test name-queries updated.
+  2. **Filename auto-scope for document chat:** other documents were cited as sources when a
+     question named one file, because document retrieval is **corpus-wide by default** —
+     nothing parsed the question for a filename (the scope plumbing itself was correct
+     end-to-end). New pure `detectFilenameScope(question, docs)` (`services/rag/scope.ts`,
+     unit-tested) matches a file by its title/stem as a whole-token run (token-boundary, lone
+     generic words ignored, whole-corpus match = no match). `askDocuments` applies it **only**
+     when the conversation has no explicit "ask selected documents" scope, as the per-request
+     `scopeDocumentIds` — narrows only, never widens; explicit scope always wins. Visible +
+     honest: a one-shot non-persisted `STREAM.scope` notice (`api.onScopeNotice`) → an
+     *"Answering from contract.pdf only"* toast in Chat. Tests: `tests/unit/rag-scope.test.ts`
+     + a `tests/integration/rag.test.ts` case proving unscoped surfaces both docs while the
+     detected scope returns only the named file. Design record: `docs/rag-design.md` §10.
 - **Doc lifecycle: finished plans become design records (2026-06-10):** implemented plan docs
   are condensed to short design records (decisions + load-bearing facts + the design as built)
   or deleted, with the full original in git history — finished plans otherwise drift and

--- a/apps/desktop/src/main/ipc/registerRagIpc.ts
+++ b/apps/desktop/src/main/ipc/registerRagIpc.ts
@@ -3,7 +3,8 @@ import { IPC, STREAM } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { Message } from '../../shared/types'
 import { appendMessage, getConversation, maybeSetTitleFromFirstMessage } from '../services/chat'
-import { generateGroundedAnswer, ragSettingsFrom } from '../services/rag'
+import { detectFilenameScope, generateGroundedAnswer, ragSettingsFrom } from '../services/rag'
+import { listDocuments } from '../services/ingestion'
 import { getSettings } from '../services/settings'
 import { log } from '../services/logging'
 import { inFlightStreams } from './inflight'
@@ -48,6 +49,25 @@ export function registerRagIpc(ctx: AppContext): void {
       maybeSetTitleFromFirstMessage(ctx.db, conversationId, text)
 
       const settings = ragSettingsFrom(getSettings(ctx.db))
+
+      // Filename auto-scope: when the conversation has NO explicit "ask selected
+      // documents" scope but the question names indexed file(s), restrict retrieval to
+      // them so other documents are not surfaced as sources. Only ever narrows; a live
+      // (non-persisted) notice tells the user which file(s) the answer is grounded in.
+      let scopeDocumentIds = conv.scopeDocumentIds
+      if (!scopeDocumentIds || scopeDocumentIds.length === 0) {
+        const candidates = listDocuments(ctx.db)
+          .filter((d) => d.status === 'indexed' && d.chunkCount > 0)
+          .map((d) => ({ id: d.id, title: d.title }))
+        const detected = detectFilenameScope(text, candidates)
+        if (detected) {
+          scopeDocumentIds = detected.ids
+          if (!event.sender.isDestroyed()) {
+            event.sender.send(STREAM.scope(conversationId), { titles: detected.titles })
+          }
+        }
+      }
+
       const controller = new AbortController()
       inFlightStreams.set(conversationId, controller)
       try {
@@ -61,8 +81,9 @@ export function registerRagIpc(ctx: AppContext): void {
           {
             signal: controller.signal,
             // "Ask selected documents" (Phase 17): the conversation's persisted scope
-            // restricts retrieval; null scope = whole corpus (unchanged behavior).
-            scopeDocumentIds: conv.scopeDocumentIds,
+            // restricts retrieval; null scope = whole corpus. When no explicit scope was
+            // set, this may carry the filename auto-scope derived from the question above.
+            scopeDocumentIds,
             // Retrieval reranker (Phase 21): null when no reranker is provisioned —
             // retrieval then keeps the pre-Phase-21 ordering byte-identical.
             reranker: ctx.reranker,

--- a/apps/desktop/src/main/services/rag/index.ts
+++ b/apps/desktop/src/main/services/rag/index.ts
@@ -4,6 +4,7 @@ import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../runtime'
 import { type Embedder, VectorIndex } from '../embeddings'
 import type { Reranker } from '../reranker'
 import { keywordSearchChunks, rrfFuse } from './hybrid'
+export { detectFilenameScope, type DetectedScope, type ScopeableDoc } from './scope'
 import { approxTokenCount } from '../ingestion/chunker'
 import { log } from '../logging'
 import {

--- a/apps/desktop/src/main/services/rag/scope.ts
+++ b/apps/desktop/src/main/services/rag/scope.ts
@@ -1,0 +1,95 @@
+// Filename auto-scope (post-MVP UX fix): when a documents-mode question names an
+// indexed file by its filename and the conversation has NO explicit "ask selected
+// documents" scope, restrict retrieval to the named file(s) so other documents are not
+// surfaced as sources.
+//
+// Why this exists: document retrieval is corpus-wide by default — the question text is
+// only ever a semantic/keyword query, so "analyze contract.pdf" runs hybrid search over
+// ALL indexed documents and the top-K can include weakly-related chunks from other files
+// (generic words like "analyze"/"summary" even inflate other docs' keyword rank). Users
+// reasonably expect naming a file to focus on it. This is a CONSERVATIVE heuristic: it
+// only ever narrows (never widens) and only when no explicit scope is set; a wrong guess
+// is visible (the toast + the cited file) and the user can rephrase or set scope manually.
+
+/** Minimum normalized length for a filename form to be matchable (avoids 1–2 char noise). */
+const MIN_FORM_LEN = 3
+
+/**
+ * Single generic words that must NOT, on their own, trigger a scope — a file literally
+ * named "Document.pdf" should not capture every "analyze this document" question. Only
+ * filters forms that EQUAL one of these; a multi-word form that merely contains one
+ * (e.g. "annual report") is unaffected.
+ */
+const GENERIC_FORMS = new Set([
+  'document',
+  'documents',
+  'file',
+  'files',
+  'doc',
+  'docs',
+  'pdf',
+  'text',
+  'note',
+  'notes',
+  'page',
+  'pages',
+  'data'
+])
+
+export interface ScopeableDoc {
+  id: string
+  title: string
+}
+
+export interface DetectedScope {
+  ids: string[]
+  titles: string[]
+}
+
+/** Lowercase, collapse every non-alphanumeric run to a single space, trim. */
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+}
+
+/** Drop a trailing file extension (".pdf", ".docx", …) so the bare name also matches. */
+function stem(title: string): string {
+  return title.replace(/\.[a-z0-9]{1,8}$/i, '')
+}
+
+/**
+ * Detect which indexed documents a question names by filename. Returns the matched
+ * documents (ids + titles) or null when none match confidently.
+ *
+ * A document matches when one of its filename forms — the full title or its
+ * extension-stripped stem, each normalized — appears in the normalized question as a
+ * whole token sequence (space-delimited on both sides). Single generic words are ignored
+ * (see GENERIC_FORMS). When the question would match EVERY indexed document it provides no
+ * narrowing, so it is treated as no match (a non-specific query, not a file reference).
+ */
+export function detectFilenameScope(
+  question: string,
+  docs: ScopeableDoc[]
+): DetectedScope | null {
+  // Pad so an includes() check is a token-boundary match on both sides.
+  const haystack = ` ${normalize(question)} `
+  if (haystack.trim() === '' || docs.length === 0) return null
+
+  const matched: ScopeableDoc[] = []
+  for (const doc of docs) {
+    const forms = new Set<string>()
+    for (const raw of [doc.title, stem(doc.title)]) {
+      const n = normalize(raw)
+      if (n.length >= MIN_FORM_LEN && !GENERIC_FORMS.has(n)) forms.add(n)
+    }
+    if ([...forms].some((f) => haystack.includes(` ${f} `))) matched.push(doc)
+  }
+
+  if (matched.length === 0) return null
+  // Matching the whole corpus is not a file reference — it narrows nothing.
+  if (matched.length === docs.length && docs.length > 1) return null
+
+  return { ids: matched.map((m) => m.id), titles: matched.map((m) => m.title) }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { EVENTS, IPC, STREAM } from '../shared/ipc'
+import { EVENTS, IPC, STREAM, type ScopeNotice } from '../shared/ipc'
 import type {
   AppSettings,
   AppStatus,
@@ -180,6 +180,14 @@ const api = {
   onReasoning: (requestId: string, cb: (delta: string) => void): (() => void) => {
     const ch = STREAM.reasoning(requestId)
     const handler = (_e: unknown, delta: string) => cb(delta)
+    ipcRenderer.on(ch, handler)
+    return () => ipcRenderer.removeListener(ch, handler)
+  },
+  /** Subscribe to the one-shot "answering from this file only" auto-scope notice for a
+   *  document answer (fired once before tokens; ephemeral, never persisted). */
+  onScopeNotice: (requestId: string, cb: (notice: ScopeNotice) => void): (() => void) => {
+    const ch = STREAM.scope(requestId)
+    const handler = (_e: unknown, notice: ScopeNotice) => cb(notice)
     ipcRenderer.on(ch, handler)
     return () => ipcRenderer.removeListener(ch, handler)
   },

--- a/apps/desktop/src/renderer/screens/ChatScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ChatScreen.tsx
@@ -240,6 +240,11 @@ export function ChatScreen({ onNavigate, initialMode, initialScopeDocumentIds }:
       pendingThinking.current += delta
       scheduleFlush()
     })
+    // Filename auto-scope notice: a one-shot hint that this document answer was
+    // restricted to the file(s) the question named (ephemeral — never persisted).
+    const unsubscribeScope = window.api.onScopeNotice(convId, ({ titles }) => {
+      if (titles.length > 0) showToast(`Answering from ${titles.join(', ')} only`)
+    })
     // Only update the visible transcript if the user is still looking at THIS
     // conversation — replacing another conversation's view with this one's messages
     // was the M2 corruption.
@@ -268,6 +273,7 @@ export function ChatScreen({ onNavigate, initialMode, initialScopeDocumentIds }:
     } finally {
       unsubscribe()
       unsubscribeReasoning()
+      unsubscribeScope()
       clearStreamBuffers()
       setStreaming(false)
       setStreamConvId(null)

--- a/apps/desktop/src/renderer/screens/WorkspaceGate.tsx
+++ b/apps/desktop/src/renderer/screens/WorkspaceGate.tsx
@@ -388,11 +388,47 @@ function PasswordField({
           variant="ghost"
           className="gate-pw-toggle"
           aria-pressed={show}
+          aria-label={show ? 'Hide password' : 'Show password'}
+          title={show ? 'Hide password' : 'Show password'}
           onClick={onToggleShow}
         >
-          {show ? 'Hide' : 'Show'}
+          <EyeIcon off={show} />
         </Button>
       )}
     </div>
+  )
+}
+
+/**
+ * Eye / eye-off glyph for the password reveal toggle. Inherits the button's text
+ * colour (`currentColor`) so it tracks the theme; decorative only (the Button carries
+ * the accessible name via aria-label), so it is hidden from the a11y tree.
+ */
+function EyeIcon({ off }: { off: boolean }): JSX.Element {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {off ? (
+        <>
+          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+          <line x1="1" y1="1" x2="23" y2="23" />
+        </>
+      ) : (
+        <>
+          <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+          <circle cx="12" cy="12" r="3" />
+        </>
+      )}
+    </svg>
   )
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -169,7 +169,16 @@ button { min-width: 24px; min-height: 24px; }
 .gate-actions-main { display: flex; gap: 10px; align-items: center; }
 .gate-pw-row { display: flex; gap: 6px; align-items: center; }
 .gate-pw-row .gate-input { flex: 1; }
-.gate-pw-toggle { flex-shrink: 0; }
+.gate-pw-toggle {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  color: var(--text-muted);
+}
+.gate-pw-toggle:hover { color: var(--text); }
+.gate-pw-toggle svg { display: block; }
 
 /* Password-strength meter: 4 segments + a word — never color alone (WCAG 1.4.1).
    Advisory only; it never disables the Create button. */

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -81,8 +81,16 @@ export const STREAM = {
   token: (requestId: string) => `chat:token:${requestId}`,
   done: (requestId: string) => `chat:done:${requestId}`,
   error: (requestId: string) => `chat:error:${requestId}`,
-  reasoning: (requestId: string) => `chat:reasoning:${requestId}`
+  reasoning: (requestId: string) => `chat:reasoning:${requestId}`,
+  // ADDITIVE: a one-shot ephemeral notice fired before a document answer when retrieval
+  // was auto-scoped to the file(s) the question named (never persisted — a live hint).
+  scope: (requestId: string) => `chat:scope:${requestId}`
 } as const
+
+/** Payload of the `scope` channel — the filenames retrieval was auto-restricted to. */
+export interface ScopeNotice {
+  titles: string[]
+}
 
 // One-off main -> renderer notices (not tied to a request).
 export const EVENTS = {

--- a/apps/desktop/tests/integration/rag.test.ts
+++ b/apps/desktop/tests/integration/rag.test.ts
@@ -11,6 +11,7 @@ import { MockEmbedder, encodeVector } from '../../src/main/services/embeddings'
 import {
   buildGroundedChatMessages,
   buildGroundedPrompt,
+  detectFilenameScope,
   generateGroundedAnswer,
   ragSettingsFrom,
   retrieve,
@@ -223,6 +224,38 @@ describe('retrieve', () => {
     const { chunks } = await retrieve(db, embedder, 'quantum chromodynamics gauge theory', strict)
     expect(chunks).toHaveLength(1)
     expect(chunks[0].text).toContain('quantum')
+  })
+
+  // Filename auto-scope (detectFilenameScope) + retrieve narrowing: naming a file in the
+  // question should keep other documents out of the sources. See scope.ts.
+  it('restricts sources to the named file when the question names a filename', async () => {
+    const db = freshDb()
+    const embedder = new MockEmbedder()
+    const contractId = await seedDocument(db, embedder, 'contract.pdf', [
+      { text: 'the liability cap under this agreement is one million dollars', pageNumber: 1 }
+    ])
+    await seedDocument(db, embedder, 'invoice.pdf', [
+      // Worded to also resemble the question so it WOULD surface without scoping.
+      { text: 'the liability cap line item on this invoice is one million dollars', pageNumber: 1 }
+    ])
+
+    const question = 'what is the liability cap in contract.pdf?'
+
+    // Without scope, both documents surface as sources (the reported bug).
+    const wide = await retrieve(db, embedder, question, SETTINGS)
+    expect(new Set(wide.chunks.map((c) => c.sourceTitle))).toEqual(
+      new Set(['contract.pdf', 'invoice.pdf'])
+    )
+
+    // The detector picks the named file, and scoped retrieval returns only its chunks.
+    const detected = detectFilenameScope(question, [
+      { id: contractId, title: 'contract.pdf' },
+      { id: 'other', title: 'invoice.pdf' }
+    ])
+    expect(detected?.ids).toEqual([contractId])
+    const scoped = await retrieve(db, embedder, question, SETTINGS, detected?.ids)
+    expect(scoped.chunks.length).toBeGreaterThan(0)
+    expect(scoped.chunks.every((c) => c.sourceTitle === 'contract.pdf')).toBe(true)
   })
 })
 

--- a/apps/desktop/tests/renderer/ChatDepth.test.tsx
+++ b/apps/desktop/tests/renderer/ChatDepth.test.tsx
@@ -107,7 +107,8 @@ describe('ChatScreen — "Answer detail" dropdown (Phase 20 / D-UI4)', () => {
       getRuntimeStatus: vi.fn(async () => status({ supportsThinkingMode: true })),
       sendChatMessage,
       onToken: vi.fn(() => () => {}),
-      onReasoning: vi.fn(() => () => {})
+      onReasoning: vi.fn(() => () => {}),
+      onScopeNotice: vi.fn(() => () => {})
     })
     render(<ChatScreen onNavigate={() => {}} />)
     await user.click(await screen.findByText('Depth chat'))
@@ -176,7 +177,8 @@ describe('ChatScreen — "Answer detail" dropdown (Phase 20 / D-UI4)', () => {
       onReasoning: vi.fn((_id: string, cb: (d: string) => void) => {
         reasoningCb = cb
         return () => {}
-      })
+      }),
+      onScopeNotice: vi.fn(() => () => {})
     })
     render(<ChatScreen onNavigate={() => {}} />)
     await user.click(await screen.findByText('Depth chat'))

--- a/apps/desktop/tests/renderer/ChatRestructure.test.tsx
+++ b/apps/desktop/tests/renderer/ChatRestructure.test.tsx
@@ -192,7 +192,8 @@ describe('ChatScreen — per-message actions (Try again · Copy · Save)', () =>
       sendChatMessage,
       exportConversation,
       onToken: vi.fn(() => () => {}),
-      onReasoning: vi.fn(() => () => {})
+      onReasoning: vi.fn(() => () => {}),
+      onScopeNotice: vi.fn(() => () => {})
     })
     render(
       <ToastProvider>

--- a/apps/desktop/tests/renderer/WorkspaceGate.test.tsx
+++ b/apps/desktop/tests/renderer/WorkspaceGate.test.tsx
@@ -161,11 +161,11 @@ describe('WorkspaceGate — create (3-step first run)', () => {
     const confirm = screen.getByPlaceholderText('Confirm password')
     expect(pw).toHaveAttribute('type', 'password')
 
-    await user.click(screen.getByRole('button', { name: /^show$/i }))
+    await user.click(screen.getByRole('button', { name: /show password/i }))
     expect(pw).toHaveAttribute('type', 'text')
     expect(confirm).toHaveAttribute('type', 'text')
 
-    await user.click(screen.getByRole('button', { name: /^hide$/i }))
+    await user.click(screen.getByRole('button', { name: /hide password/i }))
     expect(pw).toHaveAttribute('type', 'password')
     expect(confirm).toHaveAttribute('type', 'password')
   })

--- a/apps/desktop/tests/unit/rag-scope.test.ts
+++ b/apps/desktop/tests/unit/rag-scope.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { detectFilenameScope } from '../../src/main/services/rag/scope'
+
+const docs = [
+  { id: 'd1', title: 'contract.pdf' },
+  { id: 'd2', title: 'Q3 financial report.docx' },
+  { id: 'd3', title: 'invoice_2024.csv' }
+]
+
+describe('detectFilenameScope', () => {
+  it('matches a file named with its extension', () => {
+    expect(detectFilenameScope('please analyze contract.pdf', docs)).toEqual({
+      ids: ['d1'],
+      titles: ['contract.pdf']
+    })
+  })
+
+  it('matches the bare stem (no extension typed)', () => {
+    expect(detectFilenameScope('summarize the contract for me', docs)).toEqual({
+      ids: ['d1'],
+      titles: ['contract.pdf']
+    })
+  })
+
+  it('matches a multi-word filename across spaces/separators and is case-insensitive', () => {
+    // "q3 financial report" appears as a contiguous token run regardless of case.
+    expect(detectFilenameScope('what does the Q3 FINANCIAL REPORT say?', docs)).toEqual({
+      ids: ['d2'],
+      titles: ['Q3 financial report.docx']
+    })
+  })
+
+  it('normalizes underscores in the filename to a phrase match', () => {
+    expect(detectFilenameScope('open invoice 2024 and total it', docs)).toEqual({
+      ids: ['d3'],
+      titles: ['invoice_2024.csv']
+    })
+  })
+
+  it('returns null when no filename is named (generic question)', () => {
+    expect(detectFilenameScope('what are my obligations this year?', docs)).toBeNull()
+  })
+
+  it('does not match on a partial word inside another token', () => {
+    // "contractual" must not trigger the "contract" document (token-boundary match).
+    expect(detectFilenameScope('explain my contractual duties', docs)).toBeNull()
+  })
+
+  it('can match more than one named document', () => {
+    const result = detectFilenameScope('compare contract.pdf with invoice_2024', docs)
+    expect(result?.ids.sort()).toEqual(['d1', 'd3'])
+  })
+
+  it('ignores a lone generic word so a file named Document.pdf does not capture everything', () => {
+    const generic = [{ id: 'g1', title: 'Document.pdf' }, { id: 'd1', title: 'contract.pdf' }]
+    expect(detectFilenameScope('analyze this document please', generic)).toBeNull()
+  })
+
+  it('returns null when the question would match the entire corpus (no narrowing)', () => {
+    const two = [{ id: 'a', title: 'alpha.txt' }, { id: 'b', title: 'beta.txt' }]
+    expect(detectFilenameScope('compare alpha and beta', two)).toBeNull()
+  })
+
+  it('matches the single document when it is the only one and is named', () => {
+    const one = [{ id: 'only', title: 'alpha.txt' }]
+    expect(detectFilenameScope('summarize alpha', one)).toEqual({ ids: ['only'], titles: ['alpha.txt'] })
+  })
+
+  it('returns null for an empty corpus or empty question', () => {
+    expect(detectFilenameScope('contract', [])).toBeNull()
+    expect(detectFilenameScope('   ', docs)).toBeNull()
+  })
+})

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -406,6 +406,28 @@ guarantee (model never called without context) is unchanged.
   conversation's scope; removable **scope chips** above the composer show the active scope
   (existing conversations persist chip removal via `updateConversationScope`).
 
+### Filename auto-scope (post-MVP UX fix)
+
+Document retrieval is corpus-wide by default — the question text is only ever a
+semantic/keyword query, so "analyze contract.pdf" runs hybrid search over **all** indexed
+documents and the top-K can include weakly-related chunks from other files (generic words
+like "analyze"/"summary" even inflate other docs' keyword rank). Users reasonably read
+naming a file as "use only that file", so other files showing up as sources reads as a bug.
+
+- **`detectFilenameScope(question, docs)`** (`services/rag/scope.ts`, pure + unit-tested):
+  a document matches when its filename — the full title or its extension-stripped stem,
+  each normalized to lowercase alphanumeric tokens — appears in the normalized question as a
+  **whole token run** (space-delimited both sides, so "contractual" ≠ "contract"). Lone
+  generic words (`document`, `file`, `pdf`, …) never trigger on their own; a question that
+  would match the **entire** corpus narrows nothing and is treated as no match.
+- **Applied only when there is no explicit scope** — `askDocuments` runs the detector over
+  the indexed documents *just* for a conversation whose `scopeDocumentIds` is null/empty, and
+  uses the result as the per-request `scopeDocumentIds`. It can only ever **narrow**, never
+  widen; an explicit "ask selected documents" scope always wins and is left untouched.
+- **Visible + honest:** when it fires, the main process emits a one-shot, non-persisted
+  `STREAM.scope` notice (`api.onScopeNotice`) and Chat shows an *"Answering from contract.pdf
+  only"* toast, so a wrong guess is obvious and the user can rephrase or set scope manually.
+
 ### Plain-chat document awareness (plan §5.1)
 
 While ≥ 1 indexed document exists, plain Chat shows a dismissible per-conversation notice


### PR DESCRIPTION
…scope

Two frontend issues:

1) Unlock "Show" toggle → eye icon. The password-reveal control in
   WorkspaceGate's shared PasswordField (Unlock + first-run create) was a
   text "Show"/"Hide" Button; now an inline eye / eye-off SVG (currentColor,
   muted→full on hover, decorative aria-hidden). A11y preserved/improved:
   keeps aria-pressed and carries a descriptive aria-label/title.

2) Filename auto-scope for document chat. Other documents were cited as
   sources when a question named one file, because document retrieval is
   corpus-wide by default — nothing parsed the question for a filename (the
   scope plumbing itself was correct end-to-end). New pure detectFilenameScope
   (services/rag/scope.ts) matches a file by its title/stem as a whole-token
   run (token-boundary; lone generic words ignored; whole-corpus match = no
   match). askDocuments applies it only when the conversation has no explicit
   "ask selected documents" scope, as the per-request scopeDocumentIds —
   narrows only, never widens; explicit scope always wins. Visible + honest:
   a one-shot non-persisted STREAM.scope notice (api.onScopeNotice) → an
   "Answering from contract.pdf only" toast in Chat.

Tests: tests/unit/rag-scope.test.ts + a tests/integration/rag.test.ts case proving unscoped surfaces both docs while the detected scope returns only the named file. Docs: docs/rag-design.md §10 + BUILD_STATE.md polish round 4.