### PR TITLE
Fast-tier Qwen3.5 manifests (2B + 0.8B) + master CI fix

### DIFF
--- a/apps/desktop/tests/unit/save-export-bom.test.ts
+++ b/apps/desktop/tests/unit/save-export-bom.test.ts
@@ -1,4 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// `save-export.ts` imports { BrowserWindow, dialog } from 'electron' at module top. On CI the
+// electron BINARY download is skipped (ELECTRON_SKIP_BINARY_DOWNLOAD=1 in ci.yml), so importing
+// the REAL package throws "Electron failed to install correctly" before a single test runs —
+// this suite broke master CI from the moment it landed (invoice-hardening merge, bcfa876).
+// `bomFor` is pure; mock the transport like every other suite that touches this module.
+vi.mock('electron', () => ({
+  BrowserWindow: { getFocusedWindow: () => null },
+  dialog: { showSaveDialog: async () => ({ canceled: true }) }
+}))
+
 import { bomFor } from '../../src/main/ipc/save-export'
 
 // invoice-hardening-2026-07-04 P4 — the UTF-8 BOM on plain-text exports. A user's exported German

--- a/model-manifests/chat/qwen3.5-0.8b-q6.yaml
+++ b/model-manifests/chat/qwen3.5-0.8b-q6.yaml
@@ -1,0 +1,54 @@
+id: qwen3.5-0.8b-q6
+display_name: Qwen3.5 0.8B Q6_K
+family: qwen3.5
+role: chat
+format: gguf
+runtime: llama_cpp
+license: apache-2.0
+size_on_disk_gb: 0.7
+# RAM lines DELIBERATELY tier-aligned with the qwen3.5-4b entry (min 8 / rec 16), NOT the
+# honest tiny-model values: recommendModelIdByRam prefers the largest comfortable fit and the
+# smallest runnable min REGARDLESS of recommendation_rank, so honest values on a rank-0,
+# not-yet-evaled model would hijack the 8 GB recommendation from the Phase-29-benchmarked 4B
+# (exactly what the earlier local drafts did to benchmark.test.ts). The honest small-RAM story
+# ships WITH the quality eval + a real rank.
+recommended_min_ram_gb: 8
+recommended_ram_gb: 16
+# Default 0: NOT auto-recommended — the fast-tier CANDIDATE for CPU-only machines where even the
+# 4B is too slow (local llama-bench 2026-07-05 on THIS pinned file, CPU-pinned `-dev none -ngl 0`,
+# 8 threads: pp512 247.6 t/s, tg128 54.1 t/s vs the 4B's 56.5/14.7 — ~3.7x decode). SPEED ONLY: at 0.8B the free-prose surfaces (summaries, grounded-data
+# narration, map-reduce) are expected to degrade visibly; the grammar-constrained call sites
+# (categorizer/enricher/extract) should hold up. The Phase-29 quality eval
+# (tests/manual/model-eval.test.ts) + the b9849 in-app load smoke gate any promotion (D39).
+recommendation_rank: 0
+recommended_context_tokens: 4096
+# Qwen3.5 operates in thinking mode by default (emits <think>...</think>), so the chat
+# template honours `enable_thinking` → the Deep answer mode applies (like the 4B entry).
+supports_thinking_mode: true
+supports_tools: true
+local_path: models/chat/qwen3.5-0.8b-q6.gguf
+# Real hash = the upstream LFS SHA-256 published by the Hugging Face API for the unsloth repo,
+# CONFIRMED 2026-07-05 by fetching the weight and re-computing locally (639,029,504 bytes).
+# NOTE: this REPLACES the earlier local-unverified draft of this manifest — the previously
+# hand-added local file (658,066,848 bytes, sha256 5762c720…) was a DIFFERENT quant provenance
+# and does not match; re-fetch via fetch-models / `llama get` from the pinned URL below.
+sha256: 8408c5c222111cec253682b49eece2a02ed641ded68490001ec4ee160e71098e
+# Quantization choice: Q6_K, NOT the family's UD-Q4_K_XL — at 0.8B quantization error bites
+# hardest of the whole ladder, and the Q6 file is still only ~0.64 GB (speed is RAM-bandwidth
+# bound; the +bits cost ~nothing at this size). Established-quantizer provenance (unsloth), same
+# posture as the qwen3.5-2b/4b entries — the Qwen org publishes no official GGUF for 3.5.
+download:
+  url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q6_K.gguf?download=true
+  sha256: 8408c5c222111cec253682b49eece2a02ed641ded68490001ec4ee160e71098e
+  size_bytes: 639029504
+  license_url: https://huggingface.co/Qwen/Qwen3.5-0.8B/blob/main/LICENSE
+bundled_on_preconfigured_drive: false
+# Same b9849 promotion gate as the 2B/4B entries: the family is confirmed to load and stream on
+# the developer's local b9490 build; the in-app smoke on the pinned b9849 is still required
+# before promotion. Upstream is a VISION model; this .gguf runs TEXT-ONLY (no mmproj shipped).
+recommended_profiles: []
+license_review:
+  status: approved
+  reviewed_by: "project maintainer (Claude-assisted review, HF card verification)"
+  reviewed_at: "2026-07-05"
+  notes: "APPROVED 2026-07-05: base model Qwen/Qwen3.5-0.8B is apache-2.0 (per the unsloth GGUF repo card, license tag apache-2.0; LICENSE blob expected at download.license_url). QUANTIZATION PROVENANCE: the Qwen org publishes no official GGUF for the 3.5 refresh, so this manifest pins the established quantizer unsloth (https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF) — same posture as the qwen3.5-2b/4b entries. Apache-2.0 permits commercial redistribution; ship the LICENSE/NOTICE attribution with the drive. Supersedes the 2026-06-22 local-unverified draft (hand-added file of different provenance). NOT bundled, NOT promoted (rank 0): speed benchmarked locally; Phase-29 quality eval + b9849 smoke pending."

