### PR TITLE
release: v0.1.53 — Evidence Pack / Review Mode (EP-1) wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ from its first public `1.0.0` release onward.
 
 > **No public release yet.** HilbertRaum is a pre-1.0 MVP. Internal development
 > checkpoints were tagged `v0.1.0` … `v0.1.34` (2026-06-10 → 2026-06-22, mirrored
-> by the `version` field in `package.json`, currently `0.1.52`); these are rapid
+> by the `version` field in `package.json`, currently `0.1.53`); these are rapid
 > per-phase development checkpoints, **not** published releases, and have no
 > per-tag notes. **Per-tag/`version` checkpointing was paused `v0.1.34` → 2026-06-30**
 > (the audit-remediation rounds were tracked in `BUILD_STATE.md`, not version bumps), then

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -18,7 +18,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@radix-ui/react-dialog": "1.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Version checkpoint bumping `0.1.52` → `0.1.53` per the standing release ritual (root + `apps/desktop` + lockfile version fields, CHANGELOG header mention — the same 4-file shape as every prior `release:` commit).

## What this marks
The **Evidence Pack / Review Mode (EP-1)** wave, already merged to `master` via PRs #66–#73: review a document-grounded answer, record explicit human decisions, and export self-contained **HTML/PDF** evidence packs — fully local and offline.

## Pre-release smoke
A human-flow smoke of the live app (mock runtime, Windows) passed **all ten journeys**: entry points, review workspace (decisions incl. keyboard, notes, link/unlink, autosave), passage selections, ready lifecycle, HTML export (SHA-256 recomputed & matched), PDF export (bookmarks, footer pack-ID + page numbers, umlauts) + cancel, freshness (changed/missing, acknowledge, Ready survives), persistence + encrypted lock-mid-edit note survival, back-navigation, and the German locale ([Q1] markers, DE pack reads correctly).

No code changes here — version fields only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)