### PR TITLE
feat(skill): screenshot-verify — render renderer UI to PNGs without the app

### DIFF
--- a/.claude/skills/screenshot-verify/SKILL.md
+++ b/.claude/skills/screenshot-verify/SKILL.md
@@ -9,6 +9,11 @@ Render real renderer components with the **real `tokens.css` + `styles.css`** an
 then screenshot them with the already-installed Electron (`webContents.capturePage()` — no Playwright,
 no new deps, no GUI/workspace/model). Deterministic, offline.
 
+> **POSIX-only dev tool.** The capture script relies on `xvfb-run` + `ELECTRON_DISABLE_SANDBOX`
+> (Linux; macOS works without xvfb) — it does NOT run on Windows. Acceptable for a contributor-side
+> verification tool; the app itself stays Windows-first (CLAUDE.md hard rules). On Windows, verify
+> visually via `npm run dev` instead.
+
 ## Run it
 
 The capture needs GL libraries (the nix dev shell provides them) + a virtual display, so run inside the

--- a/.claude/skills/screenshot-verify/SKILL.md
+++ b/.claude/skills/screenshot-verify/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: screenshot-verify
+description: Capture pixel screenshots of HilbertRaum renderer UI (components/screens) without the full Electron app, model, or workspace — to visually verify and refine a UI change. Use after editing renderer components/CSS, or when asked to "show", "screenshot", or "verify the look" of the UI.
+---
+
+# screenshot-verify
+
+Render real renderer components with the **real `tokens.css` + `styles.css`** and a **mock `window.api`**,
+then screenshot them with the already-installed Electron (`webContents.capturePage()` — no Playwright,
+no new deps, no GUI/workspace/model). Deterministic, offline.
+
+## Run it
+
+The capture needs GL libraries (the nix dev shell provides them) + a virtual display, so run inside the
+dev shell:
+
+```bash
+nix develop --command bash -c 'cd apps/desktop && npm run screenshot'
+# or specific cases:
+nix develop --command bash -c 'cd apps/desktop && npm run preview:build && \
+  ELECTRON_DISABLE_SANDBOX=1 xvfb-run -a electron --no-sandbox scripts/screenshot.mjs documents'
+```
+
+PNGs land in `apps/desktop/screenshots/<case>.png` (git-ignored). Then **Read** each PNG to inspect it.
+
+## How it works (the moving parts)
+
+- `apps/desktop/src/renderer/preview/preview.tsx` — the harness. A `?case=<id>` selector renders one
+  component/screen wrapped in `I18nProvider` + `ToastProvider`, with a Proxy `window.api` that returns a
+  harmless default (`async () => null`) for any method, overriding the few that need real shapes
+  (`listCollections`, `listDocuments`, …). Mock data is inline.
+- `apps/desktop/vite.preview.config.ts` — builds the harness to static files in `out/preview`
+  (`npm run preview:build`), reusing the renderer's `@shared`/`@renderer` aliases.
+- `apps/desktop/scripts/screenshot.mjs` — Electron main that loads each built case over `file://` in a
+  hidden window and writes `capturePage()` to a PNG.
+
+## Add a case
+
+1. In `preview.tsx`, add an entry to `CASES`: a `label` + a `node` (render the component with mock props;
+   add window.api overrides if it calls a method on mount).
+2. Optionally add a window size in `SIZES` in `screenshot.mjs` (wide for a full screen, narrow for a
+   sidebar/popover).
+3. Run with the case id: `… scripts/screenshot.mjs <id>`.
+
+## Gotchas (already handled in the script — keep them if you edit it)
+
+- **`--no-sandbox` must be a real CLI flag** to the electron binary (the `app.commandLine` switch alone
+  is too late for the zygote → `whenReady` hangs).
+- **Do NOT top-level `await app.whenReady()`** in the ESM main — the entry module must finish evaluating
+  before `ready` fires, so it deadlocks. Use `app.whenReady().then(…)`.
+- **Add a no-op `app.on('window-all-closed', …)`** — destroying the only window otherwise auto-quits the
+  app before the next case.
+- Needs a display: wrap with `xvfb-run -a` on a headless box.
+
+## Scope
+
+For controlled, fast visual checks of components/screens. It is NOT an end-to-end test of the real app
+(no real IPC/model/workspace) — for that, drive the packaged app. Behaviour is covered by the vitest
+renderer tests; this skill is for the *look*.

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ signing.env
 .env.*
 .DS_Store
 Thumbs.db
+apps/desktop/screenshots/

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,9 @@
     "test:watch": "vitest",
     "gen:icons": "node scripts/generate-icons.mjs",
     "package": "electron-vite build && electron-builder",
