### PR TITLE
docs(release): open the release notes with a per-OS download guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,9 @@ jobs:
             const body = (m ? m[1].trim() : '');
             fs.writeFileSync('dist/NOTES.md',
               '## Which file do I need?\n\n' +
+              'The downloads are at the very bottom of this page, in the **Assets** list' +
+              ' underneath all these notes. Scroll all the way down, and click Assets if the' +
+              ' list is folded. You need exactly one file:\n\n' +
               '| Your computer | Download this ONE file |\n' +
               '|---|---|\n' +
               '| **Windows** 10/11 | **HilbertRaum-' + v + '-portable.exe** |\n' +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,10 +156,21 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
+            const v = require('./apps/desktop/package.json').version;
             const md = fs.readFileSync('CHANGELOG.md', 'utf8');
             const m = md.match(/## \[Unreleased\]([\s\S]*?)(\n## |$)/);
             const body = (m ? m[1].trim() : '');
             fs.writeFileSync('dist/NOTES.md',
+              '## Which file do I need?\n\n' +
+              '| Your computer | Download this ONE file |\n' +
+              '|---|---|\n' +
+              '| **Windows** 10/11 | **HilbertRaum-' + v + '-portable.exe** |\n' +
+              '| **macOS** (Apple Silicon) | **HilbertRaum-' + v + '-mac-arm64.app.zip** |\n' +
+              '| **Linux** | **HilbertRaum-' + v + '.AppImage** |\n\n' +
+              'The other files are NOT the app: the llama-runtime-*.zip files carry the AI' +
+              ' engine for offline/air-gapped installs only (normally the app offers that same' +
+              ' download built in), SHA256SUMS.txt is for optional download verification, and' +
+              ' the two Source code archives are the source for developers, not a runnable app.\n\n' +
               '> **This download is the app only** — a working chat needs **two more downloads**,' +
               ' both offered on the **AI Model** screen inside the app: the **AI engine**' +
               ' (llama.cpp — the screen shows an install banner until it is present; without it,' +


### PR DESCRIPTION
## What

The generated release notes now start with a "Which file do I need?" section:

- a pointer that the downloads sit in the **Assets** list at the very bottom of the page (new users read the notes top-down and never reach it),
- a three-row table mapping Windows / macOS (Apple Silicon) / Linux to the one file to download, with exact filenames built from the package version,
- one line declaring the llama-runtime zips (offline installs only), SHA256SUMS.txt, and the Source code archives as not-the-app.

## Why

The v0.1.56 page offers 8 assets and nothing on it says which one a normal user needs, or that they need to scroll past the full notes body to find them. The existing preamble only covers the follow-up engine/model downloads.

## Verification

Extracted the notes-generation snippet from the edited workflow and ran it against the repo at this commit under bash — the rendered NOTES.md carries the section with the correct 0.1.56-style filenames. No test pins this workflow text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)