### PR TITLE
Portable build cleanup: executableName + mac/win packaging workflows + TranslateGemma 16 GB fit

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -1,0 +1,80 @@
+# Build the unsigned (ad-hoc signed) macOS .app + fetch the mac Metal llama.cpp runtime.
+#
+# Produces two artifacts for the portable exFAT drive:
+#   - HilbertRaum-<version>-mac-arm64.app.zip  — ditto-zipped .app. Must STAY zipped on the
+#     drive (exFAT cannot hold the framework symlinks inside a .app bundle); the drive
+#     launcher (Start HilbertRaum.command) extracts it to a local cache and runs from there.
+#   - llama-runtime-mac-arm64.zip — llama.cpp Metal build, symlinks DEREFERENCED so the
+#     contents can be placed directly onto the exFAT drive under runtime/llama.cpp/mac/.
+#
+# No signing secrets are used: CSC_IDENTITY_AUTO_DISCOVERY=false skips Developer ID lookup
+# and notarization is not attempted (no APPLE_* env). The .app is ad-hoc signed so it runs
+# on Apple Silicon; Gatekeeper DIY flow (right-click -> Open) is documented in
+# docs/troubleshooting.md.
+name: mac-build
+
+# workflow_dispatch only works once this file is on the default branch — until
+# then the push trigger on this integration branch starts the build.
+on:
+  workflow_dispatch:
+  push:
+    branches: [ci/mac-build]
+
+jobs:
+  build-mac:
+    runs-on: macos-14 # arm64 (Apple Silicon)
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Package .app (unsigned dir target)
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npm run package
+
+      - name: Ad-hoc sign + ditto-zip the .app
+        run: |
+          set -euo pipefail
+          APP=$(ls -d apps/desktop/release/mac*/HilbertRaum.app | head -1)
+          echo "Found app bundle: $APP"
+          # Ensure a valid ad-hoc signature (required on Apple Silicon).
+          codesign --force --deep --sign - "$APP"
+          codesign --verify --verbose=2 "$APP"
+          VERSION=$(node -p "require('./apps/desktop/package.json').version")
+          # ditto preserves symlinks, resource forks and exec bits inside the zip.
+          ditto -c -k --keepParent "$APP" "HilbertRaum-${VERSION}-mac-arm64.app.zip"
+          ls -la HilbertRaum-*.app.zip
+
+      - name: Fetch mac llama.cpp runtime (Metal, arm64)
+        run: |
+          set -euo pipefail
+          STAGE="$RUNNER_TEMP/drive"
+          mkdir -p "$STAGE"
+          bash scripts/fetch-runtime.sh --target "$STAGE"
+          ls -la "$STAGE/runtime/llama.cpp/mac/"
+          # Zip WITHOUT -y so symlinks are dereferenced -> safe to extract onto exFAT.
+          (cd "$STAGE/runtime/llama.cpp" && zip -r "$GITHUB_WORKSPACE/llama-runtime-mac-arm64.zip" mac)
+
+      - name: Upload .app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hilbertraum-mac-app
+          path: HilbertRaum-*-mac-arm64.app.zip
+          if-no-files-found: error
+
+      - name: Upload runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llama-runtime-mac-arm64
+          path: llama-runtime-mac-arm64.zip
+          if-no-files-found: error

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -1,0 +1,55 @@
+# Build the portable Windows .exe for the portable exFAT drive.
+#
+# Produces one artifact:
+#   - HilbertRaum-<version>-portable.exe — a single self-contained portable build
+#     (electron-builder `portable` target, artifactName from electron-builder.yml).
+#     Copy it to the drive root next to the launchers; Start HilbertRaum.cmd sets
+#     HILBERTRAUM_DRIVE_ROOT and launches it.
+#
+# The .exe is UNSIGNED here (no WIN_CSC_* secrets in CI) — SmartScreen shows the
+# "unknown publisher" prompt; the DIY "More info -> Run anyway" flow is documented
+# in docs/troubleshooting.md. Supply WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD on a build
+# machine for a signed release.
+#
+# The llama.cpp Windows runtime is NOT fetched here — it is already staged on the
+# drive under runtime/llama.cpp/win/ (pin unchanged: llama.cpp b9849). Add a
+# fetch-runtime step if a future runtime bump needs re-staging.
+name: win-build
+
+# workflow_dispatch only works once this file is on the default branch — until then
+# the push trigger on this branch starts the build.
+on:
+  workflow_dispatch:
+  push:
+    branches: [ci/win-build]
+
+jobs:
+  build-win:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Package portable .exe
+        run: npm run package:win
+
+      - name: Locate artifact
+        shell: bash
+        run: ls -la apps/desktop/release/*.exe
+
+      - name: Upload portable exe
+        uses: actions/upload-artifact@v4
+        with:
+          name: hilbertraum-win-portable
+          path: apps/desktop/release/HilbertRaum-*-portable.exe
+          if-no-files-found: error

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -16,6 +16,12 @@
 
 appId: space.hilbertraum.app
 productName: HilbertRaum
+# electron-builder derives the per-platform executable/AppImage name from the npm package name,
+# which in this monorepo is the scoped "@hilbertraum/desktop" → "@hilbertraumdesktop"; the '@' is
+# rejected as an unsafe path char and the build fails (first seen on the linux AppImage target,
+# and it now hits mac/win too since the desktop package was renamed to a scoped name). Pin an
+# explicit, path-safe name for every platform. Keep in sync with productName.
+executableName: HilbertRaum
 
 # electron-builder 26 cannot auto-detect the Electron version in this npm workspace: `electron`
 # is pinned as a RANGE (^37 in devDependencies) and is HOISTED to the repo-root node_modules,

--- a/model-manifests/translation/translategemma-12b-it-q4.yaml
+++ b/model-manifests/translation/translategemma-12b-it-q4.yaml
@@ -10,16 +10,21 @@ runtime: llama_cpp
 license: gemma
 # 7,300,794,112 bytes ≈ 7.3 decimal GB (byte-verified via the HF tree API 2026-07-05).
 size_on_disk_gb: 7.3
-# MEASURED at TG-6 (2026-07-05, real b9849 pin — model-benchmarks.md §11). Unlike a chat model,
-# TranslateGemma runs in its OWN sidecar (D1) and NEVER alone: at the doc-task materialize step it
-# co-resides with the E5 embedder and (typically) a resident chat model. Measured co-residency floor
-# = 13.24 GiB (translation ≈9.22 + E5 ≈0.14 + a small 4B chat ≈3.89, all warm at once) — and that
-# excludes the Electron shell (~1 GiB) + the OS. Applying the model-benchmarks §4 rule (peak + ~3 GiB
-# headroom, rounded UP) to the co-residency floor ⇒ 13.24 + 3 = 16.24 → 17: the realistic minimum for
-# translation + a SMALL resident chat without paging. A 12B chat resident (≈6.5 GiB more) pushes the
-# pair well past 16 GiB — that wants the recommended 32 below.
-recommended_min_ram_gb: 17
-recommended_ram_gb: 32
+# MEASURED at TG-6 (2026-07-05, real b9849 pin — model-benchmarks.md §11). recommended_min_ram_gb is
+# the MODEL-ALONE floor — the same convention as every chat manifest and the vision role model
+# (vision = 12 for its ~4.6 GiB peak; co-residency lives in recommended_ram_gb, NOT the hard min gate
+# — §8.4 PROD-1). TranslateGemma's OWN peak RSS = 9.22 GiB (its sidecar at --ctx-size 4096); the §4
+# rule (peak + ~3 GiB headroom, rounded UP) ⇒ 9.22 + 3 = 12.22 → 13. That lands exactly where the
+# catalog puts a ~9-GiB-peak model (ministral 8.7→12, gemma4-12b 10.6→14) and, crucially, FITS A
+# STANDARD 16 GB MACHINE with headroom — the min gate (registerModelIpc §11.4) no longer refuses it.
+# (Was 17: that erroneously baked the co-residency floor into the hard min — the only manifest to do
+# so — which locked translation out of every 16 GB machine.)
+recommended_min_ram_gb: 13
+# Co-residency lives here, not in the min. Translation runs in its OWN sidecar (D1) alongside E5 + a
+# resident chat: measured floor with a small 4B chat = 13.24 GiB; with a 12B chat resident (~6.5 GiB
+# more) it wants ~24. On a 16 GB machine that pressure is handled exactly as for vision — the chat
+# sidecar's idle-teardown + the RAM-best-fit picker (known-limitations.md), not by blocking the model.
+recommended_ram_gb: 24
 # The translation sidecar launches --ctx-size 4096 (plan §2 D4: the model card states a 2K input
 # budget; 4096 leaves room for input + output). This field is the sidecar's launch window, read
 # back via the sidecar's own contextWindow() at TG-2/TG-3 — NOT a chat window.


### PR DESCRIPTION
Cleanup from the 0.1.42 cross-OS drive build. Three independent fixes uncovered while producing the portable Linux/macOS/Windows artifacts; grouped here because they're all small and packaging-adjacent.

## 1. `fix(build)` — pin `executableName` for the scoped package name
The desktop workspace package is `@hilbertraum/desktop`. electron-builder derives the per-platform executable/AppImage name from it → `@hilbertraumdesktop`, and the `@` is rejected as an unsafe path char, so **`npm run package` fails**:

```
⨯ executableName contains characters that cannot be safely used in file paths: @hilbertraumdesktop
```

First hit on the Linux AppImage; it also breaks the mac/win targets after the monorepo rename. Fix: a top-level `executableName: HilbertRaum` (== `productName`). This unblocks `npm run package` on all three OSes.

## 2. `ci` — portable mac + windows packaging workflows
`ci.yml` is only the green gate (typecheck/build/test on ubuntu+win) and produces **no installers**. Added the two workflows that build the drive artifacts:

- **`mac-build.yml`** → `macos-14` arm64: unsigned/ad-hoc `.app`, ditto-zipped for exFAT, plus the Metal `llama.cpp` runtime. (Previously lived only on the `ci/mac-build` branch.)
- **`win-build.yml`** → `windows-latest`: the portable `HilbertRaum-<version>-portable.exe`. (New — there was no Windows packaging workflow at all.)

Both land on the default branch so `workflow_dispatch` works, and keep a push trigger on their conventional `ci/mac-build` / `ci/win-build` branches. Artifacts are **unsigned** (no CSC secrets in CI); supply `WIN_CSC_*` / `CSC_LINK`+`APPLE_*` on a build machine for a signed release.

## 3. `fix(models)` — TranslateGemma min RAM 17 → 13 (runs on standard 16 GB machines)
`recommended_min_ram_gb` is a **hard gate** (`registerModelIpc.ts` §11.4): it refuses to start a model when the value exceeds machine RAM. TranslateGemma was the **only** manifest that baked the multi-model *co-residency* floor (translation 9.22 GiB + E5 + a resident chat + 3 GiB headroom = 17) into that field — which **locked it out of every standard 16 GB machine**.

Every chat manifest and the vision role model set the min to the model **alone** (peak RSS + ~3 GiB) and keep co-residency in `recommended_ram_gb` (vision = 12 min / 16 rec — model-benchmarks §8.4 PROD-1). TranslateGemma's own peak RSS is 9.22 GiB → **13** (in line with ministral 8.7→12, gemma4-12b 10.6→14). Co-residency-with-a-large-chat pressure on 16 GB is handled the same way vision already ships (chat sidecar idle-teardown + RAM-best-fit picker), not by blocking the model. `recommended_ram_gb` 32→24.

---
Verified: all three artifacts built green at 0.1.42 with these changes (Linux AppImage locally; mac + win via the new workflows) and boot/validate. No tests reference the changed manifest value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
