### PR TITLE
Promote the newest Qwen generation into the recommendation tiers (owner decision 2026-07-12)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,9 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-07-12: **Newest-Qwen promotion (owner decision): the recommendation tiers now point at the newest Qwen generation; the Qwen3.6 27B pair productized from local-test stubs; the stub [PRO] profile hijack fixed.**_
+Owner decision 2026-07-12, durable record in **`model-benchmarks.md` §6.4** (rationale: a subjective owner judgment that newer model generations improve on the ones they replace; the §9 tester eval is treated as directional, its F1 being length-confounded, EM near-tied, single-run; follow-up quality + speed benchmarks recorded as open work in §5 item 8). This partially front-runs §5 item 8's ratify-and-complete sequence BY DESIGN: the rank/RAM/test/README edits land now on product grounds; the scorer fixes, owner ratification, §3/§4 speed+RSS rows for the promoted set (the tester runs were QUALITY-ONLY), and the §9.1 smokes for the 9B and both 27Bs stay open in item 8. Changes: (1) ranks: `qwen3.5-4b-ud-q4kxl` and `qwen3.5-9b-ud-q4kxl` 0→3 (eval standing recorded honestly in each manifest: the 4B FAILED its §9 F1 bar, the 9B sat under Ministral); (2) `qwen3.6-27b-q4`/`-q5` PRODUCTIZED (unsloth GGUF download blocks, real HF-LFS hashes, apache-2.0 reviews superseding the 2026-06-22 local-test scope, ram_gb 24/32, ctx 8192) and promoted to rank 3 (here the eval AGREES: they top the §9 quality table); (3) the five 2026-06-22 local-test stubs committed earlier today carried `recommended_profiles: [PRO]`, which HIJACKED the legacy profile picker from qwen3-14b and broke `benchmark.test.ts` on master (the push had bypassed the ci-success gate) — all five emptied per D17, the gemma stub pair (`gemma-4-26b-q4`, `gemma4-coding-q8`) and `qwen3.5-9b-q8` otherwise untouched (still rank 0, license G3 provenance issues still open in the private preload review). New mapping (asserted in `benchmark.test.ts` + `committed-catalog.test.ts`, incl. a new Qwen3.6 promotion-facts pin): **≤12 GB → Qwen3.5 4B, 16–20 GB → Qwen3.5 9B, 24 GB → Qwen3.6 27B Q4, ≥32 GB → Qwen3.6 27B Q5**. Docs: README tiers+table, model-policy catalog rows + ‡ footnote, model-benchmarks §6.3 superseded-note + new §6.4. NOT changed (follow-ups, deliberate): the bundled drive default (`qwen3-4b-instruct-q4`), the DIY `--with-assets` default set (Ministral), DRIVE-NOTICES regeneration if a Qwen3.6 model is ever preloaded.
+
 _2026-07-12 — **`docs/design-review/` DELETED (contributor-clarity sweep, third item): the stale S6 composer-picker PNGs + the S12 run-surface recipe README.**_
 Owner decision 2026-07-12. The 20 `skills-s6/` PNGs (2026-06-18) predate the composer/picker changes since (#46 SkillInfoCard/ⓘ among them) and had escaped the existing delete-captures-after-review convention (commits `5e53749`/`b8020b5`/`ecd58d5` deleted every other capture set). The `skills-s12/README.md` was NOT stale — it is the recipe for the OPEN R-2 run-surface eyeball residual — so its essentials were folded into the R-2 bullet in architecture.md (§23 skills-audit ledger) with a `git show f549ce8:` pointer to the full text. Breaks nothing: the six `walk-*.mjs` capture scripts `mkdirSync` their output dir on demand; design-guidelines' capture mentions are dated design-record narrative (kept verbatim per the Phase-4 sweep's bucket (b)). Docs-only.
 
@@ -1141,7 +1144,13 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
      are recorded at those sites.
 8. **Qwen3.5/3.6 wave promotion (owner — issue #48's open half + issue #53; model-benchmarks
    §9/§9.1): the QUALITY half now EXISTS as tester evidence — remaining work is ratify + the
-   missing axes, not "run the eval from scratch".** A tester ran the §2 grounded-QA harness over
+   missing axes, not "run the eval from scratch".** *(Update 2026-07-12: steps (e) and the
+   coupled rank/RAM/test/README edits LANDED EARLY by owner decision, see the 2026-07-12
+   newest-Qwen entry + model-benchmarks §6.4; the promotion deliberately did not wait for
+   (a)-(d), which stay open exactly as written. The raw tester CSVs are now committed under
+   `eval/results/i9-9900X-vulkan-*`. Note the eval-vs-decision divergence recorded in §6.4:
+   the promoted 4B/9B ranks contradict the tester verdicts below; revisit §6.4 first if
+   (a)-(d) produce contradicting evidence.)* A tester ran the §2 grounded-QA harness over
    13 chat GGUFs incl. all six wave candidates (2026-07-09, i9-9900X + RTX 3090, b9849 binary;
    full tables in issue #48's comments; recorded in model-benchmarks §9 "Tester eval runs",
    2026-07-11). Verdicts as reported: **Qwen3.6 27B Q5/Q4 sweep the 20–24 GB tier** (rank 2/1

--- a/DRIVE-NOTICES.md
+++ b/DRIVE-NOTICES.md
@@ -28,7 +28,9 @@ runtime-family: llama_cpp b9849
 runtime-family: ocr 4.0.0_best_int
 runtime-family: whisper_cpp v1.8.6
 model: bge-reranker-v2-m3-f16 apache-2.0
+model: gemma-4-26b-q4 gemma
 model: gemma4-12b-it-qat-q4 apache-2.0
+model: gemma4-coding-q8 gemma
 model: granite-4.1-8b-q4 apache-2.0
 model: ministral3-8b-instruct-2512-q4 apache-2.0
 model: multilingual-e5-small-q8 mit
@@ -43,7 +45,10 @@ model: qwen3.5-27b-ud-q4kxl apache-2.0
 model: qwen3.5-2b-ud-q4kxl apache-2.0
 model: qwen3.5-35b-a3b-ud-q4kxl apache-2.0
 model: qwen3.5-4b-ud-q4kxl apache-2.0
+model: qwen3.5-9b-q8 apache-2.0
 model: qwen3.5-9b-ud-q4kxl apache-2.0
+model: qwen3.6-27b-q4 apache-2.0
+model: qwen3.6-27b-q5 apache-2.0
 model: translategemma-12b-it-q4 gemma
 model: whisper-small-multilingual mit
 ```
@@ -159,7 +164,7 @@ manifest's recorded `download.license_url`. A `license_review.status` other than
 `approved` is noted on the line — such a model is never pre-loaded on a sold drive
 (the sell gate requires an approved review for every manifest).
 
-### apache-2.0 (16 models)
+### apache-2.0 (19 models)
 
 Licensed under the Apache License 2.0 — the full text is reproduced once in the
 "Apache License 2.0" section at the end of this file.
@@ -179,14 +184,19 @@ Licensed under the Apache License 2.0 — the full text is reproduced once in th
 - Qwen3.5 2B (UD-Q4_K_XL) (`qwen3.5-2b-ud-q4kxl`) — upstream: https://huggingface.co/unsloth/Qwen3.5-2B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE)
 - Qwen3.5 35B-A3B (UD-Q4_K_XL) (`qwen3.5-35b-a3b-ud-q4kxl`) — upstream: https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.5-35B-A3B/blob/main/LICENSE)
 - Qwen3.5 4B (UD-Q4_K_XL) (`qwen3.5-4b-ud-q4kxl`) — upstream: https://huggingface.co/unsloth/Qwen3.5-4B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/LICENSE)
+- Qwen3.5 9B Q8_0 (`qwen3.5-9b-q8`) — upstream: (no download block — see the manifest) — license: apache-2.0
 - Qwen3.5 9B (UD-Q4_K_XL) (`qwen3.5-9b-ud-q4kxl`) — upstream: https://huggingface.co/unsloth/Qwen3.5-9B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/LICENSE)
+- Qwen3.6 27B Q4_K_M (`qwen3.6-27b-q4`) — upstream: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/LICENSE)
+- Qwen3.6 27B Q5_K_M (`qwen3.6-27b-q5`) — upstream: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF — license: apache-2.0 (https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/LICENSE)
 
-### gemma (1 model)
+### gemma (3 models)
 
 Not covered by a permissive text reproduced in this file — see each line's
 license URL for the governing terms and the manifest's `license_review` block
 for the review record.
 
+- Gemma 4 26B A4B Q4_K_M (`gemma-4-26b-q4`) — upstream: (no download block — see the manifest) — license: gemma
+- Gemma 4 Coding Q8_0 (`gemma4-coding-q8`) — upstream: (no download block — see the manifest) — license: gemma
 - TranslateGemma 12B (Q4_K_M) (`translategemma-12b-it-q4`) — upstream: https://huggingface.co/mradermacher/translategemma-12b-it-GGUF — license: gemma (https://ai.google.dev/gemma/terms) — license_review.status: pending
 
 ### mit (2 models)

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ Remaining work is **manual release acceptance** (signed builds, a live USB demo)
 
 - **A computer:** Windows (first-class), macOS, or Linux.
 - **RAM decides which model the benchmark recommends** (the app benchmarks your machine and picks the
-  best *fit*): ≤12 GB → Qwen3-4B · 16–20 GB → Ministral 8B · ≥24 GB → Gemma 4 12B (or the 30B-A3B MoE,
-  opt-in). These are *recommended best-fit* tiers, **not** hard minimums — each model's actual floor is
-  the lower **Min RAM** column in the model table below (e.g. Ministral 8B already runs from 12 GB).
+  best *fit*): ≤12 GB → Qwen3.5 4B · 16–20 GB → Qwen3.5 9B · 24 GB → Qwen3.6 27B (Q4) · ≥32 GB →
+  Qwen3.6 27B (Q5); the MoEs stay opt-in. These are *recommended best-fit* tiers, **not** hard
+  minimums — each model's actual floor is the lower **Min RAM** column in the model table below
+  (e.g. Qwen3.5 9B already runs from 12 GB).
 - **Disk space:** ~**3 GB** for the smallest *hand-built* setup (the 4B chat model + the embeddings
   model only). The one-command `--with-assets` quick-start fetches a larger **default set** (8B chat +
   embeddings + reranker + Whisper + the Qwen2.5-VL vision model + both sidecar runtimes) at ~**10.4 GB** —
@@ -200,10 +201,11 @@ policy in **[`docs/model-policy.md`](docs/model-policy.md)**.
 
 **The default set** (`-WithAssets`) is enough for everyday use: a chat model + **embeddings**
 (document Q&A) + **reranker** (retrieval quality) + **Whisper** (audio). The benchmark
-auto-recommends the best chat model that fits your RAM: **≤12 GB → Qwen3-4B, 16–20 GB → Ministral
-8B, ≥24 GB → Gemma 4 12B** (best-*fit* tiers; the table's **Min RAM** column is each model's lower
-hard floor). The **30B-A3B MoE** is opt-in (≈30B quality at ≈3.3B *active*
-params/token → near-small-model CPU speed **if** its ~18.6 GB fits in RAM).
+auto-recommends the newest-generation Qwen chat model that fits your RAM: **≤12 GB → Qwen3.5 4B,
+16–20 GB → Qwen3.5 9B, 24 GB → Qwen3.6 27B (Q4), ≥32 GB → Qwen3.6 27B (Q5)** (best-*fit* tiers;
+the table's **Min RAM** column is each model's lower hard floor). The **MoEs** (Qwen3 30B-A3B,
+Qwen3.5 35B-A3B) are opt-in (≈30B quality at ≈3B *active* params/token → near-small-model CPU
+speed **if** the ~18-22 GB weight fits in RAM).
 
 ### Chat models
 
@@ -211,13 +213,15 @@ params/token → near-small-model CPU speed **if** its ~18.6 GB fits in RAM).
 |---|---|---|---|---|
 | Qwen3 4B Instruct Q4 | Preconfigured-drive bundled default & weak-laptop fallback (smallest; keeps **Deep** answer mode). The DIY `--with-assets` default-set chat model is Ministral 3 8B (below) | ~2.7 GB | 8 GB | Apache-2.0 |
 | Qwen3 4B Instruct 2507 Q4 | Better 4B quality (no Deep) | ~2.5 GB | 8 GB | Apache-2.0 |
-| Qwen3.5 4B (UD-Q4_K_XL) | Newest 4B (not auto-recommended yet) | ~2.9 GB | 8 GB | Apache-2.0 |
+| Qwen3.5 4B (UD-Q4_K_XL) | **Recommended ≤12 GB**: newest-generation 4B | ~2.9 GB | 8 GB | Apache-2.0 |
 | Qwen3 8B Instruct Q4 | 12 GB+ laptops | ~5.0 GB | 12 GB | Apache-2.0 |
-| Ministral 3 8B Instruct (2512) Q4 | **Recommended 8B** — benchmark winner | ~5.2 GB | 12 GB | Apache-2.0 |
-| Qwen3.5 9B (UD-Q4_K_XL) | Qwen3.5 wave challenger (selectable; not auto-recommended) | ~6.0 GB | 12 GB | Apache-2.0 |
+| Ministral 3 8B Instruct (2512) Q4 | Phase-29 8B benchmark winner (selectable; the 16–20 GB pick is now Qwen3.5 9B) | ~5.2 GB | 12 GB | Apache-2.0 |
+| Qwen3.5 9B (UD-Q4_K_XL) | **Recommended 16–20 GB**: newest-generation 9B | ~6.0 GB | 12 GB | Apache-2.0 |
 | Granite 4.1 8B Q4 | Challenger (selectable, not auto-recommended) | ~5.3 GB | 12 GB | Apache-2.0 |
-| Gemma 4 12B Instruct QAT Q4_0 | **Recommended 12–14B** — benchmark winner; has **Deep** | ~7.0 GB | 14 GB | Apache-2.0 |
+| Gemma 4 12B Instruct QAT Q4_0 | Phase-29 12–14B benchmark winner; has **Deep** (selectable; the ≥24 GB pick is now Qwen3.6 27B) | ~7.0 GB | 14 GB | Apache-2.0 |
 | Qwen3 14B Instruct Q4 | Dense, 32 GB+ | ~9.3 GB | 14 GB | Apache-2.0 |
+| Qwen3.6 27B Q4_K_M | **Recommended 24 GB**: newest generation, top scorer of the 2026-07 quality eval | ~15.7 GB | 20 GB | Apache-2.0 |
+| Qwen3.6 27B Q5_K_M | **Recommended ≥32 GB**: the same top scorer at a richer quant | ~18.2 GB | 24 GB | Apache-2.0 |
 | Qwen3 30B-A3B (MoE) Q4 | ≈30B quality, ≈3B speed (opt-in) | ~18.6 GB | 24 GB | Apache-2.0 |
 | Qwen3.5 27B (UD-Q4_K_XL) | Qwen3.5 wave dense challenger (selectable; not auto-recommended) | ~17.6 GB | 24 GB | Apache-2.0 |
 | Qwen3.5 35B-A3B (UD-Q4_K_XL) | Qwen3.5 wave MoE (~3B active; opt-in, selectable) | ~22.2 GB | 24 GB | Apache-2.0 |

--- a/apps/desktop/tests/integration/benchmark.test.ts
+++ b/apps/desktop/tests/integration/benchmark.test.ts
@@ -212,18 +212,19 @@ describe('recommendation per profile', () => {
     }
   })
 
-  // Phase-29: the RAM-best-fit picker is now quality-aware (recommendation_rank). It recommends
-  // the BENCHMARK WINNER for each machine size, not the biggest-on-disk model. Issue #48
-  // (model-benchmarks.md §6.3) recalibrated the 12-14B tier to its honest comfortable RAM (24),
-  // so a 24 GB machine now reaches the tier winner instead of being served the same 8B as 16 GB.
-  it('recommends the Phase-29 benchmark winner per machine RAM (real manifests)', () => {
+  // Newest-Qwen promotion (owner decision 2026-07-12, model-benchmarks.md §6.4): the picker
+  // recommends the newest-generation Qwen model per RAM tier. The Phase-29 winners (Ministral,
+  // Gemma 4 12B) keep their ranks and stay selectable but lose the tiebreaks to the rank-3
+  // promoted set. Issue #48's honest-RAM recalibration (12-14B tier at 24) is unchanged; the
+  // Qwen3.6 27B Q4 joins that 24 GB capacity group and wins it on rank.
+  it('recommends the newest-Qwen promoted model per machine RAM (real manifests)', () => {
     const m = realManifests()
-    expect(recommendModelIdByRam(m, 8, 'chat')).toBe('qwen3-4b-instruct-q4') // default 4B (Deep)
-    expect(recommendModelIdByRam(m, 12, 'chat')).toBe('qwen3-4b-instruct-q4')
-    expect(recommendModelIdByRam(m, 16, 'chat')).toBe('ministral3-8b-instruct-2512-q4') // best 8B
-    expect(recommendModelIdByRam(m, 20, 'chat')).toBe('ministral3-8b-instruct-2512-q4') // 12-14B tier starts at 24
-    expect(recommendModelIdByRam(m, 24, 'chat')).toBe('gemma4-12b-it-qat-q4') // #48: the 20–24 GB gap
-    expect(recommendModelIdByRam(m, 32, 'chat')).toBe('gemma4-12b-it-qat-q4') // best 12-14B
+    expect(recommendModelIdByRam(m, 8, 'chat')).toBe('qwen3.5-4b-ud-q4kxl') // low-end pick
+    expect(recommendModelIdByRam(m, 12, 'chat')).toBe('qwen3.5-4b-ud-q4kxl')
+    expect(recommendModelIdByRam(m, 16, 'chat')).toBe('qwen3.5-9b-ud-q4kxl') // 8B-class tier
+    expect(recommendModelIdByRam(m, 20, 'chat')).toBe('qwen3.5-9b-ud-q4kxl') // 24 GB tier starts at 24
+    expect(recommendModelIdByRam(m, 24, 'chat')).toBe('qwen3.6-27b-q4') // eval top scorer (Q4)
+    expect(recommendModelIdByRam(m, 32, 'chat')).toBe('qwen3.6-27b-q5') // eval top scorer (Q5)
   })
 
   it('never auto-recommends the opt-in 30B MoE or the benchmark-loser Granite (real manifests)', () => {

--- a/apps/desktop/tests/integration/committed-catalog.test.ts
+++ b/apps/desktop/tests/integration/committed-catalog.test.ts
@@ -22,8 +22,10 @@ function committedManifests(): ModelManifest[] {
 // The Qwen3.5 Unsloth wave (model-policy.md "Qwen3.5 Unsloth wave"): the 4B incumbent plus the
 // 9B / 27B / 35B-A3B additions, and the later fast-tier 2B / 0.8B (issue #48 closed the test
 // gap — the fast-tier pair shipped without joining these invariants). All are text-only chat
-// models, rank 0, not bundled, not auto-recommended until the offline benchmark + b9849
-// runtime smoke promote them.
+// models, not bundled. Ranks: the 4B and 9B carry rank 3 since the newest-Qwen promotion
+// (owner decision 2026-07-12, model-benchmarks.md §6.4); the rest stay rank 0 (selectable,
+// never auto-recommended). Pin BOTH so neither an accidental demotion nor a silent promotion
+// slips through.
 const QWEN35_WAVE_IDS = [
   'qwen3.5-0.8b-q6',
   'qwen3.5-2b-ud-q4kxl',
@@ -32,6 +34,16 @@ const QWEN35_WAVE_IDS = [
   'qwen3.5-27b-ud-q4kxl',
   'qwen3.5-35b-a3b-ud-q4kxl'
 ]
+
+// The committed promotion facts of the 2026-07-12 newest-Qwen decision.
+const QWEN_WAVE_RANKS: Record<string, number> = {
+  'qwen3.5-0.8b-q6': 0,
+  'qwen3.5-2b-ud-q4kxl': 0,
+  'qwen3.5-4b-ud-q4kxl': 3,
+  'qwen3.5-9b-ud-q4kxl': 3,
+  'qwen3.5-27b-ud-q4kxl': 0,
+  'qwen3.5-35b-a3b-ud-q4kxl': 0
+}
 
 describe('committed catalog — Qwen3.5 Unsloth wave', () => {
   it('all six Qwen3.5 wave manifests are present and validate', () => {
@@ -49,8 +61,9 @@ describe('committed catalog — Qwen3.5 Unsloth wave', () => {
       expect(m.runtime, `${id} runtime`).toBe('llama_cpp')
       expect(m.format, `${id} format`).toBe('gguf')
       expect(m.family, `${id} family`).toBe('qwen3.5')
-      // Not promoted: rank 0 + no legacy profiles → never auto-recommended (asserted below too).
-      expect(m.recommendationRank, `${id} rank`).toBe(0)
+      // Ranks per the 2026-07-12 promotion record; legacy profiles stay empty for the whole
+      // wave (promotion is carried by recommendation_rank, never by the legacy profile table).
+      expect(m.recommendationRank, `${id} rank`).toBe(QWEN_WAVE_RANKS[id])
       expect(m.recommendedProfiles, `${id} profiles`).toEqual([])
       // Apache-2.0, license reviewed + approved (drive-shippable provenance).
       expect(m.license, `${id} license`).toBe('apache-2.0')
@@ -86,15 +99,15 @@ describe('committed catalog — Qwen3.5 Unsloth wave', () => {
     expect(byId['qwen3.5-9b-ud-q4kxl'].role).toBe('chat')
   })
 
-  it('NEVER auto-recommends a rank-0 Qwen3.5 model at any realistic RAM level', () => {
-    // recommendModelIdByRam is the production picker (RAM-best-fit + rank tiebreak). With rank 0
-    // the new models always lose the tiebreak to a ranked incumbent that also fits — so a
-    // Qwen3.5 wave model is never the auto-recommendation until a benchmark gives it a rank.
+  it('NEVER auto-recommends a rank-0 (unpromoted) wave model at any realistic RAM level', () => {
+    // recommendModelIdByRam is the production picker (RAM-best-fit + rank tiebreak). The
+    // 2026-07-12 promotion covers exactly the 4B and 9B (plus the Qwen3.6 27B pair below);
+    // every OTHER wave member stays rank 0 and must never be the auto-recommendation.
     const chat = committedManifests()
-    const waveSet = new Set(QWEN35_WAVE_IDS)
+    const unpromoted = new Set(QWEN35_WAVE_IDS.filter((id) => QWEN_WAVE_RANKS[id] === 0))
     for (const ram of [8, 12, 16, 24, 32, 48, 64, 128]) {
       const picked = recommendModelIdByRam(chat, ram, 'chat')
-      expect(waveSet.has(picked ?? ''), `ram=${ram} picked=${picked}`).toBe(false)
+      expect(unpromoted.has(picked ?? ''), `ram=${ram} picked=${picked}`).toBe(false)
     }
   })
 
@@ -110,6 +123,37 @@ describe('committed catalog — Qwen3.5 Unsloth wave', () => {
     ]) {
       expect(ids.has(id), `${id} still present`).toBe(true)
     }
+  })
+})
+
+// The Qwen3.6 27B pair: productized from local-test stubs and promoted to rank 3 in the
+// newest-Qwen decision (owner, 2026-07-12, model-benchmarks.md §6.4). These are the #48 tester
+// eval's top quality scorers, and the only promoted models whose promotion the eval AGREES
+// with — pin the full promotion facts so a mis-edit fails CI, not a user's drive.
+describe('committed catalog — Qwen3.6 27B pair (2026-07-12 promotion)', () => {
+  it('both Qwen3.6 manifests hold the productization + promotion invariants', () => {
+    const byId = Object.fromEntries(committedManifests().map((m) => [m.id, m]))
+    for (const id of ['qwen3.6-27b-q4', 'qwen3.6-27b-q5']) {
+      const m = byId[id]
+      expect(m, id).toBeDefined()
+      expect(m.role, `${id} role`).toBe('chat')
+      expect(m.runtime, `${id} runtime`).toBe('llama_cpp')
+      expect(m.format, `${id} format`).toBe('gguf')
+      expect(m.family, `${id} family`).toBe('qwen3.6')
+      expect(m.recommendationRank, `${id} rank`).toBe(3)
+      expect(m.recommendedProfiles, `${id} profiles`).toEqual([])
+      expect(m.license, `${id} license`).toBe('apache-2.0')
+      expect(m.licenseReview.status, `${id} review`).toBe('approved')
+      // Productized: real upstream hash (HF LFS OID) + a download block carrying the same hash.
+      expect(isRealSha256(m.sha256), `${id} real sha256`).toBe(true)
+      expect(m.download, `${id} download block`).toBeDefined()
+      expect(m.download!.sha256, `${id} download hash equals top-level`).toBe(m.sha256)
+      expect(m.mmproj, `${id} no mmproj`).toBeUndefined()
+      expect(m.recommendedContextTokens, `${id} ctx not native`).toBeLessThanOrEqual(32768)
+    }
+    // The tier split the promotion rests on: Q4 owns the 24 GB capacity group, Q5 the 32 GB one.
+    expect(byId['qwen3.6-27b-q4'].recommendedRamGb, 'Q4 comfortable tier').toBe(24)
+    expect(byId['qwen3.6-27b-q5'].recommendedRamGb, 'Q5 comfortable tier').toBe(32)
   })
 })
 

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -317,6 +317,48 @@ Net mapping (asserted in `benchmark.test.ts` at 8/12/16/20/24/32): **≤12 GB �
 16–20 GB → Ministral, ≥24 GB → Gemma 4**; Granite, the MoEs, and every rank-0 Qwen3.5 model are
 never auto-recommended. The rest of issue #48 — promoting the Qwen3.5/3.6 generation — is NOT a
 rank edit: it stays gated on the §9 eval + §9.1 smoke (owner, offline, real weights).
+*(Superseded 2026-07-12: §6.4 promoted the Qwen3.5/3.6 generation by owner decision; the
+mapping above is the historical Phase-29/issue-48 state.)*
+
+### 6.4 Newest-Qwen promotion (owner decision, 2026-07-12)
+
+**The decision.** The owner promoted the newest-generation Qwen models to `recommendation_rank: 3`
+per RAM tier: `qwen3.5-4b-ud-q4kxl` (≤12 GB), `qwen3.5-9b-ud-q4kxl` (16–20 GB), `qwen3.6-27b-q4`
+(24 GB, productized from its local-test stub with a real unsloth download source + HF-LFS hash),
+and `qwen3.6-27b-q5` (≥32 GB, same productization). Net mapping (asserted in `benchmark.test.ts`
+and `committed-catalog.test.ts`): **≤12 GB → Qwen3.5 4B, 16–20 GB → Qwen3.5 9B, 24 GB →
+Qwen3.6 27B Q4, ≥32 GB → Qwen3.6 27B Q5**. Granite, both MoEs, the fast-tier 2B/0.8B, and the
+superseded incumbents stay selectable, never auto-recommended.
+
+**The rationale (recorded verbatim so the trade-off stays visible).** A subjective owner
+judgment: newer model generations are expected to be better than the ones they replace (training
+data, instruction tuning, and multilingual quality all move forward), and the current local
+evidence is not strong enough to override that prior. The owner weighed the §9 tester eval and
+judged it directional, not decisive: its primary quality signal (F1) is length-confounded (the
+§9 scorer caveats; Qwen3.5's verbose house style), EM rates across the promoted set and the
+incumbents differ by at most ~1 point, and the runs are single-machine, single-run, pending the
+§5-item-8 scorer fixes. Follow-up benchmarks on BOTH axes (rescored quality, plus the missing
+speed/peak-RSS rows) are planned and stay recorded as open work below. Where the eval IS clear
+it AGREES with the promotion at the top end: Qwen3.6 27B Q5/Q4 lead the quality table outright
+(F1 .3573/.3523, zero unanswerable-set hallucinations for Q5).
+
+**What this supersedes.** The §-9/D17 rule "a challenger earns promotion only via the local
+eval" is amended: the owner may also promote on product/positioning grounds, and the honest
+eval standing must then be recorded next to the rank (done, in each promoted manifest and
+here). Specifically: the 4B FAILED its §9 bar against `qwen3-4b-instruct-q4` (F1 .2728 vs
+.3277, EM .9647 vs .9765) and the 9B sat under Ministral (F1 .3124/.3152 vs .3262, EM tied);
+they are recommended anyway by this decision. The b9849 load gate is satisfied for all four
+(the #48 tester ran the whole wave on the b9849 binary; the 4B additionally loaded + streamed
+through the app from the portable drive on 2026-07-12).
+
+**Still open after this decision** (unchanged from §5 item 8): the scorer follow-ups
+(refusal-phrase list, `rescore.mjs` rerun), owner ratification of the tester CSVs as canonical
+(the raw CSVs are now committed under `eval/results/i9-9900X-vulkan-*`), **speed + peak-RSS
+rows for every promoted model** (the tester runs were QUALITY-ONLY; the promoted set has no §3/§4
+rows yet, so their `recommended_min_ram_gb` values rest on file size + headroom convention, not
+measured RSS), and the §9.1 through-the-app smoke for the 9B and both 27Bs. If the speed/RSS
+rows or the rescored quality table later contradict a promoted rank, this decision is the one
+to revisit, not silently override.
 
 ---
 

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -22,9 +22,11 @@
 | Chat (better 4B) | Qwen3 4B Instruct 2507 Q4 | ~2.5 GB | 8 GB | — (deferred‡) | **Phase-29 (D18)**: beats the original 4B on every axis; the quality alternative at the 4B tier (orig 4B stays the bundled default for Deep). Instruct-only — no thinking |
 | Chat (fast-tier 0.8B) | Qwen3.5 0.8B Q6_K | ~0.6 GB | 8 GB | — (rank 0) | **Qwen3.5 fast-tier (issue #48).** Smallest runnable; Q6_K (not UD-Q4_K_XL — quant error bites hardest at 0.8B). Text-only, not bundled. **§9 eval: the surviving fast-tier candidate — the honest floor (better F1 + abstention than the 2B).** Pending b9849 smoke + owner ratification. |
 | Chat (fast-tier 2B) | Qwen3.5 2B (UD-Q4_K_XL) | ~1.3 GB | 8 GB | — (rank 0) | **Qwen3.5 fast-tier (issue #48).** CPU-only speed tier. Text-only, not bundled. **§9 eval: FAILED — worst unanswerable-discipline of all models scored (should not be recommended anywhere); the 0.8B dominates it.** Pending b9849 smoke + owner ratification. |
-| Chat (new 4B) | Qwen3.5 4B (UD-Q4_K_XL) | ~2.9 GB | 8 GB | — (rank 0) | Added 2026-06-18 (user request). unsloth Dynamic-2.0 quant; thinking-by-default (Deep applies). **Not auto-recommended/benchmarked; runtime pin bumped to b9849 (Qwen3.5 gate) but b9849 load smoke still PENDING before promotion.** Vision model run text-only. |
-| Chat (Qwen3.5 9B) | Qwen3.5 9B (UD-Q4_K_XL) | ~6.0 GB | 12 GB | — (rank 0) | **Qwen3.5 wave (2026-07-01).** unsloth Dynamic-2.0 quant; balanced-tier challenger to Ministral 3 8B / Qwen3 8B. Text-only. Not bundled/benchmarked; needs b9849 load smoke + offline eval before promotion. |
-| Chat (Qwen3.5 27B) | Qwen3.5 27B (UD-Q4_K_XL) | ~17.6 GB | 24 GB | — (rank 0) | **Qwen3.5 wave (2026-07-01).** High-end dense challenger to Gemma 4 12B / Qwen3 14B / Qwen3 30B-A3B on 32 GB machines. Text-only, opt-in (not bundled). Pending b9849 smoke + offline eval. |
+| Chat (new 4B) | Qwen3.5 4B (UD-Q4_K_XL) | ~2.9 GB | 8 GB | — (rank 3) | **Recommended ≤12 GB since the newest-Qwen promotion (owner decision 2026-07-12, `model-benchmarks.md` §6.4).** unsloth Dynamic-2.0 quant; thinking-by-default (Deep applies). §9 eval standing recorded honestly in the manifest (F1 under the Qwen3-4B incumbent, EM comparable); b9849 load observed through the app 2026-07-12. Vision model run text-only. |
+| Chat (Qwen3.5 9B) | Qwen3.5 9B (UD-Q4_K_XL) | ~6.0 GB | 12 GB | — (rank 3) | **Recommended 16–20 GB since the newest-Qwen promotion (2026-07-12, §6.4).** unsloth Dynamic-2.0 quant. §9 eval standing recorded in the manifest (F1 under Ministral, EM tied); ran on the b9849 binary in the #48 tester eval. Text-only, not bundled. |
+| Chat (Qwen3.5 27B) | Qwen3.5 27B (UD-Q4_K_XL) | ~17.6 GB | 24 GB | — (rank 0) | **Qwen3.5 wave (2026-07-01).** High-end dense challenger; superseded at its tier by the Qwen3.6 27B pair (below) before ever being promoted. Text-only, opt-in (not bundled). |
+| Chat (Qwen3.6 27B Q4) | Qwen3.6 27B Q4_K_M | ~15.7 GB | 20 GB | — (rank 3) | **Recommended 24 GB since the newest-Qwen promotion (2026-07-12, §6.4).** Productized 2026-07-12 from a local-test stub: unsloth Q4_K_M (the exact quant the #48 tester eval scored), real HF-LFS hash, apache-2.0 review. Top of the §9 quality table with its Q5 sibling. Text-only, not bundled. |
+| Chat (Qwen3.6 27B Q5) | Qwen3.6 27B Q5_K_M | ~18.2 GB | 24 GB | — (rank 3) | **Recommended ≥32 GB since the newest-Qwen promotion (2026-07-12, §6.4).** Same productization posture as the Q4; the eval's outright top scorer (F1 .3573, zero unanswerable-set hallucinations). Text-only, not bundled. |
 | Chat (Qwen3.5 35B-A3B) | Qwen3.5 35B-A3B (UD-Q4_K_XL) MoE | ~22.2 GB | 24 GB | — (rank 0) | **Qwen3.5 wave (2026-07-01).** ~35B total / ~3B active MoE (256 experts, 8+1 active); opt-in challenger to `qwen3-30b-a3b-q4`. Text-only, not bundled. Pending b9849 smoke + offline eval. |
 | Embeddings | Multilingual E5 Small (F16) | ~0.25 GB | 4 GB | all | Local document search (needed for Q&A) |
 | Reranker (optional) | BGE Reranker v2 M3 (F16) | ~1.16 GB | 6 GB | LITE+ (in the DIY `--with-assets` set; **not** on a preconfigured commercial drive — `bundled_on_preconfigured_drive:false`, advisory/unused) | Retrieval-quality pass over document search — search works fully without it |
@@ -54,11 +56,12 @@ Sizes/RAM come from each manifest
 > than mis-encode the **Phase-29** winners there, each manifest carries a `recommendation_rank`
 > (higher = preferred) that the picker now uses as the tiebreak among models that fit the
 > machine's RAM (the **quality-aware recommender** follow-up — `model-benchmarks.md` §6.2, tiers
-> since recalibrated by §6.3). Net effect on real hardware (§6.3 / issue #48, 2026-07-11; asserted
-> in `benchmark.test.ts`): **≤12 GB → Qwen3-4B (default, keeps Deep), 16–20 GB → Ministral 8B,
-> ≥24 GB → Gemma 4 12B**; Granite (loser) and the 30B MoE (opt-in) are never auto-recommended.
-> The "Auto-tier" column above is the declared `recommended_profiles` (kept as-is); the live
-> recommendation is `recommendation_rank` + RAM-best-fit.
+> since recalibrated by §6.3). Net effect on real hardware (newest-Qwen promotion, owner decision
+> 2026-07-12, `model-benchmarks.md` §6.4; asserted in `benchmark.test.ts`): **≤12 GB → Qwen3.5 4B,
+> 16–20 GB → Qwen3.5 9B, 24 GB → Qwen3.6 27B Q4, ≥32 GB → Qwen3.6 27B Q5**; Granite, both MoEs,
+> and the superseded Phase-29 winners (Ministral, Gemma 4 12B, both still ranked and selectable)
+> are never auto-recommended. The "Auto-tier" column above is the declared `recommended_profiles`
+> (kept as-is); the live recommendation is `recommendation_rank` + RAM-best-fit.
 Min-RAM values were **recalibrated from measured peak RSS** in the Phase-29 run (8B: 16→12,
 12–14B: 16→14). Adding a model is
 **manifest-only** (no code change): drop a YAML in

--- a/model-manifests/chat/gemma-4-26b-q4.yaml
+++ b/model-manifests/chat/gemma-4-26b-q4.yaml
@@ -15,7 +15,9 @@ supports_thinking_mode: false
 local_path: models/chat/gemma-4-26b-q4.gguf
 sha256: local-unverified
 # User-added local model (managed by `llama list`, symlinked into the dev-root models/chat).
-recommended_profiles: [PRO]
+# Profiles emptied 2026-07-12 (catalog rule D17): an unpromoted manifest carries no legacy
+# profiles; the stub's [PRO] was hijacking the legacy profile picker from qwen3-14b.
+recommended_profiles: []
 recommendation_rank: 0
 license_review:
   status: approved

--- a/model-manifests/chat/gemma4-coding-q8.yaml
+++ b/model-manifests/chat/gemma4-coding-q8.yaml
@@ -15,7 +15,9 @@ supports_thinking_mode: false
 local_path: models/chat/gemma4-coding-q8.gguf
 sha256: local-unverified
 # User-added local model (managed by `llama list`, symlinked into the dev-root models/chat).
-recommended_profiles: [PRO]
+# Profiles emptied 2026-07-12 (catalog rule D17): an unpromoted manifest carries no legacy
+# profiles; the stub's [PRO] was hijacking the legacy profile picker from qwen3-14b.
+recommended_profiles: []
 recommendation_rank: 0
 license_review:
   status: approved

--- a/model-manifests/chat/qwen3.5-4b-ud-q4kxl.yaml
+++ b/model-manifests/chat/qwen3.5-4b-ud-q4kxl.yaml
@@ -8,24 +8,20 @@ license: apache-2.0
 size_on_disk_gb: 2.9
 recommended_min_ram_gb: 8
 recommended_ram_gb: 16
-# Default 0: NOT auto-recommended yet. Two reasons — (1) it has not been through a benchmark
-# run like the Phase-29 models, and (2) the RUNTIME compatibility on the freshly-bumped b9849
-# build still needs a manual smoke (see the note below). Selectable manual pick; promote with a
-# real `recommendation_rank` only after it is both benchmarked AND confirmed to load on b9849.
-#
-# FIELD SIGNAL (issue #53, 2026-07-11): a tester reports this model as the best speed/quality
-# trade-off on a weak 16 GB laptop (weak iGPU, ~2 tok/s via the app — which is also an informal
-# load+stream datapoint for b9849, though not the §9.1 smoke). The issue asks to promote it as
-# the standard low-end pick; per model-benchmarks.md §9 that stays gated on the local grounded-QA
-# eval + the §9.1 smoke (field/public datapoints deliberately don't count).
-# PICKER MECHANICS FOR THE EVENTUAL PROMOTION (verified against recommendModelIdByRam): at rank
-# 1–2 this model wins NOTHING — qwen3-4b-instruct-q4 (rank 2, min 8, smaller on disk) takes the
-# ≤12 GB tiers on the tiebreaks, Ministral the 16–20 GB ones. Rank ≥ 3 makes it the ≤12 GB pick
-# but would ALSO steal 16/20 GB from Ministral (both carry recommended_ram_gb: 16) — so a
-# promotion that only targets the low end must retune recommended_ram_gb (needs the real
-# peak-RSS measurement) or rank it alongside a picker change (issue #53 option 2: feed the
-# benchmark's measured tok/s — now recorded per issue #52 — into the recommendation).
-recommendation_rank: 0
+# Rank 3 (owner decision 2026-07-12, newest-generation preference; model-benchmarks.md §6.4):
+# a subjective owner judgment that newer model generations improve on the ones they replace, so
+# the newest-generation model is recommended per tier EVEN THOUGH the #48 tester eval favors the incumbent here
+# (qwen3-4b F1 .3277 vs .2728; but F1 is length-confounded per the §9 scorer caveats, EM is
+# comparable at .9765 vs .9647, so the eval is treated as directional, not decisive). The two
+# old gates are otherwise satisfied: it HAS been through the tester eval (b9849 binary), and
+# the b9849 load gate was observed directly on 2026-07-12 (loaded + streamed through the app
+# from the portable drive, rung 1, GPU backend). The #53 field signal (best speed/quality
+# trade-off on a weak 16 GB laptop) now counts as supporting context, not the promotion basis.
+# Picker effect (verified against recommendModelIdByRam, with the full 2026-07-12 promotion
+# set): wins the ≤12 GB runnable tiers from qwen3-4b-instruct-q4 (rank 2, same min 8); does NOT
+# steal 16-20 GB because the promoted 9B (same rank 3, same recommended_ram_gb 16, bigger on
+# disk) wins that tier on the disk-size tiebreak.
+recommendation_rank: 3
 recommended_context_tokens: 4096
 # Qwen3.5 operates in thinking mode by default (emits <think>...</think>), so the chat
 # template honours `enable_thinking` → the Deep answer mode applies (like the original 4B).
@@ -47,13 +43,12 @@ download:
   size_bytes: 2912109728
   license_url: https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/LICENSE
 bundled_on_preconfigured_drive: false
-# ⚠️ REQUIRES THE b9849 RUNTIME SMOKE BEFORE PROMOTION: the runtime was BUMPED to llama.cpp
-# b9849 (2026-06-30, runtime-sources.yaml) specifically as the Qwen3.5 compatibility gate — the
-# old b9585 build is too old for this newer architecture. b9849 SHOULD load Qwen3.5, but that is
-# NOT yet confirmed by a local smoke on this project's drive (BUILD_STATE "Qwen3.5 Unsloth wave"):
-# do NOT promote (rank > 0) until the model is observed loading + streaming through the app on
-# b9849. The manifest is harmless either way. NOTE ALSO: upstream is a VISION model; this `.gguf`
-# runs TEXT-ONLY (the mmproj projector is not shipped), which is all our chat pipeline uses.
+# b9849 RUNTIME SMOKE: SATISFIED 2026-07-12. The runtime was bumped to llama.cpp b9849
+# (2026-06-30, runtime-sources.yaml) as the Qwen3.5 compatibility gate; this model was then
+# observed loading + streaming through the app from the portable drive on b9849 (rung 1, GPU
+# backend, 2026-07-12), and the #48 tester eval ran it on the same b9849 binary. NOTE: upstream
+# is a VISION model; this `.gguf` runs TEXT-ONLY (the mmproj projector is not shipped), which
+# is all our chat pipeline uses.
 recommended_profiles: []
 license_review:
   status: approved

--- a/model-manifests/chat/qwen3.5-9b-q8.yaml
+++ b/model-manifests/chat/qwen3.5-9b-q8.yaml
@@ -20,7 +20,10 @@ local_path: models/chat/qwen3.5-9b-q8.gguf
 sha256: local-unverified
 # User-added local model (downloaded via `llama get`, hardlinked into models/chat).
 # No `download:` block — the weight is supplied locally, not fetched by fetch-models.
-recommended_profiles: [PRO]
+# Profiles emptied 2026-07-12 (catalog rule D17): an unpromoted manifest carries no legacy
+# profiles; the stub's [PRO] was hijacking the legacy profile picker from qwen3-14b. Stays
+# rank 0: the productized 16-20 GB pick is the UD-Q4_K_XL sibling (qwen3.5-9b-ud-q4kxl).
+recommended_profiles: []
 recommendation_rank: 0
 license_review:
   status: approved

--- a/model-manifests/chat/qwen3.5-9b-ud-q4kxl.yaml
+++ b/model-manifests/chat/qwen3.5-9b-ud-q4kxl.yaml
@@ -10,12 +10,16 @@ size_on_disk_gb: 6.0
 # SQLite + the embedding/reranker sidecars + KV cache all need headroom alongside it.
 recommended_min_ram_gb: 12
 recommended_ram_gb: 16
-# Default 0: NOT auto-recommended. Balanced-tier challenger intended to challenge the current
-# 8B-class winners (Ministral 3 8B, Qwen3 8B). Promote with a real `recommendation_rank` ONLY
-# after it (1) beats the current 8B winner on the offline German/English grounded-QA harness AND
-# (2) is confirmed to load on the bumped b9849 runtime (manual smoke). Until then: selectable
-# manual pick, never auto-recommended.
-recommendation_rank: 0
+# Rank 3 (owner decision 2026-07-12, newest-generation preference; model-benchmarks.md §6.4):
+# a subjective owner judgment that newer model generations improve on the ones they replace, so
+# the newest-generation model is recommended per tier EVEN THOUGH the #48 tester eval placed this under the
+# incumbent Ministral 3 8B (F1 .3124/.3152 vs .3262; but F1 is length-confounded per the §9
+# scorer caveats, EM ties at .9765, so the eval is treated as directional, not decisive). It
+# HAS been through the tester eval on the b9849 binary (both this UD-Q4_K_XL and the local Q8
+# ran), which also discharges the old load-smoke gate. Picker effect (with the full 2026-07-12
+# promotion set): wins 16-20 GB from Ministral (rank 2); within the promoted pair at this tier
+# (the 4B carries the same rank 3 and recommended_ram_gb 16) it wins on the disk-size tiebreak.
+recommendation_rank: 3
 # Native context is 262,144 tokens (extensible to ~1,010,000 via YaRN). HilbertRaum recommends
 # 8192 here because this field is the SAFE LOCAL RUNTIME context budget for normal laptops, not
 # the theoretical model maximum. Revisit only after KV-cache/RAM budgeting + a long-context eval.

--- a/model-manifests/chat/qwen3.6-27b-q4.yaml
+++ b/model-manifests/chat/qwen3.6-27b-q4.yaml
@@ -7,19 +7,43 @@ runtime: llama_cpp
 license: apache-2.0
 size_on_disk_gb: 15.7
 recommended_min_ram_gb: 20
-recommended_ram_gb: 32
-# 27B Q4 weight ~15.7 GB. On the 24 GB RTX 3090 that leaves limited room for the KV
-# cache, so a modest default ctx-size; raise per-model if VRAM allows (partial offload
-# otherwise). Becomes llama-server --ctx-size.
-recommended_context_tokens: 16384
+# recommended_ram_gb recalibrated 32→24 at productization (2026-07-12): same physical tier as
+# the 12-14B pair (gemma4-12b / qwen3-14b, both 24), so the §6.2 rank decides the tier winner
+# instead of capacity alone. Weight is ~15.7 GiB; 24 GB is the honest comfortable floor.
+recommended_ram_gb: 24
+# Rank 3 (owner decision 2026-07-12, newest-generation preference; model-benchmarks.md §6.4):
+# the newest-generation model is recommended per tier (a subjective owner judgment; follow-up
+# quality + speed benchmarks recorded as open work in §5 item 8).
+# Here the promotion also AGREES with the evidence: the #48 tester eval (i9-9900X + RTX 3090,
+# b9849 binary) put Qwen3.6 27B Q4/Q5 at the top of the quality table (F1 .3523/.3573, EM .9765,
+# zero unanswerable-set hallucinations for Q5), sweeping the 20-24 GB tier. Wins the 24 GB tier
+# from gemma4-12b (rank 2); the Q5 sibling takes ≥32 GB.
+recommendation_rank: 3
+# Safe LOCAL runtime budget (catalog convention for the big additions, not the native window).
+# The earlier local-test value 16384 assumed a 24 GB RTX 3090; 8192 is the honest default for
+# a generic 24 GB machine (KV cache + sidecars need headroom). Raise per-machine in Settings.
+recommended_context_tokens: 8192
 supports_thinking_mode: true
 local_path: models/chat/qwen3.6-27b-q4.gguf
-sha256: local-unverified
-# User-added local model (managed by `llama list`, symlinked into the dev-root models/chat).
-recommended_profiles: [PRO]
-recommendation_rank: 0
+# Real hash from HuggingFace LFS metadata (git-LFS OID = the file's SHA-256), captured
+# 2026-07-12 at productization. A pre-productization local copy fetched via `llama get` may
+# hash differently; re-download through the app if verification reports a mismatch.
+sha256: 5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0
+# Quantization: unsloth Q4_K_M. The Qwen org publishes no official GGUF for the 3.6 refresh,
+# so this pins the established quantizer unsloth (same posture as every Qwen3.5 wave entry).
+# Q4_K_M (not UD-Q4_K_XL) is deliberately the productized quant: it is the exact quant the #48
+# tester eval scored, and it is ~1.8 GiB smaller, which keeps the 24 GB tier honest.
+download:
+  url: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q4_K_M.gguf?download=true
+  sha256: 5ed60d0af4650a854b1755bd392f9aef4872643dc25a254bc68043fa638392a0
+  size_bytes: 16817244384
+  license_url: https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/LICENSE
+bundled_on_preconfigured_drive: false
+# TEXT-ONLY USE: upstream Qwen3.6 is a vision-language model, but this chat manifest ships only
+# the language GGUF and no mmproj/projector, which is all our chat pipeline uses.
+recommended_profiles: []
 license_review:
   status: approved
-  reviewed_by: "vldmr (manual, local test model)"
-  reviewed_at: "2026-06-22"
-  notes: "User-added for local testing. Source: Qwen3.6-27B GGUF (Q4_K_M), license apache-2.0. Added manually via `llama get`, not via fetch-models."
+  reviewed_by: "project maintainer (Claude-assisted review, HF card/LFS verification)"
+  reviewed_at: "2026-07-12"
+  notes: "APPROVED 2026-07-12 (productization of the former local-test stub): base model Qwen/Qwen3.6-27B is apache-2.0 (verified via the HF API; LICENSE blob at download.license_url). Quantization provenance: unsloth Q4_K_M GGUF (https://huggingface.co/unsloth/Qwen3.6-27B-GGUF, card tag apache-2.0), a third-party requant of apache-2.0 weights; the Qwen org publishes no official GGUF for the 3.6 refresh, same established-quantizer posture as the Qwen3.5 wave. Apache-2.0 permits commercial redistribution; ship the LICENSE/NOTICE attribution with the drive (DRIVE-NOTICES.md regeneration required before any preload). Supersedes the 2026-06-22 local-test-scoped review."

--- a/model-manifests/chat/qwen3.6-27b-q5.yaml
+++ b/model-manifests/chat/qwen3.6-27b-q5.yaml
@@ -8,17 +8,32 @@ license: apache-2.0
 size_on_disk_gb: 18.2
 recommended_min_ram_gb: 24
 recommended_ram_gb: 32
-# 27B Q5 weight ~18.2 GB — tight on the 24 GB RTX 3090. Small default ctx-size to fit
-# the KV cache in remaining VRAM; expect partial CPU offload at larger contexts.
+# Rank 3 (owner decision 2026-07-12, newest-generation preference; see the Q4 sibling for the
+# full record): top scorer of the #48 tester eval (F1 .3573, EM .9765, zero unanswerable-set
+# hallucinations, b9849 binary). The ~18.2 GiB weight needs the 32 GB tier to be comfortable;
+# the Q4 sibling covers 24 GB. Takes ≥32 GB from gemma4-12b (rank 2).
+recommendation_rank: 3
+# Safe LOCAL runtime budget (catalog convention for the big additions), not the native window.
 recommended_context_tokens: 8192
 supports_thinking_mode: true
 local_path: models/chat/qwen3.6-27b-q5.gguf
-sha256: local-unverified
-# User-added local model (managed by `llama list`, symlinked into the dev-root models/chat).
-recommended_profiles: [PRO]
-recommendation_rank: 0
+# Real hash from HuggingFace LFS metadata (git-LFS OID = the file's SHA-256), captured
+# 2026-07-12 at productization. A pre-productization local copy fetched via `llama get` may
+# hash differently; re-download through the app if verification reports a mismatch.
+sha256: cfecab168156269f25d5ffe9e13cf2a401ca2f43a9693fa00bcd1625316ccbde
+# Quantization: unsloth Q5_K_M, the exact quant the #48 tester eval scored (established-
+# quantizer posture; the Qwen org publishes no official GGUF for the 3.6 refresh).
+download:
+  url: https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-Q5_K_M.gguf?download=true
+  sha256: cfecab168156269f25d5ffe9e13cf2a401ca2f43a9693fa00bcd1625316ccbde
+  size_bytes: 19509790944
+  license_url: https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/LICENSE
+bundled_on_preconfigured_drive: false
+# TEXT-ONLY USE: upstream Qwen3.6 is a vision-language model, but this chat manifest ships only
+# the language GGUF and no mmproj/projector, which is all our chat pipeline uses.
+recommended_profiles: []
 license_review:
   status: approved
-  reviewed_by: "vldmr (manual, local test model)"
-  reviewed_at: "2026-06-22"
-  notes: "User-added for local testing. Source: Qwen3.6-27B GGUF (Q5_K_M), license apache-2.0. Added manually via `llama get`, not via fetch-models."
+  reviewed_by: "project maintainer (Claude-assisted review, HF card/LFS verification)"
+  reviewed_at: "2026-07-12"
+  notes: "APPROVED 2026-07-12 (productization of the former local-test stub): base model Qwen/Qwen3.6-27B is apache-2.0 (verified via the HF API; LICENSE blob at download.license_url). Quantization provenance: unsloth Q5_K_M GGUF (https://huggingface.co/unsloth/Qwen3.6-27B-GGUF, card tag apache-2.0), a third-party requant of apache-2.0 weights; same established-quantizer posture as the Qwen3.5 wave. Apache-2.0 permits commercial redistribution; ship the LICENSE/NOTICE attribution with the drive (DRIVE-NOTICES.md regeneration required before any preload). Supersedes the 2026-06-22 local-test-scoped review."


### PR DESCRIPTION
## What

Owner decision (2026-07-12): the in-app recommendation now points at the newest Qwen generation per RAM tier. This is a deliberate, subjective judgment that newer model generations improve on the ones they replace; the local eval is treated as directional (its F1 is length-confounded, EM rates are near-tied, and it is a single run on one machine). Follow-up benchmarks on both quality (rescored) and speed/peak-RSS are planned and recorded as open work. Durable record with the full rationale and the honest eval divergence: `docs/model-benchmarks.md` §6.4.

**New mapping** (asserted in `benchmark.test.ts` + `committed-catalog.test.ts`):
| RAM | Recommended |
|---|---|
| ≤12 GB | Qwen3.5 4B (UD-Q4_K_XL) |
| 16–20 GB | Qwen3.5 9B (UD-Q4_K_XL) |
| 24 GB | Qwen3.6 27B Q4_K_M |
| ≥32 GB | Qwen3.6 27B Q5_K_M |

## Changes

- `qwen3.5-4b-ud-q4kxl` / `qwen3.5-9b-ud-q4kxl`: rank 0→3; eval standing recorded honestly in each manifest (the 4B failed its §9 F1 bar, the 9B sat under Ministral; the b9849 load gate is satisfied for both).
- `qwen3.6-27b-q4` / `qwen3.6-27b-q5`: **productized** from local-test stubs (unsloth download sources, real HF-LFS sha256, apache-2.0 license reviews superseding the local-test scope, honest RAM tiers 24/32, ctx 8192) and promoted to rank 3. Here the eval agrees: they top the §9 quality table.
- **Master CI repair:** the five local-test stubs committed this morning (ci gate was bypassed) carried `recommended_profiles: [PRO]`, which hijacked the legacy profile picker from `qwen3-14b` and broke `benchmark.test.ts` on master. All five emptied per D17.
- `DRIVE-NOTICES.md` regenerated for the enlarged catalog.
- Docs: README tiers + model table, model-policy catalog rows + footnote, model-benchmarks §6.3 superseded note + new §6.4, BUILD_STATE entry + §5 item 8 update.

## Deliberately NOT changed (follow-ups)

- The bundled drive default (`qwen3-4b-instruct-q4`) and the DIY `--with-assets` default set (Ministral).
- Speed/peak-RSS rows for the promoted set (the tester runs were quality-only; §5 item 8 steps a–d stay open).
- The gemma stub pair's provenance follow-ups from the preload license review.

Suite 4222 passed / 44 skipped, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)