### PR TITLE
release: v0.1.57 — version bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
0.1.56 → 0.1.57. Version fields only — the three `version` strings across `package.json`, `apps/desktop/package.json`, and `package-lock.json` (5 lines), hand-edited to keep the diff exact per the issue #49 lockfile posture. Same shape as the v0.1.56 bump (#174).

## What landed since v0.1.56

- **#178** — Qwen3.8-27B wave: benchmark evidence + promotion (§9.4)
- **#177** — release notes open with a per-OS download guide
- **#176** — `sha256_of` hashes from stdin; coreutils' backslash-escape prefix broke checksum verification on git-bash Windows paths (this is what failed the v0.1.56 tag run)
- **#175** — explicit 120 s budget on the REL-3 wedged-child dictation test

## Dependabot #83 is deliberately not in this bump

`extract-zip ≤ 2.0.1` ([GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv), high, **dev scope**) has **no patched version and never will** — the package is abandoned at 2.0.1 (last published 2023-03). Upstream Electron's fix was to swap it for `@electron-internal/extract-zip`, which only **electron ≥ 40** carries; the 39.x line ends at 39.8.10 with no backport.

Assessed and deferred to **#179** (Electron 39 → 43), which holds the full write-up. Summary of why deferral is safe:

- Single path in the tree: `electron@39.8.10` (dev) → `extract-zip`. Nothing else pulls it.
- No first-party use anywhere in `src/` or `scripts/`; dev-only, so never in the bundle or `app.asar`.
- The one invocation unpacks the Electron platform zip that `@electron/get` has already SHA256-verified against the pinned `checksums.json` — **not attacker-controlled input**.

An `overrides` alias to the fork was tested and **rejected**: it is ESM-only + native NAPI, so `require()` yields a non-callable namespace and electron 39's CJS `install.js` fails with *"extract is not a function"* — and because `ci.yml` sets `ELECTRON_SKIP_BINARY_DOWNLOAD=1`, CI would stay green while every contributor's `npm ci` broke.

## Gate

`npm run typecheck` → `npm run build` → `npm test` run locally in the repo's gate order, plus this PR's `ci-success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)