--- a/model-manifests/chat/qwen3.5-2b-ud-q4kxl.yaml
+++ b/model-manifests/chat/qwen3.5-2b-ud-q4kxl.yaml
@@ -1,0 +1,60 @@
+id: qwen3.5-2b-ud-q4kxl
+display_name: Qwen3.5 2B (UD-Q4_K_XL)
+family: qwen3.5
+role: chat
+format: gguf
+runtime: llama_cpp
+license: apache-2.0
+size_on_disk_gb: 1.3
+# RAM lines DELIBERATELY tier-aligned with the qwen3.5-4b entry (min 8 / rec 16), NOT the
+# honest tiny-model values: recommendModelIdByRam prefers the largest comfortable fit and the
+# smallest runnable min REGARDLESS of recommendation_rank, so honest values on a rank-0,
+# not-yet-evaled model would hijack the 8 GB recommendation from the Phase-29-benchmarked 4B
+# (exactly what the earlier local drafts did to benchmark.test.ts). The honest small-RAM story
+# ships WITH the quality eval + a real rank.
+recommended_min_ram_gb: 8
+recommended_ram_gb: 16
+# Default 0: NOT auto-recommended yet — same gate as the sibling qwen3.5-4b-ud-q4kxl entry:
+# it has a local llama-bench SPEED result (see the benchmark note below) but not the Phase-29
+# QUALITY eval (tests/manual/model-eval.test.ts) and not the b9849 in-app load smoke. Promote
+# with a real recommendation_rank only after both. Candidate role: the CPU-only speed tier the
+# 4B is too slow for (the ~2x-fewer-parameters decode win), with the grammar-constrained call
+# sites (categorizer/enricher/extract) expected to hold up better than free-prose surfaces.
+recommendation_rank: 0
+recommended_context_tokens: 4096
+# Qwen3.5 operates in thinking mode by default (emits <think>...</think>), so the chat
+# template honours `enable_thinking` → the Deep answer mode applies (like the 4B entry).
+supports_thinking_mode: true
+supports_tools: true
+local_path: models/chat/qwen3.5-2b-ud-q4kxl.gguf
+# Real hash captured 2026-07-05 by fetching the upstream weight and computing SHA-256
+# (file bytes matched download.size_bytes exactly: 1,339,752,704).
+sha256: 0af96165ea615bea39a04118d63f0b6d35908aea850ee4a51aa6151d851b8b35
+# Quantization choice mirrors the family decision on the 4B (user decision 2026-06-18): unsloth
+# "Dynamic 2.0" UD-Q4_K_XL — at 2B the bit depth bites even harder than at 4B, so the richer Q4
+# is worth the +0.06 GB over plain Q4_K_M (1.34 vs 1.28 GB). The Qwen org publishes no official
+# GGUF for the 3.5 refresh → established-quantizer fallback (unsloth), same posture as the 4B.
+download:
+  url: https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-UD-Q4_K_XL.gguf?download=true
+  sha256: 0af96165ea615bea39a04118d63f0b6d35908aea850ee4a51aa6151d851b8b35
+  size_bytes: 1339752704
+  license_url: https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE
+bundled_on_preconfigured_drive: false
+# LOCAL SPEED BENCHMARK 2026-07-05 (llama-bench b9490, CPU-pinned `-dev none -ngl 0`, developer
+# machine: 20-core desktop CPU — absolute numbers overstate a laptop, the RATIOS transfer):
+#   8 threads (laptop-representative):  pp512 130.5 t/s | tg128 28.0 t/s
+#   vs qwen3.5-4b-ud-q4kxl same run:    pp512  56.5 t/s | tg128 14.7 t/s  → the 2B decodes ~1.9x
+#   faster and processes prompts ~2.3x faster than the 4B; the local 0.8B Q6_K measured 47.7 tg
+#   (~3.2x) as the ceiling of the size ladder. SPEED ONLY — the Phase-29 quality eval
+#   (tests/manual/model-eval.test.ts) has not run for this model and gates any promotion.
+# ⚠️ Same b9849 promotion gate as the 4B entry: the app runtime was bumped to llama.cpp b9849
+# (2026-06-30) as the Qwen3.5 compatibility gate; the family is CONFIRMED to load and stream on
+# the developer's local b9490 build (the llama-bench run below), which predates b9849 — so the
+# in-app smoke is expected to pass but is still REQUIRED before promotion. Upstream is a VISION
+# model; this .gguf runs TEXT-ONLY (no mmproj projector shipped), which is all the chat pipeline uses.
+recommended_profiles: []
+license_review:
+  status: approved
+  reviewed_by: "project maintainer (Claude-assisted review, HF card verification)"
+  reviewed_at: "2026-07-05"
+  notes: "APPROVED 2026-07-05: base model Qwen/Qwen3.5-2B is apache-2.0 (per the unsloth GGUF repo card, license tag apache-2.0; LICENSE blob expected at download.license_url). QUANTIZATION PROVENANCE: the Qwen org publishes no official GGUF for the 3.5 refresh, so this manifest pins the established quantizer unsloth (https://huggingface.co/unsloth/Qwen3.5-2B-GGUF) — a third-party requant of apache-2.0 weights, NOT a vendor GGUF; same posture as the qwen3.5-4b-ud-q4kxl entry. Apache-2.0 permits commercial redistribution; ship the LICENSE/NOTICE attribution with the drive. NOT bundled and NOT yet promoted (rank 0): local llama-bench speed measured 2026-07-05 (see comment), Phase-29 quality eval + b9849 in-app smoke pending."


