### PR TITLE
fix(ingestion): polyfill DOMMatrix so PDF import works from a packaged drive

### DIFF
--- a/apps/desktop/src/main/services/ingestion/parsers/dommatrix-polyfill.ts
+++ b/apps/desktop/src/main/services/ingestion/parsers/dommatrix-polyfill.ts
@@ -1,0 +1,179 @@
+// Minimal, correct 2D-affine `DOMMatrix` polyfill for the Electron MAIN process.
+//
+// WHY THIS EXISTS. pdfjs-dist v6's legacy build evaluates a module-level
+// `const SCALE_MATRIX = new DOMMatrix()` at import time, and in Node it only sets
+// `globalThis.DOMMatrix` by `require("@napi-rs/canvas")`. We DELIBERATELY exclude
+// `@napi-rs/canvas` from the packaged app (electron-builder.yml `files` negation — a
+// platform-specific Skia `.node` we never import; keeps the portable bundle pure-JS /
+// cross-OS, asserted by tests/integration/packaging.test.ts). So in the PACKAGED app the
+// require fails, `globalThis.DOMMatrix` stays undefined, and `import`ing pdfjs throws
+// "DOMMatrix is not defined" → PDF import breaks. In `npm run dev` the dep is present, so
+// pdf.js polyfills itself and the bug is invisible — which is why it only surfaced from a
+// built drive.
+//
+// pdf.js guards with `if (!globalThis.DOMMatrix)`, so installing this BEFORE the pdfjs
+// import makes it skip the `@napi-rs/canvas` path entirely. Our main-process path does
+// TEXT EXTRACTION only (getTextContent) — pdf.js hands text transforms back as plain
+// arrays, independent of the global DOMMatrix — so the matrix only needs to *exist* for
+// the import to succeed. The methods are nonetheless implemented correctly (2D affine) so
+// nothing breaks if a code path ever touches them. Real rasterization (OCR) runs in the
+// hidden renderer window with the browser's own DOMMatrix and never uses this.
+
+type MatrixLike = { a: number; b: number; c: number; d: number; e: number; f: number }
+
+function isNumberArray(v: unknown): v is number[] {
+  return Array.isArray(v) && v.every((n) => typeof n === 'number')
+}
+
+/**
+ * A 2D-affine matrix `[[a c e] [b d f] [0 0 1]]` mapping a point `(x, y)` to
+ * `(a·x + c·y + e, b·x + d·y + f)`. Implements the subset of the `DOMMatrix` API pdfjs-dist
+ * touches (construction from an array / matrix, multiply/translate/scale, and self-inverse).
+ */
+class DOMMatrixPolyfill implements MatrixLike {
+  a = 1
+  b = 0
+  c = 0
+  d = 1
+  e = 0
+  f = 0
+
+  constructor(init?: number[] | MatrixLike | string) {
+    if (init == null) return // identity
+    if (typeof init === 'string') return // CSS transform strings are unused here → identity
+    if (isNumberArray(init)) {
+      if (init.length === 6) {
+        ;[this.a, this.b, this.c, this.d, this.e, this.f] = init
+      } else if (init.length === 16) {
+        // 4×4 column-major → take the 2D-affine components (m11,m12,m21,m22,m41,m42).
+        this.a = init[0]
+        this.b = init[1]
+        this.c = init[4]
+        this.d = init[5]
+        this.e = init[12]
+        this.f = init[13]
+      }
+      return
+    }
+    // DOMMatrix-like object.
+    this.a = init.a
+    this.b = init.b
+    this.c = init.c
+    this.d = init.d
+    this.e = init.e
+    this.f = init.f
+  }
+
+  get is2D(): boolean {
+    return true
+  }
+
+  get isIdentity(): boolean {
+    return this.a === 1 && this.b === 0 && this.c === 0 && this.d === 1 && this.e === 0 && this.f === 0
+  }
+
+  // DOMMatrix 4×4 accessors mapped onto the 2D-affine components (the rest are the identity's).
+  get m11(): number { return this.a }
+  get m12(): number { return this.b }
+  get m13(): number { return 0 }
+  get m14(): number { return 0 }
+  get m21(): number { return this.c }
+  get m22(): number { return this.d }
+  get m23(): number { return 0 }
+  get m24(): number { return 0 }
+  get m31(): number { return 0 }
+  get m32(): number { return 0 }
+  get m33(): number { return 1 }
+  get m34(): number { return 0 }
+  get m41(): number { return this.e }
+  get m42(): number { return this.f }
+  get m43(): number { return 0 }
+  get m44(): number { return 1 }
+
+  /** `this · other` (other applied first), returned as a new matrix. */
+  multiply(other: MatrixLike): DOMMatrixPolyfill {
+    return new DOMMatrixPolyfill([
+      this.a * other.a + this.c * other.b,
+      this.b * other.a + this.d * other.b,
+      this.a * other.c + this.c * other.d,
+      this.b * other.c + this.d * other.d,
+      this.a * other.e + this.c * other.f + this.e,
+      this.b * other.e + this.d * other.f + this.f
+    ])
+  }
+
+  private setFrom(m: MatrixLike): this {
+    this.a = m.a
+    this.b = m.b
+    this.c = m.c
+    this.d = m.d
+    this.e = m.e
+    this.f = m.f
+    return this
+  }
+
+  multiplySelf(other: MatrixLike): this {
+    return this.setFrom(this.multiply(other))
+  }
+
+  preMultiplySelf(other: MatrixLike): this {
+    return this.setFrom(new DOMMatrixPolyfill(other).multiply(this))
+  }
+
+  translate(tx = 0, ty = 0): DOMMatrixPolyfill {
+    return this.multiply({ a: 1, b: 0, c: 0, d: 1, e: tx, f: ty })
+  }
+
+  translateSelf(tx = 0, ty = 0): this {
+    return this.setFrom(this.translate(tx, ty))
+  }
+
+  scale(sx = 1, sy = sx): DOMMatrixPolyfill {
+    return this.multiply({ a: sx, b: 0, c: 0, d: sy, e: 0, f: 0 })
+  }
+
+  scaleSelf(sx = 1, sy = sx): this {
+    return this.setFrom(this.scale(sx, sy))
+  }
+
+  invertSelf(): this {
+    const det = this.a * this.d - this.b * this.c
+    if (det === 0) {
+      // Singular — DOMMatrix marks the result non-invertible (all NaN). Match that.
+      this.a = this.b = this.c = this.d = this.e = this.f = NaN
+      return this
+    }
+    const { a, b, c, d, e, f } = this
+    this.a = d / det
+    this.b = -b / det
+    this.c = -c / det
+    this.d = a / det
+    this.e = (c * f - d * e) / det
+    this.f = (b * e - a * f) / det
+    return this
+  }
+
+  inverse(): DOMMatrixPolyfill {
+    return new DOMMatrixPolyfill(this).invertSelf()
+  }
+
+  transformPoint(point: { x?: number; y?: number } = {}): { x: number; y: number; z: number; w: number } {
+    const x = point.x ?? 0
+    const y = point.y ?? 0
+    return { x: this.a * x + this.c * y + this.e, y: this.b * x + this.d * y + this.f, z: 0, w: 1 }
+  }
+}
+
+/**
+ * Install the pure-JS `DOMMatrix` on `globalThis` **if none exists** — idempotent, and a
+ * no-op where a real one is present (renderer/dev with `@napi-rs/canvas`). Call this before
+ * importing pdfjs-dist in the main process.
+ */
+export function ensureDomMatrixPolyfill(): void {
+  const g = globalThis as { DOMMatrix?: unknown }
+  if (!g.DOMMatrix) {
+    g.DOMMatrix = DOMMatrixPolyfill
+  }
+}
+
+export { DOMMatrixPolyfill }

