### PR TITLE
release: v0.1.54 — DEP-1 Dependabot remediation wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ from its first public `1.0.0` release onward.
 
 > **No public release yet.** HilbertRaum is a pre-1.0 MVP. Internal development
 > checkpoints were tagged `v0.1.0` … `v0.1.34` (2026-06-10 → 2026-06-22, mirrored
-> by the `version` field in `package.json`, currently `0.1.53`); these are rapid
+> by the `version` field in `package.json`, currently `0.1.54`); these are rapid
 > per-phase development checkpoints, **not** published releases, and have no
 > per-tag notes. **Per-tag/`version` checkpointing was paused `v0.1.34` → 2026-06-30**
 > (the audit-remediation rounds were tracked in `BUILD_STATE.md`, not version bumps), then

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Version checkpoint per the standing ritual (root + apps/desktop + lockfile version fields + CHANGELOG header mention — same 4-file recipe as v0.1.53). Marks the DEP-1 wave (PR #77 + close-out #78) on master. Suite 4678/50/4728 + typecheck + build green on the branch. After merge: annotated tag v0.1.54 on the squash commit (drives release.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)