### PR DESCRIPTION
## Why

On a CPU-only laptop even Qwen3.5-4B (UD-Q4_K_XL) is slow. This adds the two fast-tier candidates from the Unsloth Qwen3.5 collection as **manual picks** (rank 0), plus the fix that turns master CI green again.

## Contents

**1. CI fix (cherry-pick of `bfbe6a8`, also on the result-tables PRs).** `save-export-bom.test.ts` (added by the invoice-hardening merge) imports real electron, which CI can't load (`ELECTRON_SKIP_BINARY_DOWNLOAD=1`) — master CI has been red since that merge. Mocked like every other suite touching the module. **Merging this PR makes master green independently of #14/#16.**

**2. `qwen3.5-2b-ud-q4kxl`** — unsloth UD-Q4_K_XL (same established-quantizer provenance as the existing 4B entry), real verified SHA-256 (fetched, bytes matched exactly), apache-2.0 review.

**3. `qwen3.5-0.8b-q6`** — supersedes the developer's local-unverified draft: the hand-added local file turned out to be a **different quant provenance** (hash mismatch vs upstream); the manifest now pins the canonical unsloth Q6_K, hash confirmed by fetch + local recompute.

## Measured speed (llama-bench b9490, CPU-pinned `-dev none -ngl 0`, 8 threads — dev machine, ratios transfer to laptops)

| Model | pp512 | tg128 | vs 4B decode |
|---|---|---|---|
| Qwen3.5-4B UD-Q4_K_XL | 56.5 t/s | 14.7 t/s | 1× |
| **Qwen3.5-2B UD-Q4_K_XL** | 130.5 t/s | 28.0 t/s | **~1.9×** |
| **Qwen3.5-0.8B Q6_K** | 247.6 t/s | 54.1 t/s | **~3.7×** |

## Deliberate posture (D39)

Both entries ship at `recommendation_rank: 0`, `recommended_profiles: []` — selectable in the app, invisible to the recommender and to `benchmark.test.ts` (27/27 green with them present). Speed is measured; **quality is not** — the Phase-29 eval (`tests/manual/model-eval.test.ts`) and the b9849 in-app load smoke gate any promotion.

**One finding for review:** `recommendModelIdByRam` prefers comfortable/smallest-min RAM fits **regardless of `recommendation_rank`** — honest tiny-model RAM values would hijack the 8 GB recommendation from the benchmarked 4B (this is exactly how the local drafts were breaking `benchmark.test.ts`). Both manifests work around it by tier-aligning their RAM lines with the 4B (documented in-file), but the recommender arguably should treat rank 0 as "never auto-recommend" — worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)