### PR TITLE
release: v0.1.56 — version bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bumps `0.1.55` → `0.1.56` (root + `apps/desktop` + the three lockfile version fields, hand-edited so the lockfile diff stays exact per the issue #49 posture — an `npm install --package-lock-only` run wanted to shuffle inert `peer` flags and was reverted).

Covers the shipped-since-0.1.55 work: the screen-width waves (#166/#171 — centring, the tier collapse to the single 1180px frame with the 72ch prose measure, stable scrollbar gutters), the release-notes enrichment (#170), and the #169 translation-audit wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)