### PR TITLE
Electron 39 → 43: clear Dependabot #83 (unpatchable extract-zip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,19 @@ concurrency:
 permissions:
   contents: read
 
-# Keep CI fast and free of network flakiness: skip the ~100 MB Electron platform-binary
-# download (nothing here launches Electron) and short-circuit the repo's verify-electron
-# postinstall (scripts/verify-electron.mjs early-exits on either of these). See packaging.md.
+# Keep CI fast and free of network flakiness: nothing here launches Electron, so the ~100 MB
+# platform binary is never needed. Since wave DEP-4 (Electron 43) that costs nothing to arrange:
+# Electron >= 42 REMOVED the postinstall download entirely — the binary now arrives lazily on the
+# first invocation of the electron bin, which CI never performs. ELECTRON_SKIP_BINARY_DOWNLOAD
+# was dropped from this block because electron >= 42 no longer reads it; keeping it would leave a
+# knob advertising an effect it no longer has.
+#
+# HILBERTRAUM_SKIP_ELECTRON_CHECK short-circuits the repo's own verify-electron postinstall
+# (scripts/verify-electron.mjs). It is now belt-and-braces rather than load-bearing: that script
+# understands the lazy-download model and already exits 0 when the binary is simply not present
+# yet. It stays because it also skips the check on a genuinely half-extracted tree, which CI can
+# neither repair nor usefully diagnose. See packaging.md.
 env:
-  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
   HILBERTRAUM_SKIP_ELECTRON_CHECK: '1'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,15 @@
 # windows) upgrades to signed builds with no repo change — then drop the
 # CSC_IDENTITY_AUTO_DISCOVERY line below.
 #
