### PR TITLE
release: v0.1.52 — beta-feedback fixes #58 + #54 merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ from its first public `1.0.0` release onward.
 
 > **No public release yet.** HilbertRaum is a pre-1.0 MVP. Internal development
 > checkpoints were tagged `v0.1.0` … `v0.1.34` (2026-06-10 → 2026-06-22, mirrored
-> by the `version` field in `package.json`, currently `0.1.51`); these are rapid
+> by the `version` field in `package.json`, currently `0.1.52`); these are rapid
 > per-phase development checkpoints, **not** published releases, and have no
 > per-tag notes. **Per-tag/`version` checkpointing was paused `v0.1.34` → 2026-06-30**
 > (the audit-remediation rounds were tracked in `BUILD_STATE.md`, not version bumps), then

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -18,7 +18,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@radix-ui/react-dialog": "1.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Version checkpoint per the standing ritual (root + `apps/desktop` + lockfile version fields, CHANGELOG header mention) — the v0.1.51 precedent (PR #61), same four files, same shape.

Marks the two 2026-07-17 beta-feedback fixes now on master:
- #58 / PR #63 — translation page-completeness accounting (inline gap markers + UI warnings, `DocTaskStatus.gaps`).
- #54 / PR #64 — honest shape hint + bank-statement-skill pointer on aggregation-shaped no-skill listings.

Suite gate at merge: 4293 passed / 49 skipped. After merge, the `v0.1.52` tag goes on the squash commit (drives `release.yml`).

Lockfile note: version fields edited directly — the local npm here is 10.9.3, not the pinned 11.6.2, so `npm install --package-lock-only` would have churned the `peer` flags (issue #49); the diff is the same 3 version fields as v0.1.51's bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)