-    "package:win": "electron-vite build && electron-builder --win portable"
+    "package:win": "electron-vite build && electron-builder --win portable",
+    "preview:build": "vite build --config vite.preview.config.ts",
+    "screenshot": "npm run preview:build && ELECTRON_DISABLE_SANDBOX=1 xvfb-run -a electron --no-sandbox scripts/screenshot.mjs"
   },
   "engines": {
     "node": ">=22.5"

--- a/apps/desktop/scripts/screenshot.mjs
+++ b/apps/desktop/scripts/screenshot.mjs
@@ -1,0 +1,82 @@
+// Screenshot capture for the screenshot-verify skill. Loads each preview case (built to
+// out/preview by vite.preview.config.ts) in an OFFSCREEN Electron window and writes a PNG via
+// webContents.capturePage(). Offscreen rendering is fully headless (no visible window / display
+// needed) and uses the already-installed Electron — no Playwright/Puppeteer.
+//
+// Run: npm run screenshot            (default cases)
+//      npm run screenshot -- documents chat-byproject
+// Output: apps/desktop/screenshots/. On a headless box it still needs GL libs on LD_LIBRARY_PATH
+// (the nix dev shell provides them): `nix develop --command npm run screenshot`.
+import { app, BrowserWindow } from 'electron'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const previewHtml = resolve(here, '../out/preview/preview/preview.html')
+const outDir = resolve(here, '../screenshots')
+
+const SIZES = { documents: [1180, 760], 'chat-byproject': [340, 660] }
+// Electron's argv includes flags + the script path; take everything AFTER the script as case ids.
+const sIdx = process.argv.findIndex((a) => a.endsWith('screenshot.mjs'))
+let cases = (sIdx >= 0 ? process.argv.slice(sIdx + 1) : []).filter((a) => !a.startsWith('-'))
+if (cases.length === 0) cases = ['documents', 'chat-byproject']
+
+// Headless hardening (pass --no-sandbox on the CLI too; the switch alone is too late for the zygote).
+app.commandLine.appendSwitch('no-sandbox')
+app.commandLine.appendSwitch('disable-dev-shm-usage')
+// Destroying the only window would fire the default window-all-closed → app.quit(), killing the run
+// before the next case. A no-op listener keeps the app alive between captures; we quit explicitly.
+app.on('window-all-closed', () => {})
+
+// Never hang the CI/agent: bail out after a generous ceiling.
+const hardTimeout = setTimeout(() => {
+  console.error('screenshot: hard timeout, exiting')
+  process.exit(1)
+}, 90_000)
+
+function capture(c) {
+  return new Promise((done) => {
+    const [w, h] = SIZES[c] ?? [1180, 760]
+    const win = new BrowserWindow({
+      width: w,
+      height: h,
+      show: false,
+      webPreferences: { backgroundThrottling: false }
+    })
+    win.webContents.on('console-message', (_e, _l, msg) => console.log(`  [page:${c}]`, msg))
+    win.webContents.on('render-process-gone', (_e, d) => console.error(`  [gone:${c}]`, d.reason))
+    const url = `${pathToFileURL(previewHtml).href}?case=${encodeURIComponent(c)}`
+    win.webContents.once('did-finish-load', async () => {
+      // Offscreen needs a tick to paint; give React + the async window.api stubs time too.
+      await new Promise((r) => setTimeout(r, 1800))
+      try {
+        const img = await win.webContents.capturePage()
+        const file = resolve(outDir, `${c}.png`)
+        writeFileSync(file, img.toPNG())
+        console.log('captured', c, '→', file, `(${img.getSize().width}x${img.getSize().height})`)
+      } catch (e) {
+        console.error('capture failed', c, e)
+      } finally {
+        win.destroy()
+        done()
+      }
+    })
+    win.webContents.once('did-fail-load', (_e, code, desc) => {
+      console.error('load failed', c, code, desc)
+      win.destroy()
+      done()
+    })
+    win.loadURL(url)
+  })
+}
+
+// NB: do NOT top-level `await app.whenReady()` — in Electron's ESM main the entry module must finish
+// evaluating before 'ready' fires, so awaiting it here deadlocks. Use the callback form instead.
+app.whenReady().then(async () => {
+  mkdirSync(outDir, { recursive: true })
+  console.log('preview html:', previewHtml)
+  for (const c of cases) await capture(c)
+  clearTimeout(hardTimeout)
+  app.quit()
+})

--- a/apps/desktop/src/renderer/preview/preview.html
+++ b/apps/desktop/src/renderer/preview/preview.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>HilbertRaum — UI preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/renderer/preview/preview.tsx
+++ b/apps/desktop/src/renderer/preview/preview.tsx
@@ -1,0 +1,149 @@
+// Visual-preview harness for the screenshot-verify skill. Renders real renderer components with the
+// real tokens.css + styles.css and a mock `window.api`, so UI can be screenshot deterministically
+// WITHOUT the Electron app, its workspace, or a model. Pick a case with `?case=<id>`.
+//
+// Add a case: extend CASES below with a label + an element. Keep the mock data inline so a case is
+// self-describing. This file is dev-only (never bundled into the shipped app).
+import { createRoot } from 'react-dom/client'
+import type { Collection, Conversation, DocumentInfo } from '@shared/types'
+import { I18nProvider } from '../i18n'
+import { ToastProvider } from '../components'
+import { ConversationList } from '../chat/ConversationList'
+import { DocumentsScreen } from '../screens/DocumentsScreen'
+import '../tokens.css'
+import '../styles.css'
+
+// ---- Mock data (a nested project tree + a few chats) -------------------------------------------
+const now = '2026-06-25T10:00:00Z'
+function coll(id: string, name: string, parentId: string | null = null, type = 'project'): Collection {
+  return {
+    id,
+    name,
+    type: type as Collection['type'],
+    description: null,
+    builtin: type !== 'project',
+    color: null,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: null,
+    parentId
+  }
+}
+const COLLECTIONS: Collection[] = [
+  coll('lib', 'Library', null, 'library'),
+  coll('tmp', 'Temporary', null, 'temporary'),
+  coll('tax', 'Taxes'),
+  coll('tax25', '2025', 'tax'),
+  coll('tax24', '2024', 'tax'),
+  coll('legal', 'Legal'),
+  coll('legal-nda', 'NDAs', 'legal')
+]
+function conv(id: string, title: string, collectionId: string | null): Conversation {
+  return {
+    id,
+    title,
+    createdAt: now,
+    updatedAt: now,
+    modelId: null,
+    mode: 'chat',
+    scopeDocumentIds: null,
+    collectionId,
+    scope: null
+  }
+}
+const CONVERSATIONS: Conversation[] = [
+  conv('c1', 'Quarterly estimate', 'tax'),
+  conv('c2', 'Deduction questions', 'tax'),
+  conv('c3', 'NDA review with Acme', 'legal'),
+  conv('c4', 'Brainstorm', null)
+]
+function docRow(id: string, title: string): DocumentInfo {
+  return {
+    id,
+    title,
+    status: 'indexed',
+    errorMessage: null,
+    chunkCount: 5,
+    sizeBytes: 2048,
+    createdAt: now,
+    updatedAt: now,
+    collections: [{ id: 'tax', name: 'Taxes', type: 'project', role: 'source' }]
+  } as unknown as DocumentInfo
+}
+const DOCUMENTS: DocumentInfo[] = [docRow('d1', 'return-2025.pdf'), docRow('d2', 'receipts.csv')]
+
+// ---- Mock window.api: a Proxy so any unlisted method resolves to a harmless default ------------
+const overrides: Record<string, unknown> = {
+  listCollections: async () => COLLECTIONS,
+  listDocuments: async () => DOCUMENTS,
+  searchConversations: async () => [],
+  getAppStatus: async () => ({ ready: true }),
+  getImportJob: async () => null
+}
+;(window as unknown as { api: unknown }).api = new Proxy(
+  {},
+  {
+    get(_t, prop: string) {
+      if (prop in overrides) return overrides[prop]
+      // Any other call: a no-op async returning null (covers the on-interaction methods).
+      return async () => null
+    }
+  }
+)
+
+const noop = (): void => {}
+
+const CASES: Record<string, { label: string; node: JSX.Element }> = {
+  'chat-byproject': {
+    label: 'Chat sidebar — By Project folder browser',
+    node: (
+      <div style={{ width: 300, height: 620, display: 'flex' }}>
+        <ConversationList
+          conversations={CONVERSATIONS}
+          activeId="c1"
+          streaming={false}
+          mode="chat"
+          collections={COLLECTIONS}
+          onSelect={noop}
+          onNew={noop}
+          onDelete={noop}
+          onMove={noop}
+          onNewFolder={noop}
+          onCreateFolder={noop}
+          onNewInFolder={noop}
+          onOpenFolderFiles={noop}
+          onCollapse={noop}
+        />
+      </div>
+    )
+  },
+  documents: {
+    label: 'Documents — rail tree + nested folder browser',
+    node: (
+      <div style={{ width: 1100, height: 720 }}>
+        <DocumentsScreen />
+      </div>
+    )
+  }
+}
+
+const params = new URLSearchParams(location.search)
+const caseId = params.get('case') ?? 'documents'
+// The By-Project view is a localStorage preference; force it on for the chat case.
+try {
+  localStorage.setItem('hilbertraum.chat.listView', caseId === 'chat-byproject' ? 'byProject' : 'recent')
+} catch {
+  /* ignore */
+}
+const chosen = CASES[caseId] ?? CASES.documents
+
+const root = createRoot(document.getElementById('root')!)
+root.render(
+  <I18nProvider>
+    <ToastProvider>
+      <div data-preview-case={caseId} style={{ padding: 16, background: 'var(--bg, #fff)' }}>
+        {chosen.node}
+      </div>
+    </ToastProvider>
+  </I18nProvider>
+)

--- a/apps/desktop/src/renderer/preview/preview.tsx
+++ b/apps/desktop/src/renderer/preview/preview.tsx
@@ -13,9 +13,11 @@ import { DocumentsScreen } from '../screens/DocumentsScreen'
 import '../tokens.css'
 import '../styles.css'
 
-// ---- Mock data (a nested project tree + a few chats) -------------------------------------------
+// ---- Mock data (the built-ins + a few flat projects and chats) ---------------------------------
+// Collections are FLAT on this branch (no nesting/parentId) — the By-Project view groups
+// conversations under their project, it is not a folder tree.
 const now = '2026-06-25T10:00:00Z'
-function coll(id: string, name: string, parentId: string | null = null, type = 'project'): Collection {
+function coll(id: string, name: string, type = 'project'): Collection {
   return {
     id,
     name,
@@ -25,18 +27,14 @@ function coll(id: string, name: string, parentId: string | null = null, type = '
     color: null,
     createdAt: now,
     updatedAt: now,
-    archivedAt: null,
-    parentId
+    archivedAt: null
   }
 }
 const COLLECTIONS: Collection[] = [
-  coll('lib', 'Library', null, 'library'),
-  coll('tmp', 'Temporary', null, 'temporary'),
+  coll('lib', 'Library', 'library'),
+  coll('tmp', 'Temporary', 'temporary'),
   coll('tax', 'Taxes'),
-  coll('tax25', '2025', 'tax'),
-  coll('tax24', '2024', 'tax'),
-  coll('legal', 'Legal'),
-  coll('legal-nda', 'NDAs', 'legal')
+  coll('legal', 'Legal')
 ]
 function conv(id: string, title: string, collectionId: string | null): Conversation {
   return {
@@ -95,7 +93,7 @@ const noop = (): void => {}
 
 const CASES: Record<string, { label: string; node: JSX.Element }> = {
   'chat-byproject': {
-    label: 'Chat sidebar — By Project folder browser',
+    label: 'Chat sidebar — By Project grouping',
     node: (
       <div style={{ width: 300, height: 620, display: 'flex' }}>
         <ConversationList
@@ -107,18 +105,13 @@ const CASES: Record<string, { label: string; node: JSX.Element }> = {
           onSelect={noop}
           onNew={noop}
           onDelete={noop}
-          onMove={noop}
-          onNewFolder={noop}
-          onCreateFolder={noop}
-          onNewInFolder={noop}
-          onOpenFolderFiles={noop}
           onCollapse={noop}
         />
       </div>
     )
   },
   documents: {
-    label: 'Documents — rail tree + nested folder browser',
+    label: 'Documents — list with project memberships',
     node: (
       <div style={{ width: 1100, height: 720 }}>
         <DocumentsScreen />

--- a/apps/desktop/vite.preview.config.ts
+++ b/apps/desktop/vite.preview.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Standalone Vite build for the screenshot-verify preview harness (src/renderer/preview). Reuses the
+// renderer's @shared/@renderer aliases. Builds to out/preview as static files so the Electron
+// capture script (scripts/screenshot.mjs) can load them over file:// — no dev server, fully offline.
+export default defineConfig({
+  root: resolve(__dirname, 'src/renderer'),
+  base: './',
+  resolve: {
+    alias: {
+      '@shared': resolve(__dirname, 'src/shared'),
+      '@renderer': resolve(__dirname, 'src/renderer')
+    }
+  },
+  build: {
+    outDir: resolve(__dirname, 'out/preview'),
+    emptyOutDir: true,
+    rollupOptions: { input: { preview: resolve(__dirname, 'src/renderer/preview/preview.html') } }
+  },
+  plugins: [react()]
+})


### PR DESCRIPTION
Split out of #13 per review (contributor tooling has a different review bar / drift cost).

- `.claude/skills/screenshot-verify/SKILL.md` — the skill: render real renderer components with the real `tokens.css`/`styles.css` and a Proxy-mock `window.api`, screenshot via the already-installed Electron (`capturePage()`, no Playwright, no new deps).
- `preview.tsx` + `vite.preview.config.ts` + `scripts/screenshot.mjs` — the preview harness (aligned with mkg-public's flat-collection API in the follow-up commit; typechecks clean against current master).
- New commit adds the **POSIX-only** note the review asked for: the capture path (xvfb-run, `ELECTRON_DISABLE_SANDBOX`) is a Linux/macOS dev tool only and does not affect the Windows-first app.

Pairs with #19 (nix dev shell), which provides the GL libraries the capture needs on NixOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)