### PR TITLE
fix(ingestion): portable stored-copy resolver — "delete" now actually deletes (#188)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,33 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-19 — **Portable stored copies — wave CLOSED (issue #188).**_ `documents.stored_path` was
+persisted **absolute** and consumed with a bare `existsSync` at six hand-written ladders, so a
+portable drive returning under a different mount point took **every** stored copy stale at once —
+row intact, bytes intact, only the recorded string wrong. It was the **last absolute path in
+persisted state** (images, skills, checksum cache, runtime marker and `source_relative_path` had
+each already been made portable by a named prior finding), and the vault layer already disagreed:
+rekey enumerates `workspace/documents/` by directory walk. The reported export failure was the
+SMALLEST of three defects sharing that cause: **"Delete document" silently did not delete** — the
+shred's `existsSync` guard conflated "already gone, nothing to do" with "I looked in the wrong
+place", leaving encrypted user content on the drive with no row left to ever reference it
+(**measured** pre-fix, not inferred) — and re-index degraded a healthy row to `failed`. Fixed at
+the **resolver**, not the reporting screen: new `services/ingestion/stored-copy.ts` +
+`documents.stored_name` (portable leaf, lazily healed), adopted by all six sites including the
+shred; `DocumentInfo.storedCopy` so the `⋯` menu stops offering what cannot succeed;
+`original_path` demoted to a sha256-checked last resort. **Durable record:** `docs/architecture.md`
+"Portable stored copies — design record (wave 188, issue #188, §1–§8)" — decisions D1–D6, the
+safety guard the shred rests on, the verified-clean list, and the bundler landmine (§8: a string
+literal ending in the bare word `import` makes electron-vite wedge its CommonJS shim inside the
+literal; typecheck and the full suite pass and only `npm run build` fails — now tripwired in
+`repo-hygiene.test.ts`, and the standing argument for the typecheck → build → test gate order).
+**STILL OPEN, both carried into §5 item 1:** the real relocated-drive run (the code is now correct;
+the second-laptop continuity check is only *answered* by hardware), and the read-only root-cause
+diagnostic on the reporting drive, which was never run — it needs the owner's password and would
+also settle whether that drive's rows are in fact stale (the issue reports "Vorschau works"
+alongside the export failure, and preview and export share one ladder, so both cannot describe the
+same document) and count the orphaned `.enc` files past silent deletes left behind.
+
 _2026-08-18 — **Local API endpoint — wave CLOSED (P1–P6), PR #184.**_ The loaded chat model
 can now be used by **other programs on the same computer** through an opt-in, loopback-only,
 OpenAI-compatible endpoint — **off by default**, behind a consent dialog, access-key-protected by
@@ -917,7 +944,17 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    portable `.exe` + a **signed & notarized** macOS `.app`, run `build-commercial-drive`
    end-to-end onto a real drive (`-AppArtifact` the signed build), then do the spec §17 demo on
    a **fresh laptop with Wi-Fi off** + the **second-laptop continuity** check (same encrypted
-   workspace, different drive letter). The `electron-builder.yml` hooks + the pipeline are
+   workspace, different drive letter). **⚠️ 2026-08-19, wave 188 — this check has already
+   FIRED once, from a real drive, before it was ever run deliberately:** issue #188 was exactly the
+   failure it exists to catch (`documents.stored_path` absolute ⇒ every stored copy stale under a
+   different mount point, and "Delete document" silently not deleting). The code is fixed and
+   covered by `stored-copy-portability.test.ts`, but the manual check is **NOT** answered — a
+   moved-directory unit test is not a relocated drive. When it is finally run, cover **export
+   original / preview / re-index / delete** on a workspace populated under a DIFFERENT letter, and
+   confirm the rows self-heal (`documents.stored_name` populated after the first read).
+   **Also still owed:** the read-only #188 root-cause diagnostic on the reporting drive (needs the
+   owner password; settles whether that drive was stale and counts orphaned `.enc` files left by
+   past silent delete no-ops — architecture.md record §6). The `electron-builder.yml` hooks + the pipeline are
    wired; only the secrets + hardware are missing. **GPU additions:** a SmartScreen sanity
    re-check (the Vulkan build adds one more unsigned DLL of the same class) and re-running
    `build-commercial-drive` end-to-end with the two-build fetch. **Phase-38 addition:** a

--- a/apps/desktop/src/main/ipc/registerCollectionsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerCollectionsIpc.ts
@@ -11,7 +11,7 @@ import {
   renameCollection,
   setCollectionArchived
 } from '../services/collections'
-import { deleteDocument } from '../services/ingestion'
+import { deleteDocument, documentsDir } from '../services/ingestion'
 import { tMain } from '../services/i18n'
 import { workspaceAdmitsWork } from '../services/workspace-vault'
 
@@ -91,7 +91,7 @@ export function registerCollectionsIpc(ctx: AppContext): void {
         const onlyHere = projectOnlyDocumentIds(ctx.db, id)
         deleteCollection(ctx.db, id)
         for (const docId of onlyHere) {
-          deleteDocument(ctx.db, docId)
+          deleteDocument(ctx.db, documentsDir(ctx.paths.workspacePath), docId)
           deletedCount += 1
         }
       } else {

--- a/apps/desktop/src/main/ipc/registerDocsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDocsIpc.ts
@@ -571,7 +571,9 @@ export function registerDocsIpc(ctx: AppContext): void {
     // (search is scoped to `ctx.embedder.id`), so the UI can prompt a re-index.
     // Merge in-memory transcription progress so the polling UI can show
     // "Transcribing… N%" without any new channel.
-    const docs = listDocuments(ctx.db, ctx.embedder.id).map((d) => {
+    // #188: pass the store dir so every row carries `storedCopy` — the `⋯` menu needs to know
+    // whether a byte-level action can succeed BEFORE offering it. One readdir per call.
+    const docs = listDocuments(ctx.db, ctx.embedder.id, storeDir).map((d) => {
       const percent = transcribing.get(d.id)
       return percent !== undefined && d.status === 'extracting'
         ? { ...d, transcriptionProgress: percent }
@@ -598,7 +600,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     requireNoActiveTask(documentId)
     requireNoActiveSkillRun(documentId)
     log.info('Delete document', { documentId })
-    deleteDocument(ctx.db, documentId)
+    deleteDocument(ctx.db, storeDir, documentId)
     ctx.audit?.('document_deleted', 'Document deleted', { documentId })
   })
 
@@ -649,7 +651,7 @@ export function registerDocsIpc(ctx: AppContext): void {
         })
       }
       // Return the affected documents, fully populated (collections come from listDocuments).
-      const byId = new Map(listDocuments(ctx.db, ctx.embedder.id).map((d) => [d.id, d]))
+      const byId = new Map(listDocuments(ctx.db, ctx.embedder.id, storeDir).map((d) => [d.id, d]))
       return ids.map((id) => byId.get(id)).filter((d): d is DocumentInfo => d != null)
     }
   )