-# This is dev infrastructure (same network class as ci.yml): the packaging needs
-# the Electron binary, so the ELECTRON_SKIP_BINARY_DOWNLOAD knobs are deliberately
-# NOT set here. The shipped app itself makes no network calls. `npm ci` keeps the
-# install lockfile-pinned (hardening L-8, CI half).
+# This is dev infrastructure (same network class as ci.yml): the packaging needs the
+# Electron binary, so the skip knobs are deliberately NOT set here. Since wave DEP-4
+# (Electron 43) the mechanism differs from what this comment used to describe: Electron
+# >= 42 has no postinstall at all, so `npm ci` downloads nothing, and the binary arrives
+# either lazily on the first electron-bin invocation or — for the packaged artifact —
+# via electron-builder's own @electron/get fetch, which is independent of the npm
+# package. The outcome is unchanged: the release legs get the binary they need.
+# The shipped app itself makes no network calls. `npm ci` keeps the install
+# lockfile-pinned (hardening L-8, CI half).
 name: release
 
 on:

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -1593,7 +1593,7 @@ tag triggers the release workflow's draft build).
     updates so the next wave arrives as PRs, not an audit (recommendation only — not
     implemented).
 18. **DEP-4 follow-up register (owner-facing; registered at the 2026-08-18 close-out; durable
-    ledger = `docs/architecture.md` "Electron 39 → 43 — design record (wave DEP-4, PR #185)"):**
+    ledger = `docs/architecture.md` "Electron 39 → 43 — design record (wave DEP-4, PR #187)"):**
     Wave DEP-4 cleared the LAST open Dependabot alert (#83 / issue #179) by moving Electron
     39.8.10 → 43.4.0 — Chromium 142 → 150, Node 22.22.1 → 24.18.1, SQLite 3.51.2 → 3.53.1;
     `extract-zip` is gone from the tree and `npm audit` is clean. OS floors unchanged

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -1592,6 +1592,35 @@ tag triggers the release workflow's draft build).
     (script/CI unchanged). (d) **Recommend `.github/dependabot.yml`** with grouped weekly npm
     updates so the next wave arrives as PRs, not an audit (recommendation only — not
     implemented).
+18. **DEP-4 follow-up register (owner-facing; registered at the 2026-08-18 close-out; durable
+    ledger = `docs/architecture.md` "Electron 39 → 43 — design record (wave DEP-4, PR #185)"):**
+    Wave DEP-4 cleared the LAST open Dependabot alert (#83 / issue #179) by moving Electron
+    39.8.10 → 43.4.0 — Chromium 142 → 150, Node 22.22.1 → 24.18.1, SQLite 3.51.2 → 3.53.1;
+    `extract-zip` is gone from the tree and `npm audit` is clean. OS floors unchanged
+    (Win 10+/macOS 12+), no on-disk format change. Open items:
+    (a) **`.github/dependabot.yml`** — DEP-1 §5 #4, owner-APPROVED during this wave (D-4) to
+    land as its **own PR**; this was the fourth hand-rolled dependency batch. Supersedes item
+    16(d).
+    (b) **Packaged-OCR fix bundle** — unchanged, still open; see item 16(b). DEP-4 did not touch
+    it (the defect is an `asarUnpack` gap, not a runtime-version effect).
+    (c) **OCR assets on a build machine** — two DEP-4 measurement gaps exist ONLY because this
+    machine carries no `*.traineddata`: dev-mode OCR recognize, and the OCR window's RUNTIME
+    CSP leg (its baked meta WAS verified byte-exact from the shipped asar; the header is
+    page-agnostic, so the mechanism is proven by the main window). Running the packaged
+    measurement on an asset-carrying drive closes both.
+    (d) ⚠️ **Electron 44 is a CUSTOMER-FACING decision, not a routine bump** — it removes macOS 12
+    support and drops 32-bit Windows (ia32) + Linux armv7l. **E43 is the last series shipping
+    prebuilt 32-bit binaries, supported until January 2027.** Decide deliberately with the drive
+    product's OS matrix in hand; do not let it arrive as a Dependabot PR.
+    (e) **electron-builder air-gapped builds** (upstream #10039) — eb fails in air-gapped
+    environments even with a seeded cache, because `@electron/get` always fetches
+    `SHASUMS256.txt`; fixed on master only, not in any 26.15.x. Affects BUILD machines, not the
+    shipped app, but it rubs against the offline-first posture.
+    (f) **Manual legs still owed by the owner** (P4's human-only items): the `defaultPath`
+    dialog probe that decides whether Electron 43 pre-selects the host Downloads folder
+    (owner decision D-2, conditional — if it fires, pass an explicit root at the
+    `save-export.ts` seam), a real OS drag-and-drop onto the composer (`webUtils`), and a
+    double-click launch of the portable `.exe`.
 17. **STR-1 follow-up register (owner-facing; registered at the 2026-07-20 close-out; durable
     ledger = `docs/architecture.md` "Skills & tools architecture review (2026-07-19) — design
     record (wave STR-1, 2026-07-20)"):** (a) **Issue #80** — the constrained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,29 @@ first public release. Consciously-accepted gaps are tracked in
 
 ### Security
 
+- **Electron 39.8.10 → 43.4.0, clearing the last open Dependabot alert (wave DEP-4,
+  PR #185, 2026-08-18)** — alert #83 / issue #179, GHSA-jmr9-qjv8-65gv
+  (CVE-2026-56876, high), `extract-zip <= 2.0.1` unvalidated symlink path
+  traversal. Unpatchable by design: `extract-zip` is abandoned at 2.0.1, and
+  upstream Electron's fix was to replace it, so the alert could only be cleared
+  by moving Electron. `npm ls extract-zip` is now empty and `npm audit` reports
+  0 vulnerabilities. Target 43 rather than the smallest clearing major because
+  Electron supports only the latest three stable majors (41/42/43). Chromium
+  142 → 150, Node 22.22.1 → 24.18.1, SQLite 3.51.2 → 3.53.1; `@types/node` → ^24
+  so main-process code is typechecked against the runtime it ships on;
+  `engines.node` → `>=22.12` (Electron 43's own floor). **Minimum OS floors are
+  unchanged** — Windows 10+, macOS 12+ — so no existing machine is dropped, and
+  no on-disk format changed, so existing workspaces open unchanged. Re-measured
+  on the real packaged build: the CSP-on-`file://` header still attaches and
+  enforces (byte-exact to `buildCsp(false)`), the FTS5 trio still works,
+  `printToPDF` still accepts the full option set, and the permission handlers
+  still grant exactly one capability and deny the rest. Also in the wave:
+  `scripts/verify-electron.mjs` rewritten (Electron ≥ 42 removed the postinstall
+  download, and the old script would have re-created that ~100 MB download on
+  every clean install while reporting a healthy install as broken), a test
+  pinning `electron-builder.yml`'s `electronVersion` to the installed Electron
+  (the guard DEP-1 registered and nobody wrote), and electron-builder →
+  26.15.7 to clear a silent Windows PE-file-dropping regression (#9983).
 - **All 19 open Dependabot alerts cleared (wave DEP-3, PR #115, 2026-08-09)** — one
   patch/minor-only batch, no dismissals: pdfjs-dist 6.2.108 (CVE-2026-16633,
   arbitrary JS on a malicious PDF — the app was never exposed: no annotation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,7 +418,7 @@ first public release. Consciously-accepted gaps are tracked in
 ### Security
 
 - **Electron 39.8.10 → 43.4.0, clearing the last open Dependabot alert (wave DEP-4,
-  PR #185, 2026-08-18)** — alert #83 / issue #179, GHSA-jmr9-qjv8-65gv
+  PR #187, 2026-08-18)** — alert #83 / issue #179, GHSA-jmr9-qjv8-65gv
   (CVE-2026-56876, high), `extract-zip <= 2.0.1` unvalidated symlink path
   traversal. Unpatchable by design: `extract-zip` is abandoned at 2.0.1, and
   upstream Electron's fix was to replace it, so the alert could only be cleared

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -27,11 +27,17 @@ productName: HilbertRaum
 executableName: HilbertRaum
 
 # electron-builder 26 cannot auto-detect the Electron version in this npm workspace: `electron`
-# is pinned as a RANGE (^39.8.5 in devDependencies) and is HOISTED to the repo-root node_modules,
+# is pinned as a RANGE (^43.4.0 in devDependencies) and is HOISTED to the repo-root node_modules,
 # which eb — running from apps/desktop — does not resolve, so it errors on the range. Pin the
-# exact installed version here. Keep in sync with the `electron` devDependency (currently ^39.8.5 →
-# 39.8.10); bump when the installed Electron major/minor changes.
-electronVersion: 39.8.10
+# exact installed version here. Keep in sync with the `electron` devDependency (currently ^43.4.0 →
+# 43.4.0); bump when the installed Electron major/minor changes.
+#
+# THIS FIELD, NOT THE devDependency, SELECTS THE RUNTIME THAT IS ACTUALLY PACKAGED. Wave DEP-1
+# shipped Electron 37 from a build whose devDep said 39 because this line was left behind, and a
+# human caught it by luck (DEP-1 §4(b)). Since wave DEP-4 that is guarded automatically:
+# tests/integration/packaging.test.ts asserts this value equals the electron version pinned in
+# package-lock.json and satisfies the declared caret range. Edit both or the green gate fails.
+electronVersion: 43.4.0
 
 directories:
   # buildResources holds icons etc. (optional; defaults are used if absent).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -57,7 +57,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-v8": "^3.2.6",
     "electron": "^43.4.0",
-    "electron-builder": "^26.15.2",
+    "electron-builder": "^26.15.7",
     "electron-vite": "^3.1.0",
     "jsdom": "^29.1.1",
     "typescript": "^5.5.4",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "screenshot": "npm run preview:build && ELECTRON_DISABLE_SANDBOX=1 xvfb-run -a electron --no-sandbox scripts/screenshot.mjs"
   },
   "engines": {
-    "node": ">=22.5"
+    "node": ">=22.12"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",
@@ -50,13 +50,13 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^22.5.0",
+    "@types/node": "^24.9.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-v8": "^3.2.6",
-    "electron": "^39.8.5",
+    "electron": "^43.4.0",
     "electron-builder": "^26.15.2",
     "electron-vite": "^3.1.0",
     "jsdom": "^29.1.1",

--- a/apps/desktop/src/main/services/db.ts
+++ b/apps/desktop/src/main/services/db.ts
@@ -3,8 +3,12 @@ import { randomUUID } from 'node:crypto'
 import { ocrMetaFromJson } from './ingestion/ocr-meta'
 
 // SQLite storage via Node's built-in driver (no native compilation).
-// Requires the bundled Node >= 22.5; Electron is pinned ^39.8.5 (Node 22.x) so the packaged
+// Requires the bundled Node >= 22.12; Electron is pinned ^43.4.0 (Node 24.x) so the packaged
 // main process has node:sqlite (Electron 33 bundles Node 20 and lacks it).
+// Measured on the packaged Electron 43.4.0 build (DEP-4 P4, 2026-08-18): Node 24.18.1,
+// SQLite 3.53.1, with the FTS5 trio (bm25/snippet/highlight) verified working. Note the
+// SQLite version is NOT a function of the Node version — E39 bundled 3.51.2 while host
+// Node 24.13 bundles 3.50.4 — so it must be read off the real binary after every bump.
 // Encrypted-at-rest mode wraps this same file/schema.
 //
 // node:sqlite is experimental and not listed in module.builtinModules, which

--- a/apps/desktop/src/main/services/evidence-pack/print-pdf.ts
+++ b/apps/desktop/src/main/services/evidence-pack/print-pdf.ts
@@ -20,7 +20,7 @@ import { escapeHtml } from './render-html'
 //    bookmarks (render-html.ts PRINT CONTRACT: exactly 1×h1 + 8×h2 + h3 subsections, no
 //    h4+).
 //  - `generateTaggedPDF: true` asks for an accessible tagged PDF. EXPERIMENTAL per the
-//    Electron docs (still so in Electron 39; "may not adhere fully to PDF/UA and WCAG standards") — the docs
+//    Electron docs (still so in Electron 43; "may not adhere fully to PDF/UA and WCAG standards") — the docs
 //    state this honestly (known-limitations.md): accessible headings/reading order are
 //    best-effort, never a PDF/UA claim.
 //  - Footer = pack ID + `pageNumber`/`totalPages` (spec §17.1 repeating footer). Chromium
@@ -77,9 +77,13 @@ const FOOTER_FONT_STACK =
   "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
 
 /**
- * The full D-1 option set for one pack print (installed Electron 39 supports every option
+ * The full D-1 option set for one pack print (installed Electron 43 supports every option
  * — verified against the local `electron.d.ts`, not assumed; re-smoked on the 39.8.10 packaged
- * build, DEP-1 P4). Exported so the unit suite
+ * build in DEP-1 P4, and again on the 43.4.0 / Chromium 150 packaged build in DEP-4 P4
+ * 2026-08-18: every option accepted, valid `%PDF-1.4 … %%EOF`, and `generateTaggedPDF`
+ * emitted real `StructTreeRoot`/`MarkInfo` structures — still Experimental upstream, so this
+ * remains a best-effort accessibility claim and NOT a PDF/UA conformance claim).
+ * Exported so the unit suite
  * pins the literals: a dropped `preferCSSPageSize` or a template `@font-face` would
  * otherwise ship green.
  */

--- a/apps/desktop/src/main/services/ingestion/parsers/pdfjs.d.ts
+++ b/apps/desktop/src/main/services/ingestion/parsers/pdfjs.d.ts
@@ -5,7 +5,8 @@
 // Phase-38 hidden OCR rasterizer window, which deliberately uses the SAME legacy
 // build — one build everywhere; the original motive (the modern build's
 // Uint8Array.prototype.toHex, missing from Electron 37's Chromium) expired with
-// pdfjs 6.2 + Chromium 142 — see the DEP-3 record in docs/architecture.md. Only the
+// pdfjs 6.2 + Chromium 142, and stays expired on Chromium 150 / Electron 43 (wave DEP-4)
+// — see the DEP-3 and DEP-4 records in docs/architecture.md. Only the
 // node program (src/main) resolves this declaration — the web program resolves the
 // package's real pdf.d.mts — so `canvas` is structurally typed (no DOM lib here).
 declare module 'pdfjs-dist/legacy/build/pdf.mjs' {

--- a/apps/desktop/src/renderer/ocr/main.ts
+++ b/apps/desktop/src/renderer/ocr/main.ts
@@ -8,9 +8,11 @@
 // PdfParser uses, with its bundled worker (a local asset — never a CDN; the page CSP
 // enforces same-origin anyway). Historical note: the legacy build was originally forced by
 // Uint8Array.prototype.toHex (the modern v6 build called it; Electron 37's Chromium 138
-// lacked it and the very first document open failed). Chromium 142 (Electron 39) ships toHex
+// lacked it and the very first document open failed). Chromium 142 (Electron 39) shipped toHex
 // and pdfjs 6.2's modern build no longer references it — the legacy build is retained for
 // one-build-everywhere consistency with the main-process parser, no longer out of necessity.
+// Still true on Chromium 150 (Electron 43, wave DEP-4): the motive stays expired, and moving
+// further forward can only keep it that way.
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs'
 import pdfWorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.mjs?url'
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs'

--- a/apps/desktop/tests/integration/doctasks-translation.test.ts
+++ b/apps/desktop/tests/integration/doctasks-translation.test.ts
@@ -202,7 +202,14 @@ async function waitTerminal(
     if (status.state === 'done' || status.state === 'failed' || status.state === 'cancelled') {
       return status
     }
-    if (Date.now() - start > 10_000) throw new Error(`task ${jobId} never finished: ${status.state}`)
+    // 30 s, not 10: this is a HANG DETECTOR, not a timing proof — every timing assertion in
+    // this file lives in an explicit expect(), never in this bound. The #157 (DT-2) case below
+    // translates a 600-unit doc at tokenDelayMs 5 and measures ~9.4 s in isolation, i.e. 6%
+    // headroom under a 10 s bound; under full-suite CPU load on this 16 GB box it crossed and
+    // failed 3 of 4 runs at ~10.16 s with "never finished: running" — the foreign task was
+    // still legitimately translating. Same class as #84/#97/#101 and the local-api wave fix:
+    // vitest's CI testTimeout budget does NOT widen a hand-rolled poll bound like this one.
+    if (Date.now() - start > 30_000) throw new Error(`task ${jobId} never finished: ${status.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }
@@ -1009,7 +1016,14 @@ describe('targeted cancel + active-task read (FA-3: F-6 stale cancel, F-3 reload
     expect(translator.calls.length).toBe(callsAtForeignDone)
     expect(manager.getDocTask(ours.jobId).state).toBe('cancelled')
     expect(manager.hasActiveTask()).toBe(false)
-  })
+    // 60 s budget (the #101 CI value), applied per-test because THIS test is the heavy one in
+    // the file: it deliberately drives a 600-unit foreign translation to completion so that OUR
+    // task is provably still queued behind it, which costs ~9.4 s of real wall-clock even when
+    // the box is idle. Against the 15 s local default that is only 1.6x headroom, and wave DEP-4
+    // watched it fail 3 of 5 full-suite runs on a loaded 16 GB machine (a run stretching to 312 s
+    // vs the usual ~140 s). Nothing is loosened: the cancel semantics are asserted above by
+    // explicit expect()s, and waitTerminal's own 30 s bound still catches a genuine hang first.
+  }, 60_000)
 
   it('a targeted exact-id cancel hits the running task; the no-arg fallback still works (old-caller parity)', async () => {
     const a = await importDoc(600, 'a.txt')

--- a/apps/desktop/tests/integration/evidence-pack-pdf-smoke.test.ts
+++ b/apps/desktop/tests/integration/evidence-pack-pdf-smoke.test.ts
@@ -38,7 +38,42 @@ function electronBinaryPath(): string | null {
   }
 }
 
+/**
+ * Wave DEP-4: say WHY we skipped, out loud.
+ *
+ * Electron >= 42 removed the postinstall binary download — `path.txt` does not exist after a
+ * healthy fresh `npm ci`, and the binary only materializes when something first invokes the
+ * electron bin. That silently flipped this file from "always runs on the Windows dev box" (the
+ * claim in the block comment above) to "never runs until someone happens to launch Electron",
+ * and it did so without a single failing test: the E43 bump dropped 6 tests from the suite and
+ * the only visible trace was the skip count moving 50 -> 56.
+ *
+ * This is the one file that drives REAL Chromium printToPDF, so a silent skip here is a silent
+ * hole in exactly the evidence the wave exists to produce. Nothing here downloads ~100 MB behind
+ * your back — it just refuses to be quiet about the difference between "intentionally absent"
+ * and "not fetched yet".
+ */
+function announceSkipReason(): void {
+  if (process.env.HILBERTRAUM_SKIP_ELECTRON_CHECK || process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
+    return // CI, deliberately binary-free — the documented, expected case.
+  }
+  let installed = true
+  try {
+    req.resolve('electron/package.json')
+  } catch {
+    installed = false
+  }
+  if (!installed) return // no electron at all; nothing to say.
+  console.warn(
+    '[evidence-pack-pdf-smoke] SKIPPED: the electron package is installed but its platform ' +
+      'binary has not been downloaded yet (Electron >= 42 fetches lazily, so a fresh `npm ci` ' +
+      'leaves no path.txt). Real-Chromium printToPDF coverage is OFF for this run. Run ' +
+      '`npx electron --version` once to materialize the binary, then re-run.'
+  )
+}
+
 const ELECTRON_BIN = electronBinaryPath()
+if (ELECTRON_BIN === null) announceSkipReason()
 const displayReachable =
   process.platform !== 'linux' ||
   Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)

--- a/apps/desktop/tests/integration/packaging.test.ts
+++ b/apps/desktop/tests/integration/packaging.test.ts
@@ -23,6 +23,9 @@ interface BuilderConfig {
   mac?: { executableName?: string }
   linux?: { executableName?: string }
   portable?: { executableName?: string; artifactName?: string }
+  // Deliberately loose: a YAML scalar like `43.0` parses as a NUMBER, and the DEP-4 parity
+  // test below must be able to CATCH that mistake rather than be typed out of it.
+  electronVersion?: string | number
 }
 
 function loadBuilderConfig(): BuilderConfig {
@@ -259,5 +262,100 @@ describe('electron-builder pins a path-safe executableName (PR #30)', () => {
         )
       }
     }
+  })
+})
+
+// DEP-1 §5 follow-up #1, discharged by wave DEP-4 (plan P1). `electron-builder.yml`'s
+// `electronVersion:` — NOT the npm `electron` devDependency — selects the runtime that is
+// actually packaged: electron-builder 26 runs from apps/desktop and cannot resolve the hoisted
+// `^`-range devDep, so the field is a hand-maintained pin. DEP-1 §4(b) records what that costs:
+// the first `package:win` of that wave silently shipped Electron 37 after the devDep had been
+// bumped to 39, and it was caught only because a human happened to notice. The failure is
+// invisible to typecheck, test and CI — it surfaces only in the bytes of a release artifact,
+// which is the worst possible place to find a stale, still-vulnerable runtime.
+//
+// The lockfile is the source of truth here, not `node_modules`: it is committed, deterministic,
+// and it is what `npm ci` installs on every CI leg and release runner. A node_modules-only check
+// would false-pass against a stale local install. The installed copy is checked too, but only
+// when present — CI legs set ELECTRON_SKIP_BINARY_DOWNLOAD and a slimmed context may have no
+// electron at all.
+describe('electron-builder.yml electronVersion tracks the electron devDependency (DEP-1 §5 #1)', () => {
+  /** The version the lockfile pins for the hoisted root `node_modules/electron`. */
+  function lockedElectronVersion(): string {
+    const lock = JSON.parse(readFileSync(LOCKFILE, 'utf8')) as {
+      packages: Record<string, { version?: string }>
+    }
+    const entry = lock.packages['node_modules/electron']
+    expect(entry?.version, 'package-lock.json pins node_modules/electron').toBeTruthy()
+    return entry!.version!
+  }
+
+  /** The `^x.y.z` range declared in apps/desktop/package.json devDependencies. */
+  function declaredElectronRange(): string {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8')
+    ) as { devDependencies?: Record<string, string> }
+    const range = pkg.devDependencies?.electron
+    expect(range, 'apps/desktop declares an electron devDependency').toBeTruthy()
+    return range!
+  }
+
+  const parse3 = (v: string): [number, number, number] => {
+    const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v)
+    expect(m, `"${v}" is a plain three-part version`).not.toBeNull()
+    return [Number(m![1]), Number(m![2]), Number(m![3])]
+  }
+
+  it('electronVersion is a plain three-part version STRING, not a YAML number', () => {
+    const raw = loadBuilderConfig().electronVersion
+    // `electronVersion: 43.0` is valid YAML and parses to the number 43 — electron-builder
+    // would then look for a nonexistent "43" release. Two dots keep it a string; assert that.
+    expect(typeof raw, 'electronVersion must be quoted/dotted enough to stay a string').toBe(
+      'string'
+    )
+    expect(String(raw)).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('electronVersion EQUALS the electron version pinned in package-lock.json', () => {
+    const pinned = String(loadBuilderConfig().electronVersion)
+    expect(
+      pinned,
+      'electron-builder.yml packages this exact runtime — if it disagrees with the lockfile, ' +
+        'the release artifact ships a different Electron than the one CI tested (DEP-1 §4(b))'
+    ).toBe(lockedElectronVersion())
+  })
+
+  it('electronVersion satisfies the caret range declared in apps/desktop/package.json', () => {
+    const range = declaredElectronRange()
+    const caret = /^\^(\d+\.\d+\.\d+)$/.exec(range)
+    // If the range form ever changes, fail loudly rather than silently stop checking.
+    expect(caret, `electron devDependency "${range}" is a plain caret range`).not.toBeNull()
+    const [fMaj, fMin, fPat] = parse3(caret![1])
+    const [pMaj, pMin, pPat] = parse3(String(loadBuilderConfig().electronVersion))
+    expect(pMaj, 'same major as the declared floor').toBe(fMaj)
+    const atOrAbove =
+      pMin > fMin || (pMin === fMin && pPat >= fPat)
+    expect(atOrAbove, `${pMaj}.${pMin}.${pPat} is at or above the ${caret![1]} floor`).toBe(true)
+  })
+
+  it('the INSTALLED electron agrees too, when node_modules is present', () => {
+    let installed: string | null = null
+    try {
+      installed = (
+        JSON.parse(
+          readFileSync(
+            join(LOCKFILE, '..', 'node_modules', 'electron', 'package.json'),
+            'utf8'
+          )
+        ) as { version: string }
+      ).version
+    } catch {
+      // No electron installed (slimmed/lint-only context) — the lockfile assertions above
+      // are the load-bearing ones; nothing to compare against here.
+      return
+    }
+    expect(installed, 'a stale node_modules would package a runtime nobody tested').toBe(
+      String(loadBuilderConfig().electronVersion)
+    )
   })
 })

--- a/apps/desktop/tests/unit/verify-electron.test.ts
+++ b/apps/desktop/tests/unit/verify-electron.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// Wave DEP-4 (Electron 39 -> 43). `scripts/verify-electron.mjs` runs as the ROOT postinstall on
+// every contributor's `npm ci` and on every release runner, and until this wave it was WRONG in
+// a way nothing could see:
+//
+//   Electron >= 42 removed the postinstall binary download. `path.txt` is therefore ABSENT
+//   after a healthy fresh install — the binary now arrives lazily on first bin invocation. The
+//   old script read an absent `path.txt` as "extract did not finish", deleted dist/, and
+//   spawned install.js — re-creating the ~100 MB postinstall download Electron had just removed
+//   for supply-chain reasons, while printing a false "binary looks broken" NTFS diagnosis.
+//
+// CI could never catch it (it sets HILBERTRAUM_SKIP_ELECTRON_CHECK and the script early-exits),
+// and the script had no tests at all. These pin the decision itself.
+//
+// The version boundary is load-bearing, not decoration: 39 and 41 still HAVE the postinstall,
+// 42 and 43 do not (verified against the registry at this wave's P2). This repo's documented
+// Electron-43 fallback ladder includes ^41.7.2, so a version-blind script would silently lose
+// the NTFS half-extract protection on exactly that path.
+
+const SCRIPT = resolve(__dirname, '..', '..', '..', '..', 'scripts', 'verify-electron.mjs')
+
+interface VerifyElectronModule {
+  LAZY_DOWNLOAD_MAJOR: number
+  diagnose(electronDir: string, major: number): string | null
+  readElectronMajor(electronDir: string): number | null
+}
+
+let mod: VerifyElectronModule
+
+beforeAll(async () => {
+  // Dynamic import with a non-literal specifier: the script is plain .mjs outside the app's
+  // tsconfig, and importing it must have NO side effects (its CLI half is argv-guarded).
+  mod = (await import(pathToFileURL(SCRIPT).href)) as unknown as VerifyElectronModule
+})
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'hr-verify-electron-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** Build a plausible electron package dir. Omit a piece to simulate each damaged state. */
+function makeInstall(opts: {
+  pathTxt?: string | null
+  distVersion?: boolean
+  binary?: 'ok' | 'empty' | 'missing'
+}): void {
+  const { pathTxt = 'electron.exe', distVersion = true, binary = 'ok' } = opts
+  if (pathTxt !== null) writeFileSync(join(dir, 'path.txt'), pathTxt)
+  const distDir = join(dir, 'dist')
+  mkdirSync(distDir, { recursive: true })
+  if (distVersion) writeFileSync(join(distDir, 'version'), '43.4.0')
+  if (binary === 'ok') writeFileSync(join(distDir, 'electron.exe'), 'MZ-not-really-a-binary')
+  else if (binary === 'empty') writeFileSync(join(distDir, 'electron.exe'), '')
+}
+
+describe('verify-electron: the Electron 42 lazy-download boundary (DEP-4 §A)', () => {
+  it('pins the boundary at major 42', () => {
+    expect(mod.LAZY_DOWNLOAD_MAJOR).toBe(42)
+  })
+
+  it('THE LANDMINE: on Electron 43 a missing path.txt is NORMAL, not a broken install', () => {
+    makeInstall({ pathTxt: null, distVersion: false, binary: 'missing' })
+    // A fresh `npm ci` on Electron >= 42 looks exactly like this. Returning a problem here is
+    // what made the old script delete dist/ and re-download ~100 MB during postinstall.
+    expect(mod.diagnose(dir, 43)).toBeNull()
+  })
+
+  it('on Electron 42 (the boundary itself) a missing path.txt is likewise normal', () => {
+    makeInstall({ pathTxt: null, distVersion: false, binary: 'missing' })
+    expect(mod.diagnose(dir, 42)).toBeNull()
+  })
+
+  it('on Electron 41 a missing path.txt IS broken — the fallback-ladder case', () => {
+    makeInstall({ pathTxt: null, distVersion: false, binary: 'missing' })
+    // 41 still ships `postinstall: node install.js`, so path.txt should exist by now.
+    expect(mod.diagnose(dir, 41)).toMatch(/path\.txt is missing/)
+  })
+
+  it('on Electron 39 a missing path.txt IS broken', () => {
+    makeInstall({ pathTxt: null, distVersion: false, binary: 'missing' })
+    expect(mod.diagnose(dir, 39)).toMatch(/path\.txt is missing/)
+  })
+})
+
+describe('verify-electron: the genuine half-extract is still caught on every version', () => {
+  // This is the bug the script exists for (NTFS-on-Linux drops the large files during unzip
+  // while still creating the folders). It is version-independent: once path.txt exists, the
+  // download HAS run, so anything missing below is real damage.
+  for (const major of [39, 41, 42, 43]) {
+    it(`Electron ${major}: path.txt present but the binary is missing -> problem`, () => {
+      makeInstall({ binary: 'missing' })
+      expect(mod.diagnose(dir, major)).toMatch(/platform binary is missing/)
+    })
+
+    it(`Electron ${major}: a zero-length binary -> problem`, () => {
+      makeInstall({ binary: 'empty' })
+      expect(mod.diagnose(dir, major)).toMatch(/platform binary is empty/)
+    })
+
+    it(`Electron ${major}: a healthy install -> no problem`, () => {
+      makeInstall({})
+      expect(mod.diagnose(dir, major)).toBeNull()
+    })
+  }
+
+  it('a missing dist/version is a half-extract', () => {
+    makeInstall({ distVersion: false })
+    expect(mod.diagnose(dir, 43)).toMatch(/dist\/version is missing/)
+  })
+
+  it('an empty path.txt is a half-extract', () => {
+    makeInstall({ pathTxt: '   ' })
+    expect(mod.diagnose(dir, 43)).toMatch(/path\.txt is empty/)
+  })
+})
+
+describe('verify-electron: readElectronMajor', () => {
+  it('reads the major from the installed package.json', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '43.4.0' }))
+    expect(mod.readElectronMajor(dir)).toBe(43)
+  })
+
+  it('returns null when there is no package.json to read', () => {
+    expect(mod.readElectronMajor(dir)).toBeNull()
+  })
+
+  it('returns null on an unparseable version, so the caller can fall back', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: 'not-a-version' }))
+    expect(mod.readElectronMajor(dir)).toBeNull()
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10253,6 +10253,21 @@ under the `electron`-mocking suite:
   exposes the `getDroppedFilePath` seam.
 - **Packaged renderer smoke.** The app paints its onboarding screen on Chromium 150 with **zero
   console errors** and no horizontal overflow.
+- **Dialog `defaultPath` — the one candidate user-visible behaviour change, MEASURED and
+  DISPROVEN (owner-run, 2026-08-19).** Electron 43's breaking-changes list says the `defaultPath`
+  option "now defaults to the user's Downloads folder", which most directly describes the case
+  where the option is OMITTED. All 11 call sites in this repo PASS it, as a bare filename with no
+  directory, and whether a bare filename now resolves its DIRECTORY half against Downloads was
+  never stated upstream. Probed on the packaged E43 build launched from the root of a prepared
+  drive: the save dialog for the activity-log export (`registerAuditIpc.ts`, `defaultPath:
+  'activity-log.json'`) pre-selected the **drive**, not Downloads. Exports therefore do NOT start
+  landing on the host. **Owner decision D-2 is VOID** — no explicit-root change was made at the
+  `save-export.ts` seam, and the plan's inference is recorded as disproven by measurement rather
+  than carried forward as a risk. *Caveat, stated because it bounds the claim:* the drive had
+  already been used as a save target once in the same session, so this reading cannot fully
+  separate "Electron's default resolves to the working/app directory" from "the Windows shell's
+  per-app last-used directory". Both outcomes are drive-local; the Downloads hypothesis is the
+  one that is excluded, and it is the only one D-2 existed to guard against.
 - **Portable artifact on a REAL prepared drive (owner-run, 2026-08-19).** The portable `.exe`
   copied to the root of an existing encrypted drive launches by double-click, resolves that
   drive via `findPreparedDriveRoot` (`config/drive.json`) rather than falling back to a fresh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10136,7 +10136,7 @@ This record is the durable per-alert ledger; the DEP-1 record above holds the wa
    node program resolves it; the web program gets the real `pdf.d.mts`). The legacy-build
    decision itself stands — one build everywhere.
 
-## Electron 39 → 43 — design record (wave DEP-4, PR #185)
+## Electron 39 → 43 — design record (wave DEP-4, PR #187)
 
 _Wave DEP-4 (2026-08-18) cleared the last open Dependabot alert, **#83** / issue **#179** —
 GHSA-jmr9-qjv8-65gv (CVE-2026-56876, high, CVSS 8.1), `extract-zip <= 2.0.1` unvalidated symlink
@@ -10361,7 +10361,7 @@ was deleted at close-out — **no `git show` recovers it**. Citations of that fo
 | `plan §8` (abort branch / fallback ladder) | §1 — corrected to `^41.7.2` / `^42.3.4` |
 | `plan §11` (self-audit) | superseded: its findings were folded into the plan before execution |
 
-Surviving sources for anything not resolved above: this record, the phase commits, and the PR #185
+Surviving sources for anything not resolved above: this record, the phase commits, and the PR #187
 body.
 
 ## Local API endpoint — design record (wave local-api, PR #184, §1–§9)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10253,6 +10253,13 @@ under the `electron`-mocking suite:
   exposes the `getDroppedFilePath` seam.
 - **Packaged renderer smoke.** The app paints its onboarding screen on Chromium 150 with **zero
   console errors** and no horizontal overflow.
+- **Portable artifact on a REAL prepared drive (owner-run, 2026-08-19).** The portable `.exe`
+  copied to the root of an existing encrypted drive launches by double-click, resolves that
+  drive via `findPreparedDriveRoot` (`config/drive.json`) rather than falling back to a fresh
+  app-data workspace, unlocks the **existing encrypted workspace**, and lists its already-indexed
+  documents with their chunk counts. So the E43 build opens an E39-era encrypted workspace with
+  no migration and no format change — the strongest available confirmation of the "existing user
+  workspaces are unaffected" claim, on real data rather than a synthetic fixture.
 - **electron-builder packaging Electron 43:** a real `package:win` completed and reports
   `electron=43.4.0`; the parity test guarantees that is the version actually packaged.
 - **All THREE platforms package on Electron 43** (`workflow_dispatch` on `release.yml`, run

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,8 @@ a future move to Tauri/Rust is a localized swap.
   sidecar — design record" below.
 
 ## Storage
-`node:sqlite` — built into the Node bundled by **Electron ^39.8.5** (Node 22.x). It is loaded via
+`node:sqlite` — built into the Node bundled by **Electron ^43.4.0** (Node 24.x; measured 24.18.1 /
+SQLite 3.53.1 on the packaged E43 build, wave DEP-4). It is loaded via
 `createRequire` in `services/db.ts` because the experimental module is absent from
 `module.builtinModules`, which otherwise makes bundlers try to resolve a non-existent `sqlite`
 package. One SQLite DB per workspace (`workspace/hilbertraum.sqlite`) holds the original spec §8 tables
@@ -377,7 +378,7 @@ force-quit. The contract now:
 
 **Drag-drop intake (full-audit-2026-06-29 follow-up, Phase 2 — FE-A / FE-C).** Chat drag-and-drop
 attach was **silently dead in the shipped app**: `ChatScreen.pathsFromDrop` read `(file).path`, the
-non-standard `File.path` Electron **removed in v32** (the app pins `^39.8.5`; installed 39.8.10). At
+non-standard `File.path` Electron **removed in v32** (the app pins `^43.4.0`; installed 43.4.0). At
 runtime `.path` is `undefined`, so the loop produced `[]`, `attachFiles` was never called, and a drop
 did nothing — no import, no pending chip, no error. It went unnoticed because the only intake test
 (`ChatAttach.test.tsx`) **fabricated** `dataTransfer.files = [{ name, path }]`, injecting a property
@@ -406,7 +407,9 @@ never fabricate a platform property the renderer could read directly).
   red, verified). jsdom can't exercise `webUtils`, so the unit tests prove the **wiring**; the
   real-Electron leg (bridge exposes the resolver in the actual renderer; `webUtils.getPathForFile` is
   callable in the sandboxed preload on 37.10.3 (API unchanged in Electron 39 — not in the 38/39
-  breaking-changes; typechecks against 39.8.10's `electron.d.ts`) — a renderer-built File resolves
+  breaking-changes; unchanged again in Electron 43 — absent from every 40–43 breaking-change list,
+  and the packaged E43 preload still exposes the `getDroppedFilePath` seam, wave DEP-4; typechecks
+  against 43.4.0's `electron.d.ts`) — a renderer-built File resolves
   to `''` without throwing) was confirmed by launching the built preload under the app's exact
   `webPreferences`. A
   true native OS drag (Explorer → chat) isn't faithfully automatable (a synthetic File has no on-disk
@@ -9637,7 +9640,7 @@ real-Electron smoke runner needs a **`window-all-closed` no-op** (Electron's def
 otherwise races the print) and an **isolated `--user-data-dir`** (profile singleton); the
 pdfjs v6 verification path needs the legacy build + a DOMMatrix polyfill under Node, with
 `getOutline`/`getMarkInfo` asserting the bookmark tree and the tagged-PDF mark.
-`generateTaggedPDF` is EXPERIMENTAL per the Electron docs (still so in Electron 39) — accessible headings/reading order
+`generateTaggedPDF` is EXPERIMENTAL per the Electron docs (still so in Electron 43) — accessible headings/reading order
 are best-effort, **never a PDF/UA claim** (known-limitations.md). PDF bytes are
 nondeterministic (CreationDate/ID) → the HTML input stays golden, the PDF is smoke-tested.
 The freshness verdict and the outdated refusal stay BEFORE any dialog or window work for
@@ -9963,7 +9966,15 @@ saw comment-only changes (§4).
 Electron is a devDependency in npm terms but is the runtime shipped inside every packaged build,
 so the 37→39 bump forced re-measuring every fact that had been proven specifically "on Electron
 37." All of the following were re-run on the real packaged Electron **39.8.10** binary (Chromium
-**142.0.7444.265**, Node **22.22.1**, SQLite **3.51.2**):
+**142.0.7444.265**, Node **22.22.1**, SQLite **3.51.2**).
+
+> **⟶ SUPERSEDED for the version-specific facts (2026-08-18, wave DEP-4, Electron 43.4.0 /
+> Chromium 150.0.7871.224 / Node 24.18.1 / SQLite 3.53.1).** The measurements below stand as the
+> Electron-39 record; the DEP-4 record at the end of this file carries the re-taken ones. Note
+> SQLite moved 3.51.2 → **3.53.1**, which is NOT derivable from the Node version (host Node 24.13
+> bundles 3.50.4) — read it off the real binary after every bump.
+
+The Electron-39 ledger:
 
 - **CSP on `file://` (the headline):** the `onHeadersReceived` response header still ATTACHES
   and ENFORCES (`disposition: "enforce"`) in BOTH windows on the packaged build — a `base-uri`
@@ -10124,6 +10135,234 @@ This record is the durable per-alert ledger; the DEP-1 record above holds the wa
    `pdfjs.d.ts`'s inaccurate "one declaration serves both tsconfig programs" claim (only the
    node program resolves it; the web program gets the real `pdf.d.mts`). The legacy-build
    decision itself stands — one build everywhere.
+
+## Electron 39 → 43 — design record (wave DEP-4, PR #185)
+
+_Wave DEP-4 (2026-08-18) cleared the last open Dependabot alert, **#83** / issue **#179** —
+GHSA-jmr9-qjv8-65gv (CVE-2026-56876, high, CVSS 8.1), `extract-zip <= 2.0.1` unvalidated symlink
+path traversal — by removing `extract-zip` from the dependency tree entirely. It could not be
+patched: `first_patched_version` is `null` and the package is abandoned at 2.0.1 (last publish
+2023-03). Upstream Electron's remediation was **replacement, not repair** (the patched lines
+depend on `@electron-internal/extract-zip`), and an `overrides` alias had already been tested and
+rejected in #179 — the fork is ESM-only + native NAPI, so Electron 39's CJS `install.js` would get
+a non-callable namespace object and every contributor's `npm ci` would break while CI stayed
+green. The working plan (`plans/electron-43-upgrade-plan.md`) was a working paper, git-excluded,
+never committed, and deleted at close-out per the CLAUDE.md doc-lifecycle rule — this record and
+the phase commits below are the surviving sources (see the §-anchor legend at the end)._
+
+**Phase commits** (suite 5223 pass / 50 skip / 5273 total, 375 files → **5249 / 50 / 5299, 376
+files**; the +26 tests / +1 file are this wave's deliberate additions and the skip count returns
+to exactly 50; typecheck + build green at every gate, in that order): P0 `4fce4410` wave open ·
+P1 `47fb36bb` electronVersion parity test · *interlude* `b5ff27bb` #157 DT-2 load-proof budget ·
+P2 `efd1042d` the bump · P2b `39afbf68` electron-builder 26.15.7 · P3 `cb214580` automated
+re-verification · P4/P5 the packaged measurements + this record.
+
+### §1 Scope + outcome
+
+| | Before | After |
+|---|---|---|
+| `electron` | 39.8.10 (`^39.8.5`) | **43.4.0** (`^43.4.0`) |
+| Chromium | 142.0.7444.265 | **150.0.7871.224** (+8 majors) |
+| Node (main) | 22.22.1 | **24.18.1** (+2 majors) |
+| V8 | 14.x | **15.0.245.28** |
+| SQLite (`node:sqlite`) | 3.51.2 | **3.53.1** |
+| `@types/node` | ^22.5.0 (22.19.20) | **^24.9.0** (24.13.3) |
+| `engines.node` | `>=22.5` | **`>=22.12`** (Electron 43's own floor) |
+| `electron-builder` | 26.15.2 | **26.15.7** (§4c) |
+| zip extractor | `extract-zip@2.0.1` | **gone** — `@electron-internal/extract-zip` |
+
+`npm ls extract-zip` → **empty**. `npm audit` → **0 vulnerabilities** (was 2 high). No production
+dependency moved — a devDependency-only diff at the npm level, as in DEP-1 — and **no on-disk
+format changed**, so existing encrypted workspaces open unchanged in both directions.
+
+**Why 43 rather than 40, the smallest alert-clearing major.** DEP-1's rule was "floor at the
+alert-clearing version, don't chase latest." It is overridden here by Electron's support policy:
+only the latest three stable majors get security fixes, so the supported set is 41/42/43 and 40 is
+already outside it. Landing on an unsupported major to fix a security alert would mean re-running
+this wave at the next Electron CVE.
+
+**Correction to a premise the plan carried** (found at the P0 gate, from `npm audit`'s own
+advisory range): the vulnerable range is `1.3.1 - 40.10.2 || 41.0.0-alpha.1 - 41.7.1 ||
+42.0.0-alpha.1 - 42.3.3 || 43.0.0-alpha.1 - 43.0.0-beta.8`. The fork therefore landed at
+**41.7.2 / 42.3.4 / 43.0.0**, NOT at "Electron >= 40" — **all** of 40.x is vulnerable. Nothing
+propagated (43 was already the target), but the documented fallback ladder is `^41.7.2` / `^42.3.4`,
+never bare `^41` / `^42`.
+
+**Minimum OS floors are UNCHANGED** — confirmed, not assumed, because this product runs on the
+customer's machine: the `## Platform support` sections of the v39.8.10 and v43.4.0 READMEs are
+**byte-identical** (Windows 10+, macOS 12 Monterey+, Linux Ubuntu 18.04+/Fedora 32+/Debian 10+;
+the macOS-12 floor was set back at Electron 38). No customer is dropped. ⚠️ **Electron 44 is a
+different story and is a roadmap item, not a bump:** it removes macOS 12 support and drops 32-bit
+Windows (ia32) and Linux armv7l. E43 is the **last series shipping prebuilt 32-bit binaries**, EOL
+**January 2027**.
+
+### §2 Decisions (the ones that outlive the wave)
+
+- **The parity test lands BEFORE the bump.** DEP-1 §5 registered a test asserting
+  `electron-builder.yml`'s `electronVersion` matches the installed `electron`, and nobody wrote
+  it — confirmed by grep at P0: one hit in the whole repo, the yml line itself. Writing it first
+  is what made the bump safe to measure, and it paid immediately (§3).
+- **`verify-electron.mjs` is version-aware, deliberately.** Electron 39 and 41 still declare
+  `postinstall: node install.js`; 42 and 43 declare no scripts at all. Because the documented
+  fallback ladder includes `^41.7.2`, a version-blind script would silently lose the NTFS
+  half-extract protection on exactly the path a failed wave would take.
+- **Never measure the CSP header by registering `webRequest.onHeadersReceived`.** Electron allows
+  ONE listener per session, so a probe that registers its own REPLACES the app's — the very
+  handler that attaches the CSP — and then observes the absence of a header it removed itself.
+  Provoke a violation of a header-only directive (`base-uri`) and read the policy back out of the
+  violation's `originalPolicy`.
+- **Desk-check the toolchain pairing at the bump, not at the packaged run** (the plan's own audit
+  promoted this): discovering an electron-builder incompatibility during P4 wastes a packaged run.
+  It also surfaced §4(c), which had nothing to do with Electron.
+- Carried unchanged from DEP-1: one branch, one commit per phase, merged once; every
+  lockfile-writing command through pinned `npx npm@11.6.2`; the build-before-test gate order
+  (`csp-build-output.test.ts` reads the on-disk `out/`).
+
+### §3 The Electron-43 re-verification ledger (headline)
+
+Electron is a devDependency in npm terms but is the runtime shipped inside every packaged build,
+so the bump invalidates by definition every fact previously proven "on Electron 39." All of the
+following were measured on the **real packaged Windows build** (2026-08-18), not in dev and not
+under the `electron`-mocking suite:
+
+- **CSP on `file://` (the headline, and the wave's one blocking risk).** The `onHeadersReceived`
+  header still **ATTACHES and is ENFORCED** on `file://` in the packaged app on Chromium 150: a
+  `base-uri` injection — permitted by the page's baked meta, which carries no `base-uri`
+  directive — was blocked, `document.baseURI` stayed on the `file://` document, and the
+  violation's `originalPolicy` was **byte-exact** to `buildCsp(false)`. Both baked metas, read out
+  of the **shipped `app.asar`**, were byte-exact to `buildMetaCsp(false, page)` and carried no
+  `localhost`, no `ws://` and no `unsafe-eval`. This supersedes the DEP-1 Electron-39 measurement
+  of the same mechanism; the annotation lives in `security-model.md`'s CSP section.
+- **`node:sqlite` / FTS5.** Node **24.18.1**, SQLite **3.53.1**; `bm25()`, `snippet()` and
+  `highlight()` all correct in the packaged main process. The SQLite version is **not** a function
+  of the Node version (E39/Node 22.22.1 bundled 3.51.2; host Node 24.13.0 bundles 3.50.4), so it
+  cannot be inferred and must be read off the binary each time.
+- **Evidence-Pack `printToPDF`.** The full D-1 option set is still accepted on Chromium 150;
+  output is a valid `%PDF-1.4 … %%EOF`. `generateTaggedPDF` remains **Experimental** upstream but
+  now demonstrably emits `StructTreeRoot` and `MarkInfo` structures — still best-effort
+  accessibility, still **not** a PDF/UA claim.
+- **Permission taxonomy, both directions (the two-sided risk).** `permissions.ts` gates the app's
+  one allowed capability on the Chromium permission string `'media'`, and `index.ts` records that
+  without a check handler Electron **default-grants** — so a rename across 8 Chromium majors
+  fails either toward broken dictation or toward a silent widening. Measured on both handlers:
+  the REQUEST path (`getUserMedia({audio:true})`) → **GRANTED**, and `navigator.permissions.query`
+  through the CHECK path → `microphone: granted`, `camera` / `geolocation` / `notifications` all
+  **denied**. Dictation's capability survives and nothing else widened.
+- **`webUtils.getPathForFile`** (the repo's standing convention is to clear it explicitly on every
+  Electron major): absent from every 40–43 breaking-change list, and the packaged preload still
+  exposes the `getDroppedFilePath` seam.
+- **Packaged renderer smoke.** The app paints its onboarding screen on Chromium 150 with **zero
+  console errors** and no horizontal overflow.
+- **electron-builder packaging Electron 43:** a real `package:win` completed and reports
+  `electron=43.4.0`; the parity test guarantees that is the version actually packaged.
+- **Suite parity:** 5249 / 50 / 5299 across 376 files at every gate from P2 onward, including one
+  deliberately load-stressed run.
+
+**Explicitly NOT measured — recorded as gaps, not as passes:**
+- **Dev-mode OCR raster → IPC → recognize.** Not run: this build machine carries no
+  `*.traineddata` (`OCR backend selected {kind: none}`), the same gap DEP-1 hit.
+- **The OCR window's CSP at runtime.** Its baked meta was verified byte-exact from the shipped
+  asar, but the window itself opens only for OCR work and so could not be opened here. The header
+  is page-agnostic — one session-level handler emitting one `buildCsp(false)` string — so the
+  mechanism is proven by the main-window measurement; the OCR window's runtime `blob:`
+  intersection still rests on its Electron-39 measurement.
+
+### §4 Wave discoveries
+
+- **(a) `verify-electron.mjs` was silently invalidated by the Electron 42 postinstall removal —
+  the sharpest finding of the wave, and absent from issue #179.** Electron ≥ 42 removed the
+  postinstall binary download (supply-chain hardening); the binary now arrives lazily on first
+  invocation of the electron bin, so **`path.txt` legitimately does not exist after a healthy
+  fresh `npm ci`**. The old script read that as "extract did not finish" and responded by deleting
+  `dist/` and spawning `install.js` — meaning our own postinstall would have **re-created the
+  ~100 MB download Electron had just removed on purpose**, on every clean install, while printing
+  a false "binary looks broken" NTFS diagnosis, and defeating the `npm ci --ignore-scripts` flow
+  that motivated the upstream change. Proven rather than argued: the old decision function returns
+  `path.txt is missing (extract did not finish)` for a healthy Electron 43 install. CI never
+  caught it because `HILBERTRAUM_SKIP_ELECTRON_CHECK` early-exits the script, and the script had
+  no tests at all — it called `process.exit` at import time, i.e. it was **untestable by
+  construction**. Rewritten as a verifier (owner decision D-1a) with the CLI half argv-guarded and
+  the decision half pure and unit-tested (`tests/unit/verify-electron.test.ts`, +22).
+- **(b) The E42 change silently switched OFF a real test.**
+  `tests/integration/evidence-pack-pdf-smoke.test.ts` gates on reading `path.txt`, so the bump
+  dropped **6 tests with no failure anywhere** — the only visible trace was the skip count moving
+  50 → 56. That file is the **only** automated coverage of real Chromium `printToPDF`, i.e.
+  exactly what this wave most needed to re-prove, and its own comment claimed "on the first-class
+  Windows dev box a plain `npm test` always exercises it." It now announces the reason it skipped
+  and names the remedy (`npx electron --version` once), distinguishing "CI, deliberately
+  binary-free" from "installed but not fetched yet". **Generalisable lesson: a test gated on an
+  environment probe can be disabled by an upstream change without any signal — the gate must be
+  able to say why it is silent.**
+- **(c) electron-builder 26.15.2 sat inside a silent-corruption window, unrelated to Electron.**
+  eb issue #9983 (fixed in 26.15.6): the install-time `Nsis7z::Extract` plugin cannot decode the
+  BCJ2 filter that bundled 7za 24.09 applies, so the build **drops every PE file** — the main
+  `.exe`, all Chromium DLLs, the `.node` natives — while still **exiting 0**, producing an
+  unrunnable app from a build that reported success. Upstream documents it for the `nsis` target;
+  `npm run package:win` builds `portable`, which at 26.15.2 routes through the same
+  `archive()`/`app-64.7z` path, and whether portable is affected is **not stated upstream**.
+  Bumped to **26.15.7** before the packaged run rather than finding out from a release artifact;
+  that also picks up 26.15.4's fix for the sibling regression where 7za dereferenced symlinks and
+  corrupted macOS `.framework` bundles. **Verified on the shipped artifact:** the NSIS-extracted
+  payload is **SHA-256 identical** to `win-unpacked` for the main executable, `app.asar` and the
+  DLLs, and the extracted app launches and runs correctly. Note for reproducers:
+  `npm i electron-builder@latest` currently resolves to **26.15.3**, not 26.15.7 — npm's `latest`
+  tag and GitHub's "Latest" release disagree (upstream #9972); the `v26` dist-tag carries 26.15.7.
+- **(d) The `#157 DT-2` translation-cancel test was living on 6% timing headroom.** It drives a
+  600-unit foreign translation to completion (~9.4 s idle) against a hand-rolled 10 s poll bound,
+  and vitest's CI `testTimeout` widening does **not** apply to a hand-rolled poll. It failed 3 of
+  5 full-suite runs under load. Fixed as a labelled interlude commit: the poll bound became 30 s
+  (a hang detector, never a timing proof) and the test carries an explicit 60 s budget — the same
+  value CI already uses. No semantics loosened. Same family as #84/#97/#101.
+- **(e) `ELECTRON_SKIP_BINARY_DOWNLOAD` is dead** and was removed from `ci.yml`: Electron ≥ 42
+  reads it nowhere, so leaving it would advertise an effect it no longer has. CI needs no knob at
+  all now — it never invokes the electron bin, and the rewritten postinstall exits 0 on a
+  not-yet-downloaded binary. `HILBERTRAUM_SKIP_ELECTRON_CHECK` stays as belt-and-braces.
+- **(f) The `ELECTRON_RUN_AS_NODE` trap from DEP-1 §4(e) is still live** in agent tooling
+  environments — it was set in this wave's shell too, and was cleared before every dev/Electron
+  invocation. Not a repo condition; recorded so it is not re-diagnosed as a product bug.
+
+### §5 Follow-up register (owner-facing)
+
+1. **`.github/dependabot.yml`** — DEP-1 §5 follow-up #4, still open. Owner-approved during this
+   wave (decision D-4) to land as its **own PR**, deliberately not enlarging this wave's diff.
+   This was the fourth hand-rolled dependency batch (DEP-1, DEP-2, DEP-3, DEP-4).
+2. **Packaged-OCR fix bundle** — unchanged and still open (DEP-1 §5 follow-up #2): `asarUnpack`
+   the tesseract.js worker's hoisted deps, degrade the task instead of dying, make `ocrAvailable`
+   honest. Untouched by this wave — the defect is an `asarUnpack` gap, not a runtime-version
+   effect. The OCR-window CSP re-check rides along with it (§3).
+3. **OCR assets on a build machine.** Two DEP-4 gaps (dev-mode OCR recognize; the OCR window's
+   runtime CSP) exist only because no `*.traineddata` is present. Running the packaged measurement
+   on an asset-carrying drive would close both.
+4. **Electron 44 is a customer-facing decision, not a routine bump** (§1): it drops macOS 12 and
+   32-bit Windows/armv7l. E43 is the last series with prebuilt 32-bit binaries and is supported
+   until **January 2027**. Decide deliberately, with the drive product's OS matrix in hand.
+5. **electron-builder air-gapped builds** — upstream #10039: eb fails in air-gapped environments
+   even with a seeded cache, because `@electron/get` always fetches `SHASUMS256.txt`. Fixed on
+   master only, not in any 26.15.x. Relevant to this project's offline-first posture, but it
+   affects BUILD machines, not the shipped app.
+6. **`test:coverage` parallelism cap** — DEP-1 §5 follow-up #3, still open and unchanged.
+
+### §-anchor legend
+
+The phase commits cite `plan P0`…`plan P6` and the plan's `§N` sections. The plan
+(`plans/electron-43-upgrade-plan.md`) was a working paper, git-excluded and never committed, and
+was deleted at close-out — **no `git show` recovers it**. Citations of that form resolve here:
+
+| Plan citation | Resolves to |
+|---|---|
+| `plan §1` (why the bump exists) / `plan §2` (stack delta) | §1 above |
+| `plan §3` (blast radius) | §3 above (measured) + §4 (what it missed) |
+| `plan §3A` (`verify-electron.mjs` invalidated) | §4(a) |
+| `plan §3B` (`electronVersion` unguarded) | §2 + §3, and commit `47fb36bb` |
+| `plan §3E` / `§3G` (Chromium + security surfaces) | §3 above |
+| `plan §4` (risk register R1–R10) | §3 (R3/R5b/R6 cleared by measurement) + §4 |
+| `plan §5 P0`…`P6` (phases) | the phase commits listed at the top of this record |
+| `plan §7 D-1`…`D-4` (owner decisions) | §2 (D-1), §5 item 1 (D-4), §1/§3 (D-2), §3 (D-3) |
+| `plan §8` (abort branch / fallback ladder) | §1 — corrected to `^41.7.2` / `^42.3.4` |
+| `plan §11` (self-audit) | superseded: its findings were folded into the plan before execution |
+
+Surviving sources for anything not resolved above: this record, the phase commits, and the PR #185
+body.
 
 ## Local API endpoint — design record (wave local-api, PR #184, §1–§9)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10255,6 +10255,14 @@ under the `electron`-mocking suite:
   console errors** and no horizontal overflow.
 - **electron-builder packaging Electron 43:** a real `package:win` completed and reports
   `electron=43.4.0`; the parity test guarantees that is the version actually packaged.
+- **All THREE platforms package on Electron 43** (`workflow_dispatch` on `release.yml`, run
+  32187938704, owner decision D-3). `build-win` + `build-mac` + `build-linux` all succeeded —
+  win-portable 110.7 MB, mac-app 155.3 MB, linux-appimage 163.8 MB — and the `release` job
+  correctly **skipped** (it is tag-gated, so an ad-hoc dispatch publishes nothing). This closes
+  the asymmetry `packaging.md` records and that the plan had registered as an accepted residual:
+  only Windows is packaged locally, but `release.yml` builds all three, so a macOS/Linux
+  packaging break under a new Electron major would otherwise first surface **on a version tag,
+  which has no PR gate ahead of it**. Measured instead of assumed, before merge.
 - **Suite parity:** 5249 / 50 / 5299 across 376 files at every gate from P2 onward, including one
   deliberately load-stressed run.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10249,8 +10249,14 @@ under the `electron`-mocking suite:
   through the CHECK path → `microphone: granted`, `camera` / `geolocation` / `notifications` all
   **denied**. Dictation's capability survives and nothing else widened.
 - **`webUtils.getPathForFile`** (the repo's standing convention is to clear it explicitly on every
-  Electron major): absent from every 40–43 breaking-change list, and the packaged preload still
-  exposes the `getDroppedFilePath` seam.
+  Electron major): absent from every 40–43 breaking-change list, the packaged preload still
+  exposes the `getDroppedFilePath` seam, and — **owner-run on the packaged E43 build,
+  2026-08-19** — a REAL OS drag-and-drop from Explorer onto the chat composer imports the file.
+  That last leg is the one that matters and the one automation cannot fake: a synthetic
+  `DataTransfer` carries no on-disk path, so only a genuine native drag exercises the resolver.
+  The failure mode being excluded is silent by nature — when `File.path` was removed in Electron
+  32 the drop did nothing at all (no chip, no import, no error; `architecture.md` §"Drag-drop
+  intake"), so "it still works" can only be established by dropping a file and watching it land.
 - **Packaged renderer smoke.** The app paints its onboarding screen on Chromium 150 with **zero
   console errors** and no horizontal overflow.
 - **Dialog `defaultPath` — the one candidate user-visible behaviour change, MEASURED and

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1056,7 +1056,10 @@ AS-BUILT shapes; P5 was renderer/i18n-only — no shared-shape changes.
   **no preload at all** (no IPC surface; wiring-pinned in `window-security.test.ts`),
   window-open + will-navigate/will-redirect ALL denied; writes the source html sibling,
   `loadFile` (= did-finish-load) → `document.fonts.ready` → `printToPDF` with the FULL
-  D-1 option set (verified supported by the installed Electron 39 types): `pageSize:'A4'`,
+  D-1 option set (verified supported by the installed Electron 43 types, and re-smoked on
+  the packaged Electron 43.4.0 / Chromium 150 build — DEP-4 P4, 2026-08-18: every option
+  accepted, output a valid `%PDF-1.4 … %%EOF`, and `generateTaggedPDF` produced actual
+  `StructTreeRoot`/`MarkInfo` structures): `pageSize:'A4'`,
   `preferCSSPageSize` (the template's `@page` is authoritative), `printBackground`,
   `displayHeaderFooter` + empty-span `headerTemplate` (suppresses Chromium's default
   date/title header) + `footerTemplate` = escaped pack-id + `pageNumber`/`totalPages`

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1997,7 +1997,10 @@ _The **`audit §N.M`** citations in the skills/extraction residuals below refer 
   exception kills the process, and `ocrAvailable` still reports `true` beforehand, so
   nothing warns the user first. **Dev mode is unaffected** — the full raster → IPC →
   recognize pipeline was proven end to end on Electron 39 outside packaging, and no other
-  packaged feature is touched. Until the fix bundle lands (unpack the hoisted deps,
+  packaged feature is touched. Unchanged by the Electron 43 bump (wave DEP-4): the defect is
+  an `asarUnpack` gap, not a runtime-version effect, so it neither improved nor worsened —
+  and DEP-4 did NOT re-run the recognition leg at all, because that build machine carries no
+  `*.traineddata`. Until the fix bundle lands (unpack the hoisted deps,
   degrade the task instead of dying, make `ocrAvailable` honest about the packaged mode —
   registered as follow-up 2 in [`architecture.md`](architecture.md) "Dependency
   remediation — design record (wave DEP-1, PR #77)" §5), do **not** run "Make searchable

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -285,7 +285,7 @@ out on a fresh machine with no Node/npm); their layout + config shapes mirror th
 | `fetch-runtime.{ps1,sh}` | Read `runtime-sources.yaml`, pick the host build (`-Os/-Arch/-Backend` overrides; **default = the first listed build: Vulkan on win/linux, Metal on mac**; `-Backend cpu` fetches the pure-CPU safety net into `runtime/llama.cpp/<os>/cpu/`), download + verify the archive, extract into the build's `extract_to` (`chmod +x` on mac/linux), and write a `.hilbertraum-runtime.json` install marker. Idempotent **via the marker** (version + backend must match — a missing/stale marker re-fetches, so a CPU-era drive actually upgrades); `-DryRun`/`--dry-run`. `-Family`/`--family` selects the asset family: `llama_cpp` (default), `whisper_cpp` (the transcriber CLI), or `ocr` (language files). |
 | `verify-models.{ps1,sh}` | SHA-256 each present weight vs its manifest hash (placeholder → *UNVERIFIED*; real mismatch → fail/exit 1). `-Generate`/`--generate` writes `config/checksums.json`. |
 | `setup-dev.{ps1,sh}` | Dev bootstrap: `NODE_OPTIONS=--use-system-ca npm ci` (R6, set only when Node ≥ 22.15 supports the flag; skipped gracefully otherwise; `npm ci` = lockfile-exact, never rewrites `package-lock.json` — issue #49, the dev half of hardening L-8) + build + test smoke. |
-| `verify-electron.mjs` | Root **`postinstall`** (runs on every `npm install`). Verifies Electron's platform binary actually extracted; force-re-extracts from the cached download when a half-extract is detected (the silent NTFS-on-Linux `extract-zip` failure), else fails with an actionable message instead of leaving the opaque electron-vite `Electron uninstall` error for later. Cross-platform Node (not a shell mirror). Skips via `ELECTRON_SKIP_BINARY_DOWNLOAD` / `ELECTRON_OVERRIDE_DIST_PATH` / `HILBERTRAUM_SKIP_ELECTRON_CHECK`. |
+| `verify-electron.mjs` | Root **`postinstall`** (runs on every `npm install`). Detects a genuine HALF-EXTRACT — `path.txt`/`dist/version` present but the platform binary missing or zero-length (the silent NTFS-on-Linux failure) — force-re-extracts it, and otherwise fails with an actionable message instead of leaving the opaque electron-vite `Electron uninstall` error for later. Since wave DEP-4 it is **version-aware**: on Electron ≥ 42 an absent `path.txt` is NORMAL (lazy download) and the script exits 0 silently; on ≤ 41, which still ships the postinstall, an absent `path.txt` is still a broken install. Cross-platform Node (not a shell mirror); the decision half is pure and unit-tested in `tests/unit/verify-electron.test.ts`. Skips via `HILBERTRAUM_SKIP_ELECTRON_CHECK` / `ELECTRON_OVERRIDE_DIST_PATH` / `ELECTRON_SKIP_BINARY_DOWNLOAD` (the last honoured by this script only — Electron ≥ 42 ignores it). |
 
 The asset **download / verify / plan** logic is mirrored from the unit-tested
 `apps/desktop/src/main/services/assets.ts` (the canonical reference for *that* logic — keep in sync),
@@ -492,14 +492,36 @@ the explicit global install is the reliable mechanism and replaced it.
 
 **Why it can run with zero weights / zero network / zero binaries:** the unit + integration suite
 is offline by construction — mock runtime, mock embedder, `electron` mocked — and nothing in
-`typecheck`/`build`/`test` launches Electron. So CI sets two env knobs to skip the ~100 MB Electron
-platform-binary download and the repo's `verify-electron` postinstall (which only guards the
-dev-time NTFS half-extract bug):
+`typecheck`/`build`/`test` launches Electron. So the ~100 MB Electron platform binary is never
+needed in CI.
+
+**How that works changed with Electron 42 (wave DEP-4, 2026-08-18).** Electron **removed the
+`postinstall` binary download** as supply-chain hardening: the package declares no `scripts` at
+all, `install.js` survives only as an `install-electron` bin, and `index.js` downloads **lazily**
+— it reads `path.txt` and, when that or the binary is missing, spawns the installer on first use
+of the electron bin. Two consequences worth stating plainly, because both have already bitten:
+
+- **`ELECTRON_SKIP_BINARY_DOWNLOAD` is dead.** Electron ≥ 42 does not read it anywhere. It was
+  removed from `ci.yml` rather than left in place advertising an effect it no longer has.
+  `scripts/verify-electron.mjs` still honours it as its own knob for older checkouts.
+- **A fresh `npm ci` legitimately leaves NO `path.txt`.** Anything that treats an absent
+  `path.txt` as a broken install is now wrong. `verify-electron.mjs` did exactly that until
+  DEP-4 rewrote it, and would have re-created the very download Electron had just removed, on
+  every clean install, while printing a false NTFS diagnosis. Its check is now version-aware —
+  Electron 39 and 41 still HAVE the postinstall, 42 and 43 do not — because the documented
+  Electron-43 fallback ladder includes `^41.7.2`.
 
 | Env var (CI only) | Effect |
 | --- | --- |
-| `ELECTRON_SKIP_BINARY_DOWNLOAD=1` | Electron's own postinstall skips the platform-binary download. |
-| `HILBERTRAUM_SKIP_ELECTRON_CHECK=1` | [`scripts/verify-electron.mjs`](../scripts/verify-electron.mjs) early-exits (it also early-exits on the var above). |
+| `HILBERTRAUM_SKIP_ELECTRON_CHECK=1` | [`scripts/verify-electron.mjs`](../scripts/verify-electron.mjs) early-exits. Now belt-and-braces rather than load-bearing: the script already exits 0 when the binary is merely not downloaded yet. It stays because it also skips the check on a genuinely half-extracted tree, which CI can neither repair nor usefully diagnose. |
+| `ELECTRON_OVERRIDE_DIST_PATH` | Points at an out-of-tree Electron build; the one env var Electron ≥ 42's `index.js` still reads. |
+
+**Getting the binary on a dev box:** it arrives by itself the first time anything runs the
+electron bin (`npm run dev`, `npm run package:win`). To materialize it deliberately —
+e.g. so `tests/integration/evidence-pack-pdf-smoke.test.ts` (the only automated coverage of
+real Chromium `printToPDF`) does not skip — run `npx electron --version` once. That test now
+says so out loud when it skips for this reason; before DEP-4 it went silent, and the E43 bump
+dropped 6 tests with no failing signal at all.
 
 npm downloads are cached via `actions/setup-node` (`cache: npm`, keyed off the root
 `package-lock.json`); `concurrency: cancel-in-progress` cancels a superseded run when a branch/PR
@@ -576,9 +598,12 @@ publicly linkable.
 
 Non-clash with `ci.yml`: `release.yml` never fires on `pull_request`/`push: master` — only tags and
 manual dispatch. It runs on **Node 24** (electron-builder ships its own pinned Electron runtime),
-which `ci.yml`'s matrix now also covers, does **not** set the `ELECTRON_SKIP_BINARY_DOWNLOAD` knobs
-(packaging needs the binary), and installs with `npm ci` (lockfile-pinned — the CI half of hardening
-L-8). It does **not** pin the exact npm: Node 24 already bundles npm 11.x, so the `engines.npm >= 11`
+which `ci.yml`'s matrix now also covers, does **not** set the skip knobs (packaging needs the
+binary), and installs with `npm ci` (lockfile-pinned — the CI half of hardening L-8). Since
+Electron 42 the mechanism there differs from what this used to describe: `npm ci` downloads
+nothing, and the binary reaches a release leg either lazily on the first electron-bin invocation
+or — for the artifact itself — via electron-builder's own `@electron/get` fetch, which is
+independent of the npm package. The outcome is unchanged. It does **not** pin the exact npm: Node 24 already bundles npm 11.x, so the `engines.npm >= 11`
 floor holds there on the bundled npm; only CI installs the exact `npm@11.6.2`. Pinning here too
 would make the two installs byte-identical, at the cost of exercising a new step for the first time
 on a tag (a release leg has no PR gate ahead of it) — a deliberate, registered residual.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -54,7 +54,22 @@ the intersection of both**. All four policy strings live in `main/window-securit
    (2026-07-19, DEP-1 P4)** by the same method: a `base-uri` injection (both windows) and a
    `blob:` image (ocr window) — each permitted by that page's baked meta — were blocked with
    the `buildCsp(false)` string as the violation's `originalPolicy`, and both baked metas were
-   localhost-free.
+   localhost-free. **Re-confirmed again on the Electron 43.4.0 / Chromium 150.0.7871.224
+   packaged build (2026-08-18, DEP-4 P4)**, the measurement that eight Chromium majors made
+   mandatory: a `base-uri` injection in the main window was blocked, `document.baseURI` stayed
+   on the `file://` document, and the violation's `originalPolicy` was **byte-exact** to
+   `buildCsp(false)`. Both baked metas, read out of the SHIPPED `app.asar`, were byte-exact to
+   `buildMetaCsp(false, page)` and carried no `localhost`, no `ws://` and no `unsafe-eval`.
+   Method note for whoever re-runs this: do **not** measure the header by registering your own
+   `webRequest.onHeadersReceived` — Electron allows only ONE listener per session, so doing so
+   REPLACES the app's handler and the probe then observes the absence of a header it removed
+   itself. Provoke a violation of a directive that exists only in the header (`base-uri`) and
+   read the header back out of the violation's `originalPolicy`. The DEP-4 run measured only
+   the main window at runtime; the OCR window's runtime leg stayed unmeasured because that
+   window opens only for OCR work and the build machine carries no `*.traineddata` — the
+   header is page-agnostic (one session-level handler, one `buildCsp(false)` string), so the
+   mechanism is proven, but the OCR window's runtime `blob:` intersection is still carrying
+   its Electron-39 measurement.
 2. **`<meta http-equiv="Content-Security-Policy">`** in each page — `buildMetaCsp(isDev, page)`,
    **generated at build time** by the `hilbertraum:csp-meta` transform in
    `electron.vite.config.ts`. The checked-in HTML carries the dev policy (Vite HMR needs the

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "apps/*"
       ],
       "engines": {
-        "node": ">=22.5",
+        "node": ">=22.12",
         "npm": ">=11"
       }
     },
@@ -45,13 +45,13 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^22.5.0",
+        "@types/node": "^24.9.0",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/coverage-v8": "^3.2.6",
-        "electron": "^39.8.5",
+        "electron": "^43.4.0",
         "electron-builder": "^26.15.2",
         "electron-vite": "^3.1.0",
         "jsdom": "^29.1.1",
@@ -60,7 +60,7 @@
         "vitest": "^3.2.6"
       },
       "engines": {
-        "node": ">=22.5"
+        "node": ">=22.12"
       }
     },
     "apps/desktop/node_modules/commander": {
@@ -668,6 +668,16 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -772,25 +782,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -3825,13 +3871,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/papaparse": {
@@ -3896,17 +3942,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
@@ -4615,16 +4650,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -6038,22 +6063,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
-      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -6492,27 +6517,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6536,16 +6540,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -6650,21 +6644,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -9636,13 +9615,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11299,9 +11271,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12045,17 +12017,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/coverage-v8": "^3.2.6",
         "electron": "^43.4.0",
-        "electron-builder": "^26.15.2",
+        "electron-builder": "^26.15.7",
         "electron-vite": "^3.1.0",
         "jsdom": "^29.1.1",
         "typescript": "^5.5.4",
@@ -758,29 +758,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@electron/fuses/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/get": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
@@ -870,29 +847,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@electron/notarize/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/osx-sign": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
@@ -915,21 +869,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -943,33 +882,10 @@
         "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
-      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1024,9 +940,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1036,19 +952,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
@@ -1065,16 +968,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/windows-sign": {
@@ -1099,9 +992,9 @@
       }
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1112,31 +1005,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1889,29 +1757,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
@@ -2184,14 +2029,14 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.3.tgz",
+      "integrity": "sha512-SOux4+jikCnOwoJvpBp/grOqzFmJPnNSwe3sAg1Bn93YdmCiDtvolZifJIhiRq0UWMTnLRPj9/ZCMAc2W9VsMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
@@ -4228,9 +4073,9 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.2.tgz",
-      "integrity": "sha512-3mYfKOjr/ZY7gFESOcq8kylBMgGPpmlQYnpBVit4p6zIg0t/8bkWBILdMMtnjFyN2jllyBf225T8dLlz3D6oBQ==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.7.tgz",
+      "integrity": "sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4248,7 +4093,7 @@
         "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.15.0",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -4256,7 +4101,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.15.1",
+        "electron-publish": "26.15.3",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -4280,8 +4125,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.2",
-        "electron-builder-squirrel-windows": "26.15.2"
+        "dmg-builder": "26.15.7",
+        "electron-builder-squirrel-windows": "26.15.7"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -4347,42 +4192,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/app-builder-lib/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/semver": {
@@ -4396,6 +4213,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/argparse": {
@@ -4660,9 +4487,9 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.15.0",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.0.tgz",
-      "integrity": "sha512-dUx+HxVbiNsNQ4mGe1PyoC/tBmsHwBNDLdBuqWCj+rhHFE9lHgrXiGYKAM1uNlznhAaUSyMlms84VeSSr3gOBA==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4697,44 +4524,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/builder-util/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/builder-util/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/builder-util/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/bytestreamjs": {
@@ -5909,55 +5698,17 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.2.tgz",
-      "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.7.tgz",
+      "integrity": "sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -6082,18 +5833,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.2.tgz",
-      "integrity": "sha512-veKM9+dCljaC5A74Pwc0ZWQ9arOHREXWh9hUIf8NGg49ch7x+IB4QhbMzIrV5ONZIXM2OEkaxW11cAPjPtoi4A==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.7.tgz",
+      "integrity": "sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.2",
+        "dmg-builder": "26.15.7",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -6108,110 +5859,34 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.15.2",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.2.tgz",
-      "integrity": "sha512-PNl+SSRoma9mXhxycNGxutZPgvmK19v41mn8F9oecpAU2QNAldpB4HfMuA1LwFC2j8aRzzV5M9HKlKe6dfpvNw==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.7.tgz",
+      "integrity": "sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.2",
-        "builder-util": "26.15.0",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
         "electron-winstaller": "5.4.0"
       }
     },
-    "node_modules/electron-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-builder/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/electron-publish": {
-      "version": "26.15.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.1.tgz",
-      "integrity": "sha512-BMgMHOyexWn0UnOC+Afffw0DMrr0yfLp4U8YsLXwoJ3Da7LS7WUnz21teYZqO0gaApE1KgsjREWmbPqvF5JcPg==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "aws4": "^1.13.2",
-        "builder-util": "26.15.0",
+        "builder-util": "26.15.3",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
-      }
-    },
-    "node_modules/electron-publish/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-publish/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-publish/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6285,6 +5960,26 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -6646,6 +6341,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6835,9 +6545,9 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "optional": true,
@@ -7810,11 +7520,14 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9197,9 +8910,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9210,9 +8923,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9233,9 +8946,9 @@
       }
     },
     "node_modules/node-api-version/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9323,9 +9036,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9887,9 +9600,9 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10433,9 +10146,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10851,9 +10564,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10900,44 +10613,6 @@
       "dependencies": {
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
-      }
-    },
-    "node_modules/temp-file/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/temp-file/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/temp-file/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/tesseract.js": {
@@ -11393,25 +11068,25 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
         "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "11.3.1",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
       }
@@ -11424,9 +11099,9 @@
       "license": "MIT"
     },
     "node_modules/unzipper/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11436,29 +11111,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/unzipper/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/unzipper/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "package:win": "npm run package:win --workspace apps/desktop"
   },
   "engines": {
-    "node": ">=22.5",
+    "node": ">=22.12",
     "npm": ">=11"
   },
   "packageManager": "npm@11.6.2"

--- a/scripts/verify-electron.mjs
+++ b/scripts/verify-electron.mjs
@@ -2,63 +2,82 @@
 // Verify (and self-repair) the Electron platform binary after `npm install`.
 //
 // WHY THIS EXISTS — the NTFS half-extract bug:
-//   Electron's own postinstall (`node_modules/electron/install.js`) downloads a ~100 MB zip
-//   and unpacks it with `extract-zip`. On some mounts — notably an NTFS volume mounted on
-//   Linux (ntfs-3g/FUSE) — the unpack can SILENTLY fail to write the binary while still
-//   creating empty folders (e.g. `dist/locales/`). The download itself succeeds (a valid zip
-//   sits in the @electron/get cache), so there is nothing to retry at the download layer.
-//   Worse: once `node_modules/electron` exists and the lockfile matches, npm considers the
-//   package installed and NEVER re-runs its postinstall — so a second `npm install` cannot
-//   repair it. The damage only surfaces much later as electron-vite's opaque
-//   `Electron uninstall` ("binary not found") error.
+//   Electron downloads a ~100 MB zip and unpacks it. On some mounts — notably an NTFS volume
+//   mounted on Linux (ntfs-3g/FUSE) — the unpack can SILENTLY fail to write the binary while
+//   still creating empty folders (e.g. `dist/locales/`). The download itself succeeds (a valid
+//   zip sits in the @electron/get cache), so there is nothing to retry at the download layer.
+//   The damage surfaces much later as electron-vite's opaque `Electron uninstall` error.
 //
-// This script runs as the ROOT package's `postinstall`, which npm executes on EVERY
-// `npm install` (cached deps or not). On a healthy install it is a couple of stat() calls and
-// exits. When the binary is missing/empty it force-re-runs Electron's installer (re-extracting
-// from the cached zip), then re-verifies — converting a silent, deferred, opaque failure into
-// an immediate one that either self-heals or prints an actionable message.
+// WHAT CHANGED IN ELECTRON 42 (wave DEP-4, 2026-08-18) — read this before editing:
+//   Electron >= 42 REMOVED the `postinstall` binary download (supply-chain hardening). The
+//   package now declares no `scripts` at all; `install.js` survives only as a bin
+//   (`install-electron`), and `index.js` downloads LAZILY — it reads `path.txt` and, when that
+//   or the binary is missing, spawns `install.js` on first use of the bin.
+//
+//   So on Electron >= 42, `path.txt` is ABSENT after a healthy `npm ci`. That is NORMAL.
+//   The previous version of this script treated an absent `path.txt` as "extract did not
+//   finish" and responded by deleting dist/ and spawning install.js — which, on every clean
+//   install, printed a false "binary looks broken" error with a wrong NTFS diagnosis and then
+//   re-created the very ~100 MB postinstall download Electron had just removed on purpose,
+//   also defeating the `npm ci --ignore-scripts` flow that motivated the upstream change.
+//
+//   The version check below is NOT decoration. Electron 39 and 41 still HAVE the postinstall
+//   (verified against the registry: 39.8.10 and 41.10.6 declare `postinstall: node install.js`;
+//   42.9.3 and 43.4.0 declare no scripts at all). On those versions an absent `path.txt` really
+//   does mean a broken install. This repo's documented Electron-43 fallback ladder includes
+//   ^41.7.2, so a version-blind script would silently lose the NTFS protection on that path.
+//
+// What this script still catches on EVERY version: the genuine half-extract — `path.txt` (or
+// `dist/version`) present, but the platform binary missing or zero-length. npm will not re-run
+// a postinstall for an already-installed package, so on Electron < 42 a second `npm install`
+// cannot repair that; and on >= 42 a half-written dist/ makes the lazy path fail opaquely.
 //
 // Escape hatches (skip the check entirely):
-//   ELECTRON_SKIP_BINARY_DOWNLOAD=1     (binary intentionally absent — e.g. CI lint-only)
-//   ELECTRON_OVERRIDE_DIST_PATH=...     (using an out-of-tree Electron build)
-//   HILBERTRAUM_SKIP_ELECTRON_CHECK=1   (manual override)
+//   HILBERTRAUM_SKIP_ELECTRON_CHECK=1   (manual override — what CI sets)
+//   ELECTRON_OVERRIDE_DIST_PATH=...     (using an out-of-tree Electron build; still honored by
+//                                        electron >= 42's index.js, the one env var it reads)
+//   ELECTRON_SKIP_BINARY_DOWNLOAD=1     (kept as OUR OWN knob for older checkouts; note that
+//                                        electron >= 42 no longer honors it itself)
 
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 
 const TAG = '[verify-electron]';
 
-if (
-  process.env.ELECTRON_SKIP_BINARY_DOWNLOAD ||
-  process.env.ELECTRON_OVERRIDE_DIST_PATH ||
-  process.env.HILBERTRAUM_SKIP_ELECTRON_CHECK
-) {
-  process.exit(0);
-}
+/** Electron >= 42 removed the postinstall; the binary arrives lazily on first bin invocation. */
+export const LAZY_DOWNLOAD_MAJOR = 42;
 
-// Locate the installed electron package from the repo root. If it isn't installed at all
-// (e.g. a slimmed production context), there is nothing to verify — succeed quietly.
-const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
-const require = createRequire(path.join(repoRoot, 'package.json'));
-let electronDir;
-try {
-  electronDir = path.dirname(require.resolve('electron/package.json'));
-} catch {
-  process.exit(0);
-}
-
-// Mirror electron/index.js: the real executable is `dist/<contents of path.txt>`. A missing
-// path.txt, a missing `dist/version`, or a missing/empty binary all mean a broken extract.
-function binaryProblem() {
+/**
+ * Classify an installed electron package directory.
+ *
+ * Returns `null` when there is nothing to do — either a healthy install, or the perfectly
+ * normal "binary not downloaded yet" state on Electron >= 42. Returns a human-readable problem
+ * string when the install is genuinely damaged and worth repairing.
+ *
+ * Exported for tests: this is the whole decision, and it has no side effects.
+ */
+export function diagnose(electronDir, major) {
   const distDir = path.join(electronDir, 'dist');
   const pathFile = path.join(electronDir, 'path.txt');
-  if (!fs.existsSync(pathFile)) return 'path.txt is missing (extract did not finish)';
-  if (!fs.existsSync(path.join(distDir, 'version'))) return 'dist/version is missing (extract did not finish)';
+
+  if (!fs.existsSync(pathFile)) {
+    // Electron >= 42: nothing has run the bin yet, so no path.txt exists. Healthy, do nothing.
+    if (major >= LAZY_DOWNLOAD_MAJOR) return null;
+    // Electron < 42: the postinstall should have written it. This IS a broken install.
+    return 'path.txt is missing (postinstall did not finish)';
+  }
+
+  // From here the download HAS run at least once, on every version — so anything missing below
+  // is a real half-extract, which is exactly the NTFS-on-Linux failure this script exists for.
+  if (!fs.existsSync(path.join(distDir, 'version'))) {
+    return 'dist/version is missing (extract did not finish)';
+  }
   const rel = fs.readFileSync(pathFile, 'utf-8').trim();
   if (!rel) return 'path.txt is empty';
+
   const binary = path.join(distDir, rel);
   let st;
   try {
@@ -70,47 +89,91 @@ function binaryProblem() {
   return null; // healthy
 }
 
-let problem = binaryProblem();
-if (!problem) process.exit(0); // healthy — the common path
-
-console.error(`${TAG} Electron binary looks broken (${problem}).`);
-console.error(`${TAG} This is the classic half-extracted install (often an NTFS-on-Linux mount).`);
-console.error(`${TAG} Forcing a clean re-extract from the cached download…`);
-
-// Remove the half-written dist so install.js takes the "not installed" path and re-extracts
-// cleanly instead of tripping over leftover empty folders.
-try {
-  fs.rmSync(path.join(electronDir, 'dist'), { recursive: true, force: true });
-} catch (err) {
-  console.error(`${TAG} could not remove stale dist/: ${err.message}`);
+/** Read the installed electron's major version; returns null if it can't be determined. */
+export function readElectronMajor(electronDir) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(electronDir, 'package.json'), 'utf-8'));
+    const major = Number.parseInt(String(pkg.version), 10);
+    return Number.isFinite(major) ? major : null;
+  } catch {
+    return null;
+  }
 }
 
-const installJs = path.join(electronDir, 'install.js');
-const res = spawnSync(process.execPath, [installJs], {
-  cwd: electronDir,
-  stdio: 'inherit',
-  env: process.env,
-});
+function main() {
+  if (
+    process.env.ELECTRON_SKIP_BINARY_DOWNLOAD ||
+    process.env.ELECTRON_OVERRIDE_DIST_PATH ||
+    process.env.HILBERTRAUM_SKIP_ELECTRON_CHECK
+  ) {
+    return 0;
+  }
 
-problem = binaryProblem();
-if (!problem && res.status === 0) {
-  console.error(`${TAG} Re-extract succeeded — Electron binary is present.`);
-  process.exit(0);
+  // Locate the installed electron package from the repo root. If it isn't installed at all
+  // (e.g. a slimmed production context), there is nothing to verify — succeed quietly.
+  const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+  const require = createRequire(path.join(repoRoot, 'package.json'));
+  let electronDir;
+  try {
+    electronDir = path.dirname(require.resolve('electron/package.json'));
+  } catch {
+    return 0;
+  }
+
+  // An unreadable version is treated as >= 42 (the current line): the failure mode of guessing
+  // "modern" is a no-op, while guessing "old" would resurrect the false-alarm download.
+  const major = readElectronMajor(electronDir) ?? LAZY_DOWNLOAD_MAJOR;
+
+  let problem = diagnose(electronDir, major);
+  if (!problem) return 0; // healthy, or not-yet-downloaded on >= 42 — the common path
+
+  console.error(`${TAG} Electron binary looks broken (${problem}).`);
+  console.error(`${TAG} This is the classic half-extracted install (often an NTFS-on-Linux mount).`);
+  console.error(`${TAG} Forcing a clean re-extract from the cached download…`);
+
+  // Remove the half-written dist so install.js takes the "not installed" path and re-extracts
+  // cleanly instead of tripping over leftover empty folders.
+  try {
+    fs.rmSync(path.join(electronDir, 'dist'), { recursive: true, force: true });
+  } catch (err) {
+    console.error(`${TAG} could not remove stale dist/: ${err.message}`);
+  }
+
+  // install.js is still a plain CJS file at the package root on every version in play — the
+  // `postinstall` script entry disappeared in 42, the file did not (it became the
+  // `install-electron` bin). Spawning it directly works on both sides of that change.
+  const installJs = path.join(electronDir, 'install.js');
+  const res = spawnSync(process.execPath, [installJs], {
+    cwd: electronDir,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  problem = diagnose(electronDir, major);
+  if (!problem && res.status === 0) {
+    console.error(`${TAG} Re-extract succeeded — Electron binary is present.`);
+    return 0;
+  }
+
+  // Still broken: the mount genuinely can't hold the binary. Fail loudly with the real remedy
+  // rather than letting electron-vite throw its opaque "Electron uninstall" later.
+  console.error('');
+  console.error(`${TAG} ERROR: Electron's platform binary is still not installed (${problem || 'install.js exited ' + res.status}).`);
+  console.error(`${TAG} The unzip step cannot reliably write the binary onto this filesystem.`);
+  console.error(`${TAG} This is almost always an NTFS volume mounted on Linux (ntfs-3g/FUSE):`);
+  console.error(`${TAG} it can create folders but drops the large/executable files during unzip.`);
+  console.error('');
+  console.error(`${TAG} Fix: put node_modules on a native filesystem, then point the project at it:`);
+  console.error(`${TAG}   • clone/copy this repo onto an ext4/Btrfs/APFS disk and run npm install there, or`);
+  console.error(`${TAG}   • keep the repo on NTFS but redirect node_modules to a native disk:`);
+  console.error(`${TAG}       npm install --install-links=false   # then symlink node_modules → native path`);
+  console.error(`${TAG} (The portable HilbertRaum DRIVE itself can stay NTFS — this only affects the`);
+  console.error(`${TAG}  dev-time node_modules where Electron unpacks its binary.)`);
+  console.error('');
+  return 1;
 }
 
-// Still broken: the mount genuinely can't hold the binary. Fail loudly with the real remedy
-// rather than letting electron-vite throw its opaque "Electron uninstall" later.
-console.error('');
-console.error(`${TAG} ERROR: Electron's platform binary is still not installed (${problem || 'install.js exited ' + res.status}).`);
-console.error(`${TAG} extract-zip cannot reliably write the binary onto this filesystem.`);
-console.error(`${TAG} This is almost always an NTFS volume mounted on Linux (ntfs-3g/FUSE):`);
-console.error(`${TAG} it can create folders but drops the large/executable files during unzip.`);
-console.error('');
-console.error(`${TAG} Fix: put node_modules on a native filesystem, then point the project at it:`);
-console.error(`${TAG}   • clone/copy this repo onto an ext4/Btrfs/APFS disk and run npm install there, or`);
-console.error(`${TAG}   • keep the repo on NTFS but redirect node_modules to a native disk:`);
-console.error(`${TAG}       npm install --install-links=false   # then symlink node_modules → native path`);
-console.error(`${TAG} (The portable HilbertRaum DRIVE itself can stay NTFS — this only affects the`);
-console.error(`${TAG}  dev-time node_modules where Electron unpacks its binary.)`);
-console.error('');
-process.exit(1);
+// Only act when run as a script; importing this module (tests) must have no side effects.
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  process.exit(main());
+}


### PR DESCRIPTION
Clears the repo's **last open Dependabot alert** — [#83](https://github.com/HilbertraumAI/HilbertRaum/security/dependabot/83) / issue #179, GHSA-jmr9-qjv8-65gv (CVE-2026-56876, high, CVSS 8.1): `extract-zip <= 2.0.1` unvalidated symlink path traversal.

It could not be patched. `first_patched_version` is `null`, `extract-zip` is abandoned at 2.0.1 (last publish 2023-03), and upstream Electron's remediation was **replacement, not repair**. An `overrides` alias was already tested and rejected in #179 (ESM-only + native NAPI fork vs Electron 39's CJS `require()` — every contributor's `npm ci` breaks while CI stays green). So the only way to clear it is to move Electron.

**`npm ls extract-zip` → empty. `npm audit` → 0 vulnerabilities** (was 2 high).

## What moves

| | Before | After |
|---|---|---|
| `electron` | 39.8.10 | **43.4.0** |
| Chromium | 142.0.7444.265 | **150.0.7871.224** (+8 majors) |
| Node (main) | 22.22.1 | **24.18.1** |
| SQLite (`node:sqlite`) | 3.51.2 | **3.53.1** |
| `@types/node` | ^22.5.0 | **^24.9.0** |
| `engines.node` | `>=22.5` | **`>=22.12`** |
| `electron-builder` | 26.15.2 | **26.15.7** |

Target **43**, not the smallest clearing major, because Electron supports only the latest three stable majors (41/42/43) — landing on 40 would mean re-running this wave at the next Electron CVE.

**No production dependency moves** (devDependency-only at the npm level) and **no on-disk format changes**, so existing encrypted workspaces open unchanged in both directions. **Minimum OS floors are unchanged** — the `## Platform support` sections of the v39.8.10 and v43.4.0 READMEs are byte-identical (Windows 10+, macOS 12+). No machine is dropped.

## Two landmines the issue didn't mention

**1. `scripts/verify-electron.mjs` was silently invalidated.** Electron ≥ 42 removed the postinstall binary download; the binary now arrives lazily, so **`path.txt` legitimately does not exist after a healthy fresh `npm ci`**. The old script read that as "extract did not finish", deleted `dist/`, and spawned `install.js` — meaning our own postinstall would have **re-created the ~100 MB download Electron deliberately removed**, on every clean install, while printing a false NTFS diagnosis. Proven, not argued: the old decision function returns `path.txt is missing` for a *healthy* E43 install. CI never caught it (it early-exits the script) and the script had no tests — it called `process.exit` at import time, so it was untestable by construction. Rewritten as a verifier, now **version-aware** (39/41 still have the postinstall; 42/43 don't) because the documented fallback ladder includes `^41.7.2`. +22 unit tests.

**2. The `electronVersion` parity test DEP-1 registered was never written.** `electron-builder.yml`'s `electronVersion:`, not the npm devDependency, selects the runtime that actually ships — and DEP-1 §4(b) records that its first `package:win` silently shipped Electron 37 after the devDep said 39, caught only because a human noticed. This PR writes that test **first**, and it paid off immediately: between the lockfile edit and the yml edit it went red with `expected '39.8.10' to be '43.4.0'`, then green on sync.

## Measured on the real packaged build

The suite mocks `electron` and runs the renderer under jsdom, so **a green CI proves nothing about Chromium**. These come from a packaged Windows artifact:

- **CSP on `file://` still attaches AND enforces.** A `base-uri` injection was blocked, `document.baseURI` unchanged, and the violation's `originalPolicy` is **byte-exact** to `buildCsp(false)`. Both baked metas — read out of the shipped `app.asar` — are byte-exact to `buildMetaCsp(false, page)`, with no `localhost`, `ws://` or `unsafe-eval`.
- **FTS5** `bm25()` / `snippet()` / `highlight()` all correct; Node 24.18.1 / SQLite 3.53.1.
- **`printToPDF`** accepts the full D-1 option set; valid `%PDF-1.4 … %%EOF`; `generateTaggedPDF` now emits real `StructTreeRoot`/`MarkInfo`.
- **Permission taxonomy, both directions** (the two-sided risk — a Chromium rename breaks dictation *or* silently widens a grant): request path `getUserMedia({audio:true})` **GRANTED**; check path `microphone: granted`, `camera`/`geolocation`/`notifications` **denied**.
- **Packaged renderer** paints with zero console errors.

**Not measured, recorded as gaps rather than passes:** dev-mode OCR recognize, and the OCR window's *runtime* CSP leg — this build machine carries no `*.traineddata`. The header is page-agnostic, so the mechanism is proven by the main window; the OCR window's baked meta was verified byte-exact.

## Also in the wave

- **electron-builder → 26.15.7** (its own commit). 26.15.2 sits inside the #9983 window where the NSIS extractor can't decode the BCJ2 filter and **silently drops every PE file while exiting 0**. Unrelated to Electron and pre-existing. Verified on the artifact: the NSIS-extracted payload is **SHA-256 identical** to `win-unpacked` and the extracted app runs.
- **An interlude commit** fixing `#157 DT-2`, which was living on 6% timing headroom (a ~9.4 s test under a hand-rolled 10 s poll bound) and failed 3 of 5 loaded runs. No semantics loosened.
- **`evidence-pack-pdf-smoke.test.ts` had silently stopped running** — it gates on `path.txt`, so the bump dropped 6 tests with no failing signal; the only trace was the skip count moving 50 → 56. That's the only automated coverage of real Chromium `printToPDF`. It now says why it skipped.
- `ELECTRON_SKIP_BINARY_DOWNLOAD` removed from `ci.yml` (Electron ≥ 42 ignores it).

## Gate

typecheck → build → test at every phase, in that order. Suite **5223/50/5273 → 5249/50/5299** (376 files): +26 tests are this wave's deliberate additions (+4 parity, +22 verify-electron), skips back at exactly **50**.

Durable record: `docs/architecture.md` → "Electron 39 → 43 — design record (wave DEP-4)", with a §-anchor legend. `BUILD_STATE.md` §5 item 18 carries the follow-ups — including that **Electron 44 is a customer-facing decision, not a routine bump**: it drops macOS 12 and 32-bit Windows, and **E43 is the last series with prebuilt 32-bit binaries** (EOL January 2027).

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
