### PR TITLE
fix(runtime): one shared occupancy span for the in-app model lanes (#185, #186)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,35 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-19 — **Model occupancy — wave CLOSED (issues #185/#186).**_ The two issues the local-API
+wave filed out of scope were one defect seen from two sides, and were fixed together as both asked.
+"Who has the model" was answered by three registries and one hole: chat had `inFlightStreams`, doc
+tasks had their queue, **skill runs had per-DOCUMENT bookkeeping that is not a global busy signal
+(#186), and the benchmark had nothing at all (#185)** — so `startSkillRun` consulted neither of the
+other two, and two Diagnostics clicks (or one during a chat answer) both reached the model. The
+generation gate could not be the fix: it counts in-flight `chatStream` **pulls**, so a multi-step
+job reads IDLE between two of its own calls and a guard riding it would admit a second job into that
+gap. Shape: a **span** registry (`services/runtime/occupancy.ts`) on the `RuntimeManager`, held by
+the three BACKGROUND lanes only — chat keeps `inFlightStreams` as its one record, and the guards
+compose the sources (`ipc/model-busy.ts`) rather than mirroring them. `isExternallyBusy()` folds the
+spans in, so the local API now waits on a background job honestly instead of slipping into its gap.
+The skill lane is **declared in the descriptor table** (`SkillToolDescriptor.modelLane`), pinned to
+the dispatch by a source test — `'direct'` (redact/edit) takes a span, `'doctask'`
+(`categorize_transactions`) takes NONE, because its model call happens inside a task it enqueues and
+a span there would refuse its own task (the D26 deadlock). Two non-guards are load-bearing: a doc
+task never refuses on the doc-task span it holds itself (the #38 tree→extract chain enqueues from
+inside `run()`), and **chat is never refused by the benchmark** — the first-run benchmark fires right
+after unlock, so it YIELDS instead: the tokens/sec probe re-checks before it starts and on every
+chunk and **discards** a contended reading, which matters because a depressed reading steps the
+profile AND the recommendation down and is then PERSISTED (the one case where the issues'
+"degraded, not corruption" understates it). The discard raises the new persist-canonical
+`warnSpeedSkipped` — never a silent hole. **Durable record:** `docs/architecture.md` "Model
+occupancy — design record (issues #185/#186, §1–§6)" — decisions D1–D8, the full exclusion table,
+the leak posture, and what the wave deliberately did not do. **User-facing:**
+`docs/troubleshooting.md` "The model is busy — one job at a time". Suite 5312/50; 39 new tests in
+`model-occupancy.test.ts` + `model-occupancy-ipc.test.ts`. No hardware gate owed — every lane is
+exercised by scripted fake runtimes.
+
 _2026-08-19 — **Portable stored copies — wave CLOSED (issue #188).**_ `documents.stored_path` was
 persisted **absolute** and consumed with a bare `existsSync` at six hand-written ladders, so a
 portable drive returning under a different mount point took **every** stored copy stale at once —
@@ -61,7 +90,7 @@ what the audits changed, and the §-anchor legend for the retired plan's citatio
 Citations use PR # + the `local-api-p<N>` phase prefix + a record §, never a branch SHA (O6 —
 the repo squash-merges). **Filed out of scope, deliberately** (pre-existing in-app concurrency the
 new gate makes visible but does not serialize): the benchmark has no re-entrancy guard, and a skill
-run can generate alongside a chat stream — filed as **#185** and **#186**. **Post-closeout fix (owner decision 2026-08-18, prompted by a REAL attached drive):** a `policy.json` that PREDATES `allow_local_api` now inherits the permissive default instead of a packaged build's STRICT base — otherwise every drive already in the field would have read "turned off by your drive's policy" with no way to distinguish that from a deliberate ban. An explicit `false` still denies (O4 intact); a junk value and a malformed file still fail closed. Recorded as **O4b** in the design record. **Real-model smoke DONE 2026-08-18** on a real attached drive (H:, prepared "lite", encrypted
+run can generate alongside a chat stream — filed as **#185** and **#186** (both CLOSED 2026-08-19, see the model-occupancy entry above). **Post-closeout fix (owner decision 2026-08-18, prompted by a REAL attached drive):** a `policy.json` that PREDATES `allow_local_api` now inherits the permissive default instead of a packaged build's STRICT base — otherwise every drive already in the field would have read "turned off by your drive's policy" with no way to distinguish that from a deliberate ban. An explicit `false` still denies (O4 intact); a junk value and a malformed file still fail closed. Recorded as **O4b** in the design record. **Real-model smoke DONE 2026-08-18** on a real attached drive (H:, prepared "lite", encrypted
 workspace, pinned b9849 vulkan engine) against `gemma4-e2b-it-qat-q4` on GPU: default-off proven
 with the vault unlocked, 401 unauthenticated, a real non-streaming completion and a full streaming
 one, every Host/Origin/method/type refusal, **O5's dual loopback vindicated** (both `::1` and

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -347,6 +347,21 @@ function initBackend(): void {
     // closes the DB at the very end of its multi-second teardown, so without it a task admitted
     // mid-teardown would pump immediately and lazily respawn the just-suspended sidecar.
     isWorkspaceLocking: () => workspace.isLocking(),
+    // #185/#186: the other half of the chat exclusion. `isChatStreaming` above sees only the
+    // lanes that register in `inFlightStreams`; a skill run's LLM locate pass and the hardware
+    // benchmark's speed probe reach `chatStream` without ever appearing there. Scoped to the
+    // OTHER lanes — a doc task must never refuse on the doc-task span it holds itself (the #38
+    // tree→extract chain enqueues from inside `run()`, span still held).
+    occupiedLane: () => {
+      const lane = runtime.occupancy.heldLane(['doc-task'])
+      // `heldLane` already filtered it out; the re-test is what narrows the type to the two
+      // lanes the manager's dep accepts, so the exclusion above cannot be widened by accident.
+      return lane === 'doc-task' ? null : lane
+    },
+    // …and the span the RUNNING task holds, so a skill run, the benchmark, and external
+    // local-API admission see a multi-step task as continuously busy rather than idle in the
+    // gaps between its model calls.
+    beginOccupancy: () => runtime.occupancy.begin('doc-task'),
     audit
   })
 

--- a/apps/desktop/src/main/ipc/chat-stream.ts
+++ b/apps/desktop/src/main/ipc/chat-stream.ts
@@ -25,6 +25,7 @@ import {
   isExceedContextError,
   isRuntimeUnresponsiveError
 } from '../services/runtime/llama'
+import { modelBusyMessageKey } from '../services/runtime/occupancy'
 import { tMain } from '../services/i18n'
 import { log } from '../services/logging'
 import { perfMark, perfMs } from '../services/perf'
@@ -38,9 +39,9 @@ import { inFlightStreams, streamBuffers, streamSettled } from './inflight'
 
 /**
  * Shared guard preamble: the conversation must exist, a runtime must be active, no doc
- * task may be running, and no stream may already be in flight for this conversation.
- * Throws the same friendly/ephemeral errors both handlers used. Returns the looked-up
- * conversation + the active runtime so the caller can proceed.
+ * task and no model-lane skill run may be working, and no stream may already be in flight
+ * for this conversation. Throws the same friendly/ephemeral errors both handlers used.
+ * Returns the looked-up conversation + the active runtime so the caller can proceed.
  */
 export async function assertChatStreamReady(
   ctx: AppContext,
@@ -62,6 +63,18 @@ export async function assertChatStreamReady(
   // build that is only queued, not yet holding the slot) still refuses chat (plan §4.1/H10).
   if (ctx.docTasks?.hasActiveTask() && !ctx.docTasks.isYieldingBuildActive()) {
     throw new Error(DOC_TASK_BUSY_MESSAGE)
+  }
+  // #186: the same one-at-a-time rule for a skill run whose tool streams on the chat runtime
+  // directly (the `modelLane: 'direct'` redaction / document-edit locate passes). It is the
+  // same shape of work as a doc task — user-started, cancellable, visible in the run bar — and
+  // a `categorize_transactions` run has ALWAYS refused chat this way, because its model call
+  // happens inside a doc task. Without this, that one skill run was excluded and its two
+  // siblings were not. The benchmark is deliberately NOT in this check: it is short, and the
+  // first-run benchmark fires right after unlock, where refusing the user's first message
+  // would be a regression — it yields to chat instead (#185, `benchmark.ts` modelBusy).
+  // Optional-chained: partial test contexts build a fake `runtime` object with only `active()`.
+  if (ctx.runtime.occupancy?.held('skill-run')) {
+    throw new Error(tMain(modelBusyMessageKey('skill-run')))
   }
   // One active stream per conversation (shared registry across plain chat + RAG).
   if (inFlightStreams.has(conversationId)) {

--- a/apps/desktop/src/main/ipc/model-busy.ts
+++ b/apps/desktop/src/main/ipc/model-busy.ts
@@ -1,0 +1,59 @@
+import { inFlightStreams } from './inflight'
+import type { AppContext } from '../services/context'
+import type { ModelBusyLane, OccupancyLane } from '../services/runtime/occupancy'
+
+export { modelBusyMessageKey } from '../services/runtime/occupancy'
+export type { ModelBusyLane } from '../services/runtime/occupancy'
+
+// The ONE composed answer to "is anything already using the chat model, and what?" for the
+// lanes that must refuse to start on top of each other (issues #185/#186).
+//
+// It composes rather than duplicates. Each lane already owns the authoritative record of its
+// own state, and this reads each at its source:
+//
+//   chat        `inFlightStreams` — the same registry the doc-task admission guard has read
+//               since wave 3. Chat is not an occupancy span (see `runtime/occupancy.ts`).
+//   doc-task    `DocTaskManager.hasActiveTask()` — queued OR running. A queued task does not
+//               occupy the model yet, but it will the moment the pump frees, so a benchmark
+//               or a skill run admitted "into the queue's shadow" would collide seconds later.
+//               (The RUNNING half also holds an occupancy span, which is what makes a doc task
+//               visible to the external local-API lane through `isExternallyBusy`.)
+//   skill-run   an occupancy span — the SkillRunController is per-document bookkeeping, not a
+//               global busy signal, which is exactly what #186 reported.
+//   benchmark   an occupancy span — the benchmark had no registry at all (#185).
+//
+// This lives in the IPC layer because `inFlightStreams` does: `main/index.ts` already passes it
+// INTO the doc-task manager (`isChatStreaming`) rather than letting a service import upward, and
+// that direction is kept. The doc-task manager therefore does not call this — it keeps its own
+// chat check with its own pinned copy, and consults only the occupancy half.
+
+/** The context slice this needs — a `Pick` so a test can pass a two-field literal. */
+export type ModelBusyContext = Pick<AppContext, 'runtime' | 'docTasks'>
+
+/**
+ * The lane currently holding the model, or null when nothing is. Checked in refusal-copy
+ * priority: chat first (the one the user is most likely watching), then the doc-task queue,
+ * then the remaining spans oldest-first.
+ *
+ * `ignore` lets a caller exclude a lane where overlap is legitimate. The benchmark
+ * deliberately does NOT ignore its own lane — a second benchmark seeing the first is exactly
+ * the re-entrancy guard #185 asked for.
+ */
+export function modelBusyLane(
+  ctx: ModelBusyContext,
+  opts?: { ignore?: readonly ModelBusyLane[] }
+): ModelBusyLane | null {
+  const ignore = opts?.ignore ?? []
+  if (!ignore.includes('chat') && inFlightStreams.size > 0) return 'chat'
+  if (!ignore.includes('doc-task') && (ctx.docTasks?.hasActiveTask() ?? false)) return 'doc-task'
+  // `doc-task` is answered above (its span is the RUNNING subset of `hasActiveTask`), so it is
+  // always excluded here — otherwise a deliberately ignored doc task would leak back in through
+  // the span half and the `ignore` option would silently not work for that lane.
+  const spanIgnore = [...ignore, 'doc-task'].filter(
+    (lane): lane is OccupancyLane => lane !== 'chat'
+  )
+  // Optional-chained on purpose: partial test contexts build a fake `runtime` with just the
+  // methods they need, and an unwired registry means "never occupied" — the same posture as
+  // `ctx.docTasks?` above and every other late-bound probe on the context.
+  return ctx.runtime?.occupancy?.heldLane(spanIgnore) ?? null
+}

--- a/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
+++ b/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
@@ -10,6 +10,7 @@ import { discoverManifests } from '../services/models'
 import { getSettings, updateSettings } from '../services/settings'
 import { tMain } from '../services/i18n'
 import { workspaceAdmitsWork } from '../services/workspace-vault'
+import { modelBusyLane, modelBusyMessageKey } from './model-busy'
 import { log } from '../services/logging'
 
 // IPC for the hardware benchmark + model recommendation (spec §9.1, §11).
@@ -43,8 +44,37 @@ async function probeAndPersistGpu(ctx: AppContext): Promise<GpuBenchmarkInput> {
   return { name: devices[0]?.name ?? null, useful: gpuUsefulForProfile(devices) }
 }
 
-/** Run the benchmark and persist the result (the shared core of IPC + first-run). */
+/**
+ * Run the benchmark and persist the result (the shared core of IPC + first-run).
+ *
+ * #185 — the re-entrancy and busy guard. This is the only entry point (both the Diagnostics
+ * button and the first-run background call land here), and it had NO guard at all: two runs
+ * started in quick succession, or one started while a chat streamed, both reached the model.
+ * The guard is one read of the shared occupancy signal, taken and acted on SYNCHRONOUSLY —
+ * before the first `await` — so two callers cannot both see idle, and the span the run then
+ * holds covers the whole thing (GPU probe, drive probe, speed probe), which is what makes a
+ * second run see the first.
+ *
+ * The benchmark's own lane is deliberately NOT ignored: a second benchmark seeing the first
+ * IS the re-entrancy guard.
+ *
+ * Throws the friendly, localized refusal. The Diagnostics button surfaces it; the first-run
+ * caller (`maybeRunFirstBenchmark`) already logs and drops it, and re-runs next launch because
+ * `lastBenchmark` stays null.
+ */
 export async function runAndPersistBenchmark(ctx: AppContext): Promise<BenchmarkResult> {
+  const busy = modelBusyLane(ctx)
+  if (busy) throw new Error(tMain(modelBusyMessageKey(busy)))
+  const releaseOccupancy = ctx.runtime.occupancy.begin('benchmark')
+  try {
+    return await runBenchmarkAndPersist(ctx)
+  } finally {
+    releaseOccupancy()
+  }
+}
+
+/** The benchmark body, run under the `benchmark` occupancy span held by the caller above. */
+async function runBenchmarkAndPersist(ctx: AppContext): Promise<BenchmarkResult> {
   const manifests = ctx.manifestsDir
     ? discoverManifests(ctx.manifestsDir).manifests.map((m) => m.manifest)
     : []
@@ -61,7 +91,11 @@ export async function runAndPersistBenchmark(ctx: AppContext): Promise<Benchmark
     manifests,
     runtime: ctx.runtime.active(),
     gpu,
-    effectiveRead
+    effectiveRead,
+    // #185: the admission guard above ran seconds ago — before the GPU + drive probes — so
+    // re-check right at the speed probe, ignoring our OWN span (which is held for this whole
+    // function and would otherwise report the benchmark as busy against itself).
+    modelBusy: () => modelBusyLane(ctx, { ignore: ['benchmark'] }) != null
   })
 
   // Persist the last result via the settings store (spec §8 defines no benchmarks table).
@@ -98,8 +132,11 @@ export function maybeRunFirstBenchmark(ctx: AppContext): void {
     return // settings unreadable (e.g. just locked again) — a manual run still works
   }
   log.info('First run: benchmarking hardware in the background')
+  // #185: the busy refusal lands here too (this fires right after unlock, where a doc task or
+  // the user's first message can already own the model). Dropping it is correct — `lastBenchmark`
+  // stays null, so the next launch tries again, and Diagnostics can run it on demand meanwhile.
   void runAndPersistBenchmark(ctx).catch((err) =>
-    log.warn('First-run benchmark failed (re-run from Diagnostics)', String(err))
+    log.warn('First-run benchmark skipped or failed (re-run from Diagnostics)', String(err))
   )
 }
 

--- a/apps/desktop/src/main/ipc/registerSkillsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerSkillsIpc.ts
@@ -19,6 +19,8 @@ import { tMain } from '../services/i18n'
 import { workspaceAdmitsWork } from '../services/workspace-vault'
 import { log } from '../services/logging'
 import { skillNeedsNewerApp } from '../../shared/skill-manifest'
+import { getToolDescriptor } from '../../shared/skill-tools'
+import { modelBusyLane, modelBusyMessageKey } from './model-busy'
 import { getSkill, getSkillsByDeclaredId, setSkillEnabled } from '../services/skills/registry'
 import { suggestSkillsForTurn } from '../services/skills/suggest'
 import { SkillRunController } from '../services/skills/run-controller'
@@ -442,6 +444,41 @@ export function registerSkillsIpc(ctx: AppContext): void {
       }
     )
     if (!runner) return { started: false, error: tMain('main.skills.run.unavailable') }
+    // #186: the model-lane guard. A `modelLane: 'direct'` tool (the redaction / document-edit
+    // LLM locate passes) streams on the chat runtime inside its run, so it must not start on
+    // top of a chat answer, a document task, the benchmark, or another such run — before this,
+    // `startSkillRun` consulted neither `inFlightStreams` nor the doc-task registry, and the
+    // per-document `SkillRunController` key is not a global "the model is busy" signal.
+    //
+    // Two deliberate exclusions from the span:
+    //   - `modelLane: 'doctask'` (`categorize_transactions`) takes NONE. Its model call happens
+    //     inside a doc task it enqueues, which holds the `doc-task` span itself; a span here
+    //     would make that task refuse its own parent run (the D26 deadlock).
+    //   - a null runtime takes none either. The locate pass needs one — redaction degrades to
+    //     its deterministic floor and the edit tool refuses — so there is nothing to exclude,
+    //     and chat cannot be running without a runtime anyway.
+    // `ctx.runtime` is optional in the partial contexts the skills tests build; unwired ⇒ no
+    // guard and no span, exactly like `ctx.docTasks?` in the sibling checks.
+    const occupancy = ctx.runtime?.occupancy ?? null
+    const modelLane = getToolDescriptor(toolName)?.modelLane
+    const occupies = modelLane === 'direct' && occupancy != null && ctx.runtime?.active() != null
+    if (occupies) {
+      const busy = modelBusyLane(ctx)
+      if (busy) return { started: false, error: tMain(modelBusyMessageKey(busy)) }
+    }
+    // Taken BEFORE `runController.start` and synchronously, so two runs racing this handler
+    // cannot both read idle. Released in the runner's own `finally` — every terminal path
+    // (success, failure, cancel) settles that promise, and the release is idempotent.
+    const releaseOccupancy = occupies ? occupancy!.begin('skill-run') : null
+    const gatedRunner = releaseOccupancy
+      ? async (deps: Parameters<typeof runner>[0]): ReturnType<typeof runner> => {
+          try {
+            return await runner(deps)
+          } finally {
+            releaseOccupancy()
+          }
+        }
+      : runner
     try {
       // API-3 (backend-audit 2026-06-27): `documentCount` is the v1 constant 1 because every wired
       // tool is single-document (`buildToolRunner` targets exactly `targetId`). TODO: when a
@@ -457,10 +494,13 @@ export function registerSkillsIpc(ctx: AppContext): void {
         documentId: targetId,
         documentCount: 1,
         conversationId,
-        runner
+        runner: gatedRunner
       })
       return { started: true, run }
     } catch {
+      // The controller refused (a run is already in flight on this document) — it never invoked
+      // the runner, so nothing will reach that `finally`. Release here or the span leaks.
+      releaseOccupancy?.()
       // One-at-a-time: a run is already in flight ON THIS DOCUMENT. Surface its handle (SKA-17) so a
       // renderer whose own store was reset (a reload) can RE-ADOPT the orphaned run — the fallback
       // re-attach path — instead of being stuck with "cancel it first" and nothing to cancel.

--- a/apps/desktop/src/main/services/benchmark.ts
+++ b/apps/desktop/src/main/services/benchmark.ts
@@ -218,9 +218,21 @@ export const BENCHMARK_TOKEN_TARGET = 64
  */
 export async function measureTokensPerSecond(
   runtime: ModelRuntime | null | undefined,
-  opts?: { signal?: AbortSignal }
+  opts?: { signal?: AbortSignal; modelBusy?: () => boolean; onBusySkip?: () => void }
 ): Promise<number | null> {
   if (!runtime) return null
+  // #185: refuse to measure a CONTENDED model. The benchmark's own admission guard already
+  // refused to start beside a chat answer or a document task, but the admission is followed by
+  // a GPU probe and an 8 MB drive probe — seconds in which the user can send a message. A
+  // reading taken while something else generates is not slow hardware, it is a shared slot, and
+  // a low reading is not cosmetic: it steps the profile down (VERY_LOW_TOKENS_PER_SECOND) and
+  // with it the recommended model, then PERSISTS that in `settings.lastBenchmark`. Null — the
+  // same value a machine with no runtime yields — is the honest answer, and the caller turns it
+  // into `warnSpeedSkipped` so the hole is never silent.
+  if (opts?.modelBusy?.()) {
+    opts.onBusySkip?.()
+    return null
+  }
   try {
     const t0 = performance.now()
     let count = 0
@@ -230,6 +242,14 @@ export async function measureTokensPerSecond(
     )) {
       count++
       if (count >= BENCHMARK_TOKEN_TARGET) break
+      // …and DISCARD a reading that became contended mid-probe (a message sent while the 64
+      // tokens stream). Breaking runs the generator's `return()`, so the runtime manager's
+      // generation gate decrements normally — an abandoned count is exactly what its epoch
+      // guard exists to catch, and this path never creates one.
+      if (opts?.modelBusy?.()) {
+        opts.onBusySkip?.()
+        return null
+      }
     }
     const seconds = (performance.now() - t0) / 1000
     if (count === 0 || seconds <= 0) return null
@@ -262,6 +282,13 @@ export interface WarningInputs {
   /** The measured figure named in the recommendation-lowered warning. */
   tokensPerSecond?: number | null
   /**
+   * True when the tokens/sec probe was DISCARDED because another lane was using the model
+   * (#185). Distinct from a plain absent reading (no runtime at all), which stays silent —
+   * this one says why the profile below has no speed input, so a re-run is an informed choice
+   * rather than a mystery.
+   */
+  speedSkipped?: boolean
+  /**
    * Honest effective read MB/s (#108/#110) — from a REAL model-load/checksum read, never
    * the probe's page-cached read leg. Gates the slow-read warning; null/absent (no
    * qualifying read yet — a fresh install) never warns. Preflight deliberately does not
@@ -288,6 +315,13 @@ export function buildWarnings(input: WarningInputs): string[] {
     warnings.push(t('en', 'main.benchmark.warnTiny'))
   } else if (input.profile === 'UNKNOWN') {
     warnings.push(t('en', 'main.benchmark.warnUnknown'))
+  }
+
+  // #185: say so when the speed leg was skipped because the model was busy elsewhere. Placed
+  // before the tok/s warnings below, which cannot fire in the same run (they all need a
+  // measured figure), so the two never contradict each other on one card.
+  if (input.speedSkipped) {
+    warnings.push(t('en', 'main.benchmark.warnSpeedSkipped'))
   }
 
   // Issue #52: the tok/s downgrade used to be completely silent — a crawl measured on an
@@ -390,6 +424,15 @@ export interface RunBenchmarkDeps {
    * module keeps its zero-`child_process`, probe-only I/O posture.
    */
   effectiveRead?: EffectiveReadSample | null
+  /**
+   * True while ANOTHER lane is using the chat model (#185) — injected by the caller
+   * (registerBenchmarkIpc binds it to `modelBusyLane`, ignoring the benchmark's own span).
+   * Consulted immediately before the tokens/sec probe and again on every streamed chunk: a
+   * contended reading measures a shared slot, not this computer, and it would be PERSISTED as
+   * a stepped-down profile + recommendation. Absent ⇒ measure unconditionally (today's
+   * behavior for every non-IPC caller, including the preflight harnesses).
+   */
+  modelBusy?: () => boolean
   /** Injectable clock for deterministic `ranAt` in tests. */
   now?: () => Date
 }
@@ -403,7 +446,15 @@ export interface RunBenchmarkDeps {
 export async function runBenchmark(deps: RunBenchmarkDeps): Promise<BenchmarkResult> {
   const sys = detectSystem()
   const drive = await measureDriveSpeed(deps.workspacePath)
-  const tokensPerSecond = await measureTokensPerSecond(deps.runtime ?? null)
+  // #185: `speedSkipped` distinguishes "no runtime was up, nothing to measure" (silent, the
+  // long-standing behavior) from "a runtime WAS up but something else was using it" (warned).
+  let speedSkipped = false
+  const tokensPerSecond = await measureTokensPerSecond(deps.runtime ?? null, {
+    modelBusy: deps.modelBusy,
+    onBusySkip: () => {
+      speedSkipped = true
+    }
+  })
   // Issue #52: record WHICH model produced the tok/s number — the currently loaded one,
   // which is often not the recommended one. null whenever nothing was measured.
   const measuredModelId = tokensPerSecond != null ? (deps.runtime?.modelId ?? null) : null
@@ -436,6 +487,7 @@ export async function runBenchmark(deps: RunBenchmarkDeps): Promise<BenchmarkRes
     measuredModelId,
     recommendationLowered,
     tokensPerSecond,
+    speedSkipped,
     effectiveReadMbps: deps.effectiveRead?.mbps ?? null
   })
 

--- a/apps/desktop/src/main/services/doctasks/context.ts
+++ b/apps/desktop/src/main/services/doctasks/context.ts
@@ -14,6 +14,7 @@ import type {
   TranslationTargetLang
 } from '../../../shared/types'
 import type { ModelRuntime, RuntimeChatOptions } from '../runtime'
+import type { OccupancyLane } from '../runtime/occupancy'
 import type { Translator } from '../translation'
 import type { IngestionDeps } from '../ingestion'
 import type { OcrEngine } from '../ocr'
@@ -87,6 +88,27 @@ export interface DocTaskDeps {
    * unwired ⇒ never locking, so partial test deps stay valid.
    */
   isWorkspaceLocking?: () => boolean
+  /**
+   * The OTHER background lane currently holding a model-occupancy span, or null (#185/#186 —
+   * `services/runtime/occupancy.ts`). `startDocTask` refuses on it, completing the exclusion
+   * that `isChatStreaming` only half-covered: a skill run's LLM locate pass and the hardware
+   * benchmark's speed probe both reach `chatStream` without ever entering `inFlightStreams`.
+   *
+   * Deliberately scoped to the lanes OTHER than `doc-task`. A doc task must never refuse on
+   * the doc-task span: the running task holds one, and the #38 tree→extract chain enqueues its
+   * follow-up from inside `run()` while it is still held — refusing there would break the
+   * chain. Task-vs-task exclusion is the queue's job, not this signal's. Absent/unwired ⇒
+   * never occupied, so partial test deps stay valid.
+   */
+  occupiedLane?: () => Exclude<OccupancyLane, 'doc-task'> | null
+  /**
+   * Take the `doc-task` occupancy span for the RUNNING task, returning its release (#185/#186).
+   * Held across the whole dispatch so the lanes that must not join it — a skill run, the
+   * benchmark, and external local-API admission — see a multi-step task as continuously busy
+   * instead of idle in the gaps between its model calls. Absent/unwired ⇒ no span is taken and
+   * nothing else changes.
+   */
+  beginOccupancy?: () => () => void
   audit?: AuditRecorder
 }
 

--- a/apps/desktop/src/main/services/doctasks/manager.ts
+++ b/apps/desktop/src/main/services/doctasks/manager.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../shared/types'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../runtime'
 import { isExceedContextError } from '../runtime/llama'
+import { modelBusyMessageKey } from '../runtime/occupancy'
 import { ContextOverflowError } from './errors'
 import { getDocument } from '../ingestion'
 import { isPdfPath } from '../ingestion/parsers'
@@ -283,6 +284,14 @@ export class DocTaskManager {
     if (this.deps.isChatStreaming()) {
       throw new Error(tMain('main.task.refusedChatStreaming'))
     }
+    // #185/#186: the other half of the same exclusion. `isChatStreaming` sees only the lanes
+    // that register in `inFlightStreams`, which a skill run's LLM locate pass and the hardware
+    // benchmark's speed probe never do — both reach `chatStream` directly, so a task admitted
+    // beside one of them would interleave two generations on the single llama-server slot.
+    const occupied = this.deps.occupiedLane?.() ?? null
+    if (occupied) {
+      throw new Error(tMain(modelBusyMessageKey(occupied)))
+    }
     // OCR runs the local recognition engine, not the chat model — it needs the
     // vendored language files instead of a running runtime. TRANSLATION (TG-3, plan D3/O2)
     // runs the TranslateGemma sidecar — it needs the installed translation model, and the
@@ -542,9 +551,16 @@ export class DocTaskManager {
       return
     }
     this.runningId = next
+    // #185/#186: hold the `doc-task` occupancy span for exactly the dispatch. Taken here — the
+    // single place a task starts running — and released in the SAME `finally` that clears
+    // `runningId`, so the span can never outlive the task it describes. A multi-step task is
+    // then continuously busy to the lanes that must not join it (skill runs, the benchmark, and
+    // external local-API admission) instead of flickering idle between its model calls.
+    const releaseOccupancy = this.deps.beginOccupancy?.() ?? ((): void => {})
     // Track the dispatch promise so `awaitActiveTaskSettled()` (the lock/quit lifecycle) can
     // wait for this task's abort-unwind before the DB closes. `run()` never rejects.
     this.runningPromise = this.run(task).finally(() => {
+      releaseOccupancy()
       this.runningId = null
       this.runningPromise = null
       this.evictTerminalTasks()
@@ -733,7 +749,12 @@ const FRIENDLY_TASK_ERROR_KEYS: readonly MessageKey[] = [
   'main.task.ocrNotAScan',
   'main.task.ocrNoText',
   'main.task.ocrFailed',
-  'main.task.documentBusyIngesting'
+  'main.task.documentBusyIngesting',
+  // #185/#186 — the occupancy refusals `startDocTask` can throw. Only these two lanes: the
+  // chat lane is refused by `main.task.refusedChatStreaming` above, and a doc task never
+  // refuses on the doc-task lane (the queue serializes tasks; see `DocTaskDeps.occupiedLane`).
+  'main.busy.skillRun',
+  'main.busy.benchmark'
 ]
 
 /**

--- a/apps/desktop/src/main/services/runtime/index.ts
+++ b/apps/desktop/src/main/services/runtime/index.ts
@@ -1,5 +1,9 @@
 import { statSync } from 'node:fs'
 import type { ChatDepthMode, JsonSchema, RuntimeStatus } from '../../../shared/types'
+import { ModelOccupancy } from './occupancy'
+
+export { ModelOccupancy } from './occupancy'
+export type { OccupancyLane } from './occupancy'
 
 // Runtime manager (spec §7.5). Defines the swappable ModelRuntime interface so the
 // mock runtime and the real llama.cpp sidecar are interchangeable behind the same
@@ -217,6 +221,17 @@ export class RuntimeManager {
    */
   private stopped = false
 
+  /**
+   * The background-job occupancy spans (issues #185/#186 — see `occupancy.ts`). It lives on
+   * the manager because the manager is the authority on who has the model: the generation
+   * gate below answers "is a `chatStream` pull in flight RIGHT NOW", this answers "is a
+   * multi-step background job holding the model across its own gaps". Every guard that has
+   * to refuse a second job reads this one; `isExternallyBusy` folds it in so the local API
+   * waits on a doc task / skill run / benchmark honestly instead of slipping into a gap
+   * between two of its model calls.
+   */
+  readonly occupancy = new ModelOccupancy()
+
   // ---- Generation gate ------------------------------------------------------------------
   //
   // Generation reaches the model through several lanes (chat/RAG streams, doc tasks, skill
@@ -269,9 +284,14 @@ export class RuntimeManager {
    * no active runtime — fail closed. `active()` is null through the whole start window,
    * which is exactly when the #109 warm-up generation streams against the inner rung
    * runtime, invisible to the gate; treating that window as busy closes it.
+   *
+   * #185/#186: a held occupancy span counts too. Without it a doc task, a skill run, or the
+   * benchmark would look idle in the gap between two of its own model calls, and an external
+   * request admitted into that gap would then interleave with the job's next call — the same
+   * defect the spans exist to close in-app, appearing on the external lane.
    */
   isExternallyBusy(): boolean {
-    return this.current == null || this.isGenerating()
+    return this.current == null || this.isGenerating() || this.occupancy.isBusy()
   }
 
   /** Register/clear the external pre-emption hook (one consumer: local-API admission). */

--- a/apps/desktop/src/main/services/runtime/occupancy.ts
+++ b/apps/desktop/src/main/services/runtime/occupancy.ts
@@ -1,0 +1,125 @@
+// Model occupancy — the shared "a background job is holding the model" span registry
+// (issues #185/#186; architecture.md "Model occupancy — design record").
+//
+// WHY IT IS NOT THE GENERATION GATE. The `RuntimeManager` gate (index.ts) counts in-flight
+// `chatStream` pulls, which is exactly the right answer for the question it was built for
+// ("may an EXTERNAL request issue right now?") and exactly the wrong one for "is a background
+// job using the model?". A doc task, a skill run, and the benchmark are all multi-step: they
+// generate, do local work, then generate again. Between two calls the gate reads IDLE, so a
+// guard riding the raw gate would admit a second job into the gap and the two would then
+// interleave on the one llama-server slot. A SPAN closes the gaps: the job holds it from its
+// first model call to its last.
+//
+// WHICH LANES HOLD A SPAN. The three background lanes only:
+//
+//   doc-task    the DocTaskManager's RUNNING task (queued tasks do not occupy the model; the
+//               chat-side guard reads `hasActiveTask()`, which covers queued + running)
+//   skill-run   a skill run whose tool streams on the chat runtime directly — the
+//               `modelLane: 'direct'` descriptors (redact_document / apply_document_edits).
+//               `categorize_transactions` is `modelLane: 'doctask'` and takes NO span: its
+//               model call happens inside an enqueued doc task, which holds its own span.
+//               A categorize run that took one would refuse its own task (D26 deadlock).
+//   benchmark   the whole `runAndPersistBenchmark`, which is also its re-entrancy guard
+//
+// CHAT IS DELIBERATELY NOT A LANE. It already has `inFlightStreams` — the registry the
+// doc-task admission guard has always read — and duplicating it here would be a second
+// source of truth for the same fact. Chat is also the FOREGROUND: it is refused only by the
+// rules that predate this registry (an active doc task) plus the one this wave adds (a direct
+// skill run, #186), never by the benchmark. Guards that need "chat too" compose the two
+// sources; `ipc/model-busy.ts` holds that one composition.
+//
+// LEAK POSTURE. Every `begin()` is paired with a release in a `finally`, and the returned
+// release is idempotent (a double call is a no-op, not an under-count). A leaked span would
+// make background lanes — and external local-API admission, which folds this in — refuse
+// until the app restarts, so the release must never sit behind a conditional.
+
+import type { MessageKey } from '../../../shared/i18n'
+
+/** A background lane that can occupy the one chat runtime. Chat is not one — see the header. */
+export type OccupancyLane = 'doc-task' | 'skill-run' | 'benchmark'
+
+/** A lane that can be holding the model, including the foreground chat lane (`inFlightStreams`). */
+export type ModelBusyLane = 'chat' | OccupancyLane
+
+/**
+ * The friendly, content-free refusal copy for a busy lane. ONE message per lane, shared by
+ * every surface that refuses (benchmark, skill run, doc task, chat) — a per-surface × per-lane
+ * matrix would be twelve strings saying the same four things. Each names the affordance the
+ * user actually has right now (stop the answer, cancel the task, cancel the run in the bar).
+ *
+ * The doc-task manager's pre-existing chat refusal keeps `main.task.refusedChatStreaming`
+ * (renderer- and test-pinned since wave 3); it is deliberately NOT migrated onto this map.
+ */
+export function modelBusyMessageKey(lane: ModelBusyLane): MessageKey {
+  switch (lane) {
+    case 'chat':
+      return 'main.busy.chat'
+    case 'doc-task':
+      return 'main.busy.docTask'
+    case 'skill-run':
+      return 'main.busy.skillRun'
+    case 'benchmark':
+      return 'main.busy.benchmark'
+  }
+}
+
+interface Span {
+  lane: OccupancyLane
+  /** Epoch ms the span was taken — diagnostics only (a stuck lane is visible in a log line). */
+  since: number
+}
+
+/**
+ * The span registry. One instance per `RuntimeManager` (the manager is the authority on who
+ * has the model: the gate answers "right now", this answers "for the duration of a job").
+ * Pure in-process bookkeeping — no timers, no I/O, nothing to tear down.
+ */
+export class ModelOccupancy {
+  private readonly spans = new Map<symbol, Span>()
+
+  /**
+   * Take a span for `lane`. Returns an IDEMPOTENT release — call it in a `finally` on every
+   * exit path (success, throw, abort). Re-entrant by construction: two spans of the same lane
+   * simply coexist, and the lane reads busy until both release.
+   */
+  begin(lane: OccupancyLane): () => void {
+    const token = Symbol(lane)
+    this.spans.set(token, { lane, since: Date.now() })
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      this.spans.delete(token)
+    }
+  }
+
+  /** True while at least one span of `lane` is held. */
+  held(lane: OccupancyLane): boolean {
+    for (const span of this.spans.values()) if (span.lane === lane) return true
+    return false
+  }
+
+  /**
+   * The lane of the OLDEST span currently held, ignoring the lanes in `ignore` — the one the
+   * caller names in its refusal copy. Insertion order is held order (Map preserves it), so the
+   * job that has been waiting on the model longest is the one reported, not an arbitrary one.
+   * Null when nothing (relevant) is held.
+   */
+  heldLane(ignore: readonly OccupancyLane[] = []): OccupancyLane | null {
+    for (const span of this.spans.values()) {
+      if (!ignore.includes(span.lane)) return span.lane
+    }
+    return null
+  }
+
+  /** True while ANY span is held. The external-admission read (`isExternallyBusy`). */
+  isBusy(): boolean {
+    return this.spans.size > 0
+  }
+
+  /** Held spans, oldest first — for a diagnostic log line. Never used for control flow. */
+  snapshot(): Array<{ lane: OccupancyLane; heldMs: number }> {
+    const now = Date.now()
+    return [...this.spans.values()].map((s) => ({ lane: s.lane, heldMs: now - s.since }))
+  }
+}

--- a/apps/desktop/src/renderer/lib/displayMap.ts
+++ b/apps/desktop/src/renderer/lib/displayMap.ts
@@ -38,7 +38,10 @@ export const DISPLAY_MAP_KEYS: readonly MessageKey[] = [
   'main.benchmark.warnTiny',
   'main.benchmark.warnUnknown',
   'main.benchmark.warnDriveProbe',
-  'main.benchmark.warnSlowDrive'
+  'main.benchmark.warnSlowDrive',
+  // #185: the contended-probe warning is persisted into settings.lastBenchmark.warnings like
+  // its siblings, and carries no interpolated value — so it is exact-match, not INTERPOLATED.
+  'main.benchmark.warnSpeedSkipped'
 ]
 
 const KEY_BY_ENGLISH: ReadonlyMap<string, MessageKey> = new Map(

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1967,6 +1967,10 @@ export const de: Record<keyof typeof en, string> = {
   'main.benchmark.warnSlowDrive':
     'Dieses Laufwerk ist eher langsam. Modelle funktionieren trotzdem, das Laden kann aber ' +
     'länger dauern.',
+  'main.benchmark.warnSpeedSkipped':
+    'Die Textgeschwindigkeit wurde diesmal nicht gemessen, weil das Modell mit etwas anderem ' +
+    'beschäftigt war. Das Profil unten nutzt nur RAM, CPU und Laufwerksgeschwindigkeit — ' +
+    'führe den Benchmark noch einmal aus, wenn nichts anderes das Modell nutzt.',
   'main.benchmark.warnSlowRead':
     'Das Lesen von diesem Laufwerk lag bei etwa {mbps} MB/s. Beim Modellstart wird die ganze ' +
     'Modelldatei mit dieser Geschwindigkeit gelesen, Modellstarts dauern auf diesem Laufwerk ' +
@@ -2060,6 +2064,17 @@ export const de: Record<keyof typeof en, string> = {
   'main.chat.stopFirst':
     'Für diese Unterhaltung wird noch eine Antwort erstellt. Stoppe sie zuerst.',
   'main.chat.locked': 'Der Arbeitsbereich ist gesperrt. Entsperre ihn, um zu chatten.',
+  'main.busy.chat':
+    'Gerade wird eine Antwort geschrieben. Warte, bis sie fertig ist (oder stoppe sie), und ' +
+    'versuch es dann noch einmal.',
+  'main.busy.docTask':
+    'Eine Dokumentaufgabe nutzt gerade das Modell. Warte, bis sie fertig ist, oder brich sie ' +
+    'ab, und versuch es dann noch einmal.',
+  'main.busy.skillRun':
+    'Ein Skill arbeitet gerade an einem Dokument. Warte, bis er fertig ist, oder brich ihn in ' +
+    'der Leiste ab, und versuch es dann noch einmal.',
+  'main.busy.benchmark':
+    'Gerade läuft ein Hardware-Benchmark für diesen Computer. Versuch es in einem Moment noch einmal.',
   'main.task.unknownKind': 'Unbekannte Dokumentaufgabe.',
   'main.task.refusedChatStreaming':
     'Gerade wird eine Antwort geschrieben. Warte, bis sie fertig ist (oder stoppe sie), und ' +

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1912,6 +1912,14 @@ export const en = {
     'Drive speed could not be measured, so the recommendation uses RAM and CPU only.',
   'main.benchmark.warnSlowDrive':
     'This drive is on the slower side. Models will still work, but loading them may take longer.',
+  // #185: the speed measurement was DISCARDED because a chat answer or a document task
+  // started using the model while it ran — a contended reading is a slow reading, and a slow
+  // reading steps the profile (and the recommendation) down. Persist-canonical: it is stored
+  // in settings.lastBenchmark.warnings like its siblings above, so it is display-map matched.
+  'main.benchmark.warnSpeedSkipped':
+    'Text-generation speed was not measured this time, because the model was busy with ' +
+    'something else. The profile below uses RAM, CPU and drive speed only — run the ' +
+    'benchmark again when nothing else is using the model for a full reading.',
   // Interpolated persist-canonical (#110): carries the measured effective read speed, so the
   // display map reverse-matches it via a template regex (INTERPOLATED_MAP_KEYS), not exact match.
   // Names the consequence (model starts) rather than a generic slow-drive line.
@@ -2009,6 +2017,19 @@ export const en = {
   'main.chat.emptyQuestion': 'Cannot send an empty question.',
   'main.chat.stopFirst': 'A response is still being generated for this conversation. Stop it first.',
   'main.chat.locked': 'Workspace is locked. Unlock it to chat.',
+  // The shared model-occupancy refusals (issues #185/#186, `ipc/model-busy.ts`): ONE line per
+  // lane, used by every surface that refuses to start a second job on the one model — the
+  // benchmark, a skill run, a document task, and (for `skillRun`) chat itself. Each names the
+  // affordance the user has right now rather than just stating the conflict.
+  'main.busy.chat':
+    'An answer is being written right now. Wait for it to finish (or stop it), then try again.',
+  'main.busy.docTask':
+    'A document task is using the model. Wait for it to finish, or cancel it, then try again.',
+  'main.busy.skillRun':
+    'A skill is working on a document. Wait for it to finish, or cancel it in the run bar, ' +
+    'then try again.',
+  'main.busy.benchmark':
+    'A hardware benchmark is measuring this computer right now. Try again in a moment.',
   'main.task.unknownKind': 'Unknown document task.',
   'main.task.refusedChatStreaming':
     'An answer is being written right now. Wait for it to finish (or stop it), then try again.',

--- a/apps/desktop/src/shared/skill-tools.ts
+++ b/apps/desktop/src/shared/skill-tools.ts
@@ -28,6 +28,20 @@ import type { CountMessageKey, MessageKey } from './i18n'
 export type SkillToolSeamKind = 'extract' | 'downstream' | 'export'
 
 /**
+ * How a tool's model use reaches the one chat runtime — the #186 exclusion, declared here so
+ * the guard is derived from this table instead of a hand-kept name list in the IPC layer:
+ *   - `'direct'`  — the run streams on the chat runtime itself (the redaction / document-edit
+ *     LLM locate passes, the only tools `buildToolRunner` hands `deps.runtime`). These runs
+ *     hold a `skill-run` occupancy span, and refuse to start while anything else has the model.
+ *   - `'doctask'` — the model call happens inside an enqueued doc task (`categorize_transactions`,
+ *     D26). The doctask lane already owns the exclusion, and such a run must take NO span: one
+ *     that did would refuse the very task it enqueues.
+ *   - absent — the tool never calls the model (deterministic extraction, validation, exports).
+ * `tool-runs.ts` passing `deps.runtime` into a case is pinned to `'direct'` by a source test.
+ */
+export type SkillToolModelLane = 'direct' | 'doctask'
+
+/**
  * The shape of a run's terminal outcome, which the renderer maps to copy:
  *   - `count`     — a plain pluralized count ("Extracted N transactions." / "Saved N rows.").
  *   - `reconcile` — a pass/fail balance verdict keyed off `resultKind` (reconciled/unchecked/…).
@@ -92,6 +106,8 @@ export interface SkillToolDescriptor {
   labelKey: MessageKey
   /** Which dispatch seam the runner uses — keeps the wired set derived, not a parallel hardcoded list. */
   seamKind: SkillToolSeamKind
+  /** How this tool's model use reaches the chat runtime (#186). Absent ⇒ it never generates. */
+  modelLane?: SkillToolModelLane
   /** True ⇒ a write/export/destructive tool the renderer confirm-gates. MUST agree with the tool's
    *  `permissions` (`toolRequiresConfirmation`) — a registry test pins the two together. */
   confirm: boolean
@@ -188,6 +204,7 @@ export const SKILL_TOOL_DESCRIPTORS: readonly SkillToolDescriptor[] = [
     name: 'categorize_transactions',
     labelKey: 'chat.skill.tool.categorize',
     seamKind: 'downstream',
+    modelLane: 'doctask', // D26: the LLM categorizer runs INSIDE an enqueued doctask, never here
     confirm: false,
     resultShape: 'count',
     doneKey: 'chat.skill.run.done.categorize'
@@ -260,6 +277,7 @@ export const SKILL_TOOL_DESCRIPTORS: readonly SkillToolDescriptor[] = [
     name: 'redact_document',
     labelKey: 'chat.skill.tool.redactDocument',
     seamKind: 'export',
+    modelLane: 'direct', // Phase 7 D73: the LLM locate pass streams on the chat runtime
     confirm: true,
     resultShape: 'redaction',
     redactionKeys: {
@@ -276,6 +294,7 @@ export const SKILL_TOOL_DESCRIPTORS: readonly SkillToolDescriptor[] = [
     name: 'apply_document_edits',
     labelKey: 'chat.skill.tool.applyDocumentEdits',
     seamKind: 'export',
+    modelLane: 'direct', // Phase 8 D76: the LLM locate pass streams on the chat runtime
     confirm: true,
     resultShape: 'edit',
     editKeys: {

--- a/apps/desktop/tests/integration/model-occupancy-ipc.test.ts
+++ b/apps/desktop/tests/integration/model-occupancy-ipc.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+// Issues #185/#186 at the IPC entry points — the two handlers the issues actually name:
+// `runBenchmark` (which had no re-entrancy or busy guard at all) and `startSkillRun` (which
+// consulted neither `inFlightStreams` nor the doc-task registry). The registry itself, the
+// composed predicate, and the chat/doc-task seams are pinned in `model-occupancy.test.ts`.
+
+const ipcState = vi.hoisted(() => ({ handlers: new Map<string, unknown>() }))
+// A gate a test can set to HOLD the save dialog — and with it a confirmed skill run — open, so
+// the occupancy span can be observed while the run is genuinely in flight.
+const dialogState = vi.hoisted(() => ({
+  saveResult: { canceled: true } as { canceled: boolean; filePath?: string },
+  gate: undefined as Promise<void> | undefined
+}))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: unknown) => ipcState.handlers.set(channel, fn),
+    removeHandler: (channel: string) => ipcState.handlers.delete(channel)
+  },
+  BrowserWindow: { getFocusedWindow: () => null },
+  dialog: {
+    showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+    showSaveDialog: async () => {
+      if (dialogState.gate) await dialogState.gate
+      return dialogState.saveResult
+    }
+  },
+  app: { getVersion: () => '0.0.0-test' }
+}))
+
+import { registerSkillsIpc } from '../../src/main/ipc/registerSkillsIpc'
+import { runAndPersistBenchmark } from '../../src/main/ipc/registerBenchmarkIpc'
+import { inFlightStreams } from '../../src/main/ipc/inflight'
+import { RuntimeManager } from '../../src/main/services/runtime'
+import type { ModelRuntime } from '../../src/main/services/runtime'
+import { openDatabase, type Db } from '../../src/main/services/db'
+import { seedSettings, getSettings } from '../../src/main/services/settings'
+import { createAuditRecorder } from '../../src/main/services/audit'
+import { createSkillRegistry } from '../../src/main/services/skills/registry'
+import { createConversation } from '../../src/main/services/chat'
+import { IPC } from '../../src/shared/ipc'
+import { t } from '../../src/shared/i18n'
+import type { AppContext } from '../../src/main/services/context'
+import type { SkillRunState, StartSkillRunResult } from '../../src/shared/types'
+import { invoke, type IpcHandlers } from '../helpers/ipc'
+
+const handlers = ipcState.handlers as unknown as IpcHandlers
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'hilbertraum-occ-ipc-'))
+}
+
+function fakeRuntime(): ModelRuntime {
+  return {
+    modelId: 'm',
+    async start() {},
+    async stop() {},
+    async health() {
+      return { healthy: true, message: '', port: null }
+    },
+    async *chatStream() {
+      yield '[]'
+    }
+  }
+}
+
+async function startedManager(): Promise<RuntimeManager> {
+  const mgr = new RuntimeManager(() => fakeRuntime())
+  await mgr.start({ modelId: 'm', modelPath: '/m.gguf', contextTokens: 2048 })
+  return mgr
+}
+
+function writeSkill(appSkillsDir: string, id: string, tools: string[]): void {
+  const d = join(appSkillsDir, id)
+  mkdirSync(d, { recursive: true })
+  writeFileSync(
+    join(d, 'SKILL.md'),
+    [
+      '---',
+      `id: ${id}`,
+      `title: ${id}`,
+      'description: A test skill.',
+      'version: 1.0.0',
+      'kind: tool',
+      `allowedTools: [${tools.join(', ')}]`,
+      '---',
+      'Body.'
+    ].join('\n'),
+    'utf8'
+  )
+}
+
+function seedDoc(db: Db, text: string): string {
+  const now = new Date().toISOString()
+  const docId = randomUUID()
+  const storedPath = join(tempDir(), 'document.txt')
+  writeFileSync(storedPath, text, 'utf8')
+  db.prepare(
+    `INSERT INTO documents (id, title, stored_path, status, mime_type, created_at, updated_at)
+     VALUES (?, ?, ?, 'indexed', 'text/plain', ?, ?)`
+  ).run(docId, 'document.txt', storedPath, now, now)
+  db.prepare(
+    `INSERT INTO chunks (id, document_id, chunk_index, text, source_label, page_number, created_at)
+     VALUES (?, ?, 0, ?, 'p', 1, ?)`
+  ).run(randomUUID(), docId, text, now)
+  return docId
+}
+
+interface Harness {
+  db: Db
+  ctx: AppContext
+  runtime: RuntimeManager
+  conversationId: string
+  skillInstallId: string
+}
+
+/** A skills-IPC harness with a REAL, started RuntimeManager — so the #186 guard is live. */
+async function makeHarness(
+  skillId: string,
+  tools: string[],
+  docText: string,
+  opts: { docTasksActive?: boolean } = {}
+): Promise<Harness> {
+  const root = tempDir()
+  const appSkillsDir = join(root, 'app-skills')
+  const userSkillsDir = join(root, 'user-skills')
+  mkdirSync(appSkillsDir, { recursive: true })
+  mkdirSync(userSkillsDir, { recursive: true })
+  writeSkill(appSkillsDir, skillId, tools)
+  const db = openDatabase(join(root, 'test.sqlite'))
+  seedSettings(db)
+  const runtime = await startedManager()
+  const ctx = {
+    db,
+    paths: { workspacePath: root, rootPath: root },
+    workspace: { isUnlocked: () => true, documentCipher: () => null },
+    isDev: false,
+    runtime,
+    docTasks: opts.docTasksActive ? { hasActiveTask: () => true } : undefined,
+    manifestsDir: null,
+    audit: createAuditRecorder(() => db),
+    skills: createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir }),
+    ocrEngine: undefined
+  } as unknown as AppContext
+  registerSkillsIpc(ctx)
+  const docId = seedDoc(db, docText)
+  const conv = createConversation(db, {
+    mode: 'documents',
+    scope: { collectionIds: [], documentIds: [docId] }
+  })
+  return { db, ctx, runtime, conversationId: conv.id, skillInstallId: `app:${skillId}` }
+}
+
+async function startRun(
+  h: Harness,
+  toolName: string,
+  confirmed?: boolean
+): Promise<StartSkillRunResult> {
+  const { result } = await invoke(handlers, IPC.startSkillRun, {
+    skillInstallId: h.skillInstallId,
+    toolName,
+    conversationId: h.conversationId,
+    confirmed
+  })
+  return result as StartSkillRunResult
+}
+
+/** Narrow the started-run union and hand back its handle. */
+function startedHandle(start: StartSkillRunResult): string {
+  if (!start.started) throw new Error(`expected the run to start: ${JSON.stringify(start)}`)
+  return start.run.runHandle
+}
+
+/** The refusal message of a NOT-started result (the union's other arm). */
+function refusal(start: StartSkillRunResult): string | undefined {
+  if (start.started) throw new Error('expected the run to be refused')
+  return 'error' in start ? start.error : undefined
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+async function pollUntilTerminal(runHandle: string): Promise<SkillRunState> {
+  for (let i = 0; i < 200; i++) {
+    const { result } = await invoke(handlers, IPC.getSkillRun, runHandle)
+    const state = result as SkillRunState | null
+    if (state && state.state !== 'running') return state
+    await flush()
+  }
+  throw new Error('run did not terminate')
+}
+
+beforeEach(() => {
+  ipcState.handlers.clear()
+  dialogState.saveResult = { canceled: true }
+  dialogState.gate = undefined
+  inFlightStreams.clear()
+})
+
+// ---- #186: a skill run and a chat stream can no longer generate concurrently ----
+
+describe('startSkillRun — the model-lane guard (#186)', () => {
+  const DOC = 'Contact leak.source@example.com about the invoice.'
+
+  it('refuses a direct-lane run while a chat answer is streaming', async () => {
+    const h = await makeHarness('redaction', ['redact_document'], DOC)
+    inFlightStreams.set('c1', new AbortController())
+
+    const start = await startRun(h, 'redact_document', true)
+    expect(start.started).toBe(false)
+    expect(refusal(start)).toBe(t('en', 'main.busy.chat'))
+    // Nothing was taken, so a refusal cannot leave the model looking permanently busy.
+    expect(h.runtime.occupancy.isBusy()).toBe(false)
+  })
+
+  it('refuses a direct-lane run while a document task is queued or running', async () => {
+    const h = await makeHarness('redaction', ['redact_document'], DOC, { docTasksActive: true })
+    const start = await startRun(h, 'redact_document', true)
+    expect(start.started).toBe(false)
+    expect(refusal(start)).toBe(t('en', 'main.busy.docTask'))
+  })
+
+  it('refuses a direct-lane run while the benchmark is measuring', async () => {
+    const h = await makeHarness('redaction', ['redact_document'], DOC)
+    const release = h.runtime.occupancy.begin('benchmark')
+    const start = await startRun(h, 'redact_document', true)
+    expect(start.started).toBe(false)
+    expect(refusal(start)).toBe(t('en', 'main.busy.benchmark'))
+    release()
+  })
+
+  it('holds a skill-run span for the life of the run, and releases it on every exit', async () => {
+    const h = await makeHarness('redaction', ['redact_document'], DOC)
+    // Hold the save dialog open so the run is genuinely in flight while we look.
+    let openDialog!: () => void
+    dialogState.gate = new Promise<void>((resolve) => {
+      openDialog = resolve
+    })
+
+    const start = await startRun(h, 'redact_document', true)
+    expect(start.started).toBe(true)
+    // Give the run a tick to reach the dialog.
+    for (let i = 0; i < 50 && !h.runtime.occupancy.held('skill-run'); i++) await flush()
+    expect(h.runtime.occupancy.held('skill-run')).toBe(true)
+    // …and while it is held, a second run is refused with the skill-run copy.
+    const second = await startRun(h, 'redact_document', true)
+    expect(second.started).toBe(false)
+    expect(refusal(second)).toBe(t('en', 'main.busy.skillRun'))
+
+    openDialog()
+    await pollUntilTerminal(startedHandle(start))
+    // Released in the runner's own `finally` — a cancelled dialog is a terminal path too.
+    expect(h.runtime.occupancy.held('skill-run')).toBe(false)
+    expect(h.runtime.isExternallyBusy()).toBe(false)
+  })
+
+  it('takes NO span for a deterministic tool — those never reach the model', async () => {
+    const h = await makeHarness('bank', ['extract_transactions'], 'EUR\n2026-01-02 Grocery -45,90')
+    const start = await startRun(h, 'extract_transactions')
+    expect(start.started).toBe(true)
+    expect(h.runtime.occupancy.held('skill-run')).toBe(false)
+    await pollUntilTerminal(startedHandle(start))
+    expect(h.runtime.occupancy.isBusy()).toBe(false)
+  })
+
+  it('takes NO span for the doctask-lane categorizer — a span there would deadlock its own task', async () => {
+    // D26: `categorize_transactions` enqueues a doc task and the model call happens INSIDE it.
+    // A `skill-run` span here would make `startDocTask` refuse the very task the run awaits.
+    const h = await makeHarness(
+      'bank',
+      ['extract_transactions', 'categorize_transactions'],
+      'EUR\n2026-01-02 Grocery -45,90'
+    )
+    await pollUntilTerminal(startedHandle(await startRun(h, 'extract_transactions')))
+
+    const start = await startRun(h, 'categorize_transactions')
+    expect(start.started).toBe(true)
+    expect(h.runtime.occupancy.held('skill-run')).toBe(false)
+    await pollUntilTerminal(startedHandle(start))
+  })
+
+  it('takes no span when no runtime is active — there is nothing to exclude', async () => {
+    const h = await makeHarness('redaction', ['redact_document'], DOC)
+    await h.runtime.stop()
+    const start = await startRun(h, 'redact_document', true)
+    // The redaction still runs (it degrades to its deterministic floor, D78), just unguarded.
+    expect(start.started).toBe(true)
+    expect(h.runtime.occupancy.held('skill-run')).toBe(false)
+    await pollUntilTerminal(startedHandle(start))
+  })
+})
+
+// ---- #185: the benchmark's re-entrancy and busy guard ---------------------------
+
+describe('runAndPersistBenchmark — the re-entrancy and busy guard (#185)', () => {
+  async function benchCtx(): Promise<{ ctx: AppContext; runtime: RuntimeManager; db: Db }> {
+    const root = tempDir()
+    const db = openDatabase(join(root, 'test.sqlite'))
+    seedSettings(db)
+    const runtime = await startedManager()
+    const ctx = {
+      db,
+      paths: { workspacePath: root, rootPath: root },
+      workspace: { isUnlocked: () => true },
+      isDev: false,
+      runtime,
+      manifestsDir: null,
+      docTasks: undefined
+    } as unknown as AppContext
+    return { ctx, runtime, db }
+  }
+
+  it('refuses a SECOND concurrent run — the re-entrancy guard', async () => {
+    const { ctx, runtime } = await benchCtx()
+    const first = runAndPersistBenchmark(ctx)
+    // The span is taken synchronously, before the first await, so the second caller cannot
+    // race into "idle" — this is the two-Diagnostics-clicks case from the issue.
+    expect(runtime.occupancy.held('benchmark')).toBe(true)
+    await expect(runAndPersistBenchmark(ctx)).rejects.toThrow(t('en', 'main.busy.benchmark'))
+
+    await first
+    expect(runtime.occupancy.held('benchmark')).toBe(false)
+    // …and a run after the first finished is admitted normally.
+    await expect(runAndPersistBenchmark(ctx)).resolves.toBeTruthy()
+  })
+
+  it('refuses to start while a chat answer is streaming', async () => {
+    const { ctx } = await benchCtx()
+    inFlightStreams.set('c1', new AbortController())
+    await expect(runAndPersistBenchmark(ctx)).rejects.toThrow(t('en', 'main.busy.chat'))
+  })
+
+  it('refuses to start while a skill run holds the model', async () => {
+    const { ctx, runtime } = await benchCtx()
+    const release = runtime.occupancy.begin('skill-run')
+    await expect(runAndPersistBenchmark(ctx)).rejects.toThrow(t('en', 'main.busy.skillRun'))
+    release()
+  })
+
+  it('releases its span when the run throws, so one failure cannot wedge every lane', async () => {
+    const { ctx, runtime } = await benchCtx()
+    // `ctx.db` is the persistence step's only reach; make it throw AFTER the span is taken.
+    Object.defineProperty(ctx, 'db', {
+      get() {
+        throw new Error('workspace locked mid-benchmark')
+      }
+    })
+    await expect(runAndPersistBenchmark(ctx)).rejects.toThrow(/locked mid-benchmark/)
+    expect(runtime.occupancy.held('benchmark')).toBe(false)
+    expect(runtime.isExternallyBusy()).toBe(false)
+  })
+
+  it('persists a normal result and holds nothing afterwards', async () => {
+    const { ctx, runtime, db } = await benchCtx()
+    const result = await runAndPersistBenchmark(ctx)
+    expect(getSettings(db).lastBenchmark?.ranAt).toBe(result.ranAt)
+    expect(runtime.occupancy.isBusy()).toBe(false)
+  })
+})

--- a/apps/desktop/tests/integration/model-occupancy.test.ts
+++ b/apps/desktop/tests/integration/model-occupancy.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { ModelOccupancy, modelBusyMessageKey } from '../../src/main/services/runtime/occupancy'
+import { RuntimeManager } from '../../src/main/services/runtime'
+import type { ModelRuntime } from '../../src/main/services/runtime'
+import { modelBusyLane } from '../../src/main/ipc/model-busy'
+import { inFlightStreams } from '../../src/main/ipc/inflight'
+import { assertChatStreamReady } from '../../src/main/ipc/chat-stream'
+import { openDatabase, type Db } from '../../src/main/services/db'
+import { createConversation } from '../../src/main/services/chat'
+import { DocTaskManager } from '../../src/main/services/doctasks'
+import {
+  createQueuedDocument,
+  documentsDir,
+  processDocument
+} from '../../src/main/services/ingestion'
+import { runBenchmark, measureTokensPerSecond } from '../../src/main/services/benchmark'
+import { SKILL_TOOL_DESCRIPTORS, getToolDescriptor } from '../../src/shared/skill-tools'
+import { t } from '../../src/shared/i18n'
+import type { AppContext } from '../../src/main/services/context'
+import type { OccupancyLane } from '../../src/main/services/runtime/occupancy'
+
+// Issues #185/#186 — the shared model-occupancy span (architecture.md "Model occupancy —
+// design record"). Both issues were the same defect seen from two sides: the local-API wave's
+// generation gate made every lane that reaches `chatStream` VISIBLE, and that visibility showed
+// that the benchmark had no guard at all (#185) and that a skill run's LLM locate pass could
+// generate beside a chat answer (#186).
+//
+// The gate itself could not be the fix: it counts in-flight PULLS, so a multi-step job reads
+// idle between two of its own model calls, and a guard riding it would admit a second job into
+// that gap. These tests pin the span registry, the four guard seams that read it, and the two
+// deliberate NON-guards (chat is never refused by the benchmark; a doc task never refuses on
+// the doc-task span it holds itself).
+
+const opts = { modelId: 'm', modelPath: '/m.gguf', contextTokens: 2048 }
+
+/** A minimal runtime whose `chatStream` yields `tokens` — enough for the gate to see a pull. */
+function fakeRuntime(tokens: string[] = ['hi']): ModelRuntime {
+  return {
+    modelId: 'm',
+    async start() {},
+    async stop() {},
+    async health() {
+      return { healthy: true, message: '', port: null }
+    },
+    async *chatStream() {
+      for (const token of tokens) yield token
+    }
+  }
+}
+
+/** A started manager, so `active()` is non-null and `isExternallyBusy` is not fail-closed. */
+async function startedManager(runtime: ModelRuntime = fakeRuntime()): Promise<RuntimeManager> {
+  const mgr = new RuntimeManager(() => runtime)
+  await mgr.start(opts)
+  return mgr
+}
+
+/** A `modelBusyLane`-shaped context over a real manager + an optional doc-task probe. */
+function busyCtx(mgr: RuntimeManager, hasActiveTask = false): AppContext {
+  return { runtime: mgr, docTasks: { hasActiveTask: () => hasActiveTask } } as unknown as AppContext
+}
+
+beforeEach(() => {
+  inFlightStreams.clear()
+})
+
+// ---- The registry ---------------------------------------------------------------
+
+describe('ModelOccupancy (the span registry)', () => {
+  it('reports a lane busy for exactly the life of its span', () => {
+    const occ = new ModelOccupancy()
+    expect(occ.isBusy()).toBe(false)
+    expect(occ.held('benchmark')).toBe(false)
+
+    const release = occ.begin('benchmark')
+    expect(occ.isBusy()).toBe(true)
+    expect(occ.held('benchmark')).toBe(true)
+    expect(occ.held('skill-run')).toBe(false)
+
+    release()
+    expect(occ.isBusy()).toBe(false)
+    expect(occ.held('benchmark')).toBe(false)
+  })
+
+  it('releases idempotently — a double release cannot under-count a concurrent span', () => {
+    const occ = new ModelOccupancy()
+    const first = occ.begin('skill-run')
+    occ.begin('skill-run')
+    first()
+    first()
+    first()
+    // The second span is untouched: a leaked double-release must not free someone else's slot.
+    expect(occ.held('skill-run')).toBe(true)
+  })
+
+  it('reports the OLDEST held lane, and honours `ignore`', () => {
+    const occ = new ModelOccupancy()
+    const releaseTask = occ.begin('doc-task')
+    occ.begin('skill-run')
+
+    expect(occ.heldLane()).toBe('doc-task')
+    expect(occ.heldLane(['doc-task'])).toBe('skill-run')
+    expect(occ.heldLane(['doc-task', 'skill-run'])).toBeNull()
+
+    releaseTask()
+    expect(occ.heldLane()).toBe('skill-run')
+  })
+
+  it('snapshot() is diagnostics-only and lists the held lanes oldest-first', () => {
+    const occ = new ModelOccupancy()
+    occ.begin('doc-task')
+    occ.begin('benchmark')
+    expect(occ.snapshot().map((s) => s.lane)).toEqual(['doc-task', 'benchmark'])
+    for (const span of occ.snapshot()) expect(span.heldMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('gives every lane its own friendly refusal copy, in both catalogs', () => {
+    const lanes: Array<'chat' | OccupancyLane> = ['chat', 'doc-task', 'skill-run', 'benchmark']
+    const keys = lanes.map(modelBusyMessageKey)
+    expect(new Set(keys).size).toBe(lanes.length)
+    for (const key of keys) {
+      expect(t('en', key).length).toBeGreaterThan(0)
+      // A missing German value falls back to English (i18n D-L8) — pin that it is translated.
+      expect(t('de', key)).not.toBe(t('en', key))
+    }
+  })
+})
+
+// ---- The external lane ----------------------------------------------------------
+
+describe('RuntimeManager.isExternallyBusy folds the spans in (#185/#186)', () => {
+  it('is busy while a background span is held, even with no generation in flight', async () => {
+    const mgr = await startedManager()
+    expect(mgr.isGenerating()).toBe(false)
+    expect(mgr.isExternallyBusy()).toBe(false)
+
+    const release = mgr.occupancy.begin('doc-task')
+    // The gate still reads idle — this is exactly the gap a multi-step job leaves between two
+    // of its model calls, and the gap an external request used to be admitted into.
+    expect(mgr.isGenerating()).toBe(false)
+    expect(mgr.isExternallyBusy()).toBe(true)
+
+    release()
+    expect(mgr.isExternallyBusy()).toBe(false)
+  })
+
+  it('a skill-run and a benchmark span each close external admission', async () => {
+    const mgr = await startedManager()
+    for (const lane of ['skill-run', 'benchmark'] as const) {
+      const release = mgr.occupancy.begin(lane)
+      expect(mgr.isExternallyBusy()).toBe(true)
+      release()
+      expect(mgr.isExternallyBusy()).toBe(false)
+    }
+  })
+})
+
+// ---- The composed predicate -----------------------------------------------------
+
+describe('modelBusyLane (the composed answer)', () => {
+  it('composes all four lanes from their own registries', async () => {
+    const mgr = await startedManager()
+    expect(modelBusyLane(busyCtx(mgr))).toBeNull()
+
+    inFlightStreams.set('c1', new AbortController())
+    expect(modelBusyLane(busyCtx(mgr))).toBe('chat')
+    inFlightStreams.clear()
+
+    // Queued OR running: the doc-task lane is read from `hasActiveTask`, not only its span,
+    // so a task waiting in the queue still refuses a benchmark that would collide seconds later.
+    expect(modelBusyLane(busyCtx(mgr, true))).toBe('doc-task')
+
+    const release = mgr.occupancy.begin('skill-run')
+    expect(modelBusyLane(busyCtx(mgr))).toBe('skill-run')
+    release()
+
+    const releaseBench = mgr.occupancy.begin('benchmark')
+    expect(modelBusyLane(busyCtx(mgr))).toBe('benchmark')
+    releaseBench()
+    expect(modelBusyLane(busyCtx(mgr))).toBeNull()
+  })
+
+  it('`ignore` excludes a lane through BOTH halves — including a doc task holding a span', async () => {
+    const mgr = await startedManager()
+    const release = mgr.occupancy.begin('doc-task')
+    expect(modelBusyLane(busyCtx(mgr, true))).toBe('doc-task')
+    // Ignoring the lane must silence the span half too, or the option would not work at all.
+    expect(modelBusyLane(busyCtx(mgr, true), { ignore: ['doc-task'] })).toBeNull()
+    release()
+  })
+
+  it('the benchmark does NOT ignore its own lane — that read IS the re-entrancy guard', async () => {
+    const mgr = await startedManager()
+    const release = mgr.occupancy.begin('benchmark')
+    expect(modelBusyLane(busyCtx(mgr))).toBe('benchmark')
+    release()
+  })
+
+  // (Title wording avoids the two-word phrase the F-41 cast ratchet greps for.)
+  it('reports idle when the runtime/doc-task registries are unwired (partial test contexts)', () => {
+    expect(modelBusyLane({} as unknown as AppContext)).toBeNull()
+  })
+})
+
+// ---- Chat (#186, the direction that protects the user's turn) -------------------
+
+describe('assertChatStreamReady vs a model-lane skill run (#186)', () => {
+  let db: Db
+  let conversationId: string
+
+  beforeEach(() => {
+    db = openDatabase(join(mkdtempSync(join(tmpdir(), 'hilbertraum-occ-chat-')), 'test.sqlite'))
+    conversationId = createConversation(db, { mode: 'chat' }).id
+  })
+
+  function chatCtx(mgr: RuntimeManager): AppContext {
+    return { db, runtime: mgr, docTasks: undefined } as unknown as AppContext
+  }
+
+  it('refuses a chat turn while a direct skill run holds the model', async () => {
+    const mgr = await startedManager()
+    const release = mgr.occupancy.begin('skill-run')
+    await expect(assertChatStreamReady(chatCtx(mgr), conversationId)).rejects.toThrow(
+      t('en', 'main.busy.skillRun')
+    )
+    release()
+    // …and admits it again the moment the run ends.
+    await expect(assertChatStreamReady(chatCtx(mgr), conversationId)).resolves.toBeTruthy()
+  })
+
+  it('does NOT refuse a chat turn for the benchmark — the benchmark yields to chat instead', async () => {
+    const mgr = await startedManager()
+    const release = mgr.occupancy.begin('benchmark')
+    // The first-run benchmark fires right after unlock; refusing the user's first message
+    // there would be a regression, so this lane is deliberately absent from the chat guard.
+    await expect(assertChatStreamReady(chatCtx(mgr), conversationId)).resolves.toBeTruthy()
+    release()
+  })
+
+  it('does not read the doc-task SPAN — the pre-existing yielding-build exception is untouched', async () => {
+    const mgr = await startedManager()
+    const release = mgr.occupancy.begin('doc-task')
+    // A yielding tree build holds this span while it cedes the slot to chat via the arbiter.
+    // Reading the span here would refuse exactly the chat turn the handoff exists to allow.
+    await expect(assertChatStreamReady(chatCtx(mgr), conversationId)).resolves.toBeTruthy()
+    release()
+  })
+})
+
+// ---- Doc tasks (#185/#186, the admission half) ----------------------------------
+
+describe('DocTaskManager vs the occupancy spans', () => {
+  let tmp: string
+  let db: Db
+  let storeDir: string
+  let docId: string
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'hilbertraum-occ-task-'))
+    db = openDatabase(join(tmp, 'test.sqlite'))
+    storeDir = documentsDir(join(tmp, 'workspace'))
+    const file = join(tmp, 'doc.txt')
+    writeFileSync(file, Array.from({ length: 400 }, (_, i) => `word${i}`).join(' '), 'utf8')
+    const queued = createQueuedDocument(db, file)
+    expect((await processDocument(db, storeDir, queued.id)).status).toBe('indexed')
+    docId = queued.id
+  })
+
+  function makeManager(occ: ModelOccupancy, runtime: ModelRuntime | null = fakeRuntime()): DocTaskManager {
+    return new DocTaskManager({
+      getDb: () => db,
+      getRuntime: () => runtime,
+      getTranslator: () => null,
+      isChatStreaming: () => false,
+      getContextTokens: () => 4096,
+      getStoreDir: () => storeDir,
+      getIngestionDeps: () => ({}),
+      beginDocumentWork: () => () => {},
+      occupiedLane: () => {
+        const lane = occ.heldLane(['doc-task'])
+        return lane === 'doc-task' ? null : lane
+      },
+      beginOccupancy: () => occ.begin('doc-task')
+    })
+  }
+
+  it('refuses a new task while a skill run or the benchmark holds the model', () => {
+    const occ = new ModelOccupancy()
+    const manager = makeManager(occ)
+
+    const releaseSkill = occ.begin('skill-run')
+    expect(() => manager.startDocTask({ kind: 'summary', documentIds: [docId] })).toThrow(
+      t('en', 'main.busy.skillRun')
+    )
+    releaseSkill()
+
+    const releaseBench = occ.begin('benchmark')
+    expect(() => manager.startDocTask({ kind: 'summary', documentIds: [docId] })).toThrow(
+      t('en', 'main.busy.benchmark')
+    )
+    releaseBench()
+
+    // Nothing held ⇒ admitted as before.
+    expect(manager.startDocTask({ kind: 'summary', documentIds: [docId] }).jobId).toBeTruthy()
+  })
+
+  it('does NOT refuse on the doc-task span it holds itself (the #38 tree→extract chain)', () => {
+    const occ = new ModelOccupancy()
+    const manager = makeManager(occ)
+    // A running task holds this span; the chain enqueues its follow-up from inside `run()`,
+    // still holding it. Refusing there would break the chain — task-vs-task is the queue's job.
+    const release = occ.begin('doc-task')
+    expect(manager.startDocTask({ kind: 'summary', documentIds: [docId] }).jobId).toBeTruthy()
+    release()
+  })
+
+  it('holds a doc-task span for exactly the run, so the other lanes see a multi-step task', async () => {
+    const occ = new ModelOccupancy()
+    const seen: boolean[] = []
+    // Sample occupancy from INSIDE the model call — the point of the span is that it covers the
+    // whole dispatch, including the local work between two generations.
+    const sampling: ModelRuntime = {
+      ...fakeRuntime(),
+      async *chatStream() {
+        seen.push(occ.held('doc-task'))
+        yield 'a summary of the document'
+      }
+    }
+    const manager = makeManager(occ, sampling)
+    expect(occ.held('doc-task')).toBe(false)
+
+    const { jobId } = manager.startDocTask({ kind: 'summary', documentIds: [docId] })
+    const deadline = Date.now() + 10_000
+    for (;;) {
+      const state = manager.getDocTask(jobId).state
+      if (state === 'done' || state === 'failed' || state === 'cancelled') break
+      if (Date.now() > deadline) throw new Error(`task never settled: ${state}`)
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen.every(Boolean)).toBe(true)
+    // Released on the same `finally` that clears `runningId` — the span cannot outlive its task.
+    expect(occ.held('doc-task')).toBe(false)
+  })
+
+  it('an unwired occupancy dep leaves the manager byte-identical (partial test deps)', () => {
+    const manager = new DocTaskManager({
+      getDb: () => db,
+      getRuntime: () => fakeRuntime(),
+      getTranslator: () => null,
+      isChatStreaming: () => false,
+      getContextTokens: () => 4096,
+      getStoreDir: () => storeDir,
+      getIngestionDeps: () => ({}),
+      beginDocumentWork: () => () => {}
+    })
+    expect(manager.startDocTask({ kind: 'summary', documentIds: [docId] }).jobId).toBeTruthy()
+  })
+})
+
+// ---- The benchmark's contended-probe discard (#185) -----------------------------
+
+describe('the benchmark refuses to measure a contended model (#185)', () => {
+  const workspacePath = (): string => mkdtempSync(join(tmpdir(), 'hilbertraum-occ-bench-'))
+
+  it('skips the speed probe entirely when the model is already busy', async () => {
+    let calls = 0
+    const runtime: ModelRuntime = {
+      ...fakeRuntime(),
+      async *chatStream() {
+        calls++
+        yield 'x'
+      }
+    }
+    const skipped: boolean[] = []
+    const tps = await measureTokensPerSecond(runtime, {
+      modelBusy: () => true,
+      onBusySkip: () => skipped.push(true)
+    })
+    expect(tps).toBeNull()
+    expect(calls).toBe(0) // never even reached the model
+    expect(skipped).toEqual([true])
+  })
+
+  it('DISCARDS a reading that becomes contended mid-probe', async () => {
+    let busy = false
+    const runtime: ModelRuntime = {
+      ...fakeRuntime(),
+      async *chatStream() {
+        yield 'one'
+        busy = true // a chat turn starts while the 64-token probe streams
+        yield 'two'
+        yield 'three'
+      }
+    }
+    let skipped = false
+    const tps = await measureTokensPerSecond(runtime, {
+      modelBusy: () => busy,
+      onBusySkip: () => {
+        skipped = true
+      }
+    })
+    // A contended figure would be a shared slot measured as slow hardware — and a slow figure
+    // steps the profile AND the recommendation down, persisted in settings.lastBenchmark.
+    expect(tps).toBeNull()
+    expect(skipped).toBe(true)
+  })
+
+  it('turns the discard into a visible warning, never a silent hole', async () => {
+    const result = await runBenchmark({
+      workspacePath: workspacePath(),
+      manifests: [],
+      runtime: fakeRuntime(),
+      modelBusy: () => true
+    })
+    expect(result.tokensPerSecond).toBeNull()
+    expect(result.measuredModelId).toBeNull()
+    expect(result.warnings).toContain(t('en', 'main.benchmark.warnSpeedSkipped'))
+  })
+
+  it('stays silent when there was simply no runtime to measure (the long-standing case)', async () => {
+    const result = await runBenchmark({
+      workspacePath: workspacePath(),
+      manifests: [],
+      runtime: null,
+      modelBusy: () => true
+    })
+    expect(result.tokensPerSecond).toBeNull()
+    expect(result.warnings).not.toContain(t('en', 'main.benchmark.warnSpeedSkipped'))
+  })
+
+  it('measures normally with no `modelBusy` probe wired (every non-IPC caller)', async () => {
+    const result = await runBenchmark({
+      workspacePath: workspacePath(),
+      manifests: [],
+      runtime: fakeRuntime(['a', 'b', 'c'])
+    })
+    expect(result.tokensPerSecond).not.toBeNull()
+    expect(result.warnings).not.toContain(t('en', 'main.benchmark.warnSpeedSkipped'))
+  })
+})
+
+// ---- The descriptor-derived skill lane (#186) -----------------------------------
+
+describe('skill tool model lanes are declared, not hand-listed (#186)', () => {
+  it('declares exactly the two tools whose run streams on the chat runtime', () => {
+    const direct = SKILL_TOOL_DESCRIPTORS.filter((d) => d.modelLane === 'direct').map((d) => d.name)
+    expect(direct.sort()).toEqual(['apply_document_edits', 'redact_document'])
+  })
+
+  it('routes the categorizer through the doctask lane, so it takes no span of its own', () => {
+    // D26: its model call happens inside a doc task it enqueues. A `skill-run` span here would
+    // make `startDocTask` refuse the very task the run is waiting on.
+    expect(getToolDescriptor('categorize_transactions')?.modelLane).toBe('doctask')
+  })
+
+  it('leaves every deterministic tool with no lane at all', () => {
+    for (const d of SKILL_TOOL_DESCRIPTORS) {
+      if (d.name === 'redact_document' || d.name === 'apply_document_edits') continue
+      if (d.name === 'categorize_transactions') continue
+      expect(d.modelLane, d.name).toBeUndefined()
+    }
+  })
+
+  // The drift guard: `buildToolRunner` is a switch, so the ONE mechanical fact linking a tool to
+  // the model is whether its case forwards `deps.runtime`. Pin that to the declaration — a tenth
+  // tool that starts generating without declaring `modelLane: 'direct'` would otherwise silently
+  // reopen #186 (it would take no span, and refuse nothing).
+  it('pins the declaration to the dispatch: `deps.runtime` is forwarded only by `direct` tools', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/main/services/skills/tool-runs.ts'),
+      'utf8'
+    )
+    // Split the dispatch into per-`case` blocks; the last block runs to the end of the switch.
+    const blocks = source.split(/^\s*case '/m).slice(1)
+    const forwarding = new Set<string>()
+    for (const block of blocks) {
+      const name = block.slice(0, block.indexOf("'"))
+      if (/\bruntime:\s*deps\.runtime\b/.test(block)) forwarding.add(name)
+    }
+    expect(forwarding.size).toBeGreaterThan(0) // the scan actually found the dispatch
+    const declared = SKILL_TOOL_DESCRIPTORS.filter((d) => d.modelLane === 'direct').map((d) => d.name)
+    expect([...forwarding].sort()).toEqual(declared.sort())
+  })
+})

--- a/apps/desktop/tests/unit/display-map.test.ts
+++ b/apps/desktop/tests/unit/display-map.test.ts
@@ -113,7 +113,10 @@ describe('localizeServerCopy (D-L4)', () => {
       'main.benchmark.warnTiny',
       'main.benchmark.warnUnknown',
       'main.benchmark.warnDriveProbe',
-      'main.benchmark.warnSlowDrive'
+      'main.benchmark.warnSlowDrive',
+      // #185: the tokens/sec probe was discarded because another lane held the model — a
+      // persisted `lastBenchmark.warnings` entry like its siblings, and uninterpolated.
+      'main.benchmark.warnSpeedSkipped'
     ]
     expect([...DISPLAY_MAP_KEYS].sort()).toEqual(persistCanonical.sort())
     // Every mapped English value must round-trip to its German catalog value.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10491,6 +10491,10 @@ model through **five** lanes: chat/RAG, doc tasks, skill runs, the benchmark, an
 - External streams deliberately do **not** register in `inFlightStreams`: that registry drives the
   doc-task refusal, so registering them would have let an outside client block doc tasks — an
   inversion of D8.
+- **Since #185/#186 the gate has a sibling, not a successor.** It still answers "is a pull in
+  flight right now"; the occupancy spans answer "is a multi-step background job holding the model
+  across its own gaps", and `isExternallyBusy` is the OR of both. See "Model occupancy — design
+  record" below for why the gate's counter alone could not carry that second question.
 
 ### §5 The HTTP surface (P3)
 
@@ -10555,7 +10559,7 @@ model through **five** lanes: chat/RAG, doc tasks, skill runs, the benchmark, an
 | **`usage` token counts** in responses | The SSE reader discards them today; surfacing them means extending the runtime contract. Documented as absent so clients do not read `NaN` — a post-v1 candidate. |
 | **Sampling passthrough** (`top_p`, `stop`, penalties) | `RuntimeChatOptions` carries no such fields. Accept-and-ignore was chosen over extending the contract mid-wave. |
 | **A real `openai`-SDK parse test** | It would add a devDependency for a test; the wire-shape pins cover the envelope. An owner-optional line item. |
-| **Serializing the in-app lanes** (benchmark vs chat, skill run vs chat) | Pre-existing concurrency, made *visible* by the gate but not caused by it. Filed separately rather than smuggled into this wave. |
+| **Serializing the in-app lanes** (benchmark vs chat, skill run vs chat) | Pre-existing concurrency, made *visible* by the gate but not caused by it. Filed separately rather than smuggled into this wave — as **#185/#186**, closed 2026-08-19 by the shared occupancy span ("Model occupancy — design record" below), which also folds into `isExternallyBusy` so the external lane waits on a background job instead of slipping into the gap between two of its model calls. |
 
 ### §8 What the audits changed
 
@@ -10862,6 +10866,155 @@ checked — reinstating the old wording turns it red), following the DEP-3 merma
 
 **This is the standing argument for the gate order `typecheck → build → test`.** Neither typecheck
 nor the suite can see this class; only the build can.
+
+## Model occupancy — design record (issues #185/#186, §1–§6)
+
+_The 2026-08-19 wave that gave the four in-app lanes one shared "a background job is holding the
+model" signal, closing the two concurrency gaps the local-API wave surfaced but deliberately did
+not fold into its own contract (that wave's §7 "deliberate omissions" row). Branch
+`fix/issues-185-186-model-occupancy`. Both issues were the same defect seen from two sides, so
+they were designed and fixed together, exactly as both issues proposed._
+
+### §1 The defect class
+
+The one `llama-server` slot serves one job at a time. Overlapping it does not corrupt anything —
+the sidecar serializes at the slot level — but it halves both jobs' throughput, and in the
+benchmark's case it corrupts a **measurement that is then persisted**.
+
+Before this wave, "who has the model" was answered by three registries and one hole:
+
+| Lane | Its record of itself | Did the other lanes see it? |
+|---|---|---|
+| chat / RAG | `inFlightStreams` (per conversation) | yes — the doc-task admission guard reads it |
+| doc tasks | `DocTaskManager` queue + `hasActiveTask()` | yes — the chat guard reads it |
+| **skill runs** | `SkillRunController`, keyed **per document** | **no** — not a global busy signal (#186) |
+| **the benchmark** | *nothing at all* | **no** (#185) |
+
+So `startSkillRun` consulted neither `inFlightStreams` nor the doc-task registry, and the
+benchmark had no guard of any kind: two Diagnostics clicks, or one click during a chat answer,
+both reached the model.
+
+**Why the generation gate could not be the fix.** The `RuntimeManager` gate added by the local-API
+wave already sees every lane — that is how these issues were spotted — but it counts in-flight
+`chatStream` **pulls**. A doc task, a skill run, and the benchmark are all multi-step: generate, do
+local work, generate again. Between two calls the gate reads IDLE, so a guard riding it would admit
+a second job into that gap and the two would interleave on the next call. The gate answers "right
+now"; these guards need "for the duration of a job". Both issues named the shape — a shared
+occupancy span — and that is what was built.
+
+### §2 Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| D1 | A **span registry** (`services/runtime/occupancy.ts`), not a boolean on the gate | A span covers a multi-step job's own gaps; the gate's counter cannot (§1) |
+| D2 | It lives **on the `RuntimeManager`** (`runtime.occupancy`) | The manager is already the authority on who has the model, and it is a required field on `AppContext` — so no new optional context field to thread through every partial test context |
+| D3 | **Only the three background lanes take spans**; chat does not | Chat has `inFlightStreams`, which the doc-task guard has read since wave 3. A second record of the same fact is a drift source, not a simplification — and the app's hottest path gains no new bookkeeping and no new leak surface |
+| D4 | Guards **compose** the sources (`ipc/model-busy.ts`), each read at its origin | The alternative — mirroring chat and the doc-task queue into the registry — is the duplication D3 rejects. The composition is one function, not a per-call-site ladder |
+| D5 | The doc-task lane is read from **`hasActiveTask()` (queued + running)**, while its **span covers only the running task** | A queued task does not occupy the model *yet* but will the moment the pump frees, so a benchmark admitted "into the queue's shadow" would collide seconds later. The span is the narrower fact the external lane needs |
+| D6 | The skill lane is **declared in the descriptor table** (`SkillToolDescriptor.modelLane`), not hand-listed in the IPC layer | That table is already the single source every layer derives from (skills audit §6.2). A hand-kept name list in `registerSkillsIpc` is exactly the drift it exists to prevent — a tenth tool that started generating without declaring itself would silently reopen #186 |
+| D7 | `isExternallyBusy()` folds the spans in | Both issues asked for it: the local API now waits on a background job **honestly**, instead of slipping into the gap between two of its model calls — the same defect appearing on the external lane |
+| D8 | The benchmark **yields to chat** rather than blocking it | See §4 |
+
+### §3 The exclusion table as built
+
+Read down the left column for what is starting, across for what refuses it.
+
+| Entering | Refused by | Copy |
+|---|---|---|
+| chat / RAG | an active doc task (unchanged, incl. the yielding-build exception) | `main.chat.docTaskBusy` |
+| chat / RAG | a **`skill-run`** span (**new**, #186) | `main.busy.skillRun` |
+| doc task | a chat stream (unchanged) | `main.task.refusedChatStreaming` |
+| doc task | a `skill-run` or `benchmark` span (**new**) | `main.busy.*` |
+| skill run (`modelLane:'direct'`) | chat, doc task, benchmark, another direct run (**new**, #186) | `main.busy.*` |
+| benchmark | chat, doc task, skill run, **another benchmark** (**new**, #185) | `main.busy.*` |
+| external (local API) | any held span (**new**, D7) | its existing 429 |
+
+There is **one message per lane** (`main.busy.chat` / `.docTask` / `.skillRun` / `.benchmark`),
+shared by every surface that refuses — a per-surface × per-lane matrix would be twelve strings
+saying the same four things. Each names the affordance the user has right now (stop the answer,
+cancel the task, cancel the run in the bar). The doc-task manager's pre-existing chat refusal keeps
+`main.task.refusedChatStreaming`, which is renderer- and test-pinned since wave 3.
+
+Two rows are deliberately absent, and both are load-bearing:
+
+- **chat is never refused by the benchmark** (§4).
+- **a doc task never refuses on the `doc-task` span.** The running task holds one, and the #38
+  tree→extract chain enqueues its follow-up from inside `run()` while it is still held — refusing
+  there would break the chain. Task-vs-task exclusion is the queue's job, not this signal's; the
+  manager's `occupiedLane` dep is typed to exclude that lane so it cannot be widened by accident.
+
+**Why chat now refuses a direct skill run.** It is the same shape of work as a doc task —
+user-started, cancellable, visible in the run bar with its own Cancel — and a
+`categorize_transactions` run has ALWAYS refused chat this way, because its model call happens
+inside an enqueued doc task (D26). Before this wave that one skill run was excluded and its two
+siblings (`redact_document`, `apply_document_edits`) were not; this makes the three consistent.
+
+**The `modelLane` values, and the deadlock D6 avoids.** `'direct'` = the run streams on the chat
+runtime itself, so it takes a span. `'doctask'` = the model call happens inside a doc task the run
+enqueues (`categorize_transactions`), so it takes **none** — a span there would make `startDocTask`
+refuse the very task the run is waiting on. Absent = the tool never generates. A run also takes no
+span when no runtime is active: the locate pass needs one (redaction degrades to its deterministic
+floor, the edit tool refuses cleanly), so there is nothing to exclude. A source test pins the
+declaration to the dispatch: a `case` in `buildToolRunner` forwards `deps.runtime` **iff** its tool
+declares `modelLane: 'direct'`.
+
+### §4 The benchmark: a busy guard AND a yield
+
+`runAndPersistBenchmark` is the single entry point for both the Diagnostics button and the
+first-run background call, so the guard lives there. The span is taken **synchronously, before the
+first `await`** — two callers cannot both read idle — and covers the whole run (GPU probe, drive
+probe, speed probe), which is what makes a second run see the first. The benchmark's own lane is
+deliberately not ignored in that read: **a second benchmark seeing the first IS the re-entrancy
+guard.** The first-run caller already logs and drops the refusal, and re-runs next launch because
+`lastBenchmark` stays null.
+
+But a guard at admission is not enough, and blocking chat for the whole run is not acceptable:
+
+- The **first-run** benchmark fires right after unlock. Refusing the user's first message there
+  would be a regression, so the benchmark is absent from the chat guard (§3).
+- That leaves a window: admission passes, then the GPU + drive probes take seconds, and the user
+  sends a message. The tokens/sec probe would then measure a **shared slot** and report it as slow
+  hardware. That is not cosmetic — a low reading steps the profile down
+  (`VERY_LOW_TOKENS_PER_SECOND`) and with it the recommended model, and the result is **persisted**
+  into `settings.lastBenchmark`. The issue's "slow or degraded answer rather than corruption" is
+  accurate for every lane except this one.
+
+So the probe re-checks occupancy immediately before it starts **and on every streamed chunk**, and
+**discards** a contended reading (`modelBusy` / `onBusySkip` in `benchmark.ts`). `tokensPerSecond:
+null` is the honest answer and an already-supported one — it is exactly what a machine with no
+runtime yields. The discard is never silent: it raises **`main.benchmark.warnSpeedSkipped`** (a
+persist-canonical warning, so it is in `DISPLAY_MAP_KEYS`), distinct from "no runtime was up,
+nothing to measure", which stays silent as it always has. Breaking out of the `for await` runs the
+generator's `return()`, so the generation gate decrements normally — this path never creates the
+abandoned count the gate's epoch guard exists to heal.
+
+### §5 Leak posture
+
+A leaked span would make the background lanes — and external local-API admission (D7) — refuse
+until the app restarts, so every `begin()` is paired with a release that cannot be skipped:
+
+- **doc task** — taken in `pump()` (the one place a task starts running), released in the SAME
+  `finally` that clears `runningId`. The span cannot outlive the task it describes.
+- **skill run** — taken synchronously before `runController.start`, released in a `finally`
+  wrapping the runner, which every terminal path settles (success, failure, cancel, a dismissed
+  save dialog). The controller can also refuse the start *before* it ever invokes the runner (a run
+  already in flight on that document), so the `catch` releases too.
+- **benchmark** — a `try/finally` around the whole body; a mid-run throw releases it.
+
+Every release is **idempotent** — a double call is a no-op, never an under-count that would free a
+concurrent span. The tests pin that, the release-on-throw path, and the fact that a *refused* start
+takes nothing at all (a refusal must not leave the model looking permanently busy).
+
+### §6 What this wave deliberately did not do
+
+| Not done | Why |
+|---|---|
+| Make chat **pause** a skill run (the `ModelSlotArbiter` handshake) instead of refusing it | The arbiter exists for the yielding tree build, whose node boundaries are natural park points. A redaction locate pass has no such boundary, and refusing matches the doc-task precedent that the run bar's Cancel already supports |
+| Give chat its own span | D3 |
+| Serialize chat against chat | Several conversations streaming at once is pre-existing, supported behavior (`listActiveStreamConversations`), and part of neither issue |
+| Fold the doc-task **queue** into the span | D5 — the span is the "actually using the model" fact; the queue's own state is the wider one, and `modelBusyLane` reads both at their sources |
+| Drop `admission.ts`'s own `hasActiveDocTask()` leg, now that `isExternallyBusy` covers a *running* task | It also covers a **queued** one, which the span deliberately does not (D5). Removing it would narrow external admission, not simplify it. The redundancy for the running half is intentional and harmless — and that leg is the reason the external lane already respected doc tasks before this wave |
+| Retune any RAM/tok-s figure | Nothing measured changed. A benchmark that skips its speed leg simply records `tokensPerSecond: null` and says so |
 
 ## Original MVP spec — retirement record & §-anchor legend (2026-07-11)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,6 +171,35 @@ kept safely on the drive and secured at the next unlock — you don't lose the s
 
 ---
 
+## "The model is busy" — one job at a time
+
+HilbertRaum runs **one** local model, and it does **one job at a time**. When you start something
+that would need the model while it is already working, the app says so and does nothing, rather
+than running both at half speed. You will see one of these:
+
+- **"An answer is being written right now."** — a chat answer is streaming. Wait for it, or press
+  **Stop** in the chat.
+- **"A document task is using the model."** — a summary, comparison, translation or deep-index
+  build is running or queued. Wait for it, or cancel it from the document.
+- **"A skill is working on a document."** — a skill run (for example *Redact document* or an edit)
+  is in flight. Wait for it, or press **Cancel** in the run bar at the bottom of the chat.
+- **"A hardware benchmark is measuring this computer right now."** — a benchmark is running. It is
+  short; try again in a moment.
+
+Nothing is lost when you see one of these: the thing you started simply did not start. Try it
+again once the other job finishes.
+
+Two deliberate exceptions:
+
+- **Chatting is never blocked by the benchmark.** The benchmark gives way instead — if you send a
+  message while it is running, it finishes without its speed reading and says so on the Diagnostics
+  card ("Text-generation speed was not measured this time…"). Run it again when nothing else is
+  using the model if you want the full reading; the RAM, CPU and drive figures are unaffected.
+- **Chatting while a deep index is building** is allowed. That build pauses itself for your
+  question and resumes afterwards.
+
+---
+
 ## The app feels slow
 
 - **Slow drive:** running from a slow USB stick makes model loading and indexing sluggish. Use


### PR DESCRIPTION
Closes #185. Closes #186.

Both issues came from the same source and both proposed the same shape ("a shared occupancy span that doc tasks, skill runs, and the benchmark all hold… worth designing the two together"), so they are fixed together.

## The defect class

"Who has the model" was answered by three registries and one hole:

| Lane | Its record of itself | Did the other lanes see it? |
|---|---|---|
| chat / RAG | `inFlightStreams` | yes |
| doc tasks | `DocTaskManager` queue | yes |
| **skill runs** | `SkillRunController`, keyed **per document** | **no** (#186) |
| **the benchmark** | *nothing at all* | **no** (#185) |

**Why the generation gate could not be the fix.** The gate PR #184 added already sees every lane — that is how these were spotted — but it counts in-flight `chatStream` *pulls*. A doc task, a skill run, and the benchmark are all multi-step: generate, work locally, generate again. Between two calls the gate reads IDLE, so a guard riding it would admit a second job into that gap. The gate answers "right now"; these guards need "for the duration of a job".

## What changed

- **New `services/runtime/occupancy.ts`** — a span registry on the `RuntimeManager`, held by the three *background* lanes only. Chat keeps `inFlightStreams` as its single record (no new bookkeeping and no new leak surface on the hottest path); the guards **compose** the sources in `ipc/model-busy.ts` rather than mirroring them.
- **`isExternallyBusy()` folds the spans in** — the local API now waits on a background job honestly instead of slipping into the gap between two of its model calls. (`admission.ts`'s existing `hasActiveDocTask()` leg stays: it also covers a *queued* task, which the span deliberately does not.)
- **The skill lane is declared, not hand-listed** — `SkillToolDescriptor.modelLane`, pinned to the dispatch by a source test. A tenth tool that starts generating without declaring itself would otherwise silently reopen #186.

## Two non-guards that are load-bearing

- **A doc task never refuses on the doc-task span it holds itself.** The #38 tree→extract chain enqueues its follow-up from inside `run()` while the span is held; refusing there would break the chain. The manager's dep is *typed* to exclude that lane.
- **`categorize_transactions` takes no span** (`modelLane: 'doctask'`). Its model call happens inside a task it enqueues — a span there would make `startDocTask` refuse the very task the run is waiting on. This was the wave's main deadlock risk; there is a test for it.

## The benchmark yields to chat rather than blocking it

The first-run benchmark fires right after unlock, so refusing the user's first message would be a regression. Instead the tokens/sec probe re-checks occupancy before it starts **and on every streamed chunk**, and **discards** a contended reading.

That half is a small correctness upgrade over the issue's stated impact: a depressed reading is not just cosmetic — it steps the profile down (`VERY_LOW_TOKENS_PER_SECOND`) and with it the recommended model, and the result is **persisted** into `settings.lastBenchmark`. The discard raises the new persist-canonical `main.benchmark.warnSpeedSkipped`, so it is never a silent hole; "no runtime was up, nothing to measure" stays silent as it always has.

## Chat now refuses a direct skill run

Same shape of work as a doc task — user-started, cancellable, visible in the run bar with its own Cancel — and a `categorize_transactions` run has *always* refused chat this way (its model call is a doc task). Before this, that one skill run was excluded and `redact_document` / `apply_document_edits` were not.

## Verification

`npm run typecheck` → `npm run build` → `npm test`: **5312 passed / 50 skipped**, +39 new tests across `model-occupancy.test.ts` (registry, composed predicate, chat + doc-task seams, the benchmark probe) and `model-occupancy-ipc.test.ts` (the two handlers the issues name: re-entrancy, per-lane refusals, span held/released, the no-span cases). Every lane is driven by scripted fake runtimes — **no hardware gate owed**.

## Docs

- `docs/architecture.md` — "Model occupancy — design record (issues #185/#186, §1–§6)": decisions D1–D8, the full exclusion table, the leak posture, and what the wave deliberately did not do. The local-API record's §7 omissions row and §4 gate section now point at it.
- `docs/troubleshooting.md` — "The model is busy — one job at a time" (the four refusal messages and the two exceptions).
- `BUILD_STATE.md` — dated entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