--- a/apps/desktop/src/main/services/db.ts
+++ b/apps/desktop/src/main/services/db.ts
@@ -1009,6 +1009,13 @@ export function openDatabase(path: string): Db {
   // grammar allows no DEFAULT/NOT NULL, so NULL is the sentinel, coalesced in code
   // (`lifecycle` NULL ⇒ 'permanent', the parseScope precedent).
   ensureColumn(db, 'documents', 'lifecycle', 'lifecycle TEXT')
+  // Issue #188 — the stored copy's leaf name (`<id><ext>[.enc]`), RELATIVE to the workspace's
+  // `documents/` dir, mirroring `image_sessions.stored_name` and `skills.path`. `stored_path`
+  // stays (it is what a legacy row carries, and the tooltip/provenance reads it) but is no
+  // longer authoritative: it is absolute, so it goes stale the moment the drive comes back
+  // under a different mount point. Nullable — NULL means "not yet healed", and the resolver
+  // derives the leaf from `stored_path` and writes it back on the next read (D3, lazy).
+  ensureColumn(db, 'documents', 'stored_name', 'stored_name TEXT')
   ensureColumn(db, 'documents', 'source_relative_path', 'source_relative_path TEXT')
   ensureColumn(db, 'documents', 'source_folder_label', 'source_folder_label TEXT')
   ensureColumn(db, 'documents', 'pending_destination_json', 'pending_destination_json TEXT')

--- a/apps/desktop/src/main/services/doctasks/handlers/ocr.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/ocr.ts
@@ -8,7 +8,8 @@ import { join } from 'node:path'
 import { tMain } from '../../i18n'
 import { getDocument, reindexDocument, setDocumentOcr } from '../../ingestion'
 import type { OcrPage } from '../../ocr'
-import { ENCRYPTED_DOC_SUFFIX, shredFile } from '../../workspace-vault'
+import { shredFile } from '../../workspace-vault'
+import { resolveStoredCopy } from '../../ingestion/stored-copy'
 import { isAbortError } from '../../chat'
 import { log } from '../../logging'
 import type { DocTaskCtx, InternalTask } from '../context'
@@ -124,27 +125,37 @@ export async function runOcr(task: InternalTask, ctx: DocTaskCtx): Promise<strin
 async function readStoredPdfBytes(documentId: string, ctx: DocTaskCtx): Promise<Buffer> {
   const db = ctx.deps.getDb()
   const row = db
-    .prepare('SELECT title, stored_path, original_path FROM documents WHERE id = ?')
+    .prepare('SELECT id, title, stored_path, stored_name, original_path FROM documents WHERE id = ?')
     .get(documentId) as unknown as
-    | { title: string; stored_path: string | null; original_path: string | null }
+    | {
+        id: string
+        title: string
+        stored_path: string | null
+        stored_name: string | null
+        original_path: string | null
+      }
     | undefined
   if (!row) throw new Error(tMain('main.task.sourceUnreadable'))
   const cipher = ctx.deps.getIngestionDeps().cipher ?? null
+  const storeDir = ctx.deps.getStoreDir()
   try {
     // ING-8 (perf audit 2026-06-18): read the (potentially huge, up to ~1 GiB) PDF with async
     // `readFile` so the bytes stream off the main event loop instead of a blocking `readFileSync`.
-    if (row.stored_path && existsSync(row.stored_path)) {
-      if (row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX)) {
+    // #188: located through the shared resolver, so "Make searchable" still finds the stored PDF
+    // after the drive comes back under a different mount point.
+    const stored = resolveStoredCopy(db, storeDir, row)
+    if (stored) {
+      if (stored.encrypted) {
         if (!cipher) throw new Error(tMain('main.task.sourceUnreadable'))
-        const transient = join(ctx.deps.getStoreDir(), `${documentId}.parse-ocr.pdf`)
+        const transient = join(storeDir, `${documentId}.parse-ocr.pdf`)
         try {
-          await cipher.decryptFileAsync(row.stored_path, transient) // PERF-1: yields between chunks
+          await cipher.decryptFileAsync(stored.path, transient) // PERF-1: yields between chunks
           return await readFile(transient)
         } finally {
           shredFile(transient)
         }
       }
-      return await readFile(row.stored_path)
+      return await readFile(stored.path)
     }
     if (row.original_path && existsSync(row.original_path)) {
       return await readFile(row.original_path)

--- a/apps/desktop/src/main/services/doctasks/handlers/shared.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/shared.ts
@@ -167,7 +167,7 @@ export async function materializeDocument(
     })
     return info.id
   } catch (err) {
-    if (newDocId) deleteDocument(db, newDocId)
+    if (newDocId) deleteDocument(db, storeDir, newDocId)
     throw err
   } finally {
     shredFile(tempPath)

--- a/apps/desktop/src/main/services/ingestion/index.ts
+++ b/apps/desktop/src/main/services/ingestion/index.ts
@@ -48,6 +48,13 @@ import { PDF_SCAN_DETECTED_MESSAGE } from './parsers/pdf'
 import { parseOcrMeta } from './ocr-meta'
 import { chunkSegments, MAX_CHUNKS_PER_DOCUMENT } from './chunker'
 import { resolveIngestionLimits, withParseTimeout, type IngestionLimits } from './limits'
+import {
+  canonicalLeafFor,
+  locateOriginal,
+  locateStoredCopy,
+  resolveStoredCopy,
+  warnOriginalChanged
+} from './stored-copy'
 
 // Ingestion service (spec §7.7). Owns the document lifecycle:
 //   queued → extracting → chunking → embedding → indexed   (failed on error)
@@ -155,6 +162,8 @@ interface DocumentRow {
   title: string
   original_path: string | null
   stored_path: string | null
+  /** #188: leaf name of the stored copy, relative to the store dir. NULL until healed. */
+  stored_name?: string | null
   mime_type: string | null
   size_bytes: number | null
   sha256: string | null
@@ -334,11 +343,51 @@ function ocrInfoForRow(row: DocumentRow): DocumentOcrInfo | null {
   return ocrInfoOf(parseOcr(row.ocr_json))
 }
 
-function rowToInfo(row: DocumentRow, chunkCount: number, staleEmbeddings?: boolean): DocumentInfo {
+/**
+ * #188 — whether a document's workspace copy is on disk right now, for the callers that have a
+ * store dir. Derived from ONE `readdirSync` of the store per list call (`present` is a Set
+ * lookup), never a `statSync` per row: `listDocuments` is polled every 400 ms during an import
+ * and on USB each stat is a real seek (the ING-4 reasoning). `undefined` when the caller passed
+ * no store dir — those call sites are byte-identical to before.
+ */
+function storedCopyStateFor(
+  row: DocumentRow,
+  present: Set<string> | null
+): DocumentInfo['storedCopy'] {
+  if (!present) return undefined
+  const leaf = canonicalLeafFor(row)
+  if (leaf && present.has(leaf)) return 'present'
+  // A row whose file sits outside the store (a legacy absolute path that still resolves on this
+  // machine) is present too — the readers accept it, so the menu must not claim otherwise.
+  if (row.stored_path && existsSync(row.stored_path)) return 'present'
+  return 'missing'
+}
+
+/**
+ * ONE directory read of the store, turned into a name Set. Costs a single readdir per list
+ * call instead of N stats; null when the caller supplied no store dir, or the dir is
+ * unreadable (then no row claims to be missing — never scare the UI on a transient error).
+ */
+function storedCopyIndex(storeDir: string | undefined): Set<string> | null {
+  if (!storeDir) return null
+  try {
+    return new Set(readdirSync(storeDir))
+  } catch {
+    return null
+  }
+}
+
+function rowToInfo(
+  row: DocumentRow,
+  chunkCount: number,
+  staleEmbeddings?: boolean,
+  storedPresent: Set<string> | null = null
+): DocumentInfo {
   return {
     id: row.id,
     title: row.title,
     originalPath: row.original_path,
+    storedCopy: storedCopyStateFor(row, storedPresent),
     mimeType: row.mime_type,
     sizeBytes: row.size_bytes,
     status: toStatus(row.status),
@@ -686,14 +735,20 @@ export async function prepareDocument(
     const ext = extname(row.title).toLowerCase()
     const cipher = deps.cipher ?? null
 
-    // Ensure a self-contained workspace copy exists (`stored_path`). In an encrypted
-    // workspace the copy rests ENCRYPTED (`<id><ext>.enc`); `sha256`/`size_bytes`
-    // describe the plaintext content in both modes.
-    let storedPath = row.stored_path
+    // Ensure a self-contained workspace copy exists. In an encrypted workspace the copy
+    // rests ENCRYPTED (`<id><ext>.enc`); `sha256`/`size_bytes` describe the plaintext
+    // content in both modes.
+    //
+    // #188: the copy is LOCATED through the resolver, not read off `row.stored_path` — an
+    // absolute path recorded under a previous mount point would otherwise look "missing"
+    // here and send a perfectly healthy document down the re-copy path (or, with the
+    // original gone too, straight to `failed`).
+    const located = resolveStoredCopy(db, storeDir, row)
+    let storedPath = located?.path ?? null
     /** The plaintext file the parser reads. */
     let parseSource: string
 
-    if (!storedPath || !existsSync(storedPath)) {
+    if (!storedPath) {
       const origin = row.original_path
       if (!origin || !existsSync(origin)) {
         // Persist-canonical English (i18n record §3.3 rule 1): the catch below writes
@@ -716,12 +771,11 @@ export async function prepareDocument(
         await copyFile(origin, storedPath)
         parseSource = storedPath
       }
-      db.prepare('UPDATE documents SET stored_path = ?, sha256 = ?, size_bytes = ? WHERE id = ?').run(
-        storedPath,
-        sha,
-        size,
-        documentId
-      )
+      // #188: record the portable leaf alongside the absolute path. `stored_name` is what the
+      // resolver trusts; `stored_path` is kept for legacy readers and provenance.
+      db.prepare(
+        'UPDATE documents SET stored_path = ?, stored_name = ?, sha256 = ?, size_bytes = ? WHERE id = ?'
+      ).run(storedPath, basename(storedPath), sha, size, documentId)
       // Covers the source hash + the copy (encrypted or plain) into the workspace.
       perfMark('ingest_copy_done', { docId: documentId, bytes: size, ms: perfMs(copyT0) })
     } else if (cipher && !storedPath.endsWith(ENCRYPTED_DOC_SUFFIX)) {
@@ -729,9 +783,15 @@ export async function prepareDocument(
       // existed (or in plaintext mode). Re-indexing in an encrypted workspace upgrades
       // the stored copy: encrypt it, point the row at the `.enc`, parse the old
       // plaintext one last time, then shred it.
+      // #188: `storedPath` is the RESOLVED location, so the `.enc` lands beside the copy that
+      // actually exists (not beside a stale recorded path), and the portable leaf moves with it.
       const encPath = `${storedPath}${ENCRYPTED_DOC_SUFFIX}`
       await cipher.encryptFileAsync(storedPath, encPath) // PERF-1: yields between chunks
-      db.prepare('UPDATE documents SET stored_path = ? WHERE id = ?').run(encPath, documentId)
+      db.prepare('UPDATE documents SET stored_path = ?, stored_name = ? WHERE id = ?').run(
+        encPath,
+        basename(encPath),
+        documentId
+      )
       parseSource = storedPath
       transients.push(storedPath)
       storedPath = encPath
@@ -1120,8 +1180,11 @@ export async function extractDocumentPreview(
   const transients: string[] = []
   try {
     let parseSource: string
-    if (row.stored_path && existsSync(row.stored_path)) {
-      if (cipher && row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX)) {
+    // #188: resolve through the canonical location first, so a drive that came back under a
+    // different mount point still previews (and heals the row on the way past).
+    const stored = resolveStoredCopy(db, storeDir, row)
+    if (stored) {
+      if (cipher && stored.encrypted) {
         const ext = extname(row.title).toLowerCase()
         // Unique per call (DB-2): a deterministic `${documentId}.parse-preview${ext}` is shared by
         // the preview IPC, `buildDocumentSegmentReader`, and `extractSegmentTexts`, so two
@@ -1130,18 +1193,22 @@ export async function extractDocumentPreview(
         // the startup crash sweep (`workspace-vault.ts` matches `name.includes('.parse')`) covering
         // a leak. Every caller uses the returned `parseSource` local, so nothing depends on the name.
         parseSource = join(storeDir, `${documentId}.parse-preview-${randomUUID()}${ext}`)
-        await cipher.decryptFileAsync(row.stored_path, parseSource) // PERF-1: yields between chunks
+        await cipher.decryptFileAsync(stored.path, parseSource) // PERF-1: yields between chunks
         transients.push(parseSource)
-      } else if (!cipher && row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX)) {
+      } else if (!cipher && stored.encrypted) {
         // Emission (§3.3 rule 2): IPC throws below are transient — localized via tMain.
         throw new Error(tMain('main.docs.previewEncrypted'))
       } else {
-        parseSource = row.stored_path
+        parseSource = stored.path
       }
-    } else if (row.original_path && existsSync(row.original_path)) {
-      parseSource = row.original_path
     } else {
-      throw new Error(tMain('main.docs.previewGone'))
+      // #188: the user's own file is the LAST resort — on a portable drive it names a location
+      // on the other machine. A changed original still parses (re-reading current content is
+      // what a preview/re-index is for) but is recorded, so the log can explain a surprise.
+      const original = await locateOriginal(row)
+      if (!original) throw new Error(tMain('main.docs.previewGone'))
+      if (original.contentMatchesImport === false) warnOriginalChanged(documentId)
+      parseSource = original.path
     }
 
     // An OCR'd PDF previews its STORED recognition (the same ocrPages hook
@@ -1417,6 +1484,25 @@ const EXPORTABLE_TEXT_EXTENSIONS: ReadonlySet<string> = new Set([
  * shredded on the way out; the plaintext leaves the main process only as the returned
  * string, which the caller writes to the user-chosen destination.
  */
+/**
+ * #188 — the export paths' last-resort fallback to the user's own file.
+ *
+ * Export promises "the original as imported", so unlike the parse paths this one REFUSES a file
+ * whose content no longer hashes to `documents.sha256`: handing back an edited file as though it
+ * were the stored original is a quiet correctness hole, not a convenience. An undecidable hash
+ * (no recorded sha256, or an unreadable file) is allowed through — that is the pre-existing
+ * behaviour and refusing on "don't know" would break legitimate exports.
+ */
+async function originalForExport(row: DocumentRow): Promise<string> {
+  const original = await locateOriginal(row)
+  // Emission (§3.3 rule 2): IPC throws are transient — localized via tMain.
+  if (!original) throw new Error(tMain('main.docs.exportGone'))
+  if (original.contentMatchesImport === false) {
+    throw new Error(tMain('main.docs.exportOriginalChanged'))
+  }
+  return original.path
+}
+
 export async function readStoredDocumentText(
   db: Db,
   storeDir: string,
@@ -1435,8 +1521,11 @@ export async function readStoredDocumentText(
   const transients: string[] = []
   try {
     let source: string
-    if (row.stored_path && existsSync(row.stored_path)) {
-      if (row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX)) {
+    // #188: canonical location first — the recorded absolute path goes stale the moment the
+    // drive returns under a different mount point, and this is the reader that reported it.
+    const stored = resolveStoredCopy(db, storeDir, row)
+    if (stored) {
+      if (stored.encrypted) {
         if (!cipher) {
           throw new Error(tMain('main.docs.exportEncrypted'))
         }
@@ -1446,15 +1535,13 @@ export async function readStoredDocumentText(
         source = join(storeDir, `${documentId}.parse-export-${randomUUID()}${ext}`)
         // DB-7: async decrypt (PERF-1) — a large encrypted DOCX/DOC no longer blocks the main
         // process for the whole decrypt+read; the `finally` shred still runs after the await.
-        await cipher.decryptFileAsync(row.stored_path, source)
+        await cipher.decryptFileAsync(stored.path, source)
         transients.push(source)
       } else {
-        source = row.stored_path
+        source = stored.path
       }
-    } else if (row.original_path && existsSync(row.original_path)) {
-      source = row.original_path
     } else {
-      throw new Error(tMain('main.docs.exportGone'))
+      source = await originalForExport(row)
     }
     return { title: row.title, text: await readFile(source, 'utf8') }
   } finally {
@@ -1486,22 +1573,23 @@ export async function readStoredDocumentBytes(
   const transients: string[] = []
   try {
     let source: string
-    if (row.stored_path && existsSync(row.stored_path)) {
-      if (row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX)) {
+    // #188: canonical location first — this is the exact reader whose stale-path failure was
+    // reported ("Die Dokumentdatei ist nicht mehr vorhanden") while the bytes sat in the store.
+    const stored = resolveStoredCopy(db, storeDir, row)
+    if (stored) {
+      if (stored.encrypted) {
         if (!cipher) throw new Error(tMain('main.docs.exportEncrypted'))
         // Unique per call (DB-2): as above — collision-free transient, `.parse` infix for the sweep.
         source = join(storeDir, `${documentId}.parse-export-bin-${randomUUID()}${ext}`)
         // DB-7: async decrypt (PERF-1) — the §22-M1 content boundary is unchanged; the `finally`
         // shred still runs after the await.
-        await cipher.decryptFileAsync(row.stored_path, source)
+        await cipher.decryptFileAsync(stored.path, source)
         transients.push(source)
       } else {
-        source = row.stored_path
+        source = stored.path
       }
-    } else if (row.original_path && existsSync(row.original_path)) {
-      source = row.original_path
     } else {
-      throw new Error(tMain('main.docs.exportGone'))
+      source = await originalForExport(row)
     }
     return { title: row.title, mimeType: row.mime_type, bytes: await readFile(source) }
   } finally {
@@ -1577,11 +1665,20 @@ export function reconcileStuckExtracts(db: Db, beforeIso: string): number {
 // `DocumentRow` field `rowToInfo` reads is listed; `original_path` is in DocumentRow but unused by
 // the list (rowToInfo maps it but it is dropped client-side) — included to keep the row complete.
 const LIST_DOCUMENT_COLUMNS =
-  'id, title, original_path, stored_path, mime_type, size_bytes, sha256, status, error_message, ' +
+  'id, title, original_path, stored_path, stored_name, mime_type, size_bytes, sha256, status, error_message, ' +
   'summary_json, origin_json, ocr_meta_json, lifecycle, source_folder_label, tree_status, ' +
   'tree_meta_json, fully_chunked, extract_status, created_at, updated_at'
 
-export function listDocuments(db: Db, activeEmbeddingModelId?: string | null): DocumentInfo[] {
+/**
+ * #188: pass `storeDir` to have each row report whether its workspace copy is on disk
+ * (`DocumentInfo.storedCopy`), so the `⋯` menu can stop offering an export that cannot
+ * succeed. Omit it and the field stays undefined — every pre-existing caller is unchanged.
+ */
+export function listDocuments(
+  db: Db,
+  activeEmbeddingModelId?: string | null,
+  storeDir?: string
+): DocumentInfo[] {
   const rows = prepareCached(
     db,
     `SELECT ${LIST_DOCUMENT_COLUMNS} FROM documents WHERE status != 'deleted' ORDER BY created_at DESC, rowid DESC`
@@ -1637,6 +1734,7 @@ export function listDocuments(db: Db, activeEmbeddingModelId?: string | null): D
       embeddedCounts.set(e.documentId, e.n)
     }
   }
+  const storedPresent = storedCopyIndex(storeDir)
   return rows.map((r) => {
     const chunkCount = chunkCounts.get(r.id) ?? 0
     let stale: boolean | undefined
@@ -1647,7 +1745,10 @@ export function listDocuments(db: Db, activeEmbeddingModelId?: string | null): D
       if (force) stale = true
       else if (activeEmbeddingModelId) stale = (embeddedCounts.get(r.id) ?? 0) === 0
     }
-    return { ...rowToInfo(r, chunkCount, stale), collections: memberships.get(r.id) ?? [] }
+    return {
+      ...rowToInfo(r, chunkCount, stale, storedPresent),
+      collections: memberships.get(r.id) ?? []
+    }
   })
 }
 
@@ -1796,9 +1897,15 @@ function purgeDocumentDerivatives(db: Db, id: string): void {
  * workspace copy while the row delete could still fail, which is exactly the window that left a
  * corrupt, undeletable document when a bank/invoice extraction blocked the (un-transacted) delete.
  */
-export function deleteDocument(db: Db, id: string): void {
+export function deleteDocument(db: Db, storeDir: string, id: string): void {
   const row = getRow(db, id)
   if (!row) return
+  // #188: LOCATE the copy BEFORE the DB delete — afterwards the row that names it is gone and
+  // nothing could ever find it again. Keyed on the recorded absolute `stored_path`, this shred
+  // silently no-opped on a relocated drive: the rows vanished and the user's encrypted content
+  // stayed on the disk, unreferenced, forever. `locateStoredCopy` (not `resolveStoredCopy`) —
+  // healing a row we are about to delete is pointless work inside the delete path.
+  const doomed = locateStoredCopy(storeDir, row)
   // F12 (post-merge close-out): capture this doc's embedding chunk_ids BEFORE the delete so the
   // post-commit `invalidateResidentVectors` applies a named delta (drop these ids) rather than the
   // O(N) chunk-id rescan.
@@ -1821,10 +1928,12 @@ export function deleteDocument(db: Db, id: string): void {
   }
   // The DB delete committed. Now shred (overwrite-then-unlink) the workspace copy rather than a bare
   // unlink (plan M5). Best-effort: a locked/missing copy must not resurrect the already-deleted DB
-  // rows. Shredding AFTER the commit closes the DATA-1 window where the file was destroyed before a
-  // failing delete left a row with no chunks and no stored file.
-  if (row.stored_path && existsSync(row.stored_path)) {
-    shredFile(row.stored_path)
+  // rows — so this stays non-throwing (#188 §8.4: making it throw would resurrect DATA-1, leaving a
+  // half-deleted, undeletable document). Shredding AFTER the commit closes the DATA-1 window where
+  // the file was destroyed before a failing delete left a row with no chunks and no stored file.
+  // #188 changed only WHICH path is shredded, never WHEN.
+  if (doomed) {
+    shredFile(doomed.path)
   }
   // RAG-6 (Wave P4) / PERF-1 (Phase 5) / F12 (post-merge close-out) belt: this doc's vectors were
   // just DELETEd — flag the resident decoded-vector cache with the exact REMOVED chunk_ids so the

--- a/apps/desktop/src/main/services/ingestion/stored-copy.ts
+++ b/apps/desktop/src/main/services/ingestion/stored-copy.ts
@@ -1,0 +1,201 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { ENCRYPTED_DOC_SUFFIX } from '../workspace-vault'
+import { sha256File } from '../models'
+import { log } from '../logging'
+import type { Db } from '../db'
+
+// Issue #188 — the ONE place a document's bytes are located on disk.
+//
+// `documents.stored_path` was persisted ABSOLUTE (`H:\workspace\documents\<id><ext>.enc`) and
+// consumed with a bare `existsSync`. On a product whose premise is "keep the workspace on an
+// external drive and move between laptops", that means a drive returning under a different mount
+// point takes EVERY stored copy stale at once: the row is intact, the bytes are intact, only the
+// recorded string is wrong — and the app tells the user the file "is no longer present".
+//
+// The stored copy is named DETERMINISTICALLY, `<documentId><ext>[.enc]` inside the CURRENT store
+// dir, so the recorded path is redundant: the canonical location can always be recomputed. This
+// module is the single resolver every consumer goes through — the read paths (export, preview,
+// re-index, OCR, skills) AND `deleteDocument`'s shred, which is the reason this is a privacy fix
+// and not a convenience one: keyed on the stale path, the shred silently no-opped and left the
+// user's encrypted content on the drive with no row left to ever reference it again.
+//
+// This mirrors what the rest of the drive already does — `image_sessions.stored_name` (relative
+// by design), `skills.path` (folder basename), the model checksum cache (`driveRelKey`, CODE-15),
+// the runtime install marker (`markerBinaryKey`), `documents.source_relative_path` (CODE-1) — and
+// what the vault layer already assumed: password-change re-encryption enumerates
+// `workspace/documents/` by DIRECTORY WALK, never by `stored_path`.
+
+/** The columns this module needs. Every reader's row shape is a superset. */
+export interface StoredCopyRow {
+  id: string
+  stored_path: string | null
+  stored_name?: string | null
+  original_path?: string | null
+  sha256?: string | null
+}
+
+/** A located stored copy: an absolute path plus whether it rests encrypted. */
+export interface LocatedStoredCopy {
+  /** Absolute path to the file on disk, right now. */
+  path: string
+  /** Leaf name relative to the store dir (`<id><ext>[.enc]`). */
+  name: string
+  /** True when the file is a `.enc` sidecar and needs the DocumentCipher. */
+  encrypted: boolean
+  /** True when `path` differs from what the row recorded — the row wants healing. */
+  relocated: boolean
+}
+
+/**
+ * The user's own copy of the file, used only when the workspace copy cannot be found.
+ * `contentMatchesImport` is null when it could not be decided (no recorded sha256, or the
+ * hash failed) — never silently "true".
+ */
+export interface LocatedOriginal {
+  path: string
+  contentMatchesImport: boolean | null
+}
+
+/**
+ * Leaf name of `p`, split on BOTH separators.
+ *
+ * NOT `basename`: a legacy row can carry a path written on ANOTHER OS (a Windows
+ * `Z:\old\documents\<id>.pdf.enc` row read on macOS/Linux, or the reverse), and the host
+ * `basename` only understands the host separator — on posix it would return the whole
+ * Windows string. Same scar as `markerBinaryKey` / `resolveTarBinary` (the cross-platform
+ * path bugs that failed the Ubuntu CI leg): never use host path helpers on a stored string
+ * that may have been written by a different host.
+ */
+export function storedCopyLeaf(p: string): string {
+  const cut = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return cut >= 0 ? p.slice(cut + 1) : p
+}
+
+/**
+ * The canonical leaf for a row, or null when it cannot be trusted.
+ *
+ * SAFETY (this is the guard the shred rests on): the leaf is used to build a path INSIDE the
+ * store dir that `deleteDocument` will overwrite-and-unlink. So it must be a bare file name
+ * belonging to THIS document — it must start with the row's own id, which is a UUID primary
+ * key that is never reused. A name failing any check yields null, and the caller falls back to
+ * the recorded absolute path verbatim (today's behaviour), never to a guess. Without this
+ * guard a malformed/foreign `stored_name` could make the shred destroy ANOTHER document's copy.
+ */
+export function canonicalLeafFor(row: StoredCopyRow): string | null {
+  const raw = row.stored_name ?? (row.stored_path ? storedCopyLeaf(row.stored_path) : null)
+  if (!raw) return null
+  // Bare name only: no separators (a stored_name from a corrupted row), no traversal.
+  if (raw !== storedCopyLeaf(raw)) return null
+  if (raw === '.' || raw === '..' || raw.length === 0) return null
+  // Belongs to THIS document. `<id>` is a UUID; the rest is `<ext>[.enc]`.
+  if (!raw.startsWith(row.id)) return null
+  return raw
+}
+
+/**
+ * Locate a document's workspace copy, or null when there is none on disk.
+ *
+ * Order, most-portable first:
+ *   1. the CANONICAL location — `join(storeDir, <id><ext>[.enc])` — which is mount-independent
+ *      and therefore the only one that survives the drive moving;
+ *   2. the recorded absolute `stored_path`, verbatim, if it happens to exist. Keeping this makes
+ *      the resolver a strict superset of the previous behaviour: nothing that resolved before
+ *      stops resolving now.
+ *
+ * Pure and synchronous: `deleteDocument` needs it inside a sync path, and the read paths want it
+ * before they decide whether to decrypt.
+ */
+export function locateStoredCopy(storeDir: string, row: StoredCopyRow): LocatedStoredCopy | null {
+  const leaf = canonicalLeafFor(row)
+  if (leaf) {
+    const canonical = join(storeDir, leaf)
+    if (existsSync(canonical)) {
+      return {
+        path: canonical,
+        name: leaf,
+        encrypted: leaf.endsWith(ENCRYPTED_DOC_SUFFIX),
+        relocated: canonical !== row.stored_path || row.stored_name !== leaf
+      }
+    }
+  }
+  if (row.stored_path && existsSync(row.stored_path)) {
+    return {
+      path: row.stored_path,
+      name: leaf ?? storedCopyLeaf(row.stored_path),
+      encrypted: row.stored_path.endsWith(ENCRYPTED_DOC_SUFFIX),
+      // A row whose file lives OUTSIDE the store keeps resolving, but it is not "relocated" —
+      // there is nothing better to heal it to. And when `leaf` is null the guard refused the
+      // name, so writing it back would only persist a name the guard will refuse again (worse:
+      // a name belonging to another document). Never heal on this branch.
+      relocated: false
+    }
+  }
+  return null
+}
+
+/**
+ * D3 — heal the row in place once the copy has been found somewhere other than where the row
+ * said. Lazy and opportunistic, never a startup migration: an encrypted workspace on USB is the
+ * worst possible medium for a bulk write burst, and the migration could not run before unlock
+ * anyway. Same shape as `createSettingsHashStore`'s lazy adoption of legacy absolute keys
+ * (CODE-15).
+ *
+ * BEST-EFFORT by contract: a locked/closed/read-only database must never fail a read that has
+ * already succeeded. The next read simply heals again.
+ */
+export function healStoredCopy(db: Db, row: StoredCopyRow, found: LocatedStoredCopy): void {
+  if (!found.relocated) return
+  try {
+    db.prepare('UPDATE documents SET stored_path = ?, stored_name = ? WHERE id = ?').run(
+      found.path,
+      found.name,
+      row.id
+    )
+  } catch {
+    /* the read already succeeded — a heal failure must never surface to the caller */
+  }
+}
+
+/** Locate + heal in one call: what every read path wants. */
+export function resolveStoredCopy(
+  db: Db,
+  storeDir: string,
+  row: StoredCopyRow
+): LocatedStoredCopy | null {
+  const found = locateStoredCopy(storeDir, row)
+  if (found) healStoredCopy(db, row, found)
+  return found
+}
+
+/**
+ * The LAST-RESORT fallback: the user's own file at `original_path`.
+ *
+ * Deliberately demoted below the workspace copy (#188 analysis §4). On a portable drive
+ * `original_path` names a location on the OTHER machine, so it is the least durable of the two;
+ * it is nulled outright for generated documents (`setDocumentOrigin`); and — the reason for the
+ * hash — nothing used to re-check it, so a source file edited since import was handed back as
+ * though it were "the original as imported".
+ *
+ * The hash is advisory here: this function REPORTS the mismatch and lets each caller decide.
+ * Export refuses (its promise is the bytes as imported); the parse paths proceed with a warning
+ * (their promise is readable content, and re-reading a changed file is what re-index is for).
+ */
+export async function locateOriginal(row: StoredCopyRow): Promise<LocatedOriginal | null> {
+  const path = row.original_path
+  if (!path || !existsSync(path)) return null
+  if (!row.sha256) return { path, contentMatchesImport: null }
+  try {
+    return { path, contentMatchesImport: (await sha256File(path)) === row.sha256 }
+  } catch {
+    // Unreadable/racing file: undecided, never optimistically "matches".
+    return { path, contentMatchesImport: null }
+  }
+}
+
+/** Log line for the parse paths, which proceed on a changed original rather than refuse. */
+export function warnOriginalChanged(documentId: string): void {
+  log.warn('Reading the user original instead of the workspace copy; its content no longer matches what was imported', {
+    documentId
+  })
+}

--- a/apps/desktop/src/renderer/screens/DocumentsScreen.tsx
+++ b/apps/desktop/src/renderer/screens/DocumentsScreen.tsx
@@ -707,7 +707,12 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
     try {
       await window.api.exportDocumentOriginal(d.id)
     } catch (e) {
-      setError(friendlyIpcError(e))
+      // #188: name the document. This is a screen-level banner and the list can be long, so a
+      // bare "the file is no longer present" left the user guessing WHICH one failed. The
+      // common cause (a stale stored path on a relocated drive) is fixed in the resolver and
+      // the menu now disables the entry outright when the copy is genuinely gone, so what
+      // reaches here is the race — the copy vanished between the list refresh and the click.
+      setError(`${d.title}: ${friendlyIpcError(e)}`)
     }
   }
 

--- a/apps/desktop/src/renderer/screens/documents/DocRow.tsx
+++ b/apps/desktop/src/renderer/screens/documents/DocRow.tsx
@@ -447,7 +447,11 @@ export const DocRow = memo(function DocRow({
                        save dialog (the review-export §24.3 posture). */
                     <DropdownMenu.Item
                       className="menu-item"
-                      disabled={ACTIVE_STATUSES.has(d.status)}
+                      /* #188: never offer an action that cannot succeed. `storedCopy` is
+                         'missing' only when the workspace copy is genuinely not on disk —
+                         undefined means "not evaluated", which must NOT disable the entry. */
+                      disabled={ACTIVE_STATUSES.has(d.status) || d.storedCopy === 'missing'}
+                      title={d.storedCopy === 'missing' ? t('docs.exportOriginal.gone') : undefined}
                       onSelect={() => setConfirmExportOriginal(d)}
                     >
                       {t('docs.exportOriginal')}

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -601,6 +601,8 @@ export const de: Record<keyof typeof en, string> = {
   // oben). Die Warnung ist die Dokumente-Stimme des §24.3-Verschlüsselungsgrenze-Texts
   // (review.export.encryptionWarning, wortgleich).
   'docs.exportOriginal': 'Originaldatei exportieren',
+  'docs.exportOriginal.gone':
+    'Die gespeicherte Kopie dieser Datei liegt nicht auf diesem Laufwerk und kann daher nicht exportiert werden. Der extrahierte Text lässt sich weiterhin exportieren.',
   'docs.exportOriginalConfirm.title': 'Originaldatei exportieren?',
   'docs.exportOriginal.warning':
     'Diese exportierte Datei liegt außerhalb des verschlüsselten HilbertRaum-Arbeitsbereichs und ist nicht durch dein Arbeitsbereich-Passwort geschützt.',
@@ -2173,6 +2175,9 @@ export const de: Record<keyof typeof en, string> = {
     'Dieses Dokument ist verschlüsselt; entsperre den Arbeitsbereich, um es zu exportieren.',
   'main.docs.exportGone':
     'Die Dokumentdatei ist nicht mehr vorhanden. Importiere sie neu, um sie zu exportieren.',
+  'main.docs.exportOriginalChanged':
+    'Nur deine eigene Kopie dieser Datei ist noch vorhanden, und sie hat sich seit dem Import ' +
+    'geändert — sie ist also nicht mehr das Original. Exportiere stattdessen den extrahierten Text.',
   'main.docs.noStoredTranscript':
     'Für diese Aufnahme ist noch kein Transkript gespeichert. Indexiere sie neu, um sie ' +
     'noch einmal zu transkribieren.',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -574,6 +574,10 @@ export const en = {
   // (review.export.encryptionWarning, verbatim) — shown in the ConfirmDialog on every
   // platform and in the macOS save sheet via the dialog `message`.
   'docs.exportOriginal': 'Export original file',
+  // #188: the reason the entry is disabled, shown on hover — the menu no longer offers an
+  // export that would fail after the click.
+  'docs.exportOriginal.gone':
+    'The stored copy of this file is not on this drive, so it cannot be exported. You can still export its extracted text.',
   'docs.exportOriginalConfirm.title': 'Export the original file?',
   'docs.exportOriginal.warning':
     'This exported file is stored outside the encrypted HilbertRaum workspace and is not protected by your workspace password.',
@@ -2091,6 +2095,11 @@ export const en = {
   'main.docs.exportTextOnly': 'Only text documents (Markdown, TXT, CSV) can be exported this way.',
   'main.docs.exportEncrypted': 'This document is encrypted; unlock the workspace to export it.',
   'main.docs.exportGone': 'The document file is no longer on disk. Re-import it to export.',
+  // #188: the workspace copy is gone AND the user's own file has changed since import, so it is
+  // no longer the original this document was made from — exporting it would be a quiet lie.
+  'main.docs.exportOriginalChanged':
+    'Only your own copy of this file is still available, and it has changed since it was ' +
+    'imported — so it is no longer the original. Export the extracted text instead.',
   'main.docs.noStoredTranscript':
     'No transcript is stored for this recording yet. Re-index it to transcribe again.',
   'main.models.noManifests':

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1435,6 +1435,15 @@ export interface DocumentInfo {
   id: string
   title: string
   originalPath: string | null
+  /**
+   * Whether the document's workspace copy is on disk right now (#188). `'missing'` means every
+   * byte-level action — export the original, preview, re-index, OCR, skill runs — will fail, so
+   * the `⋯` menu disables them with a reason instead of failing after the click. `undefined`
+   * when not evaluated: only the callers that hold a store dir compute it (`listDocuments` with
+   * its optional third argument), so a `DocumentInfo` from `getDocument`/`createQueuedDocument`
+   * simply does not carry the signal. Treat undefined as "unknown", never as "missing".
+   */
+  storedCopy?: 'present' | 'missing'
   mimeType: string | null
   sizeBytes: number | null
   status: IngestionStatus

--- a/apps/desktop/tests/integration/data-layer-hardening.test.ts
+++ b/apps/desktop/tests/integration/data-layer-hardening.test.ts
@@ -213,7 +213,7 @@ describe('tree_edges no-dangling-chunk-edge invariant (DATA-2)', () => {
 
     // The authoritative chunk-delete path also deletes tree_nodes (purgeDocumentDerivatives), so the
     // edges cascade via their parent_id FK — the invariant the polymorphic child_id relies on.
-    deleteDocument(db, docId)
+    deleteDocument(db, mkdtempSync(join(tmpdir(), 'hilbertraum-dlh-store-')), docId)
     expect(edgeCount(db)).toBe(0) // whole tree gone
     expect(danglingChunkEdges(db)).toBe(0) // invariant holds
   })

--- a/apps/desktop/tests/integration/doctasks.test.ts
+++ b/apps/desktop/tests/integration/doctasks.test.ts
@@ -429,7 +429,7 @@ describe('summary persistence lifecycle (D25)', () => {
     const { jobId } = manager.startDocTask({ kind: 'summary', documentIds: [docId] })
     await waitTerminal(manager, jobId)
 
-    deleteDocument(db, docId)
+    deleteDocument(db, storeDir, docId)
     expect(getDocument(db, docId)).toBeNull()
     expect(getDocumentSummary(db, docId)).toBeNull()
   })

--- a/apps/desktop/tests/integration/document-delete-derivatives.test.ts
+++ b/apps/desktop/tests/integration/document-delete-derivatives.test.ts
@@ -214,7 +214,7 @@ describe('deleteDocument — purges bank/invoice derivatives (audit DATA-1, exis
     })
     expect(existsSync(storedPath)).toBe(true)
 
-    expect(() => deleteDocument(db, docId)).not.toThrow()
+    expect(() => deleteDocument(db, fileDir, docId)).not.toThrow()
 
     expect(derivedCounts(db, docId)).toEqual({
       documents: 0,

--- a/apps/desktop/tests/integration/encrypted-documents.test.ts
+++ b/apps/desktop/tests/integration/encrypted-documents.test.ts
@@ -177,7 +177,7 @@ describe('encrypted document cache (H1)', () => {
     await processDocument(db, store, doc.id, { cipher: testCipher() })
     expect(readdirSync(store)).toHaveLength(1)
 
-    deleteDocument(db, doc.id)
+    deleteDocument(db, store, doc.id)
     expect(readdirSync(store)).toHaveLength(0)
   })
 })

--- a/apps/desktop/tests/integration/ingestion.test.ts
+++ b/apps/desktop/tests/integration/ingestion.test.ts
@@ -338,7 +338,7 @@ describe('ingestion pipeline', () => {
     }).stored_path
     expect(existsSync(stored)).toBe(true)
 
-    deleteDocument(db, queued.id)
+    deleteDocument(db, storeDir, queued.id)
     expect(listDocuments(db)).toHaveLength(0)
     expect(existsSync(stored)).toBe(false)
     const n = db.prepare('SELECT COUNT(*) AS n FROM chunks WHERE document_id = ?').get(queued.id) as {

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -459,3 +459,43 @@ describe('repo hygiene — bare workspace.isUnlocked() call sites stay allowlist
     ).toEqual(ALLOWLIST)
   })
 })
+
+// #188 wave — the bundler tripwire. `electron-vite`'s `esmShimPlugin` decides where to inject its
+// CommonJS shim by finding the LAST match of a loose "static import" regex over the whole rendered
+// chunk. That regex matches the bare word `import` (preceded by whitespace/`;`/start) followed
+// immediately by a quote — which is ALSO what a string literal ending in the word "import" looks
+// like. When such a literal lands after the real last import in the bundle, the plugin computes a
+// bogus offset and wedges the shim INTO the string, and the build dies with a bewildering
+// "Unterminated string literal" pointing at unrelated code hundreds of lines away.
+//
+// It cost this wave a full debug cycle: `npm run typecheck` and the entire test suite pass, and
+// only `npm run build` fails — which is exactly why the phase gate is typecheck → build → test in
+// that order. Comments are stripped before the plugin runs, so only STRING LITERALS are the hazard.
+describe('repo hygiene — no string literal ends with the bare word "import" (#188 bundler trap)', () => {
+  const walk = (dir: string): string[] => {
+    const out: string[] = []
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name)
+      if (entry.isDirectory()) out.push(...walk(p))
+      else if (/\.(ts|tsx)$/.test(entry.name)) out.push(p)
+    }
+    return out
+  }
+  // A quote closing immediately after ` import`, with the line NOT being a real import statement.
+  const TRAP = /(^|[\s;])import(['"])/
+
+  it('no src file closes a string literal right after the word "import"', () => {
+    const offenders: string[] = []
+    for (const p of walk(join(process.cwd(), 'src'))) {
+      readFileSync(p, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (/^\s*(import|export)\s/.test(line)) return // a real import/export statement
+          if (/^\s*(\/\/|\*|\/\*)/.test(line)) return // comments are stripped before the plugin
+          if (TRAP.test(line)) offenders.push(`${p}:${i + 1}: ${line.trim()}`)
+        })
+    }
+    // If this fires: reword the string so it does not END on "import" (e.g. "…was imported").
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/desktop/tests/integration/resident-cache.test.ts
+++ b/apps/desktop/tests/integration/resident-cache.test.ts
@@ -246,7 +246,7 @@ describe('resident cache — ingestion lifecycle', () => {
     }
 
     // Delete — the delete hook invalidates; no chunks remain.
-    deleteDocument(db, queued.id)
+    deleteDocument(db, storeDir, queued.id)
     expect(index.search(qOrig, 5)).toHaveLength(0)
   })
 })

--- a/apps/desktop/tests/integration/stored-copy-portability.test.ts
+++ b/apps/desktop/tests/integration/stored-copy-portability.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync, renameSync } from 'node:fs'
+import { randomBytes, randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join, basename } from 'node:path'
+import { openDatabase, type Db } from '../../src/main/services/db'
+import {
+  createQueuedDocument,
+  processDocument,
+  reindexDocument,
+  deleteDocument,
+  documentsDir,
+  extractDocumentPreview,
+  readStoredDocumentBytes,
+  readStoredDocumentText,
+  listDocuments,
+  ENCRYPTED_DOC_SUFFIX
+} from '../../src/main/services/ingestion'
+import {
+  encryptFile,
+  decryptFile,
+  encryptFileAsync,
+  decryptFileAsync,
+  type DocumentCipher
+} from '../../src/main/services/workspace-vault'
+
+// Issue #188 — `documents.stored_path` was persisted ABSOLUTE, so a portable drive that came
+// back under a different mount point (H: → E:, or a Windows letter ↔ /Volumes/…) had EVERY
+// stored copy go stale at once: the row is fine, the bytes are fine, only the recorded string
+// is wrong. The stored copy is named DETERMINISTICALLY (`<id><ext>[.enc]`) inside the CURRENT
+// store dir, so it is always recoverable — the resolver recomputes it and heals the row.
+//
+// A "relocated drive" is reproduced here by physically MOVING the store directory and calling
+// the readers with the new path, which is exactly what a different drive letter looks like to
+// the code: same bytes, same names, a `stored_path` that no longer resolves.
+
+const SECRET_TEXT = 'wholly confidential contract clause 7: severance of unicorns'
+
+let srcDir: string
+
+beforeEach(() => {
+  srcDir = mkdtempSync(join(tmpdir(), 'hilbertraum-portability-src-'))
+})
+
+function writeSource(name: string, data: string): string {
+  const p = join(srcDir, name)
+  writeFileSync(p, data)
+  return p
+}
+
+function freshDb(): Db {
+  return openDatabase(join(mkdtempSync(join(tmpdir(), 'hilbertraum-portability-db-')), 'test.sqlite'))
+}
+
+/** A workspace root; `documentsDir` makes the `documents/` child under it. */
+function freshWorkspace(): string {
+  return mkdtempSync(join(tmpdir(), 'hilbertraum-portability-ws-'))
+}
+
+function testCipher(): DocumentCipher {
+  const key = randomBytes(32)
+  return {
+    encryptFile: (src, dest) => encryptFile(src, dest, key),
+    decryptFile: (src, dest) => decryptFile(src, dest, key),
+    encryptFileAsync: (src, dest) => encryptFileAsync(src, dest, key),
+    decryptFileAsync: (src, dest) => decryptFileAsync(src, dest, key)
+  }
+}
+
+/**
+ * Simulate the drive coming back under a different mount point: move `workspace/documents/`
+ * to a brand-new workspace root and return the NEW store dir. The DB is untouched, so every
+ * `stored_path` in it now names a directory that no longer exists — the #188 condition.
+ */
+function relocateStore(oldStore: string): string {
+  const newWorkspace = freshWorkspace()
+  const newStore = join(newWorkspace, 'documents')
+  renameSync(oldStore, newStore)
+  expect(existsSync(oldStore)).toBe(false)
+  return newStore
+}
+
+function storedPathOf(db: Db, id: string): string | null {
+  const row = db.prepare('SELECT stored_path FROM documents WHERE id = ?').get(id) as unknown as
+    | { stored_path: string | null }
+    | undefined
+  return row?.stored_path ?? null
+}
+
+describe('#188 — a relocated drive must not lose its stored copies (encrypted)', () => {
+  it('T1: exports the ORIGINAL bytes after the store dir moved', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file) // the ORIGINAL is on the other laptop — only the stored copy remains
+
+    const moved = relocateStore(store)
+
+    const { bytes } = await readStoredDocumentBytes(db, moved, doc.id, { cipher })
+    expect(bytes.toString('utf8')).toContain('severance of unicorns')
+  })
+
+  it('T1b: exports the stored TEXT and previews after the store dir moved', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+    const moved = relocateStore(store)
+
+    const { text } = await readStoredDocumentText(db, moved, doc.id, { cipher })
+    expect(text).toContain('severance of unicorns')
+
+    const preview = await extractDocumentPreview(db, moved, doc.id, { cipher })
+    expect(preview.segments.map((s) => s.text).join('\n')).toContain('severance of unicorns')
+
+    // No transient decrypted plaintext survives the relocated reads.
+    expect(readdirSync(moved).filter((n) => n.includes('.parse'))).toEqual([])
+  })
+
+  it('T6: re-index after the move succeeds and does NOT flip the row to failed', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+    const moved = relocateStore(store)
+
+    const info = await reindexDocument(db, moved, doc.id, { cipher })
+    expect(info.errorMessage).toBeNull()
+    expect(info.status).toBe('indexed')
+    expect(info.chunkCount).toBeGreaterThan(0)
+  })
+})
+
+describe('#188 — a relocated drive must not lose its stored copies (plaintext)', () => {
+  it('T2: exports the ORIGINAL bytes after the store dir moved, no cipher', async () => {
+    const db = freshDb()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, {})
+    rmSync(file)
+    const moved = relocateStore(store)
+
+    const { bytes } = await readStoredDocumentBytes(db, moved, doc.id, {})
+    expect(bytes.toString('utf8')).toContain('severance of unicorns')
+  })
+})
+
+describe('#188 — DELETE must actually delete on a relocated drive', () => {
+  it('T3: shreds the stored copy after the store dir moved (privacy, not disk space)', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+    const moved = relocateStore(store)
+    expect(readdirSync(moved)).toHaveLength(1) // the .enc copy is right there
+
+    deleteDocument(db, moved, doc.id)
+
+    // The DB rows are gone AND the encrypted bytes are gone. Before the fix the shred
+    // silently no-opped and left the user's content on the drive forever, with no row
+    // left to ever reference it again.
+    expect(db.prepare('SELECT id FROM documents WHERE id = ?').get(doc.id)).toBeUndefined()
+    expect(readdirSync(moved)).toEqual([])
+  })
+
+  it('T3b: still deletes cleanly when the stored copy really is gone', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    for (const n of readdirSync(store)) rmSync(join(store, n))
+
+    expect(() => deleteDocument(db, store, doc.id)).not.toThrow()
+    expect(db.prepare('SELECT id FROM documents WHERE id = ?').get(doc.id)).toBeUndefined()
+  })
+
+  it('T3c: never shreds a file belonging to a DIFFERENT document', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+
+    const a = createQueuedDocument(db, writeSource('a.txt', 'alpha content here'))
+    await processDocument(db, store, a.id, { cipher })
+    const b = createQueuedDocument(db, writeSource('b.txt', 'beta content here'))
+    await processDocument(db, store, b.id, { cipher })
+
+    const moved = relocateStore(store)
+    expect(readdirSync(moved)).toHaveLength(2)
+
+    deleteDocument(db, moved, a.id)
+
+    const left = readdirSync(moved)
+    expect(left).toHaveLength(1)
+    expect(left[0].startsWith(b.id)).toBe(true)
+  })
+})
+
+describe('#188 — legacy rows carrying a foreign absolute path', () => {
+  it('T4: resolves a row whose stored_path names a drive that does not exist, and heals it', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+
+    // Rewrite the row the way a drive imported on ANOTHER machine looks: a plausible,
+    // well-formed absolute path under a mount point that is not here. The file itself
+    // stays exactly where it is.
+    const realName = basename(storedPathOf(db, doc.id) as string)
+    const foreign = join('Z:', 'old-drive', 'workspace', 'documents', realName)
+    db.prepare('UPDATE documents SET stored_path = ? WHERE id = ?').run(foreign, doc.id)
+
+    const { bytes } = await readStoredDocumentBytes(db, store, doc.id, { cipher })
+    expect(bytes.toString('utf8')).toContain('severance of unicorns')
+
+    // D3: the row is HEALED in place, so the next read costs nothing extra.
+    expect(storedPathOf(db, doc.id)).toBe(join(store, realName))
+  })
+
+  it('T5: a genuinely absent stored copy still fails loudly, and delete does not throw', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+    for (const n of readdirSync(store)) rmSync(join(store, n))
+
+    await expect(readStoredDocumentBytes(db, store, doc.id, { cipher })).rejects.toThrow()
+    expect(listDocuments(db, null, store).find((d) => d.id === doc.id)?.storedCopy).toBe('missing')
+  })
+
+  it('T5b: listDocuments reports a present stored copy on a relocated drive', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    rmSync(file)
+    const moved = relocateStore(store)
+
+    expect(listDocuments(db, null, moved).find((d) => d.id === doc.id)?.storedCopy).toBe('present')
+    // Without a store dir the field stays absent — callers that never pass one are unchanged.
+    expect(listDocuments(db, null).find((d) => d.id === doc.id)?.storedCopy).toBeUndefined()
+  })
+})
+
+describe('#188 — the original is a LAST resort, and it must still be the original', () => {
+  it('T9: refuses to export a fallback original whose content changed since import', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    // The workspace copy is gone, so only the user's own file is left...
+    for (const n of readdirSync(store)) rmSync(join(store, n))
+    // ...and it has been edited since import, so it is no longer "the original".
+    writeFileSync(file, 'a completely different contract, edited after the import')
+
+    await expect(readStoredDocumentBytes(db, store, doc.id, { cipher })).rejects.toThrow(
+      /no longer the original/i
+    )
+  })
+
+  it('T9b: still exports an UNCHANGED fallback original', async () => {
+    const db = freshDb()
+    const cipher = testCipher()
+    const store = documentsDir(freshWorkspace())
+    const file = writeSource('contract.txt', SECRET_TEXT)
+
+    const doc = createQueuedDocument(db, file)
+    await processDocument(db, store, doc.id, { cipher })
+    for (const n of readdirSync(store)) rmSync(join(store, n))
+
+    const { bytes } = await readStoredDocumentBytes(db, store, doc.id, { cipher })
+    expect(bytes.toString('utf8')).toContain('severance of unicorns')
+  })
+})

--- a/apps/desktop/tests/unit/stored-copy-resolver.test.ts
+++ b/apps/desktop/tests/unit/stored-copy-resolver.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  canonicalLeafFor,
+  locateStoredCopy,
+  storedCopyLeaf
+} from '../../src/main/services/ingestion/stored-copy'
+
+// Issue #188 — the resolver's SAFETY guard. `deleteDocument` shreds whatever this returns, so
+// "which file is this document's?" is a data-destruction question, not a lookup convenience.
+
+const ID = '11111111-2222-3333-4444-555555555555'
+const OTHER = '99999999-8888-7777-6666-555555555555'
+
+function store(): string {
+  const d = join(mkdtempSync(join(tmpdir(), 'hilbertraum-resolver-')), 'documents')
+  mkdirSync(d, { recursive: true })
+  return d
+}
+
+describe('storedCopyLeaf — host-independent leaf extraction', () => {
+  it('splits on BOTH separators, so a foreign-OS path still yields its file name', () => {
+    // The scar this guards: host `basename` on posix returns the WHOLE Windows string, so a
+    // Windows-written legacy row read on the Linux CI leg would resolve to nonsense.
+    expect(storedCopyLeaf('Z:\\old\\workspace\\documents\\x.pdf.enc')).toBe('x.pdf.enc')
+    expect(storedCopyLeaf('/Volumes/HR/workspace/documents/x.pdf.enc')).toBe('x.pdf.enc')
+    expect(storedCopyLeaf('C:/mixed\\separators/x.pdf')).toBe('x.pdf')
+    expect(storedCopyLeaf('bare.pdf')).toBe('bare.pdf')
+  })
+})
+
+describe('canonicalLeafFor — the guard that keeps the shred on its own file', () => {
+  it('accepts a well-formed leaf belonging to the document', () => {
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: `${ID}.pdf.enc` })).toBe(
+      `${ID}.pdf.enc`
+    )
+  })
+
+  it('derives the leaf from a legacy absolute stored_path', () => {
+    expect(
+      canonicalLeafFor({ id: ID, stored_path: `Z:\\gone\\documents\\${ID}.pdf.enc` })
+    ).toBe(`${ID}.pdf.enc`)
+  })
+
+  it('REFUSES a name belonging to a different document', () => {
+    // Without this the delete path would shred another document's copy — unrecoverable.
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: `${OTHER}.pdf.enc` })).toBeNull()
+    expect(canonicalLeafFor({ id: ID, stored_path: `C:\\ws\\documents\\${OTHER}.pdf.enc` })).toBeNull()
+  })
+
+  it('REFUSES traversal and separator-bearing names', () => {
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: '..' })).toBeNull()
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: '.' })).toBeNull()
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: `sub/${ID}.pdf` })).toBeNull()
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: `sub\\${ID}.pdf` })).toBeNull()
+    expect(canonicalLeafFor({ id: ID, stored_path: null, stored_name: '' })).toBeNull()
+  })
+
+  it('returns null when the row names nothing at all', () => {
+    expect(canonicalLeafFor({ id: ID, stored_path: null })).toBeNull()
+  })
+})
+
+describe('locateStoredCopy', () => {
+  it('prefers the canonical location over a stale recorded path', () => {
+    const dir = store()
+    const leaf = `${ID}.pdf.enc`
+    writeFileSync(join(dir, leaf), 'ciphertext')
+
+    const found = locateStoredCopy(dir, {
+      id: ID,
+      stored_path: `Z:\\a-drive-that-is-not-here\\documents\\${leaf}`,
+      stored_name: null
+    })
+    expect(found?.path).toBe(join(dir, leaf))
+    expect(found?.encrypted).toBe(true)
+    expect(found?.relocated).toBe(true)
+  })
+
+  it('falls back to the recorded absolute path when it still resolves (strict superset)', () => {
+    const elsewhere = store()
+    const leaf = `${ID}.pdf`
+    writeFileSync(join(elsewhere, leaf), 'plaintext')
+    // A DIFFERENT store dir: the canonical probe misses, the recorded path hits.
+    const found = locateStoredCopy(store(), {
+      id: ID,
+      stored_path: join(elsewhere, leaf),
+      stored_name: null
+    })
+    expect(found?.path).toBe(join(elsewhere, leaf))
+    expect(found?.encrypted).toBe(false)
+  })
+
+  it('never returns a canonical path for a foreign leaf, even when that file exists', () => {
+    const dir = store()
+    const foreign = `${OTHER}.pdf.enc`
+    writeFileSync(join(dir, foreign), "another document's bytes")
+
+    // A corrupted row pointing at another document's file must resolve to NOTHING here,
+    // not to the neighbour's copy. Mutate `canonicalLeafFor`'s startsWith check and this
+    // goes red — which is the point of the guard.
+    expect(locateStoredCopy(dir, { id: ID, stored_path: null, stored_name: foreign })).toBeNull()
+  })
+
+  it('reports nothing when the copy is genuinely absent', () => {
+    expect(
+      locateStoredCopy(store(), { id: ID, stored_path: null, stored_name: `${ID}.pdf.enc` })
+    ).toBeNull()
+  })
+
+  it('flags a row already in its canonical place as not needing a heal', () => {
+    const dir = store()
+    const leaf = `${ID}.txt`
+    writeFileSync(join(dir, leaf), 'x')
+    const found = locateStoredCopy(dir, {
+      id: ID,
+      stored_path: join(dir, leaf),
+      stored_name: leaf
+    })
+    expect(found?.relocated).toBe(false)
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10657,6 +10657,212 @@ The wave's working paper is gone; its anchors resolve here:
 | `plan §7` (audit ledger A1–A10) | §8 above |
 | `plan §8` (six-persona ledger) | §8 above |
 
+## Portable stored copies — design record (wave 188, issue #188, §1–§8)
+
+_Issue **#188** was filed as a UI defect: "Originaldatei exportieren" failed with "Die
+Dokumentdatei ist nicht mehr vorhanden" on a real prepared drive whose `workspace/documents/`
+held 24 intact `<uuid><ext>.enc` files. The analysis found the reported symptom to be the
+smallest of three defects sharing one cause — `documents.stored_path` was persisted **absolute**
+on a drive whose whole premise is that it moves between machines. The working paper
+(`plans/issue-188-stored-path-portability.md`) was git-excluded, never committed, and deleted at
+close-out per the CLAUDE.md doc-lifecycle rule; this record is the surviving source (§-anchor
+legend at the end)._
+
+### §1 The defect class
+
+`documents.stored_path` held `H:\workspace\documents\<uuid><ext>.enc` (written at
+`ingestion/index.ts` in `prepareDocument`) and was consumed by a bare `existsSync` at **six**
+hand-written resolution ladders, none of which shared a resolver. Nothing anywhere rebased it —
+`grep rebase|relocat|driveLetter|remap` across the services layer returned nothing.
+
+So a drive returning under a different mount point (`H:` → `E:`, or a Windows letter ↔
+`/Volumes/…`) took **every** stored copy stale at once. The row was intact, the bytes were
+intact, only the recorded string was wrong — and the app told the user the file was gone.
+
+**It was the last absolute path in persisted state.** Every other path store had already been
+made portable, each by a named prior finding, and `stored_path` was simply missed:
+
+| Store | Portable | Fixed by |
+|---|---|---|
+| `image_sessions.stored_name` | relative filename under `images/` | image-understanding record |
+| `skills.path` | on-disk folder basename | Skills record |
+| `settings.checksumCache` | `driveRelKey` + lazy legacy adoption | **CODE-15** (full audit 2026-07-11) |
+| runtime install marker | posix `markerBinaryKey` | GPU wave |
+| `documents.source_relative_path` | forward-slash relative | **CODE-1** (full audit 2026-07-12) |
+| `config/drive.json`, `checksums.json` | `"models_dir": "models"`, `"local_path": "models/…"` | drive layout |
+| `documents.stored_path` | **NO** | **this wave** |
+
+The **vault layer already disagreed with the ingestion layer**: password-change re-encryption
+(`listEncryptedDocSidecars`) enumerates `workspace/documents/` by **directory walk**, never by
+`stored_path`. The `.enc` sidecars were canonically addressed everywhere except the six places
+that read them — which is why a relocated drive still re-keys correctly but cannot export.
+
+### §2 The three defects, in severity order
+
+**D-1 — "Delete document" did not delete (privacy/retention, not disk space).** The shred in
+`deleteDocument` was guarded by `if (row.stored_path && existsSync(row.stored_path))`. On a
+relocated drive that guard is false, so the DB rows committed-deleted and **the encrypted content
+stayed on the drive with no row left to ever reference, sweep, or shred it again** — the startup
+sweep (`shredStalePlaintext`) matches only `.parse`/`.tmp` names, never `<uuid><ext>.enc`. The
+guard conflated "already gone, nothing to do" with "I looked in the wrong place". Measured
+pre-fix: the row vanished and `<uuid>.txt.enc` remained. On a drive a user may sell, lend, or
+lose, this was the most serious item in the issue and it was not the item the issue reported.
+
+**D-2 — re-index degraded a healthy row.** `prepareDocument` fell through to `original_path`
+(gone, on a second laptop) and threw `main.ingest.sourceMissing`, flipping the row to `failed`.
+Non-destructive — the `sourceMissing` throw fires *before* the chunk DELETE, so the M13/C4
+"fail closed before the destructive replace" discipline already preserved the index — but it is
+the most likely user response to the reported symptom ("Importiere sie neu" → "Neu aufbereiten").
+
+**D-3 — the reported UI defect.** Export/preview/OCR/skills threw loudly and correctly; the
+complaint was that `DocumentInfo` carried **no availability signal at all**, so the `⋯` menu
+offered an action it could not perform and the failure arrived after the click, on a
+screen-level banner that did not say which document it was about.
+
+### §3 Decisions
+
+**D1 — one resolver, adopted by every consumer including the shred.** `ingestion/stored-copy.ts`
+is the single place that answers "where are this document's bytes". Scoping the fix to the export
+screen would have left D-1 in place. Six adoption sites: `prepareDocument`, `extractDocumentPreview`
+(which fans in to the Vorschau modal, skills runs, translate, compare, categorize),
+`readStoredDocumentText`, `readStoredDocumentBytes`, `readStoredPdfBytes` (OCR), `deleteDocument`.
+
+**D2 — `documents.stored_name`, not suffix probing.** A new nullable column holds the leaf
+(`<id><ext>[.enc]`) relative to the store dir, mirroring `image_sessions.stored_name`. The
+alternative — recompute `<id> + extname(title)` and probe both suffixes — works today only
+because `documents.title` is immutable (written once in `insertQueuedRow`; there is no rename
+feature) and it would have coupled on-disk resolution to a display string. `encrypted` is
+**derived** from the leaf's `.enc` suffix, exactly as the old code derived it from `stored_path`,
+so no second column was needed.
+
+**D3 — resolve at read time AND heal lazily; no bulk migration.** The resolution order is
+canonical (`join(storeDir, leaf)`) → recorded `stored_path` verbatim → the user's original. Keeping
+the recorded path as step 2 makes the resolver a **strict superset** of the previous behaviour:
+nothing that resolved before stops resolving. When step 1 wins and differs from the row,
+`healStoredCopy` writes `stored_path` + `stored_name` back — best-effort, wrapped, because a
+locked/closed/read-only DB must never fail a read that already succeeded. The same shape as
+`createSettingsHashStore`'s lazy adoption of legacy absolute keys (CODE-15). A startup migration
+was rejected: it is a write burst on the slowest possible medium, it cannot run before unlock, and
+it would need its own crash-safety story. A legacy row's leaf is derived from `stored_path`, so
+even an un-healed row resolves on its first read — including inside `deleteDocument`.
+
+**D4 — orphaned `.enc` files already on drives are reported, never swept.** A "delete every
+`.enc` with no owning row" sweep is the obvious cleanup and must not be built: a concurrent
+import has its file on disk before/while its row is written, and `stageRekey` stages
+`<file>.enc.new`. An orphan sweep would race both. Existing orphans from past silent no-ops stay
+on affected drives; the diagnostic in §6 counts them.
+
+**D5 — `original_path` demoted to a checked last resort.** On a portable drive it is the *least*
+durable of the two paths — it names a location on the other machine — yet the old ladder tried it
+immediately after a stale `stored_path`. It is also nulled outright for generated documents
+(`setDocumentOrigin`). And nothing re-checked it: a source file edited since import was handed
+back as though it were "the original as imported". Now `locateOriginal` compares it to
+`documents.sha256` and the two classes of caller diverge: **export refuses** a changed original
+(`main.docs.exportOriginalChanged` — its promise is the bytes as imported), while the **parse
+paths warn and proceed** (their promise is readable content, and re-reading current content is
+what re-index is for). An *undecidable* hash — no recorded sha256, or an unreadable file — is
+allowed through; refusing on "don't know" would break legitimate exports.
+
+**D6 — `DocumentInfo.storedCopy`, computed from one `readdirSync` per list call.** `listDocuments`
+takes an optional `storeDir`; supplied, every row reports `'present' | 'missing'`. It is
+deliberately **not** a `statSync` per row: the list is polled every 400 ms during an import and on
+USB each stat is a real seek (the ING-4 reasoning). Omit the argument and the field stays
+`undefined` — every pre-existing caller is byte-identical, and the renderer treats `undefined` as
+*unknown*, never as *missing*, so the menu entry is disabled only on a positive "missing".
+
+### §4 The safety guard (this fix touches deletion)
+
+`deleteDocument` shreds whatever the resolver returns, so "which file is this document's?" is a
+data-destruction question. `canonicalLeafFor` therefore refuses any leaf that is not a bare file
+name (no separators, no `.`/`..`) **starting with the row's own `id`** — a UUID primary key that is
+never reused. A refused leaf falls back to the recorded absolute path verbatim, never to a guess.
+Without it, a corrupted or foreign `stored_name` could make the shred destroy another document's
+copy. Three further invariants were held deliberately:
+
+- the shred still runs **strictly after** the DB commit — this wave changed *which* path is
+  shredded, never *when* (the DATA-1 ordering);
+- the shred stays **best-effort and non-throwing** — making it throw would resurrect DATA-1,
+  leaving a half-deleted, undeletable document;
+- `deleteDocument` **locates before the DB delete**, because afterwards the row that names the
+  file is gone.
+
+`storedCopyLeaf` splits on **both** separators rather than using host `basename`: a legacy row can
+carry a path written on another OS, and posix `basename` returns the whole Windows string. Same
+scar as `markerBinaryKey` / `resolveTarBinary` (the cross-platform path bugs that failed the
+Ubuntu CI leg).
+
+### §5 Transients and the encrypted workspace — unchanged
+
+Every transient is already `join(storeDir, …)` with a `.parse` infix (plus a `randomUUID()` where
+DB-2 requires it), so they are canonical and mount-independent by construction; the startup crash
+sweep matches by name inside the walked directory. A resolver change can neither strand nor leak
+them. Verified unaffected and **not** re-audited in future rounds: evidence packs (`snapshot.ts`
+reads `title, sha256, mime_type` from the DB only), audio preview and doc-task transcript
+re-extraction (read the `chunks` table, never the file), summary export, chat citations, FTS and
+vector search, password change/rekey, image sessions.
+
+### §6 What is proven, and what still needs hardware
+
+Provable in the suite, and proven: export original / export text / preview / re-index / delete
+after the store directory moves (encrypted and plaintext), a legacy row naming a drive that does
+not exist (resolves **and heals**), a genuinely absent copy (still fails loudly; `storedCopy`
+reports `'missing'`; delete does not throw), a delete that must not touch a sibling document's
+copy, and the changed-fallback-original refusal. Each guard was **mutation-checked** — reverting
+the canonical branch, removing the id guard, and putting the shred back on the recorded path each
+turned the corresponding tests red.
+
+**Still owed, and it cannot be CI'd:** the real relocated-drive run — plugging the prepared drive
+in under a different letter and confirming export, preview, delete, and re-index. That is exactly
+**BUILD_STATE §5 item 1's "second-laptop continuity check"**, which remains OPEN: this wave makes
+the code correct, but the check is only *answered* by a real run.
+
+**Also outstanding: the root-cause diagnostic on the reporting drive was never run.** The fix is
+correct in either world — D-1 and the resolver stand on their own — but two questions are still
+open on that specific drive: whether its rows are in fact stale (the issue reports "Vorschau
+works" alongside an export failure, and preview and export share the same ladder, so those two
+observations cannot both describe the same document), and how many orphaned `.enc` files past
+silent deletes left behind (D4). A read-only diagnostic that copies `config/workspace.json` +
+`hilbertraum.sqlite.enc` to scratch, decrypts the copy, and reports directory histograms with no
+titles or content was written and smoke-tested against a synthetic vault; it needs the owner's
+password to run.
+
+### §7 §-anchor legend
+
+| Working-paper anchor | Resolves to |
+|---|---|
+| `plan §1` (mechanism), `plan §2` (the six sites) | §1 + §2 above |
+| `plan §3` (loud vs silent vs worse) | §2 above (D-1/D-2/D-3) |
+| `plan §4` (`original_path` as fallback) | §3 D5 above |
+| `plan §5` (migration) | §3 D2 + D3 above |
+| `plan §6` (encrypted-workspace dimension) | §5 above |
+| `plan §7` (absolute paths elsewhere on the drive) | §1 table above |
+| `plan §8` (data-safety review of the fix) | §4 above |
+| `plan §9` (test strategy, T1–T9) | §6 above |
+| `plan §10` (the unproven hypothesis + diagnostic) | §6 above, last paragraph |
+| `plan §12` (owner decisions D1–D5) | §3 above (same numbering) |
+
+### §8 Bundler landmine (cost a debug cycle; recorded so it never recurs)
+
+`npm run build` failed with `index.mjs: ERROR: Unterminated string literal` pointing at
+`const MIME_BY_EXT = {` — untouched code — while **typecheck and the whole suite passed**.
+
+electron-vite's `esmShimPlugin` picks its CommonJS-shim injection point as the LAST match of a
+loose static-import regex (`ESMStaticImportRe`) over the entire rendered chunk. A **string literal
+ending in the bare word `import`** matches that regex:
+
+```ts
+log.warn('… it has changed since import', { documentId })   // ` import'` looks like an import
+```
+
+Sitting after the real last import in the bundle, the shim was appended INSIDE the literal.
+Comments are stripped before the plugin runs, so only string literals are the hazard (the three
+pre-existing `… import"` occurrences in comments are harmless). Reworded to `… what was imported`;
+a **tripwire** in `tests/integration/repo-hygiene.test.ts` now fails on the pattern (mutation-
+checked — reinstating the old wording turns it red), following the DEP-3 mermaid-fence precedent.
+
+**This is the standing argument for the gate order `typecheck → build → test`.** Neither typecheck
+nor the suite can see this class; only the build can.
+
 ## Original MVP spec — retirement record & §-anchor legend (2026-07-11)
 
 The frozen original product/architecture spec **`CLAUDE_HilbertRaum_MVP.md` was retired and

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -81,6 +81,15 @@ scan-detected or already OCR'd; needs the OCR engine, not the chat runtime);
 content and never leaves the DB); `AppStatus` gained the additive
 `ocrAvailable: boolean` gate. The internal `OCR_RASTER` channels (shared/ipc.ts) bind
 ONLY the hidden rasterizer window's preload, never the app bridge.
+**Issue #188 (wave 188):** `DocumentInfo` gained the optional `storedCopy?: 'present' | 'missing'`
+— whether the document's workspace copy is on disk right now, so the `⋯` menu can refuse to offer a
+byte-level action that would fail after the click. It is populated ONLY by callers that hold a store
+dir (`listDocuments(db, embedderId, storeDir)`; the docs IPC passes it), derived from ONE
+`readdirSync` of `workspace/documents/` per call rather than a stat per row. **`undefined` means
+"not evaluated", never "missing"** — `getDocument`/`createQueuedDocument` results simply do not
+carry it, and every consumer must treat absence as unknown. Backed by the additive
+`documents.stored_name` column (the stored copy's leaf name, RELATIVE to the store dir; NULL until
+the resolver heals the row) — see architecture.md "Portable stored copies — design record".
 (`pickDocuments` + `reindexDocument` are Phase-4 additions to the `IPC` registry beyond the spec
 §9.1 list — picker + re-index UX; `getPolicy` is a Phase-8 addition; the four `workspace:*` channels
 are Phase-9 additions.) `createConversation` now also accepts an optional `mode`

--- a/docs/drive-layout.md
+++ b/docs/drive-layout.md
@@ -109,6 +109,20 @@ HILBERTRAUM/
 > by `scripts/build-commercial-drive.{ps1,sh}` (canonical: `services/commercial-drive.ts`). See
 > [`packaging.md`](packaging.md).
 
+> **Portability is a whole-stack property, not just the launcher (issue #188).** The launcher
+> deriving the root from its own location is necessary but was not sufficient: until wave 188,
+> `documents.stored_path` recorded each stored copy as an **absolute** path, so a drive that came
+> back under a different letter still resolved its ROOT correctly while every stored document
+> looked missing — and "Delete document" silently stopped shredding. **Nothing on this drive may
+> persist an absolute path.** The portable spellings, all of which resolve against a dir computed
+> at runtime: `documents.stored_name` and `image_sessions.stored_name` (leaf under
+> `workspace/documents` / `workspace/images`), `skills.path` (folder basename), the checksum cache
+> (`driveRelKey`), the runtime install marker (`markerBinaryKey`, posix separators), and the
+> `local_path` fields in `config/*.json`. The one deliberate exception is
+> `documents.original_path`, which names a file on the **user's own machine** and is therefore
+> expected not to survive a move — it is a last-resort fallback, never the source of truth. See
+> architecture.md "Portable stored copies — design record".
+
 > **Naming reconciliation.** This layout reflects what the **code actually reads**,
 > which is the source of truth:
 > - Sidecar OS sub-dirs are **`win` / `mac` / `linux`** (resolved by `services/runtime/sidecar.ts`


### PR DESCRIPTION
Closes #188.

## What was actually wrong

`documents.stored_path` was persisted **absolute** and consumed with a bare `existsSync` at **six** hand-written resolution ladders, none of which shared a resolver. A portable drive returning under a different mount point (`H:` → `E:`, or a Windows letter ↔ `/Volumes/…`) therefore took **every** stored copy stale at once — row intact, bytes intact, only the recorded string wrong.

It was the **last absolute path in persisted state**. Every other path store had already been made portable, each by a named prior finding — `image_sessions.stored_name`, `skills.path`, the model checksum cache (**CODE-15**), the runtime install marker (`markerBinaryKey`), `documents.source_relative_path` (**CODE-1**), `config/*.json`. And the **vault layer already disagreed with the ingestion layer**: password-change re-encryption enumerates `workspace/documents/` by **directory walk**, never by `stored_path`. The `.enc` sidecars were canonically addressed everywhere except the six places that read them.

## The reported bug was the smallest of three

| | Defect | Severity |
|---|---|---|
| **D-1** | **"Delete document" silently did not delete.** The shred's `existsSync` guard conflated *"already gone, nothing to do"* with *"I looked in the wrong place"*. The DB rows committed-deleted and the **encrypted user content stayed on the drive**, with no row left to ever reference, sweep, or shred it — the startup sweep matches only `.parse`/`.tmp`, never `<uuid><ext>.enc`. | **Privacy/retention, not disk space.** On a drive a user may sell, lend, or lose. |
| **D-2** | Re-index degraded a healthy row to `failed`. Non-destructive (the throw fires *before* the chunk DELETE, so the M13/C4 discipline preserved the index) but it is the likely user response to the symptom: *"Importiere sie neu"* → *"Neu aufbereiten"*. | Medium |
| **D-3** | The reported UI defect — `DocumentInfo` carried no availability signal, so the `⋯` menu offered an action it could not perform and failed after the click. | The filed issue |

D-1 was **measured, not inferred**: a throwaway test against unmodified code left `3d5937ba-….txt.enc` on disk after the row was gone.

## The fix — scoped to the resolver, not the screen

- **`services/ingestion/stored-copy.ts`** — the single answer to "where are this document's bytes". Order: canonical `join(storeDir, <id><ext>[.enc])` → recorded `stored_path` verbatim → the user's original. Keeping the recorded path as step 2 makes it a **strict superset**: nothing that resolved before stops resolving. Adopted by all six sites **including the shred**.
- **`documents.stored_name`** (additive, nullable) — the portable leaf, **lazily healed** on read, following `createSettingsHashStore`'s legacy-key adoption. No startup migration: that is a write burst on the slowest medium, it cannot run before unlock, and it would need its own crash-safety story. A legacy row's leaf is recovered from `stored_path` by a **both-separator** split (host `basename` returns the whole string for a foreign-OS path — the `markerBinaryKey`/`resolveTarBinary` scar).
- **`DocumentInfo.storedCopy: 'present' | 'missing'`** from **one `readdirSync` per list call**, never a stat per row (the list is polled every 400 ms during import; on USB each stat is a real seek — ING-4). `undefined` means *not evaluated*, never *missing*.
- **`original_path` demoted to a checked last resort** — on a portable drive it is the *least* durable path, and nothing used to re-verify it, so an edited source file was handed back as "the original". Export now refuses a changed original; the parse paths warn and proceed.

### Data safety

`deleteDocument` shreds only a **bare filename starting with the row's own UUID** — a refused leaf falls back to the recorded path verbatim, never to a guess. The shred still runs **strictly after** the DB commit (this changed *which* path, never *when*) and stays **best-effort and non-throwing** — making it throw would resurrect DATA-1. No orphan sweep was built (D4): it would race a concurrent import and a staging rekey.

## Verification

Red-first, then **guard-mutated** — a test that never goes red is not a guard:

| Mutation | Went red |
|---|---|
| disable the canonical-location branch | 8 tests |
| drop the `startsWith(row.id)` guard | 2 resolver units |
| put the shred back on `row.stored_path` | T3 + T3c |

Suite **5249 / 50 / 5299 (376 files) → 5273 / 50 / 5323 (378 files)** — +24 deliberate tests, skip count unchanged. `typecheck → build → test` green in that order at every gate.

## Bundler landmine (now tripwired)

`npm run build` failed with `Unterminated string literal` pointing at untouched code, while typecheck and the **entire suite passed**. electron-vite's `esmShimPlugin` picks its CommonJS-shim injection point as the last match of a loose static-import regex over the whole chunk — and a **string literal ending in the bare word `import`** matches it, so the shim was wedged inside the literal. Reworded, and `repo-hygiene.test.ts` now fails on the pattern (mutation-checked). This is the standing argument for the gate order.

## Still open (carried into BUILD_STATE §5 item 1)

- **The real relocated-drive run.** A moved-directory test is not a relocated drive; the second-laptop continuity check is only *answered* by hardware.
- **The read-only root-cause diagnostic on the reporting drive was never run.** It needs the owner's password. It would settle whether that drive's rows are in fact stale — the issue reports "Vorschau works" alongside the export failure, and preview and export share one ladder, so both cannot describe the same document — and count the orphaned `.enc` files past silent deletes left behind.

**Record:** `docs/architecture.md` "Portable stored copies — design record (wave 188, issue #188, §1–§8)". Shared-shape change in `docs/data-contracts.md`; the portability rule in `docs/drive-layout.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