--- a/apps/desktop/src/main/services/ingestion/parsers/pdf.ts
+++ b/apps/desktop/src/main/services/ingestion/parsers/pdf.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { t } from '../../../../shared/i18n'
 import { log } from '../../logging'
+import { ensureDomMatrixPolyfill } from './dommatrix-polyfill'
 import type { DocumentParser, ExtractedSegment, ParseContext, ParsedDocument } from './index'
 import { reconstructPage, type LayoutWord } from './pdf-layout'
 
@@ -68,6 +69,11 @@ export const PdfParser: DocumentParser = {
   extensions: ['.pdf'],
   mimeType: 'application/pdf',
   async parse(filePath: string, ctx?: ParseContext): Promise<ParsedDocument> {
+    // pdfjs-dist v6's legacy build evaluates `new DOMMatrix()` at import time and, in Node,
+    // only sources it from `@napi-rs/canvas` — which we exclude from the package. Install a
+    // pure-JS DOMMatrix first (idempotent; a no-op where a real one exists) so the import
+    // succeeds in the packaged main process. See dommatrix-polyfill.ts.
+    ensureDomMatrixPolyfill()
     const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
     const data = new Uint8Array(await readFile(filePath))
     // `verbosity: 0` (VerbosityLevel.ERRORS) silences pdf.js's font-program WARNINGS — e.g. the

--- a/apps/desktop/tests/unit/dommatrix-polyfill.test.ts
+++ b/apps/desktop/tests/unit/dommatrix-polyfill.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  DOMMatrixPolyfill,
+  ensureDomMatrixPolyfill
+} from '../../src/main/services/ingestion/parsers/dommatrix-polyfill'
+
+// Guards the "DOMMatrix is not defined" PDF-import failure from a packaged drive: pdfjs-dist
+// v6 evaluates `new DOMMatrix()` at import time and, in Node, only polyfills it from
+// `@napi-rs/canvas`, which we exclude from the bundle. The parser installs this pure-JS
+// matrix first. These tests pin (a) the math pdf.js relies on and (b) the install contract.
+
+const IDENTITY: [number, number, number, number, number, number] = [1, 0, 0, 1, 0, 0]
+
+function toArr(m: DOMMatrixPolyfill): number[] {
+  return [m.a, m.b, m.c, m.d, m.e, m.f]
+}
+
+describe('DOMMatrixPolyfill', () => {
+  it('defaults to the identity and constructs from a 6-tuple', () => {
+    expect(toArr(new DOMMatrixPolyfill())).toEqual(IDENTITY)
+    expect(new DOMMatrixPolyfill()).toHaveProperty('isIdentity', true)
+    expect(toArr(new DOMMatrixPolyfill([2, 0, 0, 3, 5, 7]))).toEqual([2, 0, 0, 3, 5, 7])
+  })
+
+  it('extracts the 2D-affine components from a 4x4 (16-length) array', () => {
+    // column-major m11,m12,..,m41,m42 at indices 0,1,4,5,12,13
+    const m = new DOMMatrixPolyfill([2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0, 5, 7, 0, 1])
+    expect(toArr(m)).toEqual([2, 0, 0, 3, 5, 7])
+  })
+
+  it('copies from a DOMMatrix-like object', () => {
+    expect(toArr(new DOMMatrixPolyfill({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 }))).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('translate maps points correctly', () => {
+    const p = new DOMMatrixPolyfill().translate(10, 20).transformPoint({ x: 1, y: 1 })
+    expect([p.x, p.y]).toEqual([11, 21])
+  })
+
+  it('scale maps points correctly', () => {
+    const p = new DOMMatrixPolyfill().scale(2, 3).transformPoint({ x: 4, y: 5 })
+    expect([p.x, p.y]).toEqual([8, 15])
+  })
+
+  it('multiply composes transforms (translate then scale applied to a point)', () => {
+    // this = scale(2,2) · translate(10,0): the point is translated first, then scaled.
+    const m = new DOMMatrixPolyfill().scale(2, 2).multiply(new DOMMatrixPolyfill().translate(10, 0))
+    const p = m.transformPoint({ x: 1, y: 1 })
+    expect([p.x, p.y]).toEqual([22, 2])
+  })
+
+  it('invertSelf yields the true inverse (M · M⁻¹ = identity)', () => {
+    const m = new DOMMatrixPolyfill([2, 1, 1, 3, 5, 7])
+    const round = m.multiply(new DOMMatrixPolyfill(m).invertSelf())
+    for (const [got, want] of [
+      [round.a, 1], [round.b, 0], [round.c, 0], [round.d, 1], [round.e, 0], [round.f, 0]
+    ]) {
+      expect(got).toBeCloseTo(want, 10)
+    }
+  })
+
+  it('a singular matrix inverts to NaN (matches DOMMatrix)', () => {
+    const m = new DOMMatrixPolyfill([1, 2, 2, 4, 0, 0]).invertSelf() // det = 0
+    expect(Number.isNaN(m.a)).toBe(true)
+  })
+})
+
+describe('ensureDomMatrixPolyfill', () => {
+  const hadReal = 'DOMMatrix' in globalThis
+  const original = (globalThis as { DOMMatrix?: unknown }).DOMMatrix
+
+  beforeEach(() => {
+    delete (globalThis as { DOMMatrix?: unknown }).DOMMatrix
+  })
+  afterEach(() => {
+    if (hadReal) (globalThis as { DOMMatrix?: unknown }).DOMMatrix = original
+    else delete (globalThis as { DOMMatrix?: unknown }).DOMMatrix
+  })
+
+  it('installs the polyfill when none exists', () => {
+    ensureDomMatrixPolyfill()
+    expect((globalThis as { DOMMatrix?: unknown }).DOMMatrix).toBe(DOMMatrixPolyfill)
+    // and the installed constructor actually works
+    const Ctor = (globalThis as { DOMMatrix?: unknown }).DOMMatrix as unknown as typeof DOMMatrixPolyfill
+    expect(toArr(new Ctor([1, 0, 0, 1, 2, 3]))).toEqual([1, 0, 0, 1, 2, 3])
+  })
+
+  it('does not override an existing (real) DOMMatrix', () => {
+    class Realish {}
+    ;(globalThis as { DOMMatrix?: unknown }).DOMMatrix = Realish
+    ensureDomMatrixPolyfill()
+    expect((globalThis as { DOMMatrix?: unknown }).DOMMatrix).toBe(Realish)
+  })
+})


### PR DESCRIPTION
## Symptom

Launching the portable build **from a drive** and importing a **PDF** fails with **`DOMMatrix is not defined`**. Other formats (DOCX/CSV) import fine, and `npm run dev` shows no problem.

## Root cause

`pdfjs-dist` v6's legacy build evaluates a module-level `new DOMMatrix()` at **import time** and, in Node, only sets `globalThis.DOMMatrix` by `require("@napi-rs/canvas")`. We **deliberately exclude** that native Skia package from the package (`electron-builder.yml` `files` negation — keeps the portable bundle pure-JS / cross-OS; asserted by `tests/integration/packaging.test.ts`). So in the **packaged** app the require fails, `DOMMatrix` stays undefined, and `import`ing pdfjs throws. In `dev` the dep is present, so pdf.js polyfills itself and the bug is invisible — which is why it only surfaces from a built drive (the runtime-only-failure class the packaging docs already warn about).

## Fix

Install a small, **correct pure-JS 2D-affine `DOMMatrix`** on `globalThis` **before** importing pdfjs. pdf.js guards with `if (!globalThis.DOMMatrix)`, so it then skips the `@napi-rs/canvas` path entirely — the exclusion (and its test) stay intact, and the bundle stays pure-JS / cross-OS. Our main-process path does **text extraction only** (transforms come back as plain arrays), so the matrix only needs to *exist*; the methods are implemented correctly regardless. Rasterization (OCR) keeps using the hidden renderer window's real `DOMMatrix`.

## Verification

- **Repro (canvas blocked, mimicking the packaged build):** `import` fails **without** the polyfill (`DOMMatrix is not defined`) and **succeeds with** it.
- **Unit tests** (`dommatrix-polyfill.test.ts`, 10): matrix math (identity / from-array / from-4×4 / multiply / translate / scale / invert incl. singular→NaN) + install contract (sets when absent, never overrides a real `DOMMatrix`).
- Existing PDF parser tests (73) still green; `typecheck` green.
- Rebuilt `.exe` smoke-tested from a real drive.

## Note

Independent of #15 (electron-builder 26 packaging). Both target `master`; **building the `.exe` needs both** (this branch is based on `master`, which still lacks the eb-26 packaging fix from #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)