### PR TITLE
release: v0.1.55 — Gemma 4 QAT wave manifests + DEP-2 security batch + CI-flake fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ from its first public `1.0.0` release onward.
 
 > **No public release yet.** HilbertRaum is a pre-1.0 MVP. Internal development
 > checkpoints were tagged `v0.1.0` … `v0.1.34` (2026-06-10 → 2026-06-22, mirrored
-> by the `version` field in `package.json`, currently `0.1.54`); these are rapid
+> by the `version` field in `package.json`, currently `0.1.55`); these are rapid
 > per-phase development checkpoints, **not** published releases, and have no
 > per-tag notes. **Per-tag/`version` checkpointing was paused `v0.1.34` → 2026-06-30**
 > (the audit-remediation rounds were tracked in `BUILD_STATE.md`, not version bumps), then

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Version checkpoint 0.1.54 → 0.1.55 per the standing ritual (root + apps/desktop + lockfile version fields via pinned `npx npm@11.6.2 install --package-lock-only`, CHANGELOG header mention) — the exact v0.1.54 (#79) file set.

Marks on master since v0.1.54:
- **Gemma 4 QAT wave** (PR #83 + merge review): 4 official Google QAT Q4_0 chat manifests (E2B / E4B / 26B-A4B / 31B), rank 0 pending the §9.3 eval; wave test pins hardened; CLAUDE.md design section rescoped
- **DEP-2** (PR #85): Dependabot #56 + the post-DEP-1 advisory batch — tar CRITICAL cluster, js-yaml, fast-uri, dompurify (prod-scope), brace-expansion ×7 — `npm audit` 0, 0 open alerts
- **#84 CI-flake fix** (PR #86): FTS timing budget 100→500 ms + 60 s seeding timeout

After merge: annotated tag `v0.1.55` on the squash commit (triggers release.yml → three build legs → **draft** release for the owner's manual smoke + publish decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)