### PR TITLE
release: v0.1.51 — audit-2026-07-16 wave checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ from its first public `1.0.0` release onward.
 
 > **No public release yet.** HilbertRaum is a pre-1.0 MVP. Internal development
 > checkpoints were tagged `v0.1.0` … `v0.1.34` (2026-06-10 → 2026-06-22, mirrored
-> by the `version` field in `package.json`, currently `0.1.50`); these are rapid
+> by the `version` field in `package.json`, currently `0.1.51`); these are rapid
 > per-phase development checkpoints, **not** published releases, and have no
 > per-tag notes. **Per-tag/`version` checkpointing was paused `v0.1.34` → 2026-06-30**
 > (the audit-remediation rounds were tracked in `BUILD_STATE.md`, not version bumps), then

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -18,7 +18,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@radix-ui/react-dialog": "1.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Version checkpoint after the PR #60 merge (full-audit 2026-07-16 remediation wave, 41/41 findings, gate 4,271/49, ledger architecture.md §50): version fields 0.1.50 → 0.1.51 (root + apps/desktop + lockfile) + the CHANGELOG header mention. The v0.1.51 tag lands on the merge commit (local until the owner pushes it, per the standing tag policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)