### PR TITLE
fix(packaging): make electron-builder 26 build the portable .exe

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -17,6 +17,13 @@
 appId: space.hilbertraum.app
 productName: HilbertRaum
 
+# electron-builder 26 cannot auto-detect the Electron version in this npm workspace: `electron`
+# is pinned as a RANGE (^37 in devDependencies) and is HOISTED to the repo-root node_modules,
+# which eb — running from apps/desktop — does not resolve, so it errors on the range. Pin the
+# exact installed version here. Keep in sync with the `electron` devDependency (currently ^37 →
+# 37.10.3); bump when the installed Electron major/minor changes.
+electronVersion: 37.10.3
+
 directories:
   # buildResources holds icons etc. (optional; defaults are used if absent).
   buildResources: build
@@ -39,7 +46,12 @@ files:
   # the pure-JS / cross-OS portable posture (a Windows .node on a macOS/Linux drive).
   # Exclude every platform variant. tests/integration/packaging.test.ts asserts this stays.
   - '!**/node_modules/@napi-rs/canvas*/**'
-includeSubNodeModules: true
+# NOTE: `includeSubNodeModules: true` was REMOVED in electron-builder 26 (it now errors as an
+# unknown property). v26's reworked dependency collector already follows hoisted/nested
+# node_modules trees by default, so mammoth's transitive deps still come along. If a hoisted
+# externalized dep ever goes missing from app.asar, build from apps/desktop or disable hoisting
+# (see docs/packaging.md "Portable build"). ALWAYS smoke-test a PDF/DOCX/CSV import + encrypted
+# workspace from the produced .exe — a missing dep surfaces only at runtime.
 # No native addons (node:sqlite is built into Electron; parsers are pure-JS) → skip rebuild.
 npmRebuild: false
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -117,10 +117,15 @@ npm run package:win    # build + a Windows portable .exe specifically
 Key config points:
 - **Electron ≥ 37 (Node 22.x)** is required so the packaged main process has `node:sqlite`
   (`electron` is pinned `^37`). A downgraded/stripped runtime would lose it — do not downgrade.
+  Because `electron` is pinned as a **range** and hoisted to the repo-root `node_modules`,
+  electron-builder 26 cannot auto-detect it from `apps/desktop` — so `electron-builder.yml` pins
+  **`electronVersion`** explicitly (keep it in sync with the `electron` devDependency when bumping).
 - **Production `dependencies` ship inside `app.asar`** (`pdfjs-dist` / `mammoth` / `papaparse` /
   `yaml` / `@noble/hashes`), so the `require()`s in the parsers, manifest loader, and the vault KDF
-  resolve at runtime. `electron-builder.yml` sets `includeSubNodeModules: true` (so hoisted/nested
-  trees — e.g. mammoth's transitive deps — are collected) and `npmRebuild: false` (no native addons).
+  resolve at runtime. electron-builder 26's collector follows **hoisted/nested** `node_modules` trees
+  (e.g. mammoth's transitive deps) **by default** — the old `includeSubNodeModules: true` option was
+  removed in eb 26 (it now errors as an unknown property) and is no longer needed. `npmRebuild: false`
+  (no native addons).
   **These are externalized, so a missing one only fails at RUNTIME, not in the green gate — after
   packaging, smoke-test importing a PDF, a DOCX, and a CSV, AND creating/unlocking an encrypted
   workspace (exercises `@noble/hashes` argon2id), from the produced `.exe`.**


### PR DESCRIPTION
## Why

Packaging is a manual step — the green gate (typecheck/test/build) skips `electron-builder`, so the config was **never exercised** against the pinned `electron-builder ^26.15.2`. Two latent errors blocked **every** `npm run package:win`:

1. **`includeSubNodeModules: true`** → hard schema error (unknown property in eb 26). eb 26's reworked dependency collector already follows hoisted/nested `node_modules` by default, so this option is obsolete. Verified the externalized prod deps (`mammoth` / `pdfjs-dist` / `papaparse` / `yaml` / `@noble/hashes`) still land in `app.asar`, and `tesseract.js`/`-core` stay `asarUnpack`ed.
2. **Electron version not resolvable** → eb 26 cannot auto-detect Electron in this hoisted npm workspace (`electron` is pinned as the `^37` **range** and lives in the repo-root `node_modules`, which eb — run from `apps/desktop` — does not resolve). Fixed by pinning `electronVersion: 37.10.3` explicitly (keep in sync with the `electron` devDependency).

## Verification

- `npm run package:win` now produces `HilbertRaum-0.1.38-portable.exe`.
- `app.asar` inspection: externalized parser libs + vault crypto present; `tesseract` unpacked; `model-manifests` shipped as `extraResources`.
- Real bring-up smoke from a prepared drive (`llama.cpp` **b9849**, CPU): Ministral 3 8B answers cleanly; **Qwen3.5 4B/9B load + generate on b9849** (resolves the open runtime-compat question in their manifests — though they remain very thinking-heavy by default and still need a benchmark before promotion).

## Notes

- Windows-only portable target; macOS/Linux unaffected.
- Docs in `docs/packaging.md` still describe `includeSubNodeModules` — a follow-up doc pass could refresh that reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)