### PR TITLE
fix(tests): the read-only stored-copy diagnostic — rebuilt, run, and its password path fixed (#190 phases 1–2)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -44,8 +44,30 @@ New `tests/helpers/console-password.ts` + `tests/unit/console-password.test.ts` 
 worker's own non-TTY stdin is the witness; the source pin was mutation-checked). The header now
 carries the invocation that actually works here: `..\..\node_modules\.bin\vitest.cmd` — `npx` is
 blocked by this machine's PowerShell execution policy. **Still owner-owned:** checkbox 2 (cleanup
-posture — a recommendation is written, no sweep built) and checkbox 4 (second-laptop continuity; the
-G:\ run above is a valid "before" snapshot for it).
+posture — a recommendation is written, no sweep built).
+
+_2026-08-20 — **The relocation continuity check RAN — issue #190 checkbox 4 ANSWERED, and #188's
+worst defect is now proven fixed on hardware.**_ The same drive came back under a different letter
+(`G:\` → `K:\`), which is exactly the check BUILD_STATE §5 item 1 has carried as open since wave 188.
+Run as diagnostic → functional walk in the app → diagnostic, with the app **quit cleanly in between**
+— load-bearing, because the healed rows live in the plaintext working DB until `lockEncryptedVault`
+re-encrypts it, so an "after" run against a still-unlocked workspace reads the PRE-walk state and
+looks like nothing healed. Measured: `stored_name` populated **0 → 14 / 24**, stale **24 → 10**,
+resolved-as-recorded **0 → 14**, orphans **1 → 1**, 24 rows all still `indexed`, nothing at rest.
+Per-row tokens moved `EOPSH` → `ENOP` for exactly the 14 documents that were opened. **Four things
+no test could establish:** (1) D3's lazy heal works on a real relocated drive and heals ONLY what is
+read — no startup migration burst, which is what D3 traded a bulk migration away for; (2) **D-1 is
+fixed on hardware** — an import + delete left NO new orphan, where pre-#189 it would have left a
+second one; (3) the pre-walk baseline reproduced the §9.1 report field for field under the new
+letter, same orphan token included, so the canonical-location step is genuinely mount-independent
+rather than accidentally right on one drive; (4) the vault teardown is clean under the new letter.
+**Residual:** the delete leg used a post-#189 throwaway row, so D-1's *original* condition (a legacy
+row whose absolute `stored_path` names the old mount point) is still not exercised directly — 10 such
+rows remain on that drive. **Filed out of scope: #194** — the re-index leg SUCCEEDED but gave the
+operator no feedback of any kind; the single-document path returns silently from the shared `run()`
+helper while bulk "Re-index all" toasts and carries a determinate progress bar, and its failure path
+is the screen-level banner that does not name the document — **D-3 recurring on a neighbouring
+action**, which wave 188 fixed for export and never swept. Record: `architecture.md` §9.4.
 
 _2026-08-20 — **Stored-copy diagnostic REBUILT — issue #190 phase 1 (no hardware, no password, fully
 CI-verified).**_ `architecture.md` §6 said the #188 root-cause diagnostic "was written and
@@ -954,11 +976,22 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    workspace, different drive letter). **⚠️ 2026-08-19, wave 188 — this check has already
    FIRED once, from a real drive, before it was ever run deliberately:** issue #188 was exactly the
    failure it exists to catch (`documents.stored_path` absolute ⇒ every stored copy stale under a
-   different mount point, and "Delete document" silently not deleting). The code is fixed and
-   covered by `stored-copy-portability.test.ts`, but the manual check is **NOT** answered — a
-   moved-directory unit test is not a relocated drive. When it is finally run, cover **export
-   original / preview / re-index / delete** on a workspace populated under a DIFFERENT letter, and
-   confirm the rows self-heal (`documents.stored_name` populated after the first read).
+   different mount point, and "Delete document" silently not deleting). **✅ ANSWERED 2026-08-20 —
+   the continuity half is DONE** (`G:\` → `K:\`, diagnostic → functional walk → diagnostic, app quit
+   cleanly in between because the healed rows sit in the plaintext working DB until the vault
+   teardown re-encrypts it). Export original, preview and re-index all work on the relocated drive;
+   **14 of 24 rows self-healed on first read** (`stored_name` populated 0 → 14, stale 24 → 10, and
+   the 10 still stale are exactly the documents never opened — D3's lazy heal, no migration burst);
+   an import + delete left **no new orphan** (count stayed 1), which is **D-1 proven fixed on
+   hardware**; the teardown left nothing at rest under the new letter. Record:
+   `architecture.md` §9.4. **Residual:** the delete leg used a post-#189 throwaway row, so D-1's
+   *original* condition — a legacy row whose absolute `stored_path` names the old mount point — is
+   still not exercised directly; 10 such rows remain on that drive if it is ever worth one real
+   document. **Filed out of scope: #194** — the re-index leg succeeded but gave NO feedback at all
+   (the single-document path returns silently from `run()` while bulk "Re-index all" toasts and
+   shows progress; its failure path is the unnamed screen banner — D-3 recurring on a neighbouring
+   action). What is still owed on THIS item is the rest of it: certs, a signed/notarized build, and
+   the fresh-laptop Wi-Fi-off demo.
    **✅ The diagnostic half of issue #190 is DISCHARGED (2026-08-20).** The read-only stored-copy
    diagnostic was RUN on the reporting drive (`G:\`) and the drive came back byte-identical:
    **24 rows, 24 stale, 24 healable**, `stored_name` column absent (pre-#189 schema), **1 orphan

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,35 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-20 — **Stored-copy diagnostic REBUILT — issue #190 phase 1 (no hardware, no password, fully
+CI-verified).**_ `architecture.md` §6 said the #188 root-cause diagnostic "was written and
+smoke-tested against a synthetic vault" and only needed the owner's password. **It never existed**:
+it lived in the git-excluded working paper and went with it at close-out — nothing matching it was
+ever committed on any branch. So #190 checkbox 1 was never hardware-blocked; it was ordinary CI-able
+work, and that is what this wave did. §6 now carries the correction and a new **§9** records the
+tool as built. Shape: a **pure classifier + renderer** (`tests/helpers/stored-copy-audit.ts` — rows
++ a directory listing in, report out, no I/O), a **read-only collector**
+(`stored-copy-audit-run.ts` — copy → decrypt the COPY → open `{ readOnly: true }` → probe the schema
+→ query → walk `documents/` → shred the scratch), a **witness** (`read-only-witness.ts`), the
+env-gated operator shell (`tests/manual/stored-copy-diagnostic.test.ts`), and both CI halves. It is
+test-tree code on purpose — it must not ship in the bundle as dead code, and `tsconfig.web.json`
+already typechecks `tests/`. Three things are load-bearing: every MUTATING vault entry point is
+forbidden by name (`unlockEncryptedVault` commits/discards staged rekeys and can roll a `.recovery`
+over the `.enc`; `openDatabase` writes the schema + ~20 `ensureColumn` calls just by opening), the
+`stored_name` column is **probed** because the reporting drive predates #189, and the report is
+public-issue-safe **by construction** (counts, two closed allowlists, 8-char shape tokens — no
+titles, content, paths or file names, asserted against a vault full of planted secrets). Seven
+mutations each turned the intended test red, incl. the dangerous one — a loose `.enc` match that
+files a live `<id><ext>.enc.new` as an orphan. The first end-to-end operator smoke against a
+synthetic drive earned its keep: it exposed a phantom orphan (a row whose corrupt strings name
+nothing left its healthy copy unclaimed), fixed by making a file’s LEADING id a fourth ownership
+source — over-counting orphans is the one error direction that can cost data.
+**D4 rider:** orphans are NOT inert —
+`listEncryptedDocSidecars` walks the directory, so a **v1** vault's first password change re-encrypts
+every orphan and stages an `.enc.new` for each (a v2 rekey is O(1) and does not); that asymmetry is
+why the report carries the descriptor version. **Deliberately not built:** any cleanup/sweep —
+#190 checkbox 2 is an owner decision that needs the orphan count first. Suite 5363/361 files green.
+
 _2026-08-19 — **Model occupancy — wave CLOSED (issues #185/#186).**_ The two issues the local-API
 wave filed out of scope were one defect seen from two sides, and were fixed together as both asked.
 "Who has the model" was answered by three registries and one hole: chat had `inFlightStreams`, doc
@@ -94,17 +123,19 @@ the **resolver**, not the reporting screen: new `services/ingestion/stored-copy.
 `documents.stored_name` (portable leaf, lazily healed), adopted by all six sites including the
 shred; `DocumentInfo.storedCopy` so the `⋯` menu stops offering what cannot succeed;
 `original_path` demoted to a sha256-checked last resort. **Durable record:** `docs/architecture.md`
-"Portable stored copies — design record (wave 188, issue #188, §1–§8)" — decisions D1–D6, the
+"Portable stored copies — design record (wave 188, issues #188/#190, §1–§9)" — decisions D1–D6, the
 safety guard the shred rests on, the verified-clean list, and the bundler landmine (§8: a string
 literal ending in the bare word `import` makes electron-vite wedge its CommonJS shim inside the
 literal; typecheck and the full suite pass and only `npm run build` fails — now tripwired in
 `repo-hygiene.test.ts`, and the standing argument for the typecheck → build → test gate order).
-**STILL OPEN, both carried into §5 item 1:** the real relocated-drive run (the code is now correct;
-the second-laptop continuity check is only *answered* by hardware), and the read-only root-cause
-diagnostic on the reporting drive, which was never run — it needs the owner's password and would
-also settle whether that drive's rows are in fact stale (the issue reports "Vorschau works"
-alongside the export failure, and preview and export share one ladder, so both cannot describe the
-same document) and count the orphaned `.enc` files past silent deletes left behind.
+**STILL OPEN, both now tracked in issue #190 (see the 2026-08-20 entry above):** the real
+relocated-drive run (the code is now correct; the second-laptop continuity check is only *answered*
+by hardware), and the read-only root-cause diagnostic on the reporting drive — which §6 wrongly
+claimed already existed. It has since been REBUILT and CI-proven (§9); running it on that drive
+needs the owner's password and would settle whether its rows are in fact stale (the issue reports
+"Vorschau works" alongside the export failure, and preview and export share one ladder, so both
+cannot describe the same document) and count the orphaned `.enc` files past silent deletes left
+behind.
 
 _2026-08-18 — **Local API endpoint — wave CLOSED (P1–P6), PR #184.**_ The loaded chat model
 can now be used by **other programs on the same computer** through an opt-in, loopback-only,
@@ -1012,9 +1043,18 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    moved-directory unit test is not a relocated drive. When it is finally run, cover **export
    original / preview / re-index / delete** on a workspace populated under a DIFFERENT letter, and
    confirm the rows self-heal (`documents.stored_name` populated after the first read).
-   **Also still owed:** the read-only #188 root-cause diagnostic on the reporting drive (needs the
-   owner password; settles whether that drive was stale and counts orphaned `.enc` files left by
-   past silent delete no-ops — architecture.md record §6). The `electron-builder.yml` hooks + the pipeline are
+   **Also still owed (issue #190):** RUN the read-only stored-copy diagnostic on the reporting
+   drive. It exists as of 2026-08-20 and is CI-proven (architecture.md record §9); the run needs
+   the owner's password, and the tool never writes to the drive. From `apps/desktop/`, in an
+   interactive shell (it prompts for the password with no echo):
+   `$env:HILBERTRAUM_STORED_COPY_AUDIT = "H:\"; npx vitest run tests/manual/stored-copy-diagnostic.test.ts`
+   Its output is public-issue-safe by construction — paste it into #190. It settles whether that
+   drive's rows are stale, counts the orphaned `.enc` files left by past silent delete no-ops (the
+   number #190 checkbox 2 waits on), and its extension histogram settles the checkbox-3
+   contradiction (leading hypothesis: one AUDIO document — audio preview reads the stored chunks
+   and never touches the file). **It also doubles as the continuity check's evidence collector:**
+   run it before and after the relocation; `stale` / `healable` / `stored_name populated` is the
+   self-heal proof in pasteable form. The `electron-builder.yml` hooks + the pipeline are
    wired; only the secrets + hardware are missing. **GPU additions:** a SmartScreen sanity
    re-check (the Vulkan build adds one more unsigned DLL of the same class) and re-running
    `build-commercial-drive` end-to-end with the two-build fetch. **Phase-38 addition:** a

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,34 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-20 — **The diagnostic RAN on the real drive (G:\), and it refuted our own leading
+hypothesis — issue #190 checkbox 1 ANSWERED, checkbox 3 re-answered.**_ Measured, drive byte-identical
+(the read-only witness passed): encrypted workspace, **v2** descriptor, `stored_name` column ABSENT
+(pre-#189 schema), **24 rows, 24 stale, 24 healable, 0 unnamed, 0 with no copy anywhere**; **1 orphan
+`.enc`, 115.2 KiB**; file classes stored-copy 25 (2.1 MiB) with **zero** parse-transients and **zero**
+staged rekey files; extensions pdf 17 / docx 6 / md 1; nothing at rest (.recovery, -wal, -shm,
+`.enc.new` all absent). So **#188 is confirmed outright** — drive-letter relocation took the whole
+corpus stale at once, every byte still at the canonical location, and the #189 resolver heals all 24
+on first read. **But `audio` rows = 0, which kills the record's leading explanation of checkbox 3**
+("one audio document previews from chunks while export fails"). The replacement, re-verified against
+the pre-#189 code rather than traced: `extractDocumentPreview` and `readStoredDocumentBytes` had
+*identical* ladders (`stored_path` → `original_path` → throw), audio was the only chunk-backed branch,
+the Vorschau modal never opens on a failed preview, and there is no cache — so with 24/24 stale,
+preview failed for EVERY document on that drive. The contradiction is **TEMPORAL** (the "Vorschau
+works" observation predates the relocation), not per-document. `architecture.md` §9 and §6 corrected.
+**Harness fix (phase 2):** the password prompt was gated on `process.stdin.isTTY`, which vitest's
+FORKED WORKER makes permanently false — the hidden prompt could never fire from any shell, and the
+failure text told the operator to "re-run from an interactive shell", which cannot help. It now reads
+the console DEVICE directly (`\\.\CONIN$` / `/dev/tty`, opened `r+` so `SetConsoleMode` is permitted,
+raw mode via libuv = echo off); no console ⇒ **fail fast** with the copy-pasteable
+`Read-Host -AsSecureString` / `read -rs` recipe, never a cooked read that would echo the password.
+New `tests/helpers/console-password.ts` + `tests/unit/console-password.test.ts` (5 tests — the
+worker's own non-TTY stdin is the witness; the source pin was mutation-checked). The header now
+carries the invocation that actually works here: `..\..\node_modules\.bin\vitest.cmd` — `npx` is
+blocked by this machine's PowerShell execution policy. **Still owner-owned:** checkbox 2 (cleanup
+posture — a recommendation is written, no sweep built) and checkbox 4 (second-laptop continuity; the
+G:\ run above is a valid "before" snapshot for it).
+
 _2026-08-20 — **Stored-copy diagnostic REBUILT — issue #190 phase 1 (no hardware, no password, fully
 CI-verified).**_ `architecture.md` §6 said the #188 root-cause diagnostic "was written and
 smoke-tested against a synthetic vault" and only needed the owner's password. **It never existed**:
@@ -48,125 +76,13 @@ every orphan and stages an `.enc.new` for each (a v2 rekey is O(1) and does not)
 why the report carries the descriptor version. **Deliberately not built:** any cleanup/sweep —
 #190 checkbox 2 is an owner decision that needs the orphan count first. Suite 5363/361 files green.
 
-_2026-08-19 — **Model occupancy — wave CLOSED (issues #185/#186).**_ The two issues the local-API
-wave filed out of scope were one defect seen from two sides, and were fixed together as both asked.
-"Who has the model" was answered by three registries and one hole: chat had `inFlightStreams`, doc
-tasks had their queue, **skill runs had per-DOCUMENT bookkeeping that is not a global busy signal
-(#186), and the benchmark had nothing at all (#185)** — so `startSkillRun` consulted neither of the
-other two, and two Diagnostics clicks (or one during a chat answer) both reached the model. The
-generation gate could not be the fix: it counts in-flight `chatStream` **pulls**, so a multi-step
-job reads IDLE between two of its own calls and a guard riding it would admit a second job into that
-gap. Shape: a **span** registry (`services/runtime/occupancy.ts`) on the `RuntimeManager`, held by
-the three BACKGROUND lanes only — chat keeps `inFlightStreams` as its one record, and the guards
-compose the sources (`ipc/model-busy.ts`) rather than mirroring them. `isExternallyBusy()` folds the
-spans in, so the local API now waits on a background job honestly instead of slipping into its gap.
-The skill lane is **declared in the descriptor table** (`SkillToolDescriptor.modelLane`), pinned to
-the dispatch by a source test — `'direct'` (redact/edit) takes a span, `'doctask'`
-(`categorize_transactions`) takes NONE, because its model call happens inside a task it enqueues and
-a span there would refuse its own task (the D26 deadlock). Two non-guards are load-bearing: a doc
-task never refuses on the doc-task span it holds itself (the #38 tree→extract chain enqueues from
-inside `run()`), and **chat is never refused by the benchmark** — the first-run benchmark fires right
-after unlock, so it YIELDS instead: the tokens/sec probe re-checks before it starts and on every
-chunk and **discards** a contended reading, which matters because a depressed reading steps the
-profile AND the recommendation down and is then PERSISTED (the one case where the issues'
-"degraded, not corruption" understates it). The discard raises the new persist-canonical
-`warnSpeedSkipped` — never a silent hole. **Durable record:** `docs/architecture.md` "Model
-occupancy — design record (issues #185/#186, §1–§6)" — decisions D1–D8, the full exclusion table,
-the leak posture, and what the wave deliberately did not do. **User-facing:**
-`docs/troubleshooting.md` "The model is busy — one job at a time". Suite 5312/50; 39 new tests in
-`model-occupancy.test.ts` + `model-occupancy-ipc.test.ts`. No hardware gate owed — every lane is
-exercised by scripted fake runtimes.
-
-_2026-08-19 — **MTP speculative decoding — wave CLOSED in code, TWO HARDWARE GATES OWED (issue
-#182).**_ The Qwen3.8 GGUFs already contained a trained-in draft head (`blk.64.nextn.*`) that
-llama-server loaded and ignored — the "unused tensor" warnings in every §4 log were the feature
-sitting unused. `qwen3.8-27b-q4` and `qwen3.8-27b-q5` now carry a new manifest field
-`speculative_decoding: mtp`, worth a **measured +38–45 % decode** on the §9.4 rig. Shape:
-the manifest **opts in**, the start ladder **decides**. The field is a **closed enum** the runtime
-maps to a fixed flag pair, never a free-form arg list — manifests are on-drive and user-editable,
-and `buildArgs` appends extras LAST, so a smuggled `--host 0.0.0.0` would beat the loopback-only
-invariant. Mechanism: a new **rung 1a** above the plain GPU rung, so rung 1 IS the automatic
-fallback (an older runtime, a weight without the head, a driver refusal → one failed attempt, then
-exactly today's behavior). Three guards, all conservative-by-construction because llama.cpp answers
-a VRAM shortfall by *silently offloading fewer layers* rather than failing (the #42 class): the rung
-is skipped unless the session-cached probe shows ONE device with the weight's bytes + 3.5 GiB free
-(the measured sum — it independently reproduces "Q6_K does not fit 24 GB"); a rung-1a start failure
-never persists `gpuAutoDisabled` and latches the model off for the session; a mid-session rung-1a
-crash takes its own handler that restarts **on the GPU** with MTP off, instead of exiling the
-machine to CPU over an optional speed-up. Forced-CPU rungs never carry the flags — that is issue
-gate 3 ("harmless on CPU, or drop it off-GPU") closed structurally, without hardware. "Try GPU
-again" re-arms the latch. **Durable record:** `docs/architecture.md` "MTP speculative decoding —
-design record (issue #182, §1–§7)" — decisions, the precondition arithmetic, the failure paths, and
-what the wave deliberately did not do. Field reference: `docs/model-policy.md` "Manifest fields";
-status + gate figures: `docs/model-benchmarks.md` §9.4 "Gate results". **Both hardware gates RAN
-AND PASSED 2026-08-19 on the i9-9900X + RTX 3090 rig** (tracked in §5 item 8b): the §2 grounded-QA
-re-run with MTP on held score parity inside cross-run tolerance for both quants (q4 F1 .3499 vs
-.3500, q5 .3518 vs .3523; zero hallucinations and 1.0000 unanswerable-abstention held; 92/100 resp.
-91/100 answers byte-identical, every diff a near-tie token flip), and the §9.1 smoke legs on the
-b9849 pin passed for both quants incl. rung-1a selection, full offload with 24 GB headroom (peak
-VRAM 19.7 / 21.5 GiB), clean teardown, and the shim-forced fall-through + re-arm legs. No RAM/VRAM
-line was retuned: the manifests keep their pre-MTP measured numbers until re-measured with the
-flag on.
-
-_2026-08-19 — **Portable stored copies — wave CLOSED (issue #188).**_ `documents.stored_path` was
-persisted **absolute** and consumed with a bare `existsSync` at six hand-written ladders, so a
-portable drive returning under a different mount point took **every** stored copy stale at once —
-row intact, bytes intact, only the recorded string wrong. It was the **last absolute path in
-persisted state** (images, skills, checksum cache, runtime marker and `source_relative_path` had
-each already been made portable by a named prior finding), and the vault layer already disagreed:
-rekey enumerates `workspace/documents/` by directory walk. The reported export failure was the
-SMALLEST of three defects sharing that cause: **"Delete document" silently did not delete** — the
-shred's `existsSync` guard conflated "already gone, nothing to do" with "I looked in the wrong
-place", leaving encrypted user content on the drive with no row left to ever reference it
-(**measured** pre-fix, not inferred) — and re-index degraded a healthy row to `failed`. Fixed at
-the **resolver**, not the reporting screen: new `services/ingestion/stored-copy.ts` +
-`documents.stored_name` (portable leaf, lazily healed), adopted by all six sites including the
-shred; `DocumentInfo.storedCopy` so the `⋯` menu stops offering what cannot succeed;
-`original_path` demoted to a sha256-checked last resort. **Durable record:** `docs/architecture.md`
-"Portable stored copies — design record (wave 188, issues #188/#190, §1–§9)" — decisions D1–D6, the
-safety guard the shred rests on, the verified-clean list, and the bundler landmine (§8: a string
-literal ending in the bare word `import` makes electron-vite wedge its CommonJS shim inside the
-literal; typecheck and the full suite pass and only `npm run build` fails — now tripwired in
-`repo-hygiene.test.ts`, and the standing argument for the typecheck → build → test gate order).
-**STILL OPEN, both now tracked in issue #190 (see the 2026-08-20 entry above):** the real
-relocated-drive run (the code is now correct; the second-laptop continuity check is only *answered*
-by hardware), and the read-only root-cause diagnostic on the reporting drive — which §6 wrongly
-claimed already existed. It has since been REBUILT and CI-proven (§9); running it on that drive
-needs the owner's password and would settle whether its rows are in fact stale (the issue reports
-"Vorschau works" alongside the export failure, and preview and export share one ladder, so both
-cannot describe the same document) and count the orphaned `.enc` files past silent deletes left
-behind.
-
-_2026-08-18 — **Local API endpoint — wave CLOSED (P1–P6), PR #184.**_ The loaded chat model
-can now be used by **other programs on the same computer** through an opt-in, loopback-only,
-OpenAI-compatible endpoint — **off by default**, behind a consent dialog, access-key-protected by
-default, existing only while the workspace is unlocked, and forbiddable by drive policy. The wave
-also closed a latent gap it did not create: every `llama-server` sidecar is now authenticated with
-a per-spawn env-delivered key, redacted from every stderr-derived surface. **Durable record:**
-`docs/architecture.md` "Local API endpoint — design record (wave local-api, PR #184, §1–§9)" —
-decisions D1–D9, owner options O1–O6, the as-built gate/HTTP/UX design, the deliberate omissions,
-what the audits changed, and the §-anchor legend for the retired plan's citations. **Security half:**
-`docs/security-model.md` "The fifth threat: same-machine processes". **Wire contract:**
-`docs/data-contracts.md`. **User-facing:** `PRIVACY.md`, `SECURITY.md`, `docs/user-guide.md`
-("Use HilbertRaum from other apps"), `docs/troubleshooting.md` ("Connecting another app").
-Citations use PR # + the `local-api-p<N>` phase prefix + a record §, never a branch SHA (O6 —
-the repo squash-merges). **Filed out of scope, deliberately** (pre-existing in-app concurrency the
-new gate makes visible but does not serialize): the benchmark has no re-entrancy guard, and a skill
-run can generate alongside a chat stream — filed as **#185** and **#186** (both CLOSED 2026-08-19, see the model-occupancy entry above). **Post-closeout fix (owner decision 2026-08-18, prompted by a REAL attached drive):** a `policy.json` that PREDATES `allow_local_api` now inherits the permissive default instead of a packaged build's STRICT base — otherwise every drive already in the field would have read "turned off by your drive's policy" with no way to distinguish that from a deliberate ban. An explicit `false` still denies (O4 intact); a junk value and a malformed file still fail closed. Recorded as **O4b** in the design record. **Real-model smoke DONE 2026-08-18** on a real attached drive (H:, prepared "lite", encrypted
-workspace, pinned b9849 vulkan engine) against `gemma4-e2b-it-qat-q4` on GPU: default-off proven
-with the vault unlocked, 401 unauthenticated, a real non-streaming completion and a full streaming
-one, every Host/Origin/method/type refusal, **O5's dual loopback vindicated** (both `::1` and
-`localhost` answer on this Win11 box), 4×~10k-char endurance streams, **D8 pre-emption**
-(`preempted_by_user`, `[DONE]` absent) and **D7 lock kill** (`server_stopped` 449 ms BEFORE the
-vault teardown — the pinned stop-first order). Evidence table in the design record §9. Remaining
-manual gap: no PACKAGED-build smoke (this was a dev run via `HILBERTRAUM_DRIVE_ROOT`), and the
-key-off/regenerate dialogs were not captured.
-
-_Older dated entries (2026-08-16 and earlier) and the Skills S2–S12 handoff sections were
+_Older dated entries (2026-08-19 and earlier) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
 retention budget), the 2026-07-11…2026-08-16 closed-wave block on 2026-08-18 (pre-wave archive
-ritual) — citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
+ritual), and the four CLOSED waves of 2026-08-18/19 (local API #184, portable stored copies #188,
+MTP speculative decoding #182, model occupancy #185/#186) on 2026-08-20 for the retention budget —
+citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 
 ---
@@ -1043,18 +959,23 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    moved-directory unit test is not a relocated drive. When it is finally run, cover **export
    original / preview / re-index / delete** on a workspace populated under a DIFFERENT letter, and
    confirm the rows self-heal (`documents.stored_name` populated after the first read).
-   **Also still owed (issue #190):** RUN the read-only stored-copy diagnostic on the reporting
-   drive. It exists as of 2026-08-20 and is CI-proven (architecture.md record §9); the run needs
-   the owner's password, and the tool never writes to the drive. From `apps/desktop/`, in an
-   interactive shell (it prompts for the password with no echo):
-   `$env:HILBERTRAUM_STORED_COPY_AUDIT = "H:\"; npx vitest run tests/manual/stored-copy-diagnostic.test.ts`
-   Its output is public-issue-safe by construction — paste it into #190. It settles whether that
-   drive's rows are stale, counts the orphaned `.enc` files left by past silent delete no-ops (the
-   number #190 checkbox 2 waits on), and its extension histogram settles the checkbox-3
-   contradiction (leading hypothesis: one AUDIO document — audio preview reads the stored chunks
-   and never touches the file). **It also doubles as the continuity check's evidence collector:**
-   run it before and after the relocation; `stale` / `healable` / `stored_name populated` is the
-   self-heal proof in pasteable form. The `electron-builder.yml` hooks + the pipeline are
+   **✅ The diagnostic half of issue #190 is DISCHARGED (2026-08-20).** The read-only stored-copy
+   diagnostic was RUN on the reporting drive (`G:\`) and the drive came back byte-identical:
+   **24 rows, 24 stale, 24 healable**, `stored_name` column absent (pre-#189 schema), **1 orphan
+   `.enc` (115.2 KiB)** on a **v2** descriptor, zero parse-transients, zero staged rekey files,
+   audio rows **0**. That confirms #188 outright and makes this drive a valid **"before" snapshot**
+   for the continuity check below — re-run the same command after the relocation and the
+   `stale` / `healable` / `stored_name populated` triple is the self-heal proof in pasteable form
+   (it should read 0 stale / 24 populated once the app has read each document once). From
+   `apps/desktop/` (the prompt is hidden and reads the console device, not stdin — `npx` is blocked
+   by this machine's execution policy, so use the `.cmd` shim):
+   `$env:HILBERTRAUM_STORED_COPY_AUDIT = "G:\"; ..\..\node_modules\.bin\vitest.cmd run tests/manual/stored-copy-diagnostic.test.ts`
+   Its output is public-issue-safe by construction — paste it into #190. **What it settled:**
+   checkbox 1 (yes, stale — all of them), the checkbox-2 number (one orphan), and checkbox 3 — for
+   which it **refuted** the record's leading "one AUDIO document" hypothesis (audio rows = 0). The
+   surviving answer is temporal: under pre-#189 code 24/24 stale means preview failed for every
+   document too, so the "Vorschau works" observation predates the relocation. See
+   `architecture.md` §9. The `electron-builder.yml` hooks + the pipeline are
    wired; only the secrets + hardware are missing. **GPU additions:** a SmartScreen sanity
    re-check (the Vulkan build adds one more unsigned DLL of the same class) and re-running
    `build-commercial-drive` end-to-end with the two-build fetch. **Phase-38 addition:** a

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -43,8 +43,26 @@ raw mode via libuv = echo off); no console ⇒ **fail fast** with the copy-paste
 New `tests/helpers/console-password.ts` + `tests/unit/console-password.test.ts` (5 tests — the
 worker's own non-TTY stdin is the witness; the source pin was mutation-checked). The header now
 carries the invocation that actually works here: `..\..\node_modules\.bin\vitest.cmd` — `npx` is
-blocked by this machine's PowerShell execution policy. **Still owner-owned:** checkbox 2 (cleanup
-posture — a recommendation is written, no sweep built).
+blocked by this machine's PowerShell execution policy.
+
+_2026-08-20 — **Cleanup posture DECIDED (owner): leave the orphans, ship nothing — issue #190
+checkbox 2 closed, and with it the last open item of the wave.**_ The decision D4's rider deferred
+until the count and the descriptor version were known was taken on that evidence: **n=1,
+115.2 KiB, v2**. v2 means a password change is the O(1) `rewrapVaultKey`, so the rider's expensive
+branch (a v1 migration re-encrypting every orphan, with the ENOSPC exposure that scales with
+orphaned bytes) never applies here; what remains is 115 KiB of unreferenced ciphertext beside
+2.1 MiB of live ciphertext under the same key — ~5% of the drive's document ciphertext, and nothing
+at all against an attacker without the password. The load-bearing argument against building even
+the *opt-in* version: a one-time named delete IS safer than a sweep, but the safety comes from **a
+human picked the file**, not from guards — put it in the app and code picks the file again, which
+reinstates D4's race and the D10 over-count hazard (the phantom-orphan bug the first end-to-end
+smoke found). The surface would be Diagnostics-only + unlock-gated + typed confirmation + an
+import/rekey refusal + de-AT copy + tests, i.e. a permanently-reachable delete path over the
+encrypted store shipped for a one-off 115 KiB, for a condition #189 already made unreachable.
+**Revisit trigger** (so this does not decay into "never look again"): any run reporting a **v1**
+descriptor with orphans, or orphan bytes at a material fraction of the store (order >50 files or
+>100 MiB) — both already reported by the diagnostic, so no new code is needed to notice. Record:
+`architecture.md` **§9.2 (D14)**, with a pointer from the §3 D4 rider.
 
 _2026-08-20 — **The relocation continuity check RAN — issue #190 checkbox 4 ANSWERED, and #188's
 worst defect is now proven fixed on hardware.**_ The same drive came back under a different letter

--- a/apps/desktop/tests/helpers/console-password.ts
+++ b/apps/desktop/tests/helpers/console-password.ts
@@ -1,0 +1,196 @@
+import { closeSync, openSync, writeSync } from 'node:fs'
+import { ReadStream } from 'node:tty'
+
+// Issue #190 phase 2 — read a password from the OPERATOR'S CONSOLE, not from `process.stdin`.
+//
+// WHY THIS EXISTS. The first version of the diagnostic harness prompted only when
+// `process.stdin.isTTY`. Vitest runs every test file in a FORKED WORKER whose stdin is a pipe, so
+// `isTTY` is `undefined` there NO MATTER what the operator's shell is — the hidden prompt could
+// never fire, and the failure message told the operator to "re-run from an interactive shell",
+// which cannot help. Measured on Windows PowerShell during the 2026-08-20 operator run; only the
+// env-var fallback worked, which is the variant with the shell-history hazard.
+//
+// So the prompt must bypass the worker's streams entirely and talk to the console device:
+//   * Windows — `\\.\CONIN$` / `\\.\CONOUT$`. The path MUST be the device form (`//./CONIN$`):
+//     libuv makes a bare `CONIN$` absolute against the cwd first, which turns it into ENOENT.
+//     It must also be opened READ-WRITE (`r+`): `SetConsoleMode` needs `GENERIC_READ |
+//     GENERIC_WRITE` on the handle, and a `'r'` open fails `setRawMode` with EPERM.
+//   * POSIX — `/dev/tty`, the controlling terminal, opened `r+` for the same reason.
+//
+// ECHO SUPPRESSION is the whole point, and it is delegated, not hand-rolled: `tty.ReadStream`'s
+// `setRawMode(true)` is libuv's `uv_tty_set_mode(UV_TTY_MODE_RAW)`, which clears
+// `ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT` on Windows and drops ECHO/ICANON on POSIX. Node exposes
+// no console-mode API of its own, so if raw mode is NOT available we refuse: a cooked read would
+// echo the workspace password onto the screen, and a half-hidden prompt is worse than no prompt.
+// `openConsolePrompt` therefore probes raw mode as part of opening and returns `null` on failure,
+// and the caller fails fast with `consoleUnavailableMessage()` — a copy-pasteable recipe that
+// keeps the password out of the shell history, not an instruction that cannot be followed.
+
+/** The env var the harness reads when the console prompt is unavailable. */
+export const PASSWORD_ENV_VAR = 'HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD'
+
+/** A console opened for a hidden prompt: raw (no echo) input, plus a write side for the prompt. */
+export type ConsolePrompt = {
+  /** The console's input, already in raw mode. */
+  input: ReadStream
+  /** Write to the console DIRECTLY — vitest captures `process.stdout`, so the prompt would vanish. */
+  write: (text: string) => void
+  /** Restore cooked mode and release both handles. Idempotent. */
+  close: () => void
+}
+
+const DEVICES =
+  process.platform === 'win32'
+    ? { input: '//./CONIN$', output: '//./CONOUT$' }
+    : { input: '/dev/tty', output: '/dev/tty' }
+
+/**
+ * Open the controlling console with echo suppressed, or return `null` when there is none (a CI
+ * runner, a detached process, a redirected console) or when raw mode is refused. Never falls back
+ * to an echoing read.
+ */
+export function openConsolePrompt(): ConsolePrompt | null {
+  let inFd: number | null = null
+  let outFd: number | null = null
+  let input: ReadStream | null = null
+  try {
+    inFd = openSync(DEVICES.input, 'r+')
+    outFd = DEVICES.output === DEVICES.input ? inFd : openSync(DEVICES.output, 'w')
+    input = new ReadStream(inFd)
+    input.setRawMode(true) // throws (EPERM / ENOTTY) when this is not a real console — refuse then
+  } catch {
+    // Release whatever got as far as opening. The ReadStream owns `inFd` once constructed, so it
+    // is closed by `destroy()`, never by a second `closeSync`.
+    try {
+      input?.destroy()
+    } catch {
+      /* already gone */
+    }
+    if (outFd != null && outFd !== inFd) closeSyncQuiet(outFd)
+    if (inFd != null && input == null) closeSyncQuiet(inFd)
+    return null
+  }
+
+  const stream = input
+  const writeFd = outFd
+  let closed = false
+  return {
+    input: stream,
+    write: (text: string): void => {
+      if (closed) return
+      try {
+        writeSync(writeFd, text)
+      } catch {
+        /* the console went away mid-prompt — the read below will fail loudly enough */
+      }
+    },
+    close: (): void => {
+      if (closed) return
+      closed = true
+      try {
+        stream.setRawMode(false)
+      } catch {
+        /* best effort — we are on the way out */
+      }
+      stream.pause()
+      try {
+        stream.destroy()
+      } catch {
+        /* already gone */
+      }
+      if (writeFd !== inFd) closeSyncQuiet(writeFd)
+    }
+  }
+}
+
+function closeSyncQuiet(fd: number): void {
+  try {
+    closeSync(fd)
+  } catch {
+    /* already closed */
+  }
+}
+
+/**
+ * The fail-fast text for "there is no console to prompt on". It carries a recipe that WORKS from
+ * the operator's shell and keeps the secret out of the history file — typed at a prompt, never on
+ * a command line — because the alternative the old message offered ("re-run from an interactive
+ * shell") is not a thing the operator can do: vitest's worker has a piped stdin either way.
+ */
+export function consoleUnavailableMessage(): string {
+  const recipe =
+    process.platform === 'win32'
+      ? // Read-Host -AsSecureString keeps the typed characters off the screen and out of
+        // PSReadLine's ConsoleHost_history.txt; the Marshal round-trip is the documented way to
+        // get the plaintext back out of a SecureString in Windows PowerShell.
+        `  $env:${PASSWORD_ENV_VAR} = [Runtime.InteropServices.Marshal]::PtrToStringAuto(\n` +
+        `    [Runtime.InteropServices.Marshal]::SecureStringToBSTR((Read-Host -AsSecureString "Workspace password")))`
+      : // `read -s` does not echo, and a value typed at a prompt never enters the history file.
+        `  read -rs -p "Workspace password: " ${PASSWORD_ENV_VAR}\n` +
+        `  export ${PASSWORD_ENV_VAR}`
+  return (
+    'This workspace is encrypted and no console is available for the hidden password prompt ' +
+    `(${DEVICES.input} could not be opened in raw mode). Set the password into the environment ` +
+    'with the recipe below — it is typed at a prompt, so it never lands in the shell history — ' +
+    'then re-run:\n\n' +
+    `${recipe}\n\n` +
+    'Clear it afterwards, and note that the value is readable in the process environment by ' +
+    'anything running as you while it is set.'
+  )
+}
+
+/**
+ * Prompt for a password on the console with the input hidden. Throws
+ * `consoleUnavailableMessage()` when there is no console — never an echoing fallback, and never a
+ * partially-typed password (Ctrl-C rejects).
+ *
+ * `open` is injectable so the no-console path is CI-testable on every platform.
+ */
+export async function promptHiddenPassword(
+  prompt = 'Workspace password (input hidden, Enter to submit): ',
+  open: () => ConsolePrompt | null = openConsolePrompt
+): Promise<string> {
+  const con = open()
+  if (!con) throw new Error(consoleUnavailableMessage())
+  con.write(prompt)
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      let buf = ''
+      const finish = (fn: () => void): void => {
+        con.input.removeListener('data', onData)
+        con.write('\n')
+        fn()
+      }
+      const onData = (chunk: string): void => {
+        for (const ch of chunk) {
+          if (ch === '\r' || ch === '\n') {
+            const out = buf
+            buf = ''
+            finish(() => {
+              resolve(out)
+            })
+            return
+          }
+          if (ch === '\u0003') {
+            // Ctrl-C: abort the run rather than proceeding with a partial password.
+            buf = ''
+            finish(() => {
+              reject(new Error('cancelled'))
+            })
+            return
+          }
+          if (ch === '\u007f' || ch === '\b') {
+            buf = buf.slice(0, -1)
+            continue
+          }
+          buf += ch
+        }
+      }
+      con.input.setEncoding('utf8')
+      con.input.on('data', onData)
+      con.input.resume()
+    })
+  } finally {
+    con.close()
+  }
+}

--- a/apps/desktop/tests/helpers/read-only-witness.ts
+++ b/apps/desktop/tests/helpers/read-only-witness.ts
@@ -1,0 +1,74 @@
+import { readdirSync, statSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { join, relative } from 'node:path'
+
+// Issue #190 — the evidence half of the diagnostic's safety contract.
+//
+// "The tool never writes to the drive" is the single claim the whole thing rests on, and a claim
+// backed only by careful code review is exactly the kind that decays. This turns it into an
+// assertion: fingerprint the drive tree, run the diagnostic, fingerprint again, require the two
+// identical. The integration test does that in CI against a synthetic vault; the manual harness
+// does the same against the real drive and FAILS THE RUN if anything moved.
+//
+// The fingerprint deliberately includes mtime as well as size: `openDatabase`'s `db.exec(SCHEMA)`
+// + `ensureColumn` sweep — the accidental write this guards against — can leave a same-size file
+// with a new mtime, and a size-only witness would sleep through it. It also lists directory
+// ENTRIES, so a `.recovery` rolled forward, a staged `.enc.new` swapped in, or a plaintext working
+// DB decrypted onto the drive all show up as an added or removed path.
+//
+// It hashes rather than reads content: the fingerprint of a user's drive must not itself become a
+// pile of file names in a test log.
+
+export interface TreeFingerprint {
+  /** Number of entries walked (files + directories). */
+  entries: number
+  /** SHA-256 over `relpath|size|mtimeMs` of every entry, in sorted order. */
+  digest: string
+}
+
+/** Directories that legitimately change while the app is not running — none today; kept so a
+ *  future exclusion has one obvious home rather than being sprinkled through call sites. */
+const IGNORED = new Set<string>()
+
+/**
+ * Walk `root` and hash the shape of everything under it.
+ *
+ * Best-effort per entry: an unreadable file contributes `?` rather than aborting the walk, because
+ * a witness that throws on a transiently-locked file (Windows AV/indexer) would turn a clean run
+ * into a scary failure. A file that becomes unreadable BETWEEN the two fingerprints still changes
+ * the digest, which is the behaviour we want.
+ */
+export function fingerprintTree(root: string): TreeFingerprint {
+  const lines: string[] = []
+  const walk = (dir: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      lines.push(`${relative(root, dir).split('\\').join('/')}|?|?`)
+      return
+    }
+    for (const name of entries.sort()) {
+      if (IGNORED.has(name)) continue
+      const full = join(dir, name)
+      const rel = relative(root, full).split('\\').join('/')
+      try {
+        const st = statSync(full)
+        lines.push(`${rel}|${String(st.size)}|${String(st.mtimeMs)}`)
+        if (st.isDirectory()) walk(full)
+      } catch {
+        lines.push(`${rel}|?|?`)
+      }
+    }
+  }
+  walk(root)
+  return {
+    entries: lines.length,
+    digest: createHash('sha256').update(lines.join('\n')).digest('hex')
+  }
+}
+
+/** True when the tree is byte-for-byte, mtime-for-mtime unchanged. */
+export function treeUnchanged(before: TreeFingerprint, after: TreeFingerprint): boolean {
+  return before.entries === after.entries && before.digest === after.digest
+}

--- a/apps/desktop/tests/helpers/stored-copy-audit-run.ts
+++ b/apps/desktop/tests/helpers/stored-copy-audit-run.ts
@@ -1,0 +1,301 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  type Dirent
+} from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import { join, resolve, sep } from 'node:path'
+import { resolvePaths } from '../../src/main/services/workspace'
+import {
+  readVaultDescriptor,
+  decryptFile,
+  shredFile,
+  RECOVERY_SUFFIX,
+  REKEY_SUFFIX,
+  type VaultDescriptor
+} from '../../src/main/services/workspace-vault'
+import { deriveKey, verifyKey, decrypt } from '../../src/main/services/security/crypto'
+import {
+  auditStoredCopies,
+  formatStoredCopyAuditReport,
+  type AuditDirEntry,
+  type AuditRow,
+  type StoredCopyAuditReport
+} from './stored-copy-audit'
+
+// Issue #190 — the READ-ONLY collector behind the stored-copy diagnostic.
+//
+// It gathers everything `auditStoredCopies` needs from a real (or synthetic) drive and hands it to
+// the pure classifier. It is a test helper, not app code, on purpose: it must never ship in the
+// bundle as dead code, and `tsconfig.web.json` already includes `tests/` so it stays typechecked.
+//
+// ============================ SAFETY CONTRACT ============================
+// This may run against the ONLY copy of a user's data. Every rule below is load-bearing:
+//
+//  • NOTHING under `root` is ever opened for writing. The drive is touched with `existsSync`,
+//    `statSync`, `readdirSync` and `copyFileSync`-as-SOURCE only.
+//  • The vault lifecycle functions are NEVER called against the drive. `unlockEncryptedVault`
+//    MUTATES: it runs `recoverPendingRekey` (which commits or discards staged rekeys and can roll
+//    a `.recovery` forward OVER the `.enc`), and it decrypts a plaintext working DB onto the
+//    drive. `openDatabase` runs `db.exec(SCHEMA)` plus ~20 `ensureColumn` calls, so merely opening
+//    the database writes to it — which is also why `stored_name` may not exist here and is probed
+//    with `PRAGMA table_info` instead of assumed.
+//  • `config/workspace.json` and `workspace/hilbertraum.sqlite.enc` are COPIED to a scratch
+//    directory outside the drive; the COPY is what gets decrypted and opened.
+//  • The copy is opened `new DatabaseSync(path, { readOnly: true })` — supported on the repo's
+//    Node floor (`engines.node >= 22.12`), which `stored-copy-audit.test.ts` proves in CI on the
+//    22.x leg rather than taking on trust.
+//  • The unlock is re-implemented over the copy by REUSING the shipped primitives
+//    (`readVaultDescriptor`, `deriveKey`, `verifyKey`, `decrypt` for the v2 envelope unwrap,
+//    `decryptFile`). No hand-rolled crypto.
+//  • The scratch plaintext is shredded in a `finally`, and every key buffer is zeroed.
+//
+// `read-only-witness.ts` turns "never writes to the drive" from a claim into a CI assertion: the
+// integration test fingerprints the whole drive tree before and after a run and requires it
+// byte-identical.
+
+/** Thrown when the supplied password does not open the vault. Content-free by design. */
+export class AuditWrongPasswordError extends Error {
+  constructor() {
+    super('The workspace password did not open this vault')
+    this.name = 'AuditWrongPasswordError'
+  }
+}
+
+export interface AuditRunOptions {
+  /** The drive root — the directory holding `config/` and `workspace/`. Never written to. */
+  root: string
+  /** Workspace password. Omit for a `plaintext_dev` workspace (no descriptor on disk). */
+  password?: string
+  /**
+   * Where the scratch copy is made. MUST NOT be under `root` — a scratch inside the drive would
+   * write the decrypted database onto the very medium this tool exists to leave untouched.
+   */
+  scratchRoot: string
+}
+
+export interface AuditRunResult {
+  report: StoredCopyAuditReport
+  /** The rendered, public-issue-safe text. */
+  text: string
+  /** Operational notes about the RUN itself (never about the data). */
+  notes: string[]
+}
+
+/** True when `child` is `parent` or lives under it. Both are resolved first. */
+export function isUnder(parent: string, child: string): boolean {
+  const p = resolve(parent)
+  const c = resolve(child)
+  if (p === c) return true
+  return c.startsWith(p.endsWith(sep) ? p : p + sep)
+}
+
+/** Read the descriptor's KDF salt + params and hand back the FILE key (v2: the unwrapped data
+ *  key; v1: the password-derived key). The KEK is zeroed before returning. */
+function fileKeyFor(descriptor: VaultDescriptor, password: string): Buffer {
+  const salt = Buffer.from(descriptor.saltB64, 'base64')
+  const kek = deriveKey(password, salt, descriptor.kdf)
+  const verifier = {
+    iv: Buffer.from(descriptor.verifier.ivB64, 'base64'),
+    tag: Buffer.from(descriptor.verifier.tagB64, 'base64'),
+    ciphertext: Buffer.from(descriptor.verifier.ciphertextB64, 'base64')
+  }
+  if (!verifyKey(kek, verifier)) {
+    kek.fill(0)
+    throw new AuditWrongPasswordError()
+  }
+  if (descriptor.dataKey) {
+    const dataKey = decrypt(kek, {
+      iv: Buffer.from(descriptor.dataKey.ivB64, 'base64'),
+      tag: Buffer.from(descriptor.dataKey.tagB64, 'base64'),
+      ciphertext: Buffer.from(descriptor.dataKey.ciphertextB64, 'base64')
+    })
+    kek.fill(0)
+    return dataKey
+  }
+  return kek
+}
+
+/** Files (never directories) in `dir`, as leaf name + size. Missing dir ⇒ empty. */
+function listFiles(dir: string): AuditDirEntry[] {
+  const out: AuditDirEntry[] = []
+  let entries: Dirent[]
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return out // no documents/ dir on this drive yet
+  }
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    let bytes = 0
+    try {
+      bytes = statSync(join(dir, e.name)).size
+    } catch {
+      /* raced or unreadable — count it, size unknown */
+    }
+    out.push({ name: e.name, bytes })
+  }
+  return out
+}
+
+/** Column names of `documents`, via a read-only PRAGMA (never `ensureColumn`). */
+function columnsOf(db: DatabaseSync, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  return new Set(rows.map((r) => r.name))
+}
+
+/**
+ * Collect + classify. Read-only with respect to `root`; everything it writes lives under a
+ * freshly-made subdirectory of `scratchRoot`, which is shredded and removed before returning.
+ */
+export function runStoredCopyAudit(opts: AuditRunOptions): AuditRunResult {
+  const notes: string[] = []
+  if (!existsSync(opts.root)) throw new Error('The drive root does not exist')
+  if (isUnder(opts.root, opts.scratchRoot)) {
+    // The one mistake that would defeat every other guard in this file.
+    throw new Error('The scratch directory must not be inside the drive root')
+  }
+  mkdirSync(opts.scratchRoot, { recursive: true })
+  const scratch = mkdtempSync(join(opts.scratchRoot, 'hr-audit-'))
+
+  // `resolvePaths` is pure (no mkdir) — `ensureWorkspaceDirs`/`documentsDir` are the ones that
+  // create directories, and neither is called here.
+  const paths = resolvePaths({ envRoot: opts.root, fallbackRoot: opts.root })
+  const descriptorPath = join(paths.configPath, 'workspace.json')
+  const encPath = `${paths.dbPath}.enc`
+  const storeDir = join(paths.workspacePath, 'documents')
+
+  const atRest = {
+    recovery: existsSync(`${paths.dbPath}${RECOVERY_SUFFIX}`),
+    wal: existsSync(`${paths.dbPath}-wal`),
+    shm: existsSync(`${paths.dbPath}-shm`),
+    dbRekeyStaged: existsSync(`${encPath}${REKEY_SUFFIX}`)
+  }
+
+  const descriptor = readVaultDescriptor(descriptorPath)
+  const scratchDb = join(scratch, 'audit.sqlite')
+  let fileKey: Buffer | null = null
+  let db: DatabaseSync | null = null
+
+  try {
+    if (descriptor) {
+      if (!existsSync(encPath)) {
+        throw new Error('This workspace has a vault descriptor but no encrypted database')
+      }
+      if (!opts.password) throw new Error('This workspace is encrypted — a password is required')
+      // Copy FIRST, decrypt the copy. `config/workspace.json` is copied too so the run is
+      // reproducible from the scratch bundle alone if it ever needs re-examination.
+      copyFileSync(descriptorPath, join(scratch, 'workspace.json'))
+      const scratchEnc = join(scratch, 'audit.sqlite.enc')
+      copyFileSync(encPath, scratchEnc)
+      fileKey = fileKeyFor(descriptor, opts.password)
+      decryptFile(scratchEnc, scratchDb, fileKey)
+      notes.push(`decrypted a ${String(statSync(scratchEnc).size)}-byte copy in scratch`)
+    } else {
+      if (!existsSync(paths.dbPath)) {
+        throw new Error('No workspace database found at this root (neither .enc nor plaintext)')
+      }
+      copyFileSync(paths.dbPath, scratchDb)
+      // A plaintext_dev workspace can be at rest WITH a live WAL. Bring its sidecars along so the
+      // copy is the same database the app would see; an encrypted vault never needs this (lock
+      // checkpoints before it re-encrypts).
+      for (const suffix of ['-wal', '-shm']) {
+        if (existsSync(`${paths.dbPath}${suffix}`)) {
+          copyFileSync(`${paths.dbPath}${suffix}`, `${scratchDb}${suffix}`)
+        }
+      }
+      notes.push('plaintext_dev workspace — no password needed')
+    }
+
+    try {
+      db = new DatabaseSync(scratchDb, { readOnly: true })
+      db.prepare('SELECT 1').get()
+    } catch (err) {
+      // SQLite cannot replay a WAL through a read-only handle. Recover ON THE SCRATCH COPY —
+      // writing there is explicitly allowed and the drive is not involved — then re-open
+      // read-only so the query path keeps its guarantee.
+      db?.close()
+      db = null
+      if (!existsSync(`${scratchDb}-wal`)) throw err
+      const rw = new DatabaseSync(scratchDb)
+      rw.exec('PRAGMA wal_checkpoint(TRUNCATE);')
+      rw.close()
+      db = new DatabaseSync(scratchDb, { readOnly: true })
+      notes.push('a live -wal was checkpointed ON THE SCRATCH COPY before the read-only open')
+    }
+
+    const cols = columnsOf(db, 'documents')
+    const hasStoredName = cols.has('stored_name')
+    // The reporting drive predates #189, where `stored_name` is added by `ensureColumn` at open —
+    // which this tool must not trigger. A naive `SELECT ... stored_name` throws there.
+    const select = [
+      'id',
+      'status',
+      'stored_path',
+      hasStoredName ? 'stored_name' : "NULL AS stored_name",
+      'original_path',
+      'mime_type'
+    ].join(', ')
+    const raw = db.prepare(`SELECT ${select} FROM documents`).all() as Array<
+      Record<string, string | null>
+    >
+    const rows: AuditRow[] = raw.map((r) => ({
+      id: String(r.id),
+      status: String(r.status ?? ''),
+      stored_path: r.stored_path ?? null,
+      // `undefined` (column absent) and `null` (column present, row unhealed) are different
+      // findings and the report distinguishes them.
+      stored_name: hasStoredName ? (r.stored_name ?? null) : undefined,
+      original_path: r.original_path ?? null,
+      mime_type: r.mime_type ?? null
+    }))
+
+    const dirEntries = listFiles(storeDir)
+    const existingRecordedPaths = rows
+      .map((r) => r.stored_path)
+      .filter((p): p is string => Boolean(p))
+      .filter((p) => {
+        try {
+          return existsSync(p)
+        } catch {
+          return false
+        }
+      })
+
+    const report = auditStoredCopies({
+      rows,
+      dirEntries,
+      existingRecordedPaths,
+      storedNameColumn: hasStoredName,
+      descriptorVersion: descriptor ? descriptor.version : null,
+      atRest
+    })
+    return { report, text: formatStoredCopyAuditReport(report), notes }
+  } finally {
+    try {
+      db?.close()
+    } catch {
+      /* already closed */
+    }
+    if (fileKey) fileKey.fill(0)
+    // Shred every scratch artifact that could hold plaintext, then drop the directory. The shred
+    // is the same overwrite-then-unlink the app uses; `rmSync` alone would leave the bytes.
+    for (const name of ['audit.sqlite', 'audit.sqlite-wal', 'audit.sqlite-shm', 'audit.sqlite.enc', 'audit.sqlite.tmp', 'workspace.json']) {
+      try {
+        shredFile(join(scratch, name))
+      } catch {
+        /* best-effort */
+      }
+    }
+    try {
+      rmSync(scratch, { recursive: true, force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/apps/desktop/tests/helpers/stored-copy-audit.ts
+++ b/apps/desktop/tests/helpers/stored-copy-audit.ts
@@ -1,0 +1,557 @@
+import { canonicalLeafFor, storedCopyLeaf } from '../../src/main/services/ingestion/stored-copy'
+
+// Issue #190 — the PURE half of the stored-copy diagnostic: given the `documents` rows and a
+// listing of `workspace/documents/`, decide what is stale, what is healable, what is genuinely
+// missing, and which `.enc` files on disk have no owning row (the ORPHAN count left behind by the
+// pre-#189 delete no-op). No fs, no crypto, no I/O — every fact this module needs is handed in,
+// so CI can prove it against a synthetic vault with exact counts. The read-only collector that
+// feeds it lives in `stored-copy-audit-run.ts`; the operator shell in
+// `tests/manual/stored-copy-diagnostic.test.ts`.
+//
+// WHY THIS FILE EXISTS AT ALL: `docs/architecture.md` "Portable stored copies" §6 claimed a
+// diagnostic "was written and smoke-tested against a synthetic vault". It was not — it lived in
+// the git-excluded working paper and was deleted with it. Nothing matching it was ever committed.
+// This is the rebuild, and the §6 correction lands with it.
+//
+// OUTPUT CONTRACT (the reason for the shape of every field below): the report is designed to be
+// pasted into a PUBLIC GitHub issue. It therefore carries NO titles, NO content, NO user paths and
+// NO file names — only counts, histograms, and "shape tokens" (an 8-char id prefix + an extension
+// CLASS drawn from a closed allowlist + flag letters). `stored-copy-audit.test.ts` asserts that a
+// report rendered from a vault full of distinctive secrets contains none of them.
+//
+// It reuses the shipped `canonicalLeafFor` rather than re-deriving "where would this document's
+// bytes be" — the diagnostic's whole value is that its verdict is the app's verdict, so a
+// divergence between the two would be the one bug that makes the numbers meaningless. That is
+// worth the import graph `stored-copy.ts` drags in; nothing in it runs at import time.
+
+/**
+ * What a file in `workspace/documents/` is, by NAME alone.
+ *
+ * The distinction that matters is `stored-copy` vs everything else: only a `stored-copy` with no
+ * owning row is an orphan, and the orphan count is what a future cleanup decision (issue #190
+ * checkbox 2) would rest on. Mistaking a staged rekey file or an in-flight import transient for an
+ * orphan is exactly the D4 race the wave-188 record refuses to build a sweep around — so the
+ * classes below are ordered most-specific-first and the tests pin the ordering.
+ */
+export type FileClass =
+  /** `<id><ext>[.enc]` — a document's workspace copy (or something shaped exactly like one). */
+  | 'stored-copy'
+  /** `*.parse*` — an ingest/preview/export/dictation/doc-task transient. Shredded by the sweep. */
+  | 'parse-transient'
+  /** `<file>.enc.new` — `stageRekey` staging for an in-flight or interrupted password change. */
+  | 'rekey-staged'
+  /** `*.tmp` — `encryptFile`'s atomic-write temp, incl. `.enc.tmp` / `.enc.new.tmp` / `.rekey.tmp`. */
+  | 'write-temp'
+  /** Anything else. Never counted as an orphan; reported so an unknown writer cannot hide. */
+  | 'unknown'
+
+/** One file in `workspace/documents/`, as the collector saw it. */
+export interface AuditDirEntry {
+  /** Bare leaf name. */
+  name: string
+  /** Size on disk in bytes. */
+  bytes: number
+}
+
+/**
+ * The `documents` columns the audit reads. Deliberately a narrow projection: `title`,
+ * `error_message` and every `*_json` column can carry user content and are never selected.
+ * `mime_type` is a class, not content, and is the only extension source a row keeps once its
+ * stored copy is gone.
+ */
+export interface AuditRow {
+  id: string
+  status: string
+  stored_path: string | null
+  /**
+   * `undefined` when the DB has no `stored_name` column at all — the reporting drive predates
+   * #189 and the column is only added by `ensureColumn` at open, which the diagnostic must never
+   * trigger. `null` means the column exists but this row has not been healed yet.
+   */
+  stored_name?: string | null
+  original_path: string | null
+  mime_type: string | null
+}
+
+/** At-rest artifacts that each mean an unclean last session or an interrupted password change. */
+export interface AtRestFlags {
+  /** `<db>.recovery` — a failed lock left the working file as the only fresh copy (CODE-1b). */
+  recovery: boolean
+  /** `<db>-wal` at rest — the last session did not check-point/close cleanly. */
+  wal: boolean
+  /** `<db>-shm` at rest — same. */
+  shm: boolean
+  /** `<db>.enc.new` — a password change was interrupted after staging the database. */
+  dbRekeyStaged: boolean
+}
+
+export interface AuditInput {
+  /** Every row of `documents`. */
+  rows: readonly AuditRow[]
+  /** Files (not directories) in `workspace/documents/`, leaf names + sizes. */
+  dirEntries: readonly AuditDirEntry[]
+  /**
+   * The subset of recorded `stored_path` values that exist on disk EXACTLY as recorded. Handed
+   * in rather than derived, because a legacy row can name a path OUTSIDE the store dir, which the
+   * directory listing cannot answer. Keeps this module I/O-free.
+   */
+  existingRecordedPaths: readonly string[]
+  /** Whether `PRAGMA table_info(documents)` lists `stored_name`. */
+  storedNameColumn: boolean
+  /** Vault descriptor version (1 = direct key, 2 = envelope), or null for `plaintext_dev`. */
+  descriptorVersion: number | null
+  atRest: AtRestFlags
+}
+
+/** Per-class file tally. */
+export interface ClassTally {
+  count: number
+  bytes: number
+}
+
+export interface StoredCopyAuditReport {
+  /** (1) Row counts. */
+  documents: {
+    total: number
+    byStatus: Record<string, number>
+  }
+  rows: {
+    /** (2) Rows whose recorded `stored_path` does not exist as recorded. */
+    stale: number
+    /** (3) Of the stale rows, how many resolve at the canonical location — the healable set. */
+    healable: number
+    /** Stale rows the canonical-leaf SAFETY guard refuses to name (`canonicalLeafFor` → null). */
+    staleUnnameable: number
+    /** (4) Rows that claim a stored copy but have none anywhere. */
+    missingEverywhere: number
+    /** Rows that never recorded a stored copy at all (queued / failed-before-copy). Not a defect. */
+    neverStored: number
+    /** Rows whose copy is where the row says it is. */
+    resolvedAsRecorded: number
+  }
+  /** (5) `stored-copy`-shaped files in `workspace/documents/` claimed by no row. */
+  orphans: {
+    count: number
+    bytes: number
+    /** Shape tokens, one per orphan. */
+    tokens: string[]
+  }
+  /** (6) File-class histogram over `workspace/documents/`. */
+  fileClasses: Record<FileClass, ClassTally>
+  /** (7) Extension-CLASS histogram over rows. Required: it is what settles the #190 contradiction. */
+  extensions: Record<string, number>
+  /** Rows whose extension class is audio — the leading hypothesis for "Vorschau works". */
+  audioRows: number
+  /** (8) `stored_name` adoption. */
+  storedName: {
+    column: boolean
+    populated: number
+  }
+  /** (9) Vault descriptor version — decides the rekey blast radius. */
+  vault: {
+    descriptorVersion: number | null
+    mode: 'encrypted' | 'plaintext_dev'
+  }
+  /** (10) Unclean-session / interrupted-password-change findings. */
+  atRest: AtRestFlags
+  /** Shape tokens, one per row. */
+  rowTokens: string[]
+}
+
+// ---- extension classes -----------------------------------------------------------
+//
+// A CLOSED allowlist. An extension is normally harmless, but "the one .p7s on the drive" is
+// identifying and this text is meant for a public issue — so anything off the list collapses to
+// `other`. The list is exactly `MIME_BY_EXT` from `ingestion/index.ts` (what the app can import),
+// which is also why it is complete enough to answer the audio question.
+
+const EXT_CLASSES = [
+  'txt',
+  'md',
+  'pdf',
+  'docx',
+  'csv',
+  'wav',
+  'mp3',
+  'flac',
+  'ogg',
+  'png',
+  'jpg'
+] as const
+
+/** Extension classes that are audio — the #190 contradiction hinges on this set. */
+const AUDIO_CLASSES = new Set<string>(['wav', 'mp3', 'flac', 'ogg'])
+
+const EXT_ALIASES: Record<string, string> = {
+  text: 'txt',
+  log: 'txt',
+  markdown: 'md',
+  mdown: 'md',
+  tsv: 'csv',
+  jpeg: 'jpg'
+}
+
+const MIME_TO_CLASS: Record<string, string> = {
+  'text/plain': 'txt',
+  'text/markdown': 'md',
+  'application/pdf': 'pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'text/csv': 'csv',
+  'audio/wav': 'wav',
+  'audio/mpeg': 'mp3',
+  'audio/flac': 'flac',
+  'audio/ogg': 'ogg',
+  'image/png': 'png',
+  'image/jpeg': 'jpg'
+}
+
+const allowed = new Set<string>(EXT_CLASSES)
+
+function normalizeExt(raw: string): string {
+  const lower = raw.replace(/^\./, '').toLowerCase()
+  const aliased = EXT_ALIASES[lower] ?? lower
+  return allowed.has(aliased) ? aliased : 'other'
+}
+
+/**
+ * Extension class of a stored-copy leaf: strip a trailing `.enc`, strip the `<id>` prefix when the
+ * name carries one, and classify what is left. Returns null when the leaf has no extension at all.
+ */
+function extClassFromLeaf(leaf: string, id?: string): string | null {
+  let name = leaf
+  if (name.toLowerCase().endsWith('.enc')) name = name.slice(0, -4)
+  if (id && name.startsWith(id)) name = name.slice(id.length)
+  const dot = name.lastIndexOf('.')
+  if (dot < 0 || dot === name.length - 1) return null
+  return normalizeExt(name.slice(dot + 1))
+}
+
+/**
+ * Extension class of a ROW. The stored-copy leaf is preferred (it is what the bytes on disk are
+ * actually called); `mime_type` is the fallback that keeps the histogram complete for a row whose
+ * copy is gone. `none` when neither says anything.
+ */
+export function extClassOf(row: AuditRow): string {
+  const leaf = row.stored_name ?? (row.stored_path ? storedCopyLeaf(row.stored_path) : null)
+  if (leaf) {
+    const fromLeaf = extClassFromLeaf(leaf, row.id)
+    if (fromLeaf) return fromLeaf
+  }
+  if (row.mime_type) {
+    const fromMime = MIME_TO_CLASS[row.mime_type.toLowerCase()]
+    if (fromMime) return fromMime
+    return 'other'
+  }
+  return 'none'
+}
+
+// ---- file classification ---------------------------------------------------------
+
+/** A leading RFC-4122-shaped id, which is what every writer into the store dir prefixes with. */
+const UUID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+/**
+ * Classify one file in `workspace/documents/` by name.
+ *
+ * ORDER IS LOAD-BEARING and the tests pin it. The full set of writers into this directory:
+ *   • ingest re-index            `<id>.parse<ext>`
+ *   • preview / export           `<id>.parse-preview-<uuid><ext>`, `<id>.parse-export[-bin]-<uuid><ext>`
+ *   • dictation                  `<uuid>.parse-dictation.wav`
+ *   • transcription              `<uuid>.parse-transcript*`
+ *   • doc tasks                  `<jobId>.parse.md`, `<id>.parse-ocr.pdf`
+ *   • `encryptFile`              `<dest>.tmp`  (so `<id><ext>.enc.tmp`, `<id><ext>.enc.new.tmp`)
+ *   • `stageRekey`               `<id><ext>.enc.new`, and `<id><ext>.enc.rekey.tmp` in between
+ *   • the stored copy itself     `<id><ext>.enc` (encrypted) or `<id><ext>` (plaintext_dev)
+ *
+ * A `.enc.new` is a LIVE staged rekey of a LIVE document. Classifying it as a stored copy would
+ * park it in the orphan bucket and hand a future cleanup a file whose deletion loses the user's
+ * data mid-password-change. `.parse` is checked first because a transient can end in `.enc`-ish
+ * shapes, and `.tmp` before `.enc` for the same reason.
+ */
+export function classifyFile(name: string): FileClass {
+  const lower = name.toLowerCase()
+  if (lower.includes('.parse')) return 'parse-transient'
+  if (lower.endsWith('.enc.new')) return 'rekey-staged'
+  if (lower.endsWith('.tmp')) return 'write-temp'
+  if (lower.endsWith('.enc')) return 'stored-copy'
+  // plaintext_dev workspaces store `<id><ext>` with no suffix at all; an id-shaped prefix is the
+  // only thing that separates such a copy from a stray file somebody dropped in the directory.
+  if (UUID_PREFIX.test(name)) return 'stored-copy'
+  return 'unknown'
+}
+
+// ---- shape tokens ----------------------------------------------------------------
+
+/** First 8 characters of an id — enough to correlate two lines of the report, useless alone. */
+function idPrefix(id: string): string {
+  return id.slice(0, 8).toLowerCase()
+}
+
+/**
+ * Row flags:
+ *   E  the stored copy rests encrypted (`.enc` leaf)
+ *   N  `stored_name` is populated (the row has been healed, or was written post-#189)
+ *   O  an `original_path` is recorded
+ *   P  the copy is exactly where the row says it is
+ *   S  STALE — the recorded `stored_path` does not exist as recorded
+ *   H  HEALABLE — a stale row whose copy is at the canonical location
+ *   M  MISSING — the row claims a copy and there is none anywhere
+ *   X  the canonical-leaf safety guard refuses this row's name (`canonicalLeafFor` → null)
+ *   -  the row never recorded a stored copy (queued / failed before the copy was made)
+ */
+function rowFlags(f: {
+  encrypted: boolean
+  storedName: boolean
+  original: boolean
+  present: boolean
+  stale: boolean
+  healable: boolean
+  missing: boolean
+  unnameable: boolean
+  neverStored: boolean
+}): string {
+  let s = ''
+  if (f.neverStored) s += '-'
+  if (f.encrypted) s += 'E'
+  if (f.storedName) s += 'N'
+  if (f.original) s += 'O'
+  if (f.present) s += 'P'
+  if (f.stale) s += 'S'
+  if (f.healable) s += 'H'
+  if (f.missing) s += 'M'
+  if (f.unnameable) s += 'X'
+  return s === '' ? '.' : s
+}
+
+/** Coarse size bucket for an orphan — an exact byte count of one file is more identifying. */
+function sizeBucket(bytes: number): string {
+  if (bytes < 64 * 1024) return '<64K'
+  if (bytes < 1024 * 1024) return '<1M'
+  if (bytes < 8 * 1024 * 1024) return '<8M'
+  if (bytes < 64 * 1024 * 1024) return '<64M'
+  return '>=64M'
+}
+
+// ---- the audit -------------------------------------------------------------------
+
+function emptyClasses(): Record<FileClass, ClassTally> {
+  return {
+    'stored-copy': { count: 0, bytes: 0 },
+    'parse-transient': { count: 0, bytes: 0 },
+    'rekey-staged': { count: 0, bytes: 0 },
+    'write-temp': { count: 0, bytes: 0 },
+    unknown: { count: 0, bytes: 0 }
+  }
+}
+
+/**
+ * Classify a whole workspace. Pure: same input, same report, no clock and no randomness — the
+ * report is stable enough to diff between two runs of the same drive.
+ */
+export function auditStoredCopies(input: AuditInput): StoredCopyAuditReport {
+  const present = new Set(input.existingRecordedPaths)
+  const onDisk = new Set(input.dirEntries.map((e) => e.name))
+
+  // Every leaf any row could be referring to. DELIBERATELY GENEROUS: a name claimed by a row is
+  // never an orphan, so all three sources count — the healed `stored_name`, the leaf of the
+  // recorded `stored_path` (which the safety guard may refuse, but a refused name is still
+  // evidence that a row is about that file), and the canonical leaf. Over-claiming produces an
+  // UNDER-count of orphans; under-claiming produces a false orphan, and a false orphan is the one
+  // that could get a live document deleted.
+  const claimed = new Set<string>()
+  for (const row of input.rows) {
+    if (row.stored_name) claimed.add(row.stored_name)
+    if (row.stored_path) claimed.add(storedCopyLeaf(row.stored_path))
+    const canonical = canonicalLeafFor(row)
+    if (canonical) claimed.add(canonical)
+  }
+  // The fourth, and the one that closes the false-orphan hole the first three leave open: a row
+  // whose recorded strings are corrupt or unnameable (`canonicalLeafFor` → null) names NOTHING, so
+  // its perfectly healthy `<id><ext>.enc` on disk would be reported as an orphan. But the store's
+  // naming is `<documentId><ext>[.enc]` and the id is a never-reused UUID primary key — so a file
+  // whose LEADING id is a live row's id belongs to that row, whatever the row happens to have
+  // recorded. Found by the first end-to-end operator smoke, where a deliberately mangled
+  // `stored_path` turned a live document into a phantom orphan.
+  const rowIds = new Set(input.rows.map((r) => r.id.toLowerCase()))
+
+  const byStatus: Record<string, number> = {}
+  const extensions: Record<string, number> = {}
+  const rowTokens: string[] = []
+  let stale = 0
+  let healable = 0
+  let staleUnnameable = 0
+  let missingEverywhere = 0
+  let neverStored = 0
+  let resolvedAsRecorded = 0
+  let storedNamePopulated = 0
+  let audioRows = 0
+
+  for (const row of input.rows) {
+    byStatus[row.status] = (byStatus[row.status] ?? 0) + 1
+    const cls = extClassOf(row)
+    extensions[cls] = (extensions[cls] ?? 0) + 1
+    if (AUDIO_CLASSES.has(cls)) audioRows++
+    if (row.stored_name) storedNamePopulated++
+
+    const claimsCopy = Boolean(row.stored_path) || Boolean(row.stored_name)
+    const recordedPresent = Boolean(row.stored_path) && present.has(row.stored_path as string)
+    const canonical = canonicalLeafFor(row)
+    const canonicalPresent = canonical !== null && onDisk.has(canonical)
+
+    // "Stale" is strictly about the RECORDED string: a row that names a path which is not there.
+    // A row with no `stored_path` at all cannot be stale — it never recorded one.
+    const isStale = Boolean(row.stored_path) && !recordedPresent
+    const isHealable = isStale && canonicalPresent
+    const isUnnameable = isStale && canonical === null
+    const isMissing = claimsCopy && !recordedPresent && !canonicalPresent
+    const isNeverStored = !claimsCopy
+
+    if (isStale) stale++
+    if (isHealable) healable++
+    if (isUnnameable) staleUnnameable++
+    if (isMissing) missingEverywhere++
+    if (isNeverStored) neverStored++
+    if (recordedPresent) resolvedAsRecorded++
+
+    const leafForEnc = row.stored_name ?? (row.stored_path ? storedCopyLeaf(row.stored_path) : '')
+    rowTokens.push(
+      `${idPrefix(row.id)} ${cls} ${rowFlags({
+        encrypted: leafForEnc.toLowerCase().endsWith('.enc'),
+        storedName: Boolean(row.stored_name),
+        original: Boolean(row.original_path),
+        present: recordedPresent || canonicalPresent,
+        stale: isStale,
+        healable: isHealable,
+        missing: isMissing,
+        unnameable: isUnnameable,
+        neverStored: isNeverStored
+      })}`
+    )
+  }
+
+  const fileClasses = emptyClasses()
+  const orphanTokens: string[] = []
+  let orphanCount = 0
+  let orphanBytes = 0
+
+  for (const entry of input.dirEntries) {
+    const cls = classifyFile(entry.name)
+    fileClasses[cls].count++
+    fileClasses[cls].bytes += entry.bytes
+    if (cls !== 'stored-copy') continue
+    if (claimed.has(entry.name)) continue
+    const prefixMatch = UUID_PREFIX.exec(entry.name)
+    if (prefixMatch && rowIds.has(prefixMatch[0].toLowerCase())) continue // owned by id
+    orphanCount++
+    orphanBytes += entry.bytes
+    const prefix = prefixMatch ? idPrefix(prefixMatch[0]) : '????????'
+    const ext = extClassFromLeaf(entry.name) ?? 'none'
+    orphanTokens.push(`${prefix} ${ext} ${sizeBucket(entry.bytes)}`)
+  }
+
+  return {
+    documents: { total: input.rows.length, byStatus },
+    rows: {
+      stale,
+      healable,
+      staleUnnameable,
+      missingEverywhere,
+      neverStored,
+      resolvedAsRecorded
+    },
+    orphans: { count: orphanCount, bytes: orphanBytes, tokens: orphanTokens.sort() },
+    fileClasses,
+    extensions,
+    audioRows,
+    storedName: { column: input.storedNameColumn, populated: storedNamePopulated },
+    vault: {
+      descriptorVersion: input.descriptorVersion,
+      mode: input.descriptorVersion === null ? 'plaintext_dev' : 'encrypted'
+    },
+    atRest: input.atRest,
+    rowTokens: rowTokens.sort()
+  }
+}
+
+// ---- rendering -------------------------------------------------------------------
+
+function histogram(counts: Record<string, number>): string[] {
+  return Object.entries(counts)
+    .sort((a, b) => (b[1] - a[1] !== 0 ? b[1] - a[1] : a[0].localeCompare(b[0])))
+    .map(([k, v]) => `    ${k.padEnd(16)} ${String(v)}`)
+}
+
+/** Human size. Small totals render in KiB so a real finding never prints as "0.0 MiB". */
+function size(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`
+  return `${(bytes / 1024).toFixed(1)} KiB`
+}
+
+/**
+ * Render the report as the text an operator pastes into issue #190.
+ *
+ * Everything printed comes from `StoredCopyAuditReport` — counts, class names from the two closed
+ * allowlists, and shape tokens. No caller-supplied string reaches this function, which is what
+ * makes "safe to paste in public" a property of the code rather than of the operator's care.
+ */
+export function formatStoredCopyAuditReport(report: StoredCopyAuditReport): string {
+  const L: string[] = []
+  L.push('HilbertRaum stored-copy audit (issue #190) — read-only, no titles, no content, no paths')
+  L.push('')
+  L.push(`workspace mode          ${report.vault.mode}`)
+  L.push(
+    `vault descriptor        ${report.vault.descriptorVersion === null ? 'n/a' : `v${String(report.vault.descriptorVersion)}`}`
+  )
+  L.push(`stored_name column      ${report.storedName.column ? 'present' : 'ABSENT (pre-#189 schema)'}`)
+  L.push(
+    `stored_name populated   ${String(report.storedName.populated)} / ${String(report.documents.total)}`
+  )
+  L.push('')
+  L.push(`(1) documents rows      ${String(report.documents.total)}`)
+  L.push(...histogram(report.documents.byStatus))
+  L.push('')
+  L.push(`(2) stale stored_path   ${String(report.rows.stale)}   (recorded path not present as recorded)`)
+  L.push(`(3)   of those healable ${String(report.rows.healable)}   (copy IS at the canonical location)`)
+  L.push(`      of those unnamed  ${String(report.rows.staleUnnameable)}   (safety guard refuses the leaf)`)
+  L.push(`(4) no copy anywhere    ${String(report.rows.missingEverywhere)}`)
+  L.push(`    never stored a copy ${String(report.rows.neverStored)}   (queued / failed before the copy)`)
+  L.push(`    resolved as recorded ${String(report.rows.resolvedAsRecorded)}`)
+  L.push('')
+  L.push(
+    `(5) ORPHAN .enc files   ${String(report.orphans.count)}   ${size(report.orphans.bytes)} unreferenced`
+  )
+  for (const t of report.orphans.tokens) L.push(`    ${t}`)
+  if (report.rows.staleUnnameable > 0) {
+    L.push(
+      `    NOTE: ${String(report.rows.staleUnnameable)} row(s) record a leaf the safety guard refuses; ` +
+        'their copies are attributed by id, not by name.'
+    )
+  }
+  L.push('')
+  L.push('(6) file classes in workspace/documents/')
+  for (const [k, v] of Object.entries(report.fileClasses)) {
+    L.push(`    ${k.padEnd(16)} ${String(v.count).padStart(5)}  ${size(v.bytes)}`)
+  }
+  L.push('')
+  L.push('(7) extension classes over rows')
+  L.push(...histogram(report.extensions))
+  L.push(`    -> audio rows    ${String(report.audioRows)}   (#190 checkbox 3 hypothesis)`)
+  L.push('')
+  L.push('(10) at rest')
+  L.push(`    .recovery        ${report.atRest.recovery ? 'PRESENT — a lock failed' : 'no'}`)
+  L.push(`    -wal             ${report.atRest.wal ? 'PRESENT — unclean last session' : 'no'}`)
+  L.push(`    -shm             ${report.atRest.shm ? 'PRESENT — unclean last session' : 'no'}`)
+  L.push(
+    `    db .enc.new      ${report.atRest.dbRekeyStaged ? 'PRESENT — interrupted password change' : 'no'}`
+  )
+  L.push('')
+  L.push('row shape tokens  <id8> <ext-class> <flags>')
+  L.push('  flags: E encrypted  N stored_name set  O original_path set  P copy found')
+  L.push('         S stale  H healable  M missing everywhere  X leaf refused by the guard')
+  L.push('         - never stored a copy   . none of the above')
+  for (const t of report.rowTokens) L.push(`  ${t}`)
+  L.push('')
+  L.push('orphan shape tokens  <id8> <ext-class> <size-bucket>')
+  L.push('')
+  return L.join('\n')
+}

--- a/apps/desktop/tests/integration/stored-copy-audit-run.test.ts
+++ b/apps/desktop/tests/integration/stored-copy-audit-run.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { openDatabase, type Db } from '../../src/main/services/db'
+import {
+  createEncryptedVaultOnDisk,
+  encryptFile,
+  lockEncryptedVault,
+  shredFile,
+  unlockEncryptedVault,
+  vaultPathsFrom,
+  type VaultPaths
+} from '../../src/main/services/workspace-vault'
+import { runStoredCopyAudit, isUnder, AuditWrongPasswordError } from '../helpers/stored-copy-audit-run'
+import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
+
+// Issue #190 — end-to-end CI proof for the stored-copy diagnostic against a SYNTHETIC vault.
+//
+// The unit suite proves the classifier's arithmetic on hand-built inputs. This proves the part
+// that actually touches a drive: copy → decrypt the copy → open read-only → probe the schema →
+// query → walk `workspace/documents/` → classify → shred the scratch. It plants a known
+// population — healthy rows, stale rows, healable rows, genuine orphans, and ONE OF EACH
+// transient class — and asserts exact counts.
+//
+// It also asserts the safety contract itself, which is the reason this file exists rather than
+// leaving the collector exercised only by the hardware-gated manual harness: the drive tree is
+// fingerprinted before and after the run (path + size + mtime of every entry) and must come back
+// IDENTICAL. That is what would catch an accidental `openDatabase` (schema + ~20 `ensureColumn`
+// writes), an `unlockEncryptedVault` (decrypts a plaintext DB onto the drive and can roll a
+// `.recovery` forward over the `.enc`), or a scratch path that landed inside the drive.
+
+const PASSWORD = 'correct-horse-battery-staple-190'
+
+/** A secret that must never reach the report — the titles and content of the planted documents. */
+const SECRET_TITLE = 'Scheidungsvereinbarung-Muster-vertraulich.pdf'
+const SECRET_TEXT = 'clause 7: the unicorn stable remains with the petitioner'
+
+let root: string
+let scratchRoot: string
+let vaultPaths: VaultPaths
+let storeDir: string
+
+function paths(r: string): VaultPaths {
+  return vaultPathsFrom({
+    configPath: join(r, 'config'),
+    dbPath: join(r, 'workspace', 'hilbertraum.sqlite')
+  })
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'hr-190-drive-'))
+  scratchRoot = mkdtempSync(join(tmpdir(), 'hr-190-scratch-'))
+  mkdirSync(join(root, 'config'), { recursive: true })
+  mkdirSync(join(root, 'workspace'), { recursive: true })
+  vaultPaths = paths(root)
+  storeDir = join(root, 'workspace', 'documents')
+  mkdirSync(storeDir, { recursive: true })
+})
+
+/** Write a plaintext file into the store dir and return its leaf. */
+function plantPlain(leaf: string, content: string): string {
+  writeFileSync(join(storeDir, leaf), content)
+  return leaf
+}
+
+/** Encrypt `content` into the store dir under `leaf` with the vault's file key. */
+function plantEncrypted(leaf: string, content: string, key: Buffer): string {
+  const tmp = join(scratchRoot, `plant-${randomUUID()}`)
+  writeFileSync(tmp, content)
+  try {
+    encryptFile(tmp, join(storeDir, leaf), key)
+  } finally {
+    shredFile(tmp)
+  }
+  return leaf
+}
+
+interface PlantedRow {
+  id: string
+  title: string
+  storedPath: string | null
+  storedName?: string | null
+  originalPath?: string | null
+  mime?: string | null
+  status?: string
+}
+
+function insertRows(db: Db, rows: PlantedRow[]): void {
+  const now = new Date().toISOString()
+  for (const r of rows) {
+    db.prepare(
+      `INSERT INTO documents (id, title, original_path, stored_path, stored_name, mime_type,
+         size_bytes, sha256, status, error_message, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      r.id,
+      r.title,
+      r.originalPath ?? null,
+      r.storedPath,
+      r.storedName ?? null,
+      r.mime ?? null,
+      null,
+      null,
+      r.status ?? 'indexed',
+      null,
+      now,
+      now
+    )
+  }
+}
+
+describe('#190 stored-copy diagnostic — an encrypted vault with a known population', () => {
+  // The planted population, fixed so the expected counts below are exact.
+  const healthy = randomUUID() // resolves exactly where the row says
+  const stale = randomUUID() // recorded under the OLD mount point, copy still canonical
+  const gone = randomUUID() // recorded, and the copy is nowhere
+  const queued = randomUUID() // never stored a copy
+  const audio = randomUUID() // healthy audio — the checkbox-3 hypothesis
+  const orphanA = randomUUID() // a copy left by the pre-#189 delete no-op
+  const orphanB = randomUUID() // ditto
+  const staged = randomUUID() // a live document mid-password-change
+  const transient = randomUUID() // an in-flight import
+
+  function buildVault(): void {
+    createEncryptedVaultOnDisk(vaultPaths, PASSWORD)
+    const vault = unlockEncryptedVault(vaultPaths, PASSWORD)
+    try {
+      insertRows(vault.db, [
+        {
+          id: healthy,
+          title: SECRET_TITLE,
+          storedPath: join(storeDir, `${healthy}.pdf.enc`),
+          storedName: `${healthy}.pdf.enc`,
+          originalPath: join(root, 'nowhere', SECRET_TITLE)
+        },
+        // The #188 signature: the row still names `H:\…`, the bytes are in the CURRENT store dir.
+        {
+          id: stale,
+          title: SECRET_TITLE,
+          storedPath: `H:\\workspace\\documents\\${stale}.docx.enc`
+        },
+        { id: gone, title: SECRET_TITLE, storedPath: `H:\\workspace\\documents\\${gone}.txt.enc` },
+        { id: queued, title: SECRET_TITLE, storedPath: null, status: 'queued', mime: 'application/pdf' },
+        {
+          id: audio,
+          title: SECRET_TITLE,
+          storedPath: join(storeDir, `${audio}.wav.enc`),
+          storedName: `${audio}.wav.enc`
+        },
+        // The document whose rekey is staged — it has a row, so its `.enc` is NOT an orphan and
+        // its `.enc.new` must not be counted as one either.
+        {
+          id: staged,
+          title: SECRET_TITLE,
+          storedPath: join(storeDir, `${staged}.pdf.enc`),
+          storedName: `${staged}.pdf.enc`
+        }
+      ])
+      // Store copies, encrypted under the real vault file key.
+      plantEncrypted(`${healthy}.pdf.enc`, SECRET_TEXT, vault.key)
+      plantEncrypted(`${stale}.docx.enc`, SECRET_TEXT, vault.key)
+      plantEncrypted(`${audio}.wav.enc`, SECRET_TEXT, vault.key)
+      plantEncrypted(`${staged}.pdf.enc`, SECRET_TEXT, vault.key)
+      // The orphans: `.enc` files whose rows were committed-deleted while the shred no-opped.
+      plantEncrypted(`${orphanA}.pdf.enc`, SECRET_TEXT, vault.key)
+      plantEncrypted(`${orphanB}.wav.enc`, SECRET_TEXT, vault.key)
+      // One of each transient class.
+      plantEncrypted(`${staged}.pdf.enc.new`, SECRET_TEXT, vault.key) // stageRekey
+      plantPlain(`${transient}.parse-preview-${randomUUID()}.pdf`, SECRET_TEXT) // preview
+      plantPlain(`${randomUUID()}.parse-dictation.wav`, SECRET_TEXT) // dictation
+      plantPlain(`${transient}.parse-ocr.pdf`, SECRET_TEXT) // doc task
+      plantPlain(`${transient}.pdf.enc.tmp`, SECRET_TEXT) // encryptFile temp
+      plantPlain('stray-note.txt', SECRET_TEXT) // an unknown writer
+    } finally {
+      lockEncryptedVault(vaultPaths, vault.db, vault.key)
+    }
+  }
+
+  it('reports the exact stale / healable / missing / orphan counts', () => {
+    buildVault()
+    const { report } = runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+
+    expect(report.documents.total).toBe(6)
+    expect(report.documents.byStatus).toEqual({ indexed: 5, queued: 1 })
+
+    // (2)/(3) — the staleness verdict. `stale` and `gone` both name `H:\…`; only `stale` has its
+    // bytes at the canonical location, which is exactly the question the reporting drive poses.
+    expect(report.rows.stale).toBe(2)
+    expect(report.rows.healable).toBe(1)
+    expect(report.rows.missingEverywhere).toBe(1)
+    expect(report.rows.neverStored).toBe(1)
+    expect(report.rows.resolvedAsRecorded).toBe(3)
+
+    // (5) — the orphan count, the number issue #190 checkbox 2 is waiting on.
+    expect(report.orphans.count).toBe(2)
+    expect(report.orphans.bytes).toBeGreaterThan(0)
+    expect(report.orphans.tokens.map((t) => t.split(' ')[0]).sort()).toEqual(
+      [orphanA.slice(0, 8), orphanB.slice(0, 8)].sort()
+    )
+
+    // (6) — file classes. 6 stored copies on disk (4 owned + 2 orphaned), one of each transient.
+    expect(report.fileClasses['stored-copy'].count).toBe(6)
+    expect(report.fileClasses['rekey-staged'].count).toBe(1)
+    expect(report.fileClasses['write-temp'].count).toBe(1)
+    expect(report.fileClasses['parse-transient'].count).toBe(3)
+    expect(report.fileClasses.unknown.count).toBe(1)
+
+    // (7) — the extension histogram, and the one audio row that settles the #188 contradiction.
+    expect(report.extensions).toEqual({ pdf: 3, docx: 1, txt: 1, wav: 1 })
+    expect(report.audioRows).toBe(1)
+
+    // (8)/(9)
+    expect(report.storedName).toEqual({ column: true, populated: 3 })
+    expect(report.vault).toEqual({ descriptorVersion: 2, mode: 'encrypted' })
+    expect(report.atRest).toEqual({ recovery: false, wal: false, shm: false, dbRekeyStaged: false })
+  })
+
+  it('does not write a single byte to the drive', () => {
+    buildVault()
+    const before = fingerprintTree(root)
+    runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+    const after = fingerprintTree(root)
+    expect(treeUnchanged(before, after), 'the diagnostic must leave the drive untouched').toBe(true)
+    // Specifically: no plaintext working DB, and the `.enc` is byte-identical.
+    expect(existsSync(vaultPaths.dbPath)).toBe(false)
+    expect(existsSync(`${vaultPaths.dbPath}-wal`)).toBe(false)
+  })
+
+  it('leaves no scratch artifact behind', () => {
+    buildVault()
+    runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+    expect(readdirSync(scratchRoot)).toEqual([])
+  })
+
+  it('the rendered report contains no title and no document content', () => {
+    buildVault()
+    const { text } = runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+    expect(text).not.toContain(SECRET_TITLE)
+    expect(text).not.toContain('Scheidungsvereinbarung')
+    expect(text).not.toContain(SECRET_TEXT)
+    expect(text).not.toContain('unicorn')
+    expect(text).not.toContain(root) // no user paths
+    expect(text).not.toContain('H:\\')
+    expect(text).not.toContain(healthy) // full ids never appear
+    expect(text).toContain(healthy.slice(0, 8)) // 8-char shape prefixes do
+  })
+
+  it('refuses a wrong password without touching the drive', () => {
+    buildVault()
+    const before = fingerprintTree(root)
+    expect(() => runStoredCopyAudit({ root, password: 'wrong', scratchRoot })).toThrow(
+      AuditWrongPasswordError
+    )
+    expect(treeUnchanged(before, fingerprintTree(root))).toBe(true)
+  })
+
+  it('refuses a scratch directory inside the drive root', () => {
+    // The one mistake that would defeat every other guard: the decrypted copy would land on the
+    // very medium the tool exists to leave alone.
+    buildVault()
+    expect(() =>
+      runStoredCopyAudit({ root, password: PASSWORD, scratchRoot: join(root, 'scratch') })
+    ).toThrow(/must not be inside the drive root/)
+    expect(existsSync(join(root, 'scratch'))).toBe(false)
+  })
+
+  it('reports an interrupted password change and an unclean session as separate findings', () => {
+    buildVault()
+    // A staged DB rekey and a `.recovery` snapshot, each its own finding (report item 10).
+    writeFileSync(`${vaultPaths.encPath}.new`, 'staged')
+    writeFileSync(`${vaultPaths.dbPath}.recovery`, 'preserved')
+    writeFileSync(`${vaultPaths.dbPath}-wal`, 'wal')
+    const { report, text } = runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+    expect(report.atRest).toEqual({ recovery: true, wal: true, shm: false, dbRekeyStaged: true })
+    expect(text).toContain('interrupted password change')
+    // And crucially it did NOT act on any of them — `recoverPendingRekey` was never invoked.
+    expect(readFileSync(`${vaultPaths.encPath}.new`, 'utf8')).toBe('staged')
+    expect(readFileSync(`${vaultPaths.dbPath}.recovery`, 'utf8')).toBe('preserved')
+  })
+})
+
+describe('#190 stored-copy diagnostic — a v1 vault and a plaintext_dev workspace', () => {
+  it('unwraps a legacy v1 descriptor (direct key, no envelope)', () => {
+    // v1 vs v2 is report item 9 because it decides the password-change blast radius: a v1 vault's
+    // first password change re-encrypts the whole corpus, so every orphan is re-encrypted too.
+    createEncryptedVaultOnDisk(vaultPaths, PASSWORD, undefined, { legacyV1: true })
+    const vault = unlockEncryptedVault(vaultPaths, PASSWORD)
+    const id = randomUUID()
+    try {
+      insertRows(vault.db, [
+        { id, title: SECRET_TITLE, storedPath: join(storeDir, `${id}.pdf.enc`), storedName: `${id}.pdf.enc` }
+      ])
+      plantEncrypted(`${id}.pdf.enc`, SECRET_TEXT, vault.key)
+    } finally {
+      lockEncryptedVault(vaultPaths, vault.db, vault.key)
+    }
+    const before = fingerprintTree(root)
+    const { report } = runStoredCopyAudit({ root, password: PASSWORD, scratchRoot })
+    expect(treeUnchanged(before, fingerprintTree(root))).toBe(true)
+    expect(report.vault).toEqual({ descriptorVersion: 1, mode: 'encrypted' })
+    expect(report.documents.total).toBe(1)
+    expect(report.orphans.count).toBe(0)
+  })
+
+  it('audits a plaintext_dev workspace with no password at all', () => {
+    const db = openDatabase(vaultPaths.dbPath)
+    const id = randomUUID()
+    const orphan = randomUUID()
+    insertRows(db, [
+      { id, title: SECRET_TITLE, storedPath: join(storeDir, `${id}.pdf`), storedName: `${id}.pdf` }
+    ])
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE);')
+    db.close()
+    plantPlain(`${id}.pdf`, SECRET_TEXT)
+    plantPlain(`${orphan}.pdf`, SECRET_TEXT) // a plaintext orphan — no `.enc` suffix to key on
+    const before = fingerprintTree(root)
+    const { report, text } = runStoredCopyAudit({ root, scratchRoot })
+    // The plaintext branch has its OWN witness: it copies the LIVE working DB, so an accidental
+    // `openDatabase` there would rewrite the schema of the user's actual database.
+    expect(treeUnchanged(before, fingerprintTree(root))).toBe(true)
+    expect(report.vault).toEqual({ descriptorVersion: null, mode: 'plaintext_dev' })
+    expect(report.orphans.count).toBe(1)
+    expect(report.orphans.tokens[0].startsWith(orphan.slice(0, 8))).toBe(true)
+    expect(text).not.toContain(SECRET_TEXT)
+  })
+
+  it('handles a DB with no stored_name column at all (the pre-#189 schema)', () => {
+    // The reporting drive predates #189. `stored_name` is added by `ensureColumn` AT OPEN, which
+    // the diagnostic must never trigger — so a naive `SELECT ... stored_name` throws on the one
+    // machine that matters. Reproduced by dropping the column from a built schema.
+    const db = openDatabase(vaultPaths.dbPath)
+    const id = randomUUID()
+    insertRows(db, [{ id, title: SECRET_TITLE, storedPath: join(storeDir, `${id}.pdf`) }])
+    db.exec('ALTER TABLE documents DROP COLUMN stored_name')
+    db.exec('PRAGMA wal_checkpoint(TRUNCATE);')
+    db.close()
+    plantPlain(`${id}.pdf`, SECRET_TEXT)
+
+    const { report, text } = runStoredCopyAudit({ root, scratchRoot })
+    expect(report.storedName).toEqual({ column: false, populated: 0 })
+    expect(report.documents.total).toBe(1)
+    expect(report.rows.resolvedAsRecorded).toBe(1)
+    expect(text).toContain('ABSENT (pre-#189 schema)')
+  })
+})
+
+describe('#190 stored-copy diagnostic — scratch containment', () => {
+  it('isUnder recognises the drive root, a child, and a sibling with a shared prefix', () => {
+    const base = mkdtempSync(join(tmpdir(), 'hr-190-under-'))
+    try {
+      expect(isUnder(base, base)).toBe(true)
+      expect(isUnder(base, join(base, 'a', 'b'))).toBe(true)
+      // `H:\driveX` must not count as inside `H:\drive` — a plain `startsWith` says it does.
+      expect(isUnder(base, `${base}-sibling`)).toBe(false)
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/tests/manual/stored-copy-diagnostic.test.ts
+++ b/apps/desktop/tests/manual/stored-copy-diagnostic.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runStoredCopyAudit, isUnder } from '../helpers/stored-copy-audit-run'
 import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
+import { PASSWORD_ENV_VAR, promptHiddenPassword } from '../helpers/console-password'
 
 // MANUAL stored-copy diagnostic (issue #190 checkbox 1) — NOT CI.
 //
@@ -13,27 +14,40 @@ import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
 // be CI'd is pointing it at the real prepared drive, which needs the drive and the owner's
 // password — hence the env gate, in the shape of the other `tests/manual/*-smoke.test.ts` files.
 //
+// RUN OF RECORD: 2026-08-20 against the prepared drive on `G:\` (encrypted, v2 descriptor,
+// pre-#189 schema). 24/24 rows stale, 24/24 healable, 1 orphan (115.2 KiB), tree byte-identical.
+// The measured report and what it settles are in `docs/architecture.md` §9.
+//
 // ---------------------------------------------------------------------------------------------
-// RUN IT
+// RUN IT — from `apps/desktop/`.
 //
 //   PowerShell (Windows — the reporting drive):
-//     $env:HILBERTRAUM_STORED_COPY_AUDIT = "H:\"          # the drive ROOT (holds config\ + workspace\)
-//     npx vitest run tests/manual/stored-copy-diagnostic.test.ts
+//     $env:HILBERTRAUM_STORED_COPY_AUDIT = "G:\"          # the drive ROOT (holds config\ + workspace\)
+//     ..\..\node_modules\.bin\vitest.cmd run tests/manual/stored-copy-diagnostic.test.ts
 //
 //   bash / zsh (macOS, Linux):
 //     HILBERTRAUM_STORED_COPY_AUDIT=/Volumes/HILBERTRAUM \
-//       npx vitest run tests/manual/stored-copy-diagnostic.test.ts
+//       ../../node_modules/.bin/vitest run tests/manual/stored-copy-diagnostic.test.ts
 //
-//   Run it from `apps/desktop/`. The report is printed to stdout; add
+//   Use those paths, NOT `npx` — it is blocked by the PowerShell execution policy on the
+//   maintainer's machine (its shim is a `.ps1`). The `node_modules/.bin/vitest.cmd` form above is
+//   a `.cmd` and runs under any policy. The report is printed to stdout; add
 //   HILBERTRAUM_STORED_COPY_AUDIT_OUT=<file> to also write it somewhere you can copy from.
 //
-// THE PASSWORD. The harness prompts on the terminal (no echo) whenever stdin is a TTY, which is
-// the way to supply it: nothing is recorded anywhere. If you must run non-interactively, set
-//   HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD=…
-// and understand the hazard: an environment variable typed at a shell lands in that shell's
-// HISTORY (bash `~/.bash_history`, PowerShell's PSReadLine `ConsoleHost_history.txt`, which is a
-// plain file in your roaming profile) and is readable in the process environment by anything
-// running as you. Prefer the prompt. A `plaintext_dev` workspace needs no password at all.
+// THE PASSWORD. The harness prompts on the CONSOLE with the input hidden — `\\.\CONIN$` on
+// Windows, `/dev/tty` on POSIX, in raw mode, opened directly. It deliberately does NOT look at
+// `process.stdin`: vitest runs this file in a forked worker whose stdin is a pipe, so
+// `process.stdin.isTTY` is always false and a prompt gated on it can never fire, however
+// interactive your shell is (measured on Windows PowerShell, 2026-08-20 — it is why the run of
+// record had to use the env var). Nothing is recorded anywhere.
+//
+// If there is no console at all — CI, a detached process, a redirected terminal — the run FAILS
+// FAST with the exact recipe for setting `HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD` from a hidden
+// prompt (`Read-Host -AsSecureString` / `read -rs`), because a value typed at a prompt does not
+// enter the shell history the way one typed on a command line does (bash `~/.bash_history`,
+// PowerShell's PSReadLine `ConsoleHost_history.txt` — a plain file in your roaming profile).
+// While it is set it is readable in the process environment by anything running as you, so clear
+// it afterwards. A `plaintext_dev` workspace needs no password at all.
 //
 // WHAT IT WILL NOT DO. It never writes to the drive: it copies `config/workspace.json` +
 // `workspace/hilbertraum.sqlite.enc` to a scratch directory in your temp dir, decrypts the COPY,
@@ -45,56 +59,14 @@ import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
 //
 // WHAT THE OUTPUT IS FOR. It is designed to be pasted verbatim into public issue #190: counts,
 // histograms, and shape tokens only — no titles, no content, no paths, no file names. Read it
-// once before pasting anyway (checklist in the PR body).
+// once before pasting anyway (checklist in the PR body). It is also the evidence collector for
+// the second-laptop continuity check (BUILD_STATE §5 item 1): run it before and after the
+// relocation and compare the stale / healable / `stored_name populated` triple.
 
 const ROOT = process.env.HILBERTRAUM_STORED_COPY_AUDIT?.trim() ?? ''
-const PASSWORD_ENV = process.env.HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD ?? ''
+const PASSWORD_ENV = process.env[PASSWORD_ENV_VAR] ?? ''
 const OUT = process.env.HILBERTRAUM_STORED_COPY_AUDIT_OUT?.trim() ?? ''
 const enabled = ROOT.length > 0 && existsSync(ROOT)
-
-/** Read a password from the terminal without echoing it. Never logged, never persisted. */
-async function promptPassword(): Promise<string> {
-  const stdin = process.stdin
-  process.stdout.write('Workspace password (input hidden, Enter to submit): ')
-  return new Promise<string>((resolve, reject) => {
-    let buf = ''
-    const finish = (fn: () => void): void => {
-      stdin.removeListener('data', onData)
-      stdin.setRawMode?.(false)
-      stdin.pause()
-      process.stdout.write('\n')
-      fn()
-    }
-    const onData = (chunk: string): void => {
-      for (const ch of chunk) {
-        if (ch === '\r' || ch === '\n') {
-          const out = buf
-          buf = ''
-          finish(() => {
-            resolve(out)
-          })
-          return
-        }
-        if (ch === '\u0003') {
-          // Ctrl-C: abort the run rather than proceeding with a partial password.
-          finish(() => {
-            reject(new Error('cancelled'))
-          })
-          return
-        }
-        if (ch === '\u007f' || ch === '\b') {
-          buf = buf.slice(0, -1)
-          continue
-        }
-        buf += ch
-      }
-    }
-    stdin.setRawMode?.(true)
-    stdin.resume()
-    stdin.setEncoding('utf8')
-    stdin.on('data', onData)
-  })
-}
 
 describe.skipIf(!enabled)('HILBERTRAUM_STORED_COPY_AUDIT — read-only stored-copy diagnostic (#190)', () => {
   it(
@@ -113,16 +85,8 @@ describe.skipIf(!enabled)('HILBERTRAUM_STORED_COPY_AUDIT — read-only stored-co
 
       let password = PASSWORD_ENV
       const needsPassword = existsSync(join(ROOT, 'config', 'workspace.json'))
-      if (needsPassword && !password) {
-        if (!process.stdin.isTTY) {
-          throw new Error(
-            'This workspace is encrypted and stdin is not a terminal. Re-run from an interactive ' +
-              'shell for the hidden prompt, or set HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD (see the ' +
-              'shell-history hazard in this file’s header).'
-          )
-        }
-        password = await promptPassword()
-      }
+      // The console prompt, or a fail-fast carrying the recipe. Never an echoing fallback.
+      if (needsPassword && !password) password = await promptHiddenPassword()
 
       // The read-only witness. Anything that moves between these two fingerprints — a size, an
       // mtime, an added or removed path — fails the run and is a defect in the tool, not in the

--- a/apps/desktop/tests/manual/stored-copy-diagnostic.test.ts
+++ b/apps/desktop/tests/manual/stored-copy-diagnostic.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runStoredCopyAudit, isUnder } from '../helpers/stored-copy-audit-run'
+import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
+
+// MANUAL stored-copy diagnostic (issue #190 checkbox 1) — NOT CI.
+//
+// This is the operator harness. Everything it does is proven in CI by
+// `tests/integration/stored-copy-audit-run.test.ts` (exact counts against a synthetic vault, plus
+// the read-only witness) and `tests/unit/stored-copy-audit.test.ts` (the classifier). What CANNOT
+// be CI'd is pointing it at the real prepared drive, which needs the drive and the owner's
+// password — hence the env gate, in the shape of the other `tests/manual/*-smoke.test.ts` files.
+//
+// ---------------------------------------------------------------------------------------------
+// RUN IT
+//
+//   PowerShell (Windows — the reporting drive):
+//     $env:HILBERTRAUM_STORED_COPY_AUDIT = "H:\"          # the drive ROOT (holds config\ + workspace\)
+//     npx vitest run tests/manual/stored-copy-diagnostic.test.ts
+//
+//   bash / zsh (macOS, Linux):
+//     HILBERTRAUM_STORED_COPY_AUDIT=/Volumes/HILBERTRAUM \
+//       npx vitest run tests/manual/stored-copy-diagnostic.test.ts
+//
+//   Run it from `apps/desktop/`. The report is printed to stdout; add
+//   HILBERTRAUM_STORED_COPY_AUDIT_OUT=<file> to also write it somewhere you can copy from.
+//
+// THE PASSWORD. The harness prompts on the terminal (no echo) whenever stdin is a TTY, which is
+// the way to supply it: nothing is recorded anywhere. If you must run non-interactively, set
+//   HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD=…
+// and understand the hazard: an environment variable typed at a shell lands in that shell's
+// HISTORY (bash `~/.bash_history`, PowerShell's PSReadLine `ConsoleHost_history.txt`, which is a
+// plain file in your roaming profile) and is readable in the process environment by anything
+// running as you. Prefer the prompt. A `plaintext_dev` workspace needs no password at all.
+//
+// WHAT IT WILL NOT DO. It never writes to the drive: it copies `config/workspace.json` +
+// `workspace/hilbertraum.sqlite.enc` to a scratch directory in your temp dir, decrypts the COPY,
+// opens the copy read-only, and shreds the scratch on the way out. It never calls
+// `unlockEncryptedVault`, `recoverPendingRekey`, `preserveNewerPlaintext`, `lockEncryptedVault`
+// or `openDatabase` against the drive — each of those MUTATES (see the safety contract in
+// `tests/helpers/stored-copy-audit-run.ts`). It fingerprints the whole drive tree before and
+// after and FAILS if a single size or mtime moved.
+//
+// WHAT THE OUTPUT IS FOR. It is designed to be pasted verbatim into public issue #190: counts,
+// histograms, and shape tokens only — no titles, no content, no paths, no file names. Read it
+// once before pasting anyway (checklist in the PR body).
+
+const ROOT = process.env.HILBERTRAUM_STORED_COPY_AUDIT?.trim() ?? ''
+const PASSWORD_ENV = process.env.HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD ?? ''
+const OUT = process.env.HILBERTRAUM_STORED_COPY_AUDIT_OUT?.trim() ?? ''
+const enabled = ROOT.length > 0 && existsSync(ROOT)
+
+/** Read a password from the terminal without echoing it. Never logged, never persisted. */
+async function promptPassword(): Promise<string> {
+  const stdin = process.stdin
+  process.stdout.write('Workspace password (input hidden, Enter to submit): ')
+  return new Promise<string>((resolve, reject) => {
+    let buf = ''
+    const finish = (fn: () => void): void => {
+      stdin.removeListener('data', onData)
+      stdin.setRawMode?.(false)
+      stdin.pause()
+      process.stdout.write('\n')
+      fn()
+    }
+    const onData = (chunk: string): void => {
+      for (const ch of chunk) {
+        if (ch === '\r' || ch === '\n') {
+          const out = buf
+          buf = ''
+          finish(() => {
+            resolve(out)
+          })
+          return
+        }
+        if (ch === '\u0003') {
+          // Ctrl-C: abort the run rather than proceeding with a partial password.
+          finish(() => {
+            reject(new Error('cancelled'))
+          })
+          return
+        }
+        if (ch === '\u007f' || ch === '\b') {
+          buf = buf.slice(0, -1)
+          continue
+        }
+        buf += ch
+      }
+    }
+    stdin.setRawMode?.(true)
+    stdin.resume()
+    stdin.setEncoding('utf8')
+    stdin.on('data', onData)
+  })
+}
+
+describe.skipIf(!enabled)('HILBERTRAUM_STORED_COPY_AUDIT — read-only stored-copy diagnostic (#190)', () => {
+  it(
+    'audits the drive without writing to it and prints a report safe to paste in public',
+    { timeout: 600_000 },
+    async () => {
+      const scratchRoot = join(tmpdir(), 'hilbertraum-stored-copy-audit')
+      mkdirSync(scratchRoot, { recursive: true })
+      // The scratch MUST NOT live on the drive — a decrypted copy landing there is exactly the
+      // outcome this harness exists to avoid. `runStoredCopyAudit` refuses too; this fails first
+      // and with an instruction rather than a stack trace.
+      expect(
+        isUnder(ROOT, scratchRoot),
+        'TMPDIR points inside the drive — set it elsewhere before running'
+      ).toBe(false)
+
+      let password = PASSWORD_ENV
+      const needsPassword = existsSync(join(ROOT, 'config', 'workspace.json'))
+      if (needsPassword && !password) {
+        if (!process.stdin.isTTY) {
+          throw new Error(
+            'This workspace is encrypted and stdin is not a terminal. Re-run from an interactive ' +
+              'shell for the hidden prompt, or set HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD (see the ' +
+              'shell-history hazard in this file’s header).'
+          )
+        }
+        password = await promptPassword()
+      }
+
+      // The read-only witness. Anything that moves between these two fingerprints — a size, an
+      // mtime, an added or removed path — fails the run and is a defect in the tool, not in the
+      // drive.
+      const before = fingerprintTree(ROOT)
+      let result
+      try {
+        result = runStoredCopyAudit({ root: ROOT, password: password || undefined, scratchRoot })
+      } finally {
+        password = ''
+      }
+      const after = fingerprintTree(ROOT)
+
+      const text = result.text
+      process.stdout.write(`\n${text}\n`)
+      for (const note of result.notes) process.stdout.write(`note: ${note}\n`)
+      if (OUT) {
+        expect(isUnder(ROOT, OUT), 'the output file must not be written to the drive').toBe(false)
+        writeFileSync(OUT, text, 'utf8')
+        process.stdout.write(`report written to ${OUT}\n`)
+      }
+
+      expect(
+        treeUnchanged(before, after),
+        `THE DRIVE CHANGED during the run (${String(before.entries)} → ${String(after.entries)} entries). ` +
+          'Do not trust this report; report it as a bug in the diagnostic.'
+      ).toBe(true)
+
+      // A sanity floor: an empty report means the harness was pointed at the wrong root.
+      expect(result.report.documents.total).toBeGreaterThan(0)
+    }
+  )
+})

--- a/apps/desktop/tests/unit/console-password.test.ts
+++ b/apps/desktop/tests/unit/console-password.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  PASSWORD_ENV_VAR,
+  consoleUnavailableMessage,
+  openConsolePrompt,
+  promptHiddenPassword,
+  type ConsolePrompt
+} from '../helpers/console-password'
+
+// Issue #190 phase 2 — CI proof for the console password path of the manual diagnostic.
+//
+// THE DEFECT THIS PINS. The first harness prompted only `if (process.stdin.isTTY)`. Vitest runs
+// every test file in a FORKED WORKER whose stdin is a pipe, so that branch is dead in the only
+// process that ever executes it — the prompt could not fire from a fully interactive PowerShell,
+// and the operator was told to "re-run from an interactive shell", which cannot help. THIS FILE
+// RUNS IN THAT SAME WORKER, so the assertion below is the defect's own witness rather than a
+// simulation of it.
+//
+// What is CI-able here is everything except a human typing: the no-console fail-fast, the exact
+// recipe it carries, the refusal to fall back to an echoing read, and the harness header telling
+// the truth about how to run it. The keystroke path is exercised by the operator run.
+
+const MANUAL = join(__dirname, '..', 'manual', 'stored-copy-diagnostic.test.ts')
+
+describe('console password prompt (#190) — the non-TTY path', () => {
+  it("the vitest worker's stdin is NOT a TTY — the branch the old harness gated on is dead here", () => {
+    // If this ever becomes true, vitest changed its pooling and the header's explanation needs
+    // revisiting — but the console-device prompt keeps working either way.
+    expect(process.stdin.isTTY).toBeFalsy()
+  })
+
+  it('fails fast with the copy-pasteable recipe when there is no console, and never echoes', async () => {
+    await expect(promptHiddenPassword('pw: ', () => null)).rejects.toThrow(PASSWORD_ENV_VAR)
+    const msg = consoleUnavailableMessage()
+
+    // It must name the env var and a recipe that WORKS from the operator's shell...
+    expect(msg).toContain(PASSWORD_ENV_VAR)
+    if (process.platform === 'win32') {
+      expect(msg).toContain('Read-Host -AsSecureString')
+      expect(msg).toContain('SecureStringToBSTR')
+      expect(msg).toContain('PtrToStringAuto')
+    } else {
+      expect(msg).toContain('read -rs')
+    }
+    // ...and must NOT repeat the advice that wasted an operator round trip: no shell is
+    // "interactive" enough to give a forked vitest worker a TTY on stdin.
+    expect(msg.toLowerCase()).not.toContain('interactive shell')
+    // The hazard of the fallback is stated where the operator reads it.
+    expect(msg).toContain('shell history')
+  })
+
+  it('never resolves a password from a console it could not put into raw mode', async () => {
+    // A console whose `setRawMode` fails must be treated as absent, not read in cooked mode —
+    // a cooked read echoes the workspace password onto the screen.
+    let opened = 0
+    const refusing = (): ConsolePrompt | null => {
+      opened += 1
+      return null // exactly what `openConsolePrompt` returns when the raw-mode probe throws
+    }
+    await expect(promptHiddenPassword('pw: ', refusing)).rejects.toThrow(/no console is available/)
+    expect(opened).toBe(1)
+  })
+
+  it('opening the console is safe to attempt anywhere: it yields a raw stream or null', () => {
+    // CI runners have no controlling terminal, so this is `null` there; on a developer machine
+    // with a console it opens. Either way it must not throw, and it must leave nothing behind.
+    const con = openConsolePrompt()
+    if (con) {
+      expect(con.input.isRaw).toBe(true) // raw = echo suppressed, which is the whole contract
+      con.close()
+      con.close() // idempotent — a double close must not throw on the way out of a failed run
+      expect(con.input.isRaw).toBe(false) // cooked mode restored for the operator's shell
+    } else {
+      expect(con).toBeNull()
+    }
+  })
+
+  it('the manual harness reads the console, not process.stdin, and its header says how to run it', () => {
+    const src = readFileSync(MANUAL, 'utf8')
+    // Comments explain the dead `isTTY` branch on purpose; the CODE must not contain it.
+    const code = src
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('//'))
+      .join('\n')
+    // The fix is adopted, not re-implemented next to the old one.
+    expect(code).toContain("from '../helpers/console-password'")
+    expect(code).toContain('promptHiddenPassword(')
+    expect(code).not.toContain('process.stdin')
+    expect(code).not.toContain('isTTY')
+    expect(code).not.toContain('setRawMode') // the hand-rolled prompt is gone, not duplicated
+    // The header must not advertise an invocation that is blocked on the maintainer's machine.
+    expect(src).not.toContain('npx vitest')
+    expect(src).toContain('node_modules\\.bin\\vitest.cmd')
+  })
+})

--- a/apps/desktop/tests/unit/stored-copy-audit.test.ts
+++ b/apps/desktop/tests/unit/stored-copy-audit.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import {
+  auditStoredCopies,
+  classifyFile,
+  extClassOf,
+  formatStoredCopyAuditReport,
+  type AuditDirEntry,
+  type AuditInput,
+  type AuditRow
+} from '../helpers/stored-copy-audit'
+import { fingerprintTree, treeUnchanged } from '../helpers/read-only-witness'
+
+// Issue #190 — CI proof for the PURE half of the stored-copy diagnostic.
+//
+// The tool's whole purpose is to produce numbers a cleanup decision (issue #190 checkbox 2) will
+// rest on, so the numbers have to be exact and the class boundaries have to be the RIGHT ones.
+// The wave-188 discipline applies: each guard below is written so that breaking it turns a test
+// red, and the mutation runs are recorded in the design record.
+//
+// The direction of danger is asymmetric and the tests encode that: an UNDER-count of orphans is
+// merely uninformative; an OVER-count invents an orphan out of a live file (a staged rekey, an
+// in-flight import) and would hand a future sweep a file whose deletion loses user data.
+
+const CLEAN_AT_REST = { recovery: false, wal: false, shm: false, dbRekeyStaged: false }
+
+function row(over: Partial<AuditRow> & { id: string }): AuditRow {
+  return {
+    status: 'indexed',
+    stored_path: null,
+    stored_name: null,
+    original_path: null,
+    mime_type: null,
+    ...over
+  }
+}
+
+function input(over: Partial<AuditInput>): AuditInput {
+  return {
+    rows: [],
+    dirEntries: [],
+    existingRecordedPaths: [],
+    storedNameColumn: true,
+    descriptorVersion: 2,
+    atRest: CLEAN_AT_REST,
+    ...over
+  }
+}
+
+describe('#190 stored-copy audit — file classification', () => {
+  const id = randomUUID()
+
+  it('separates a stored copy from every transient class a writer can leave in documents/', () => {
+    // The complete writer inventory for `workspace/documents/` (see the module header).
+    expect(classifyFile(`${id}.pdf.enc`)).toBe('stored-copy')
+    expect(classifyFile(`${id}.pdf`)).toBe('stored-copy') // plaintext_dev workspace
+    expect(classifyFile(`${id}.parse.pdf`)).toBe('parse-transient') // re-index
+    expect(classifyFile(`${id}.parse-preview-${randomUUID()}.pdf`)).toBe('parse-transient')
+    expect(classifyFile(`${id}.parse-export-${randomUUID()}.pdf`)).toBe('parse-transient')
+    expect(classifyFile(`${id}.parse-export-bin-${randomUUID()}.pdf`)).toBe('parse-transient')
+    expect(classifyFile(`${randomUUID()}.parse-dictation.wav`)).toBe('parse-transient')
+    expect(classifyFile(`${randomUUID()}.parse-transcript.txt`)).toBe('parse-transient')
+    expect(classifyFile(`${id}.parse.md`)).toBe('parse-transient') // doc-task markdown
+    expect(classifyFile(`${id}.parse-ocr.pdf`)).toBe('parse-transient')
+    expect(classifyFile(`${id}.pdf.enc.new`)).toBe('rekey-staged') // stageRekey
+    expect(classifyFile(`${id}.pdf.enc.tmp`)).toBe('write-temp') // encryptFile
+    expect(classifyFile(`${id}.pdf.enc.new.tmp`)).toBe('write-temp')
+    expect(classifyFile(`${id}.pdf.enc.rekey.tmp`)).toBe('write-temp')
+    expect(classifyFile('notes.txt')).toBe('unknown') // no id prefix: somebody's stray file
+  })
+
+  it('MUTATION GUARD — a staged rekey file is never a stored copy, and never an orphan', () => {
+    // `<id><ext>.enc.new` is a LIVE document being re-encrypted during a password change. A
+    // classifier matching `.enc` loosely (`includes` instead of `endsWith`, or checking `.enc`
+    // before `.enc.new`) parks it in the orphan bucket — and a cleanup built on that count would
+    // delete the only copy of that document mid-rekey. This is the single most dangerous
+    // misclassification the tool can make.
+    const staged = `${id}.pdf.enc.new`
+    expect(classifyFile(staged)).toBe('rekey-staged')
+    const r = auditStoredCopies(input({ dirEntries: [{ name: staged, bytes: 4096 }] }))
+    expect(r.orphans.count).toBe(0)
+    expect(r.fileClasses['rekey-staged']).toEqual({ count: 1, bytes: 4096 })
+    expect(r.fileClasses['stored-copy'].count).toBe(0)
+  })
+
+  it('MUTATION GUARD — an in-flight import transient is never an orphan', () => {
+    // The other half of the D4 race: a concurrent import has its transient (and, briefly, its
+    // file) on disk before the row is written.
+    const t = `${id}.parse-preview-${randomUUID()}.pdf`
+    const r = auditStoredCopies(input({ dirEntries: [{ name: t, bytes: 10 }] }))
+    expect(r.orphans.count).toBe(0)
+    expect(r.fileClasses['parse-transient'].count).toBe(1)
+  })
+})
+
+describe('#190 stored-copy audit — ownership', () => {
+  it('a file claimed by ANY of the three row sources is not an orphan', () => {
+    // Over-claiming under-counts orphans (harmless); under-claiming invents one (dangerous).
+    const a = randomUUID()
+    const b = randomUUID()
+    const c = randomUUID()
+    const rows = [
+      // healed row: `stored_name` alone names the file
+      row({ id: a, stored_name: `${a}.pdf.enc`, stored_path: null }),
+      // legacy row on a relocated drive: only the stale absolute path names it
+      row({ id: b, stored_path: `H:\\old\\workspace\\documents\\${b}.docx.enc` }),
+      // a row whose file sits outside the store dir entirely (nothing to heal it to)
+      row({ id: c, stored_path: `/elsewhere/${c}.txt.enc` })
+    ]
+    const dirEntries: AuditDirEntry[] = [
+      { name: `${a}.pdf.enc`, bytes: 1 },
+      { name: `${b}.docx.enc`, bytes: 2 },
+      { name: `${c}.txt.enc`, bytes: 3 }
+    ]
+    const r = auditStoredCopies(input({ rows, dirEntries }))
+    expect(r.orphans.count).toBe(0)
+    expect(r.fileClasses['stored-copy'].count).toBe(3)
+  })
+
+  it('MUTATION GUARD — a live row with an UNNAMEABLE leaf still owns its file', () => {
+    // Found by the first end-to-end operator smoke. A row whose recorded strings are corrupt names
+    // nothing the first three sources can match — `canonicalLeafFor` refuses the leaf — so its
+    // perfectly healthy copy looked like an orphan. The store's naming is `<documentId><ext>[.enc]`
+    // and the id is a never-reused UUID primary key, so a file whose LEADING id is a live row's id
+    // belongs to that row whatever the row recorded. Dropping the id fallback re-creates a phantom
+    // orphan out of live user data — the exact failure the orphan count must never have.
+    const id = randomUUID()
+    const rows = [row({ id, stored_path: 'H:garbage-no-separators.enc', stored_name: '../evil.enc' })]
+    const r = auditStoredCopies(
+      input({ rows, dirEntries: [{ name: `${id}.docx.enc`, bytes: 99 }] })
+    )
+    expect(r.orphans.count).toBe(0)
+    expect(r.rows.staleUnnameable).toBe(1)
+    // ...and the report says so, so nobody reads the orphan line as more certain than it is.
+    expect(formatStoredCopyAuditReport(r)).toContain('the safety guard refuses')
+  })
+
+  it('counts a genuine orphan with its bytes and a shape token', () => {
+    const orphan = randomUUID()
+    const r = auditStoredCopies(
+      input({ dirEntries: [{ name: `${orphan}.pdf.enc`, bytes: 5_000_000 }] })
+    )
+    expect(r.orphans.count).toBe(1)
+    expect(r.orphans.bytes).toBe(5_000_000)
+    expect(r.orphans.tokens).toEqual([`${orphan.slice(0, 8)} pdf <8M`])
+  })
+})
+
+describe('#190 stored-copy audit — the row ladder', () => {
+  const a = randomUUID() // healthy, resolves as recorded
+  const b = randomUUID() // stale but healable at the canonical location
+  const c = randomUUID() // stale and gone everywhere
+  const d = randomUUID() // never stored a copy (queued)
+  const e = randomUUID() // healthy audio
+  const f = randomUUID() // stale, and the safety guard refuses its leaf
+
+  const rows: AuditRow[] = [
+    row({ id: a, stored_path: `/new/workspace/documents/${a}.pdf.enc`, stored_name: `${a}.pdf.enc` }),
+    row({ id: b, stored_path: `H:\\old\\workspace\\documents\\${b}.docx.enc` }),
+    row({ id: c, stored_path: `H:\\old\\workspace\\documents\\${c}.txt.enc` }),
+    row({ id: d, stored_path: null, status: 'queued', mime_type: 'application/pdf' }),
+    row({ id: e, stored_path: `/new/workspace/documents/${e}.wav.enc`, stored_name: `${e}.wav.enc` }),
+    // A corrupted/foreign `stored_name`: `canonicalLeafFor` refuses it (traversal + wrong owner),
+    // so the resolver would fall back to the recorded absolute path verbatim — which is gone.
+    row({ id: f, stored_path: `H:\\old\\elsewhere\\weird.enc`, stored_name: '../evil.enc' })
+  ]
+  const dirEntries: AuditDirEntry[] = [
+    { name: `${a}.pdf.enc`, bytes: 1000 },
+    { name: `${b}.docx.enc`, bytes: 2000 },
+    { name: `${e}.wav.enc`, bytes: 3000 }
+  ]
+  const existingRecordedPaths = [
+    `/new/workspace/documents/${a}.pdf.enc`,
+    `/new/workspace/documents/${e}.wav.enc`
+  ]
+  const report = auditStoredCopies(input({ rows, dirEntries, existingRecordedPaths }))
+
+  it('counts documents by status', () => {
+    expect(report.documents.total).toBe(6)
+    expect(report.documents.byStatus).toEqual({ indexed: 5, queued: 1 })
+  })
+
+  it('counts stale rows, and how many of them are healable — the staleness verdict', () => {
+    // This pair is the whole point of the tool on the reporting drive: stale > 0 with
+    // healable == stale means "the drive moved and every copy is still there".
+    expect(report.rows.stale).toBe(3) // b, c, f
+    expect(report.rows.healable).toBe(1) // b — the copy IS at the canonical location
+    expect(report.rows.staleUnnameable).toBe(1) // f — the guard refuses the leaf
+    expect(report.rows.missingEverywhere).toBe(2) // c and f
+    expect(report.rows.neverStored).toBe(1) // d
+    expect(report.rows.resolvedAsRecorded).toBe(2) // a and e
+  })
+
+  it('MUTATION GUARD — a row with no stored_path at all is never counted stale', () => {
+    // A queued row has recorded nothing; folding it into `stale` would inflate the very number
+    // the cleanup decision reads.
+    const only = auditStoredCopies(input({ rows: [rows[3]] }))
+    expect(only.rows.stale).toBe(0)
+    expect(only.rows.missingEverywhere).toBe(0)
+    expect(only.rows.neverStored).toBe(1)
+  })
+
+  it('builds the extension histogram over rows, with mime_type as the fallback source', () => {
+    // REQUIRED by #190 checkbox 3: audio is the only document class whose PREVIEW does not touch
+    // the file (it replays the stored chunks via `audioSegmentsFromChunks`), so exactly one audio
+    // document explains "Vorschau works" alongside an export failure with no contradiction.
+    expect(report.extensions).toEqual({ pdf: 2, docx: 1, txt: 1, wav: 1, other: 1 })
+    expect(report.audioRows).toBe(1)
+  })
+
+  it('reports stored_name adoption', () => {
+    expect(report.storedName).toEqual({ column: true, populated: 3 })
+  })
+
+  it('emits one shape token per row and per orphan', () => {
+    expect(report.rowTokens).toHaveLength(6)
+    for (const t of report.rowTokens) expect(t).toMatch(/^[0-9a-f]{8} [a-z]+ [-ENOPSHMX.]+$/)
+  })
+})
+
+describe('#190 stored-copy audit — schema and vault findings', () => {
+  it('distinguishes an ABSENT stored_name column from an unpopulated one', () => {
+    // The reporting drive predates #189 and the column is added by `ensureColumn` at open, which
+    // the diagnostic must never trigger — so "absent" is a real, expected state, not an error.
+    const id = randomUUID()
+    const absent = auditStoredCopies(
+      input({ rows: [row({ id, stored_name: undefined, stored_path: `/x/${id}.pdf.enc` })], storedNameColumn: false })
+    )
+    expect(absent.storedName).toEqual({ column: false, populated: 0 })
+    expect(formatStoredCopyAuditReport(absent)).toContain('ABSENT (pre-#189 schema)')
+  })
+
+  it('reports the descriptor version and the plaintext_dev case', () => {
+    expect(auditStoredCopies(input({ descriptorVersion: 1 })).vault).toEqual({
+      descriptorVersion: 1,
+      mode: 'encrypted'
+    })
+    expect(auditStoredCopies(input({ descriptorVersion: null })).vault).toEqual({
+      descriptorVersion: null,
+      mode: 'plaintext_dev'
+    })
+  })
+
+  it('surfaces each at-rest finding separately', () => {
+    const r = auditStoredCopies(
+      input({ atRest: { recovery: true, wal: true, shm: false, dbRekeyStaged: true } })
+    )
+    const text = formatStoredCopyAuditReport(r)
+    expect(text).toContain('.recovery        PRESENT — a lock failed')
+    expect(text).toContain('-wal             PRESENT — unclean last session')
+    expect(text).toContain('-shm             no')
+    expect(text).toContain('db .enc.new      PRESENT — interrupted password change')
+  })
+})
+
+describe('#190 stored-copy audit — the report is safe to paste in public', () => {
+  it('leaks no path, no file name and no unlisted extension into the rendered text', () => {
+    const id = randomUUID()
+    const orphan = randomUUID()
+    const rows = [
+      row({
+        id,
+        // Everything identifying the tool could possibly echo: a drive letter, a folder name, a
+        // user name, and an off-allowlist extension.
+        stored_path: `H:\\Users\\ImogenSchmidt\\Steuerbescheid-2019\\workspace\\documents\\${id}.p7s.enc`,
+        original_path: 'H:\\Users\\ImogenSchmidt\\Steuerbescheid-2019\\Original.p7s',
+        mime_type: 'application/pkcs7-signature'
+      })
+    ]
+    const text = formatStoredCopyAuditReport(
+      auditStoredCopies(
+        input({ rows, dirEntries: [{ name: `${orphan}.p7s.enc`, bytes: 12 }] })
+      )
+    )
+    for (const secret of [
+      'ImogenSchmidt',
+      'Steuerbescheid',
+      'Original.p7s',
+      'H:\\',
+      'pkcs7',
+      'p7s',
+      id, // the full id — only the 8-char prefix may appear
+      orphan
+    ]) {
+      expect(text, `report must not contain "${secret}"`).not.toContain(secret)
+    }
+    // The 8-char prefixes ARE present: they are what lets two lines of the report be correlated.
+    expect(text).toContain(id.slice(0, 8))
+    expect(text).toContain(orphan.slice(0, 8))
+    // The off-allowlist extension collapsed to the closed-set label.
+    expect(extClassOf(rows[0])).toBe('other')
+  })
+})
+
+describe('#190 diagnostic — the read-only capabilities it depends on', () => {
+  it('node:sqlite honours { readOnly: true } on the engines floor (>= 22.12)', () => {
+    // The diagnostic opens the decrypted COPY read-only as its innermost guard. CI runs both ends
+    // of the supported Node range, so this asserts the option is real on the 22.x leg rather than
+    // trusting the docs — if a floor bump ever loses it, this goes red before the drive does.
+    const dir = mkdtempSync(join(tmpdir(), 'hr-audit-ro-'))
+    try {
+      const path = join(dir, 'probe.sqlite')
+      const w = new DatabaseSync(path)
+      w.exec('CREATE TABLE t (a TEXT)')
+      w.exec("INSERT INTO t VALUES ('x')")
+      w.close()
+      const r = new DatabaseSync(path, { readOnly: true })
+      try {
+        expect(r.prepare('SELECT a FROM t').all()).toEqual([{ a: 'x' }])
+        expect(() => r.exec('CREATE TABLE z (b TEXT)')).toThrow(/readonly/i)
+      } finally {
+        r.close()
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('the read-only witness notices a size change, an mtime change, and a new entry', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hr-audit-witness-'))
+    try {
+      mkdirSync(join(dir, 'sub'))
+      writeFileSync(join(dir, 'sub', 'a.bin'), 'aaa')
+      const before = fingerprintTree(dir)
+      expect(treeUnchanged(before, fingerprintTree(dir))).toBe(true)
+
+      writeFileSync(join(dir, 'sub', 'a.bin'), 'aaaa') // size change
+      expect(treeUnchanged(before, fingerprintTree(dir))).toBe(false)
+
+      writeFileSync(join(dir, 'sub', 'a.bin'), 'aaa') // back to the same size...
+      const sameSize = fingerprintTree(dir)
+      utimesSync(join(dir, 'sub', 'a.bin'), new Date(0), new Date(0)) // ...but a different mtime
+      expect(treeUnchanged(sameSize, fingerprintTree(dir))).toBe(false)
+
+      const withNew = fingerprintTree(dir)
+      writeFileSync(join(dir, 'sub', 'b.bin'), 'b') // a new entry (a rolled-forward .recovery)
+      expect(treeUnchanged(withNew, fingerprintTree(dir))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10843,10 +10843,13 @@ copy, and the changed-fallback-original refusal. Each guard was **mutation-check
 the canonical branch, removing the id guard, and putting the shred back on the recorded path each
 turned the corresponding tests red.
 
-**Still owed, and it cannot be CI'd:** the real relocated-drive run — plugging the prepared drive
-in under a different letter and confirming export, preview, delete, and re-index. That is exactly
-**BUILD_STATE §5 item 1's "second-laptop continuity check"**, which remains OPEN: this wave makes
-the code correct, but the check is only *answered* by a real run.
+**What could not be CI'd — the real relocated-drive run — has now been done (2026-08-20).** The
+prepared drive came back under a different letter (`G:\` → `K:\`) and export, preview, re-index and
+delete were all exercised on it, with a read-only diagnostic before and after. That is
+**BUILD_STATE §5 item 1's "second-laptop continuity check"**, and it is answered: 14 of 24 rows
+self-healed on first read (`stored_name` populated 0 → 14, stale 24 → 10, and the 10 that stayed
+stale are exactly the documents never opened), and a delete left **no new orphan**. The measured
+before/after and its one residual gap are in **§9.4**.
 
 **The root-cause diagnostic on the reporting drive — RUN, and its questions ANSWERED (2026-08-20).**
 The fix was correct in either world — D-1 and the resolver stand on their own — but two questions
@@ -11101,6 +11104,56 @@ One more operator-facing correction rides along: `npx` is blocked by the PowerSh
 policy on the maintainer's machine (its shim is a `.ps1`), so the header now documents
 `..\..\node_modules\.bin\vitest.cmd run tests/manual/stored-copy-diagnostic.test.ts` from
 `apps/desktop/`.
+
+### §9.4 The relocation continuity check, measured (2026-08-20, `G:\` → `K:\`)
+
+The drive that produced the §9.1 report came back under a **different letter**, which is the
+relocation BUILD_STATE §5 item 1 exists to exercise. It was run as diagnostic → functional walk →
+diagnostic. The app was quit cleanly between the walk and the second run, and that ordering is
+load-bearing: the healed rows live in the plaintext working DB until `lockEncryptedVault`
+re-encrypts it, so an "after" run against a still-unlocked workspace reads the PRE-walk state and
+looks like nothing healed.
+
+| | Before walk | After walk |
+|---|---|---|
+| `stored_name` column | ABSENT (pre-#189 schema) | **present** (`ensureColumn` ran at open) |
+| `stored_name` populated | **0 / 24** | **14 / 24** |
+| stale `stored_path` | **24** | **10** |
+| of those healable | 24 | 10 |
+| resolved as recorded | **0** | **14** |
+| ORPHAN `.enc` files | 1 (115.2 KiB) | **1 (115.2 KiB)** — unchanged |
+| documents rows | 24, all indexed | 24, all indexed |
+| at rest | all clean | all clean |
+
+Per-row tokens make it unambiguous: 14 rows moved from `EOPSH` (copy found, **S**tale,
+**H**ealable) to `ENOP` (`stored_name` set, no `S`, no `H`), and the 10 still stale are exactly the
+documents never opened. Four things are established that no test could establish:
+
+1. **D3's lazy heal works on a genuinely relocated drive, and only where it should.** Nothing
+   healed that was not read — there is no startup migration burst, which is what D3 traded away a
+   bulk migration for.
+2. **D-1 is fixed on hardware.** A throwaway document was imported and deleted; the orphan count
+   stayed at **1** and `documents/` returned to 25 files. Pre-#189 that delete would have left a
+   **second** orphan — the silent no-op that made "delete" not delete.
+3. **The pre-walk baseline reproduced §9.1 field for field under the new letter**, same orphan
+   token included, so the resolver's canonical-location step is genuinely mount-independent rather
+   than accidentally right on one drive.
+4. **The vault teardown is clean under the new letter** — no plaintext working DB, no `-wal`, no
+   `-shm`, no `.recovery`, no `.enc.new`.
+
+**The residual, stated plainly.** The delete leg used a **post-#189** row, born with `stored_name`
+set, so its shred resolved through the canonical path. It did **not** reproduce D-1's original
+condition — a *legacy* row whose recorded absolute `stored_path` still names the old mount point.
+Ten such rows remain on that drive (the ones still flagged `EOPSH`), so the leg can be run directly
+at the cost of one real document. It is not owed by the check's wording, and it is the one thing
+this run did not settle.
+
+**Also found, and filed out of scope: issue #194.** The re-index leg succeeded but gave the
+operator no feedback of any kind — "it worked" and "nothing happened" were the same event. The
+single-document path returns silently from the shared `run()` helper while the **bulk** "Re-index
+all" toasts and carries a determinate progress bar. Its failure path is the screen-level banner
+that does not name the document — **D-3 recurring on a neighbouring action**, which this wave fixed
+for export and did not sweep.
 
 ## Model occupancy — design record (issues #185/#186, §1–§6)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10668,7 +10668,7 @@ The wave's working paper is gone; its anchors resolve here:
 | `plan §7` (audit ledger A1–A10) | §8 above |
 | `plan §8` (six-persona ledger) | §8 above |
 
-## Portable stored copies — design record (wave 188, issue #188, §1–§8)
+## Portable stored copies — design record (wave 188, issues #188/#190, §1–§9)
 
 _Issue **#188** was filed as a UI defect: "Originaldatei exportieren" failed with "Die
 Dokumentdatei ist nicht mehr vorhanden" on a real prepared drive whose `workspace/documents/`
@@ -10763,6 +10763,27 @@ import has its file on disk before/while its row is written, and `stageRekey` st
 `<file>.enc.new`. An orphan sweep would race both. Existing orphans from past silent no-ops stay
 on affected drives; the diagnostic in §6 counts them.
 
+**D4 rider (issue #190, 2026-08-20) — orphans are NOT inert, so "leave them" is a decision with a
+cost, not a no-op.** This record originally framed them as pure retention residue. They are also
+*participants*, because the vault layer addresses sidecars by DIRECTORY WALK, not by row:
+`listEncryptedDocSidecars` filters `workspace/documents/` on `.endsWith('.enc')` and has no idea
+which files a `documents` row owns. Consequences, in blast-radius order:
+
+- On a **v1** vault the first password change is the journaled v1→v2 migration, and `stageRekey`
+  runs the full decrypt → re-encrypt → fsync → shred-old → rename cycle **over every orphan too**.
+  So each orphan costs its own bytes twice in I/O on the slowest medium the product targets, and
+  the migration transiently needs free space for **every** orphan's `.enc.new` at once — an ENOSPC
+  exposure that scales with orphaned bytes, on a stick that is often nearly full.
+- On a **v2** vault a password change is the O(1) key re-wrap (`rewrapVaultKey`), so orphans cost
+  nothing there. That asymmetry is precisely why the diagnostic reports the descriptor version
+  (report item 9): v1 + many orphans is a materially different situation from v2 + many orphans.
+- Either way an orphan is **still encrypted user content on a drive the owner may sell, lend or
+  lose**, carried forward by every migration instead of being retired by one.
+
+None of this changes D4's refusal to build an automatic sweep. It changes what "leave them" means,
+and it is why the cleanup posture (issue #190 checkbox 2) is an owner decision taken **after** the
+orphan count and the descriptor version are known, not a default.
+
 **D5 — `original_path` demoted to a checked last resort.** On a portable drive it is the *least*
 durable of the two paths — it names a location on the other machine — yet the old ladder tried it
 immediately after a stale `stored_path`. It is also nulled outright for generated documents
@@ -10832,10 +10853,17 @@ correct in either world — D-1 and the resolver stand on their own — but two 
 open on that specific drive: whether its rows are in fact stale (the issue reports "Vorschau
 works" alongside an export failure, and preview and export share the same ladder, so those two
 observations cannot both describe the same document), and how many orphaned `.enc` files past
-silent deletes left behind (D4). A read-only diagnostic that copies `config/workspace.json` +
-`hilbertraum.sqlite.enc` to scratch, decrypts the copy, and reports directory histograms with no
-titles or content was written and smoke-tested against a synthetic vault; it needs the owner's
-password to run.
+silent deletes left behind (D4). Both are tracked as **issue #190**.
+
+> **CORRECTION (issue #190, 2026-08-20).** This paragraph previously stated that the read-only
+> diagnostic "was written and smoke-tested against a synthetic vault" and only needed the owner's
+> password. **That was factually wrong.** The tool lived in the git-excluded working paper
+> (`plans/issue-188-stored-path-portability.md`) and went with it at close-out; nothing matching it
+> was ever committed on any branch, so from the repository's point of view it did not exist. The
+> lesson is the doc-lifecycle rule's own: a design record may cite a working paper's *reasoning*,
+> never inherit its *artifacts* — anything a later wave has to run has to be in the tree.
+>
+> It has been rebuilt, in the tree, and is CI-proven rather than smoke-tested. See **§9** below.
 
 ### §7 §-anchor legend
 
@@ -10873,6 +10901,92 @@ checked — reinstating the old wording turns it red), following the DEP-3 merma
 
 **This is the standing argument for the gate order `typecheck → build → test`.** Neither typecheck
 nor the suite can see this class; only the build can.
+
+### §9 The stored-copy diagnostic, as rebuilt (issue #190 phase 1, 2026-08-20)
+
+The read-only diagnostic §6 wrongly claimed to exist now does exist, in the tree, split so that
+everything except the drive itself is proven by CI:
+
+| File | What it is |
+|---|---|
+| `apps/desktop/tests/helpers/stored-copy-audit.ts` | The **pure classifier + report renderer**. Takes rows + a directory listing, returns a report. No fs, no crypto, no I/O. |
+| `apps/desktop/tests/helpers/stored-copy-audit-run.ts` | The **read-only collector**: copy → decrypt the copy → open read-only → probe the schema → query → walk `documents/` → classify → shred the scratch. |
+| `apps/desktop/tests/helpers/read-only-witness.ts` | The **witness**: fingerprints a tree (path + size + mtime of every entry) so "it never writes to the drive" is an assertion, not a claim. |
+| `apps/desktop/tests/manual/stored-copy-diagnostic.test.ts` | The **operator shell**, env-gated on `HILBERTRAUM_STORED_COPY_AUDIT` in the `tests/manual/*-smoke.test.ts` shape. Hidden TTY password prompt. |
+| `apps/desktop/tests/unit/stored-copy-audit.test.ts` | Classifier fixtures, the mutation guards, the public-safety assertion, and the `node:sqlite` `{ readOnly: true }` floor probe (CI runs both ends of `engines.node`). |
+| `apps/desktop/tests/integration/stored-copy-audit-run.test.ts` | The collector end-to-end against a **synthetic vault** (v2, legacy v1, and `plaintext_dev`) with exact counts, plus the witness on each branch. |
+
+It is **test-tree code on purpose**: it must not ship in the app bundle as dead code, and
+`tsconfig.web.json` already includes `tests/`, so it stays typechecked and cannot rot silently.
+
+**D7 — everything that mutates is forbidden, by name.** `unlockEncryptedVault` is *not* an unlock:
+it runs `recoverPendingRekey` (which commits or discards staged rekeys and can roll a `.recovery`
+forward **over** the `.enc`) and decrypts a plaintext working DB onto the drive. `openDatabase`
+runs `db.exec(SCHEMA)` plus ~20 `ensureColumn` calls, so merely *opening* writes. Neither, nor
+`preserveNewerPlaintext` / `lockEncryptedVault`, is ever called against the drive. The minimal
+unlock is re-composed over the **copy** from the shipped primitives — `readVaultDescriptor`,
+`deriveKey`, `verifyKey`, `decrypt` (the v2 envelope unwrap), `decryptFile` — so there is no
+hand-rolled crypto and no second implementation to drift. Keys are zeroed; the scratch plaintext
+is shredded in a `finally`.
+
+**D8 — the schema is probed, never assumed.** `stored_name` is added by `ensureColumn` **at open**,
+which this tool must not trigger, and the reporting drive predates #189 — so `PRAGMA
+table_info(documents)` decides whether the column is selected at all. A naive `SELECT … stored_name`
+throws on the one machine that matters. "Column absent" and "column present but unpopulated" are
+reported as different findings.
+
+**D9 — the output is safe by construction, not by care.** The report carries counts, histograms
+over two **closed** allowlists (extension classes, file classes), and shape tokens — an 8-char id
+prefix, an extension class, flag letters, and a coarse size bucket for orphans. No titles, no
+content, no paths, no file names, and an off-allowlist extension collapses to `other` (one unusual
+extension on a drive is identifying). `title`, `error_message` and every `*_json` column are never
+selected; `mime_type` is, because it is a class and it keeps the extension histogram complete for a
+row whose copy is gone. A CI test renders a report from a vault full of distinctive secrets and
+asserts none of them survive.
+
+**D10 — ownership is deliberately over-generous, and the id is the final word.** The error
+directions are not symmetric: under-counting orphans is merely uninformative, while over-counting
+invents an orphan out of live user data and would hand a future cleanup a file to destroy. So a
+file is claimed by a row if ANY of four sources says so — the healed `stored_name`, the leaf of the
+recorded `stored_path`, `canonicalLeafFor`, and finally the file's own **leading id**. The fourth
+was added after the first end-to-end operator smoke, which showed the hole the other three leave: a
+row whose recorded strings are corrupt (the safety guard refuses the leaf) names *nothing*, so its
+perfectly healthy `<id><ext>.enc` was reported as an orphan. The store's naming is
+`<documentId><ext>[.enc]` and the id is a never-reused UUID primary key, so a file whose leading id
+is a live row's id belongs to that row whatever the row recorded. When any such row exists the
+report says so on the orphan line, so the count is never read as more certain than it is.
+
+**D11 — the safety contract is witnessed, not asserted.** The integration test fingerprints the
+whole synthetic drive before and after every run and requires it identical; the manual harness does
+the same against the real drive and **fails the run** if a size, an mtime, or an entry moved. Seven
+mutations were run and each turned the intended test red: (a) matching `.enc` loosely so a staged
+`<id><ext>.enc.new` becomes an orphan — the most dangerous misclassification the tool can make,
+since a cleanup built on that count would delete a live document mid-rekey; (b) claiming ownership
+from `stored_path` only, which invents an orphan out of a healed row; (c) counting a row with no
+`stored_path` as stale, inflating the number the cleanup decision reads; (d) a naive `startsWith`
+in the scratch-containment check, which lets `…/driveX` pass as outside `…/drive`; (e) selecting
+`stored_name` unconditionally, which throws on the pre-#189 schema; (f) an `openDatabase` against
+the drive, which the witness caught on both the encrypted and the plaintext branch; (g) dropping
+the id-based ownership of D10, which re-creates the phantom orphan the smoke found.
+
+**The extension histogram is a required output, and it is what settles #190 checkbox 3.** The
+issue records "Vorschau works" alongside the export failure; pre-#189 the preview and export
+ladders were structurally identical (`stored_path` → `original_path` → throw), so they cannot
+disagree about the same document. The exception is **audio**, whose preview reads the stored
+CHUNKS via `audioSegmentsFromChunks` and never touches the file at all. OCR'd PDFs do **not**
+qualify — `ocrPages` feeds the parser, which still needs the file. So **one audio document explains
+both observations with no contradiction**, which is the leading hypothesis; the fallbacks are two
+different documents or two different sessions. The histogram plus the per-row shape tokens
+distinguish all three.
+
+**Deliberately not built (issue #190 phases 3–4).** No cleanup, no sweep, not even an opt-in one:
+the posture is an owner decision that needs the orphan count and the descriptor version first (D4
+rider above). If it is ever built it must be explicit, owner-confirmed, unlocked-only, and refuse
+to start with an import or a rekey in flight — D4's race is the whole problem. The second-laptop
+continuity check (BUILD_STATE §5 item 1) is likewise a human run, but the diagnostic **doubles as
+its evidence collector**: run it before and after the relocation and the `stale` / `healable` /
+`stored_name populated` triple is exactly the "rows self-heal on first read" proof that check owes,
+in a form that can be pasted into the issue.
 
 ## Model occupancy — design record (issues #185/#186, §1–§6)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10784,6 +10784,10 @@ None of this changes D4's refusal to build an automatic sweep. It changes what "
 and it is why the cleanup posture (issue #190 checkbox 2) is an owner decision taken **after** the
 orphan count and the descriptor version are known, not a default.
 
+> **The decision was taken on 2026-08-20: leave them, ship no cleanup.** The evidence it rests on
+> (n=1, 115.2 KiB, v2 — so this rider's expensive v1 branch does not apply) and the revisit trigger
+> are recorded as **D14 in §9.2**.
+
 **D5 — `original_path` demoted to a checked last resort.** On a portable drive it is the *least*
 durable of the two paths — it names a location on the other machine — yet the old ladder tried it
 immediately after a stale `stored_path`. It is also nulled outright for generated documents
@@ -11055,18 +11059,40 @@ cannot be concurrent: the contradiction is **TEMPORAL** — two sessions, with t
 observation predating the drive-letter change — not per-document. Nothing in the fix depends on
 this; it is recorded because the issue's narrative did.
 
-### §9.2 What is still owner-owned
+### §9.2 The cleanup posture — DECIDED (owner, 2026-08-20): leave them
 
-**Deliberately not built (issue #190 phases 3–4).** No cleanup, no sweep, not even an opt-in one:
-the posture is an owner decision, and it needed the orphan count and the descriptor version first
-(D4 rider above) — which §9.1 now supplies, at n=1 on a v2 vault. If it is ever built it must be
-explicit, owner-confirmed, unlocked-only, and refuse to start with an import or a rekey in flight —
-D4's race is the whole problem. The second-laptop continuity check (BUILD_STATE §5 item 1) is
-likewise a human run, but the diagnostic **doubles as its evidence collector**: the §9.1 run is
-already a valid **"before" snapshot**, and re-running it after the relocation gives the
-`stale` / `healable` / `stored_name populated` triple — exactly the "rows self-heal on first read"
-proof that check owes, in a form that can be pasted into the issue (it should read 0 stale and
-24 populated once each document has been read once).
+**D14 — orphaned `.enc` files stay. No cleanup ships: not a sweep, not an opt-in one, not a
+Diagnostics button.** D4 refused an *automatic* sweep on the race; the rider then said "leave them"
+was a decision with a cost that could only be taken once the orphan count and the descriptor
+version were known. §9.1 supplied both — **n=1, 115.2 KiB, v2** — and the owner took the decision on
+that evidence. The reasoning, recorded so a later wave does not relitigate it from scratch:
+
+- **The measured cost of leaving is near zero.** v2 means a password change is the O(1)
+  `rewrapVaultKey`, so the rider's expensive branch — a v1 migration re-encrypting every orphan and
+  transiently needing `.enc.new` space for all of them — does not apply. What remains is retention:
+  115 KiB of ciphertext with no owning row, on a drive already carrying 2.1 MiB of live ciphertext
+  under the same key. Deleting it removes ~5% of the drive's document ciphertext and nothing at all
+  against an attacker without the password.
+- **A one-time named delete really is safer than a sweep — but that safety is not transferable.**
+  It comes from *a human picked the file*, not from guards. Put it in the app and code picks the
+  file again, which reinstates D4's race and the D10 over-count hazard (the phantom-orphan bug the
+  first end-to-end smoke found). The safe version of this operation is a human deleting one named
+  file with the app quit, which needs no product surface at all.
+- **The surface would be disproportionate:** Diagnostics-only, unlock-gated, a count and a byte
+  figure, typed confirmation, a refusal path with an import or rekey in flight, de-AT copy and
+  tests — a permanently-reachable delete path over the encrypted store, shipped for a one-off
+  115 KiB, plus a new support question for a condition #189 already made unreachable.
+- **Revisit trigger, so "leave it" does not decay into "never look again":** re-open if a run ever
+  reports a **v1** descriptor with any orphans, or orphan bytes reaching a material fraction of the
+  store (order of >50 files or >100 MiB). The diagnostic already reports both, so the trigger is
+  observable without new code.
+
+If it is ever built anyway, the constraints stand unchanged: explicit, owner-confirmed,
+unlocked-only, and refusing to start with an import or a rekey in flight — D4's race is the whole
+problem.
+
+**The diagnostic doubles as the continuity check's evidence collector**, and that is no longer
+hypothetical: the §9.1 run served as the "before" snapshot and §9.4 is the "after".
 
 ### §9.3 The password prompt had to bypass `process.stdin` (phase 2)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10848,12 +10848,22 @@ in under a different letter and confirming export, preview, delete, and re-index
 **BUILD_STATE §5 item 1's "second-laptop continuity check"**, which remains OPEN: this wave makes
 the code correct, but the check is only *answered* by a real run.
 
-**Also outstanding: the root-cause diagnostic on the reporting drive was never run.** The fix is
-correct in either world — D-1 and the resolver stand on their own — but two questions are still
-open on that specific drive: whether its rows are in fact stale (the issue reports "Vorschau
-works" alongside an export failure, and preview and export share the same ladder, so those two
-observations cannot both describe the same document), and how many orphaned `.enc` files past
-silent deletes left behind (D4). Both are tracked as **issue #190**.
+**The root-cause diagnostic on the reporting drive — RUN, and its questions ANSWERED (2026-08-20).**
+The fix was correct in either world — D-1 and the resolver stand on their own — but two questions
+were open on that specific drive: whether its rows are in fact stale, and how many orphaned `.enc`
+files past silent deletes left behind (D4). Both are now measured, on `G:\`, with the drive coming
+back byte-identical:
+
+- **Stale: yes, all of them — 24 rows, 24 stale, 24 healable, 0 with no copy anywhere.** The
+  relocation took the entire corpus at once and every byte is still at the canonical location, so
+  the #189 resolver heals all 24 on first read. #188 is confirmed outright, not merely plausible.
+- **Orphans: one, 115.2 KiB**, on a **v2** descriptor — so it costs nothing at rekey (D4 rider).
+  The `documents/` directory also held zero parse-transients and zero staged `.enc.new` files.
+- The `stored_name` column was **absent** (pre-#189 schema), which is what D8 exists for.
+
+The "Vorschau works alongside an export failure" contradiction is settled too, and **not** the way
+this record first guessed — see **§9**, which carries the measured report, the refutation, and the
+verification that replaced it.
 
 > **CORRECTION (issue #190, 2026-08-20).** This paragraph previously stated that the read-only
 > diagnostic "was written and smoke-tested against a synthetic vault" and only needed the owner's
@@ -10863,7 +10873,8 @@ silent deletes left behind (D4). Both are tracked as **issue #190**.
 > lesson is the doc-lifecycle rule's own: a design record may cite a working paper's *reasoning*,
 > never inherit its *artifacts* — anything a later wave has to run has to be in the tree.
 >
-> It has been rebuilt, in the tree, and is CI-proven rather than smoke-tested. See **§9** below.
+> It has been rebuilt, in the tree, is CI-proven rather than smoke-tested, and has now been run for
+> real. See **§9** below.
 
 ### §7 §-anchor legend
 
@@ -10902,7 +10913,7 @@ checked — reinstating the old wording turns it red), following the DEP-3 merma
 **This is the standing argument for the gate order `typecheck → build → test`.** Neither typecheck
 nor the suite can see this class; only the build can.
 
-### §9 The stored-copy diagnostic, as rebuilt (issue #190 phase 1, 2026-08-20)
+### §9 The stored-copy diagnostic, as rebuilt and as run (issue #190 phases 1–2, 2026-08-20)
 
 The read-only diagnostic §6 wrongly claimed to exist now does exist, in the tree, split so that
 everything except the drive itself is proven by CI:
@@ -10912,7 +10923,9 @@ everything except the drive itself is proven by CI:
 | `apps/desktop/tests/helpers/stored-copy-audit.ts` | The **pure classifier + report renderer**. Takes rows + a directory listing, returns a report. No fs, no crypto, no I/O. |
 | `apps/desktop/tests/helpers/stored-copy-audit-run.ts` | The **read-only collector**: copy → decrypt the copy → open read-only → probe the schema → query → walk `documents/` → classify → shred the scratch. |
 | `apps/desktop/tests/helpers/read-only-witness.ts` | The **witness**: fingerprints a tree (path + size + mtime of every entry) so "it never writes to the drive" is an assertion, not a claim. |
-| `apps/desktop/tests/manual/stored-copy-diagnostic.test.ts` | The **operator shell**, env-gated on `HILBERTRAUM_STORED_COPY_AUDIT` in the `tests/manual/*-smoke.test.ts` shape. Hidden TTY password prompt. |
+| `apps/desktop/tests/manual/stored-copy-diagnostic.test.ts` | The **operator shell**, env-gated on `HILBERTRAUM_STORED_COPY_AUDIT` in the `tests/manual/*-smoke.test.ts` shape. Hidden password prompt read from the console DEVICE (§9.3). |
+| `apps/desktop/tests/helpers/console-password.ts` | The **console password prompt** (§9.3): opens the terminal DEVICE (`\\.\CONIN$` / `/dev/tty`) in raw mode, or fails fast with a recipe. Never `process.stdin`. |
+| `apps/desktop/tests/unit/console-password.test.ts` | CI proof for the non-TTY path: the forked worker’s own piped stdin, the fail-fast text, the no-cooked-fallback refusal, and a source pin on the harness. |
 | `apps/desktop/tests/unit/stored-copy-audit.test.ts` | Classifier fixtures, the mutation guards, the public-safety assertion, and the `node:sqlite` `{ readOnly: true }` floor probe (CI runs both ends of `engines.node`). |
 | `apps/desktop/tests/integration/stored-copy-audit-run.test.ts` | The collector end-to-end against a **synthetic vault** (v2, legacy v1, and `plaintext_dev`) with exact counts, plus the witness on each branch. |
 
@@ -10969,24 +10982,125 @@ in the scratch-containment check, which lets `…/driveX` pass as outside `…/d
 the drive, which the witness caught on both the encrypted and the plaintext branch; (g) dropping
 the id-based ownership of D10, which re-creates the phantom orphan the smoke found.
 
-**The extension histogram is a required output, and it is what settles #190 checkbox 3.** The
-issue records "Vorschau works" alongside the export failure; pre-#189 the preview and export
-ladders were structurally identical (`stored_path` → `original_path` → throw), so they cannot
-disagree about the same document. The exception is **audio**, whose preview reads the stored
-CHUNKS via `audioSegmentsFromChunks` and never touches the file at all. OCR'd PDFs do **not**
-qualify — `ocrPages` feeds the parser, which still needs the file. So **one audio document explains
-both observations with no contradiction**, which is the leading hypothesis; the fallbacks are two
-different documents or two different sessions. The histogram plus the per-row shape tokens
-distinguish all three.
+### §9.1 The measured run (2026-08-20, `G:\`) — and the hypothesis it refuted
+
+The report, verbatim as pasted into #190. The drive was byte-identical afterwards (the §D11
+witness passed), and one row carries no `original_path` — a generated document, which
+`setDocumentOrigin` nulls by design.
+
+```
+workspace mode          encrypted
+vault descriptor        v2
+stored_name column      ABSENT (pre-#189 schema)
+stored_name populated   0 / 24
+
+(1) documents rows      24        all indexed
+(2) stale stored_path   24
+(3)   of those healable 24
+      of those unnamed   0
+(4) no copy anywhere     0
+    never stored a copy  0
+    resolved as recorded 0
+(5) ORPHAN .enc files    1        115.2 KiB   token: 72957f7f pdf <1M
+(6) file classes        stored-copy 25 (2.1 MiB); parse-transient 0; rekey-staged 0;
+                        write-temp 0; unknown 0
+(7) extension classes   pdf 17, docx 6, md 1     -> audio rows 0
+(10) at rest            .recovery no, -wal no, -shm no, db .enc.new no
+```
+
+**#188 confirmed outright.** 24/24 stale, 24/24 healable, 0 with no copy anywhere: the drive-letter
+relocation took the whole corpus stale in one step and every byte is still at the canonical
+location, so the resolver heals all 24 on first read. **Field residue is one orphan, 115.2 KiB, on
+a v2 descriptor** — the cheap side of the D4-rider asymmetry (a v2 rekey is the O(1) key re-wrap,
+so this orphan costs nothing at a password change), and the directory holds no transients and no
+staged rekey files, so nothing is mid-flight. That is the whole input to the checkbox-2 cleanup
+decision, and it is a much smaller number than "leave them" was defended against.
+
+**The extension histogram was the required output for #190 checkbox 3, and it REFUTED this
+record's own leading hypothesis.** §9 previously argued that the issue's "Vorschau works" alongside
+the export failure was explained by **one audio document**, whose preview reads the stored CHUNKS
+via `audioSegmentsFromChunks` and never touches the file. **Audio rows = 0.** There is no audio
+document on that drive, so that explanation is dead — pdf 17 / docx 6 / md 1 is the whole corpus,
+and every one of those classes needs the file.
+
+**What replaced it, verified against the pre-#189 code rather than traced.** The temporal reading
+below rests on the claim that preview and export shared one ladder — the same trace that produced
+the refuted audio hypothesis — so it was re-walked directly against the pre-#189 tree
+(`2151e445`, the commit before the #189 fix), covering every path the Vorschau modal can reach and
+every path "Originaldatei exportieren" can reach:
+
+| Path | Ladder, pre-#189 | Chunk-backed or cached? |
+|---|---|---|
+| `extractDocumentPreview` (non-audio) | `stored_path` → `original_path` → throw `main.docs.previewGone` | no |
+| `extractDocumentPreview` (audio) | stored `chunks` only | **yes — the sole exception** |
+| `extractDocumentPreviewPage` (what the modal actually calls) | thin slice wrapper over the above | no |
+| `readStoredDocumentBytes` ("Originaldatei exportieren") | `stored_path` → `original_path` → throw `main.docs.exportGone` | no |
+| `readStoredDocumentText` (`docs:export`) | same, after a text-extension gate | no |
+| `buildDocumentSegmentReader` (skills / translate / compare) | `extractDocumentPreview` | no |
+
+Three further checks close the fan-in: the modal is opened by `setPreview(await previewDocument(id))`
+in `DocumentsScreen`, so a thrown preview **never opens a modal** (the failure lands in the screen
+banner instead); the modal's own extra sources are the persisted summary and coverage, both
+DB-only, and it is only reachable once the preview resolved; and OCR'd PDFs do **not** qualify as a
+second exception — `ocrPages` feeds the parser, which still needs the file. Even the two German
+strings are near-identical (`main.docs.previewGone` / `main.docs.exportGone` both open "Die
+Dokumentdatei ist nicht mehr vorhanden."), differing only in the trailing infinitive.
+
+So with 24/24 stale under pre-#189 code, **preview failed for every document on that drive**,
+including the generated `.md` row whose `original_path` is null. The two observations therefore
+cannot be concurrent: the contradiction is **TEMPORAL** — two sessions, with the "Vorschau works"
+observation predating the drive-letter change — not per-document. Nothing in the fix depends on
+this; it is recorded because the issue's narrative did.
+
+### §9.2 What is still owner-owned
 
 **Deliberately not built (issue #190 phases 3–4).** No cleanup, no sweep, not even an opt-in one:
-the posture is an owner decision that needs the orphan count and the descriptor version first (D4
-rider above). If it is ever built it must be explicit, owner-confirmed, unlocked-only, and refuse
-to start with an import or a rekey in flight — D4's race is the whole problem. The second-laptop
-continuity check (BUILD_STATE §5 item 1) is likewise a human run, but the diagnostic **doubles as
-its evidence collector**: run it before and after the relocation and the `stale` / `healable` /
-`stored_name populated` triple is exactly the "rows self-heal on first read" proof that check owes,
-in a form that can be pasted into the issue.
+the posture is an owner decision, and it needed the orphan count and the descriptor version first
+(D4 rider above) — which §9.1 now supplies, at n=1 on a v2 vault. If it is ever built it must be
+explicit, owner-confirmed, unlocked-only, and refuse to start with an import or a rekey in flight —
+D4's race is the whole problem. The second-laptop continuity check (BUILD_STATE §5 item 1) is
+likewise a human run, but the diagnostic **doubles as its evidence collector**: the §9.1 run is
+already a valid **"before" snapshot**, and re-running it after the relocation gives the
+`stale` / `healable` / `stored_name populated` triple — exactly the "rows self-heal on first read"
+proof that check owes, in a form that can be pasted into the issue (it should read 0 stale and
+24 populated once each document has been read once).
+
+### §9.3 The password prompt had to bypass `process.stdin` (phase 2)
+
+The first harness prompted only `if (process.stdin.isTTY)`. **Vitest runs every test file in a
+forked worker whose stdin is a pipe**, so that branch is dead in the only process that ever
+executes it — the hidden prompt could not fire from a fully interactive PowerShell, and the failure
+text told the operator to "re-run from an interactive shell", which cannot help. The §9.1 run
+worked only through the env-var fallback, the variant with the shell-history hazard.
+
+**D12 — talk to the console device, not to the process's streams.** `tests/helpers/console-password.ts`
+opens `\\.\CONIN$` / `\\.\CONOUT$` on Windows and `/dev/tty` on POSIX. Two details are load-bearing
+and each cost a probe: the Windows path must be the **device form** (`//./CONIN$`) because libuv
+makes a bare `CONIN$` absolute against the cwd and turns it into ENOENT, and it must be opened
+**read-write** (`r+`) because `SetConsoleMode` needs `GENERIC_READ | GENERIC_WRITE` — a `'r'` open
+fails `setRawMode` with EPERM. The prompt is written to the console handle too, since vitest
+captures `process.stdout`.
+
+**D13 — echo suppression is delegated, and its absence is fatal rather than degraded.** Node
+exposes no console-mode API, so raw mode comes from `tty.ReadStream.setRawMode(true)` — libuv's
+`uv_tty_set_mode(UV_TTY_MODE_RAW)`, which clears `ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT` on Windows
+and drops ECHO/ICANON on POSIX. Raw mode is probed **as part of opening**; if it is refused the
+opener returns `null` and the harness **fails fast** with a copy-pasteable
+`Read-Host -AsSecureString` / `read -rs` recipe for the env var. There is deliberately no cooked
+fallback: a half-hidden prompt echoes the workspace password onto the screen, which is worse than
+no prompt on a product whose premise is that nothing leaves the space.
+
+CI covers everything except a human typing, and the coverage is the defect's own witness rather
+than a simulation of it: `tests/unit/console-password.test.ts` runs **in that same forked worker**,
+so it asserts `process.stdin.isTTY` is falsy directly, then pins the fail-fast message (the recipe,
+the env var, the history hazard, and the *absence* of the "interactive shell" advice), the refusal
+to resolve from a console that could not be put into raw mode, and a source pin on the harness —
+mutation-checked by reinstating the `isTTY` gate, which turns it red.
+
+One more operator-facing correction rides along: `npx` is blocked by the PowerShell execution
+policy on the maintainer's machine (its shim is a `.ps1`), so the header now documents
+`..\..\node_modules\.bin\vitest.cmd run tests/manual/stored-copy-diagnostic.test.ts` from
+`apps/desktop/`.
 
 ## Model occupancy — design record (issues #185/#186, §1–§6)
 

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -20,6 +20,120 @@
 > `../BUILD_STATE.md` pointer above and any `http(s)://` targets; a few `](…)` sequences that were only
 > ever inline code (a regex, an `arr[kind](args)` call) are untouched because they never rendered as links.
 
+_2026-08-19 — **Model occupancy — wave CLOSED (issues #185/#186).**_ The two issues the local-API
+wave filed out of scope were one defect seen from two sides, and were fixed together as both asked.
+"Who has the model" was answered by three registries and one hole: chat had `inFlightStreams`, doc
+tasks had their queue, **skill runs had per-DOCUMENT bookkeeping that is not a global busy signal
+(#186), and the benchmark had nothing at all (#185)** — so `startSkillRun` consulted neither of the
+other two, and two Diagnostics clicks (or one during a chat answer) both reached the model. The
+generation gate could not be the fix: it counts in-flight `chatStream` **pulls**, so a multi-step
+job reads IDLE between two of its own calls and a guard riding it would admit a second job into that
+gap. Shape: a **span** registry (`services/runtime/occupancy.ts`) on the `RuntimeManager`, held by
+the three BACKGROUND lanes only — chat keeps `inFlightStreams` as its one record, and the guards
+compose the sources (`ipc/model-busy.ts`) rather than mirroring them. `isExternallyBusy()` folds the
+spans in, so the local API now waits on a background job honestly instead of slipping into its gap.
+The skill lane is **declared in the descriptor table** (`SkillToolDescriptor.modelLane`), pinned to
+the dispatch by a source test — `'direct'` (redact/edit) takes a span, `'doctask'`
+(`categorize_transactions`) takes NONE, because its model call happens inside a task it enqueues and
+a span there would refuse its own task (the D26 deadlock). Two non-guards are load-bearing: a doc
+task never refuses on the doc-task span it holds itself (the #38 tree→extract chain enqueues from
+inside `run()`), and **chat is never refused by the benchmark** — the first-run benchmark fires right
+after unlock, so it YIELDS instead: the tokens/sec probe re-checks before it starts and on every
+chunk and **discards** a contended reading, which matters because a depressed reading steps the
+profile AND the recommendation down and is then PERSISTED (the one case where the issues'
+"degraded, not corruption" understates it). The discard raises the new persist-canonical
+`warnSpeedSkipped` — never a silent hole. **Durable record:** `docs/architecture.md` "Model
+occupancy — design record (issues #185/#186, §1–§6)" — decisions D1–D8, the full exclusion table,
+the leak posture, and what the wave deliberately did not do. **User-facing:**
+`docs/troubleshooting.md` "The model is busy — one job at a time". Suite 5312/50; 39 new tests in
+`model-occupancy.test.ts` + `model-occupancy-ipc.test.ts`. No hardware gate owed — every lane is
+exercised by scripted fake runtimes.
+
+_2026-08-19 — **MTP speculative decoding — wave CLOSED in code, TWO HARDWARE GATES OWED (issue
+#182).**_ The Qwen3.8 GGUFs already contained a trained-in draft head (`blk.64.nextn.*`) that
+llama-server loaded and ignored — the "unused tensor" warnings in every §4 log were the feature
+sitting unused. `qwen3.8-27b-q4` and `qwen3.8-27b-q5` now carry a new manifest field
+`speculative_decoding: mtp`, worth a **measured +38–45 % decode** on the §9.4 rig. Shape:
+the manifest **opts in**, the start ladder **decides**. The field is a **closed enum** the runtime
+maps to a fixed flag pair, never a free-form arg list — manifests are on-drive and user-editable,
+and `buildArgs` appends extras LAST, so a smuggled `--host 0.0.0.0` would beat the loopback-only
+invariant. Mechanism: a new **rung 1a** above the plain GPU rung, so rung 1 IS the automatic
+fallback (an older runtime, a weight without the head, a driver refusal → one failed attempt, then
+exactly today's behavior). Three guards, all conservative-by-construction because llama.cpp answers
+a VRAM shortfall by *silently offloading fewer layers* rather than failing (the #42 class): the rung
+is skipped unless the session-cached probe shows ONE device with the weight's bytes + 3.5 GiB free
+(the measured sum — it independently reproduces "Q6_K does not fit 24 GB"); a rung-1a start failure
+never persists `gpuAutoDisabled` and latches the model off for the session; a mid-session rung-1a
+crash takes its own handler that restarts **on the GPU** with MTP off, instead of exiling the
+machine to CPU over an optional speed-up. Forced-CPU rungs never carry the flags — that is issue
+gate 3 ("harmless on CPU, or drop it off-GPU") closed structurally, without hardware. "Try GPU
+again" re-arms the latch. **Durable record:** `docs/architecture.md` "MTP speculative decoding —
+design record (issue #182, §1–§7)" — decisions, the precondition arithmetic, the failure paths, and
+what the wave deliberately did not do. Field reference: `docs/model-policy.md` "Manifest fields";
+status + gate figures: `docs/model-benchmarks.md` §9.4 "Gate results". **Both hardware gates RAN
+AND PASSED 2026-08-19 on the i9-9900X + RTX 3090 rig** (tracked in §5 item 8b): the §2 grounded-QA
+re-run with MTP on held score parity inside cross-run tolerance for both quants (q4 F1 .3499 vs
+.3500, q5 .3518 vs .3523; zero hallucinations and 1.0000 unanswerable-abstention held; 92/100 resp.
+91/100 answers byte-identical, every diff a near-tie token flip), and the §9.1 smoke legs on the
+b9849 pin passed for both quants incl. rung-1a selection, full offload with 24 GB headroom (peak
+VRAM 19.7 / 21.5 GiB), clean teardown, and the shim-forced fall-through + re-arm legs. No RAM/VRAM
+line was retuned: the manifests keep their pre-MTP measured numbers until re-measured with the
+flag on.
+
+_2026-08-19 — **Portable stored copies — wave CLOSED (issue #188).**_ `documents.stored_path` was
+persisted **absolute** and consumed with a bare `existsSync` at six hand-written ladders, so a
+portable drive returning under a different mount point took **every** stored copy stale at once —
+row intact, bytes intact, only the recorded string wrong. It was the **last absolute path in
+persisted state** (images, skills, checksum cache, runtime marker and `source_relative_path` had
+each already been made portable by a named prior finding), and the vault layer already disagreed:
+rekey enumerates `workspace/documents/` by directory walk. The reported export failure was the
+SMALLEST of three defects sharing that cause: **"Delete document" silently did not delete** — the
+shred's `existsSync` guard conflated "already gone, nothing to do" with "I looked in the wrong
+place", leaving encrypted user content on the drive with no row left to ever reference it
+(**measured** pre-fix, not inferred) — and re-index degraded a healthy row to `failed`. Fixed at
+the **resolver**, not the reporting screen: new `services/ingestion/stored-copy.ts` +
+`documents.stored_name` (portable leaf, lazily healed), adopted by all six sites including the
+shred; `DocumentInfo.storedCopy` so the `⋯` menu stops offering what cannot succeed;
+`original_path` demoted to a sha256-checked last resort. **Durable record:** `docs/architecture.md`
+"Portable stored copies — design record (wave 188, issues #188/#190, §1–§9)" — decisions D1–D6, the
+safety guard the shred rests on, the verified-clean list, and the bundler landmine (§8: a string
+literal ending in the bare word `import` makes electron-vite wedge its CommonJS shim inside the
+literal; typecheck and the full suite pass and only `npm run build` fails — now tripwired in
+`repo-hygiene.test.ts`, and the standing argument for the typecheck → build → test gate order).
+**STILL OPEN, both now tracked in issue #190 (see the 2026-08-20 entry above):** the real
+relocated-drive run (the code is now correct; the second-laptop continuity check is only *answered*
+by hardware), and the read-only root-cause diagnostic on the reporting drive — which §6 wrongly
+claimed already existed. It has since been REBUILT and CI-proven (§9); running it on that drive
+needs the owner's password and would settle whether its rows are in fact stale (the issue reports
+"Vorschau works" alongside the export failure, and preview and export share one ladder, so both
+cannot describe the same document) and count the orphaned `.enc` files past silent deletes left
+behind.
+
+_2026-08-18 — **Local API endpoint — wave CLOSED (P1–P6), PR #184.**_ The loaded chat model
+can now be used by **other programs on the same computer** through an opt-in, loopback-only,
+OpenAI-compatible endpoint — **off by default**, behind a consent dialog, access-key-protected by
+default, existing only while the workspace is unlocked, and forbiddable by drive policy. The wave
+also closed a latent gap it did not create: every `llama-server` sidecar is now authenticated with
+a per-spawn env-delivered key, redacted from every stderr-derived surface. **Durable record:**
+`docs/architecture.md` "Local API endpoint — design record (wave local-api, PR #184, §1–§9)" —
+decisions D1–D9, owner options O1–O6, the as-built gate/HTTP/UX design, the deliberate omissions,
+what the audits changed, and the §-anchor legend for the retired plan's citations. **Security half:**
+`docs/security-model.md` "The fifth threat: same-machine processes". **Wire contract:**
+`docs/data-contracts.md`. **User-facing:** `PRIVACY.md`, `SECURITY.md`, `docs/user-guide.md`
+("Use HilbertRaum from other apps"), `docs/troubleshooting.md` ("Connecting another app").
+Citations use PR # + the `local-api-p<N>` phase prefix + a record §, never a branch SHA (O6 —
+the repo squash-merges). **Filed out of scope, deliberately** (pre-existing in-app concurrency the
+new gate makes visible but does not serialize): the benchmark has no re-entrancy guard, and a skill
+run can generate alongside a chat stream — filed as **#185** and **#186** (both CLOSED 2026-08-19, see the model-occupancy entry above). **Post-closeout fix (owner decision 2026-08-18, prompted by a REAL attached drive):** a `policy.json` that PREDATES `allow_local_api` now inherits the permissive default instead of a packaged build's STRICT base — otherwise every drive already in the field would have read "turned off by your drive's policy" with no way to distinguish that from a deliberate ban. An explicit `false` still denies (O4 intact); a junk value and a malformed file still fail closed. Recorded as **O4b** in the design record. **Real-model smoke DONE 2026-08-18** on a real attached drive (H:, prepared "lite", encrypted
+workspace, pinned b9849 vulkan engine) against `gemma4-e2b-it-qat-q4` on GPU: default-off proven
+with the vault unlocked, 401 unauthenticated, a real non-streaming completion and a full streaming
+one, every Host/Origin/method/type refusal, **O5's dual loopback vindicated** (both `::1` and
+`localhost` answer on this Win11 box), 4×~10k-char endurance streams, **D8 pre-emption**
+(`preempted_by_user`, `[DONE]` absent) and **D7 lock kill** (`server_stopped` 449 ms BEFORE the
+vault teardown — the pinned stop-first order). Evidence table in the design record §9. Remaining
+manual gap: no PACKAGED-build smoke (this was a dev run via `HILBERTRAUM_DRIVE_ROOT`), and the
+key-off/regenerate dialogs were not captured.
+
 _2026-08-16 — **Qwen3.8-27B wave PROMOTED (same branch `bench/qwen3.8-27b-wave` / PR #178): full generational handover ratified by the owner — `qwen3.8-27b-q4` rank 3 takes 24 GB, `qwen3.8-27b-q5` rank 3 takes ≥32 GB, the Qwen3.6 pair drops to rank 1, `qwen3.8-27b-q6` enters rank 0 as the selectable 24 GB-GPU quality ceiling; license review + real HF-LFS hashes + §9.1 smokes ALL discharged.**_
 Everything the promotion gate requires, in one pass: (1) license review APPROVED per manifest (base + unsloth GGUF both apache-2.0 via HF API, LICENSE blob verified; full record `offline-intelligence-private/legal/model-licensing-qwen38-addendum-2026-08-16.md`); (2) three manifests with HF-LFS OID hashes independently confirmed by on-disk SHA-256 (the G2/G3 provenance discipline met on day one — no local-test-stub phase); (3) **§9.1 smokes PASSED all legs for all three quants, ON THE b9849 PIN** (CDP/`_electron` dev build; in-app sha256 verify 66/76/90 s, balanced 0 reasoning frames / Deep 34-36, grounded `[S1]` cite from an imported doc, abort ends stream ≤5 ms, VmHWM 17.14/19.68/22.52 GiB, clean stop + quit teardowns) — which also discharges the §9.4 b10430-basis runtime-compat caveat; (4) mapping pins updated (`benchmark.test.ts`, `committed-catalog.test.ts` incl. a new Qwen3.8 wave block) + docs swept (model-benchmarks §6.4 amendment + §9.4 outcome/smoke records, model-policy, benchmark.md, README, CHANGELOG). UD-Q4_K_XL deliberately got NO manifest (out-decoded by q5 at equal quality). Durable record: **model-benchmarks.md §9.4 "Wave outcome — RATIFIED"**. Residual: none for the catalog; the G1 `licenses/`-folder item (drive preload artifacts) is unchanged and only bites a future preload.
 


### PR DESCRIPTION
Phases 1 and 2 of issue #190: the read-only stored-copy diagnostic, rebuilt and CI-proven — **and now RUN, on the real prepared drive (`G:\`, 2026-08-20), which came back byte-identical.** **No cleanup or sweep is built here** — #190 checkbox 2 is an owner decision, and the number it waits on now exists: **one orphan, 115.2 KiB, on a v2 descriptor.**

> ⚠️ **The run refuted this PR’s own leading hypothesis for checkbox 3.** Audio rows are **0**. The "one audio document" explanation is dead; see [#190 checkbox 3](#190-checkbox-3--refuted-and-replaced) below for the verified replacement.

## The correction that started this

`docs/architecture.md` "Portable stored copies" **§6** said the #188 root-cause diagnostic *"was written and smoke-tested against a synthetic vault"* and only needed the owner's password.

**It never existed.** It lived in the git-excluded working paper (`plans/issue-188-stored-path-portability.md`) and went with it at close-out; nothing matching it was ever committed on any branch. So #190 checkbox 1 was never hardware-blocked the way the issue says — it was ordinary CI-able work, and that is what this PR does. §6 now carries the correction, and a new **§9** records the tool as built.

The lesson is the doc-lifecycle rule's own: a design record may cite a working paper's *reasoning*, never inherit its *artifacts*.

## What was built

Test-tree code on purpose — it must not ship in the app bundle as dead code, and `tsconfig.web.json` already typechecks `tests/`.

| File | What it is |
|---|---|
| `tests/helpers/stored-copy-audit.ts` | **Pure classifier + renderer.** Rows + a directory listing in, report out. No fs, no crypto, no I/O. |
| `tests/helpers/stored-copy-audit-run.ts` | **Read-only collector.** copy → decrypt the COPY → open read-only → probe the schema → query → walk `documents/` → shred the scratch. |
| `tests/helpers/read-only-witness.ts` | **The witness.** Fingerprints a tree (path + size + mtime of every entry). |
| `tests/manual/stored-copy-diagnostic.test.ts` | The env-gated operator shell, in the `tests/manual/*-smoke.test.ts` shape. Hidden password prompt read from the console **device** (phase 2, below). |
| `tests/helpers/console-password.ts` | **Phase 2.** The console password prompt: `\\.\CONIN$` / `/dev/tty`, raw mode, or a fail-fast recipe. Never `process.stdin`. |
| `tests/unit/console-password.test.ts` | **Phase 2.** CI proof for the non-TTY path — the forked worker’s own piped stdin is the witness. |
| `tests/unit/stored-copy-audit.test.ts` | Classifier fixtures, mutation guards, the public-safety assertion, the `node:sqlite` `{ readOnly: true }` floor probe. |
| `tests/integration/stored-copy-audit-run.test.ts` | The collector end-to-end against a **synthetic vault** — v2, legacy v1, and `plaintext_dev` — with exact counts. |

### One deviation from the suggested shape, and why

The brief suggested a pure classifier + an env-gated shell + a unit test. I added a **third layer** — the collector as its own helper, exercised end-to-end by an integration test against a synthetic vault built with `createEncryptedVaultOnDisk`.

The reason: with only the suggested split, everything that actually touches a drive (the decrypt, the read-only open, the schema probe, the shred, and above all *"it never writes"*) would be exercised **only** by the hardware-gated manual harness — i.e. proven by nobody until it runs against the one drive that matters. Now the shell contains just the env gate, the password prompt, and printing; everything else is CI. The witness makes "never writes to the drive" an assertion rather than a claim, on the encrypted, v1 and plaintext branches.

## Safety contract

- The drive is touched with `existsSync` / `statSync` / `readdirSync` / `copyFileSync`-as-**source** only.
- Every **mutating** vault entry point is forbidden by name. `unlockEncryptedVault` is not an unlock: it runs `recoverPendingRekey` (commits/discards staged rekeys, can roll a `.recovery` forward **over** the `.enc`) and decrypts a plaintext working DB onto the drive. `openDatabase` runs `db.exec(SCHEMA)` + ~20 `ensureColumn` calls, so merely *opening* writes. Neither, nor `preserveNewerPlaintext` / `lockEncryptedVault`, is ever called against the drive.
- `config/workspace.json` + `hilbertraum.sqlite.enc` are copied to scratch; the **copy** is decrypted and opened `new DatabaseSync(path, { readOnly: true })`. That option is real on the repo's Node floor (`engines.node >= 22.12`) — a CI probe asserts it rather than trusting the docs, and CI runs both ends of the range.
- The minimal unlock is re-composed over the copy from the shipped primitives (`readVaultDescriptor`, `deriveKey`, `verifyKey`, `decrypt` for the v2 envelope unwrap, `decryptFile`). No hand-rolled crypto.
- Keys zeroed; scratch plaintext shredded in a `finally`; a scratch path inside the drive root is refused.
- The whole drive tree is fingerprinted before and after every run and must come back identical.

`stored_name` is **probed** with `PRAGMA table_info`, never assumed — it is added by `ensureColumn` at open (which this tool must not trigger) and the reporting drive predates #189. "Column absent" and "column present but unpopulated" are different findings.

## Output contract

Counts, histograms over two **closed** allowlists, and shape tokens (`<id8> <ext-class> <flags>`). No titles, no content, no paths, no file names; an off-allowlist extension collapses to `other`. `title`, `error_message` and every `*_json` column are never selected. A CI test renders a report from a vault full of distinctive secrets and asserts none survive.

## Mutation record

Seven mutations, each turned the intended test red:

| # | Mutation | Caught by |
|---|---|---|
| a | match `.enc` loosely, so a staged `<id><ext>.enc.new` becomes an orphan | classifier + integration counts |
| b | claim ownership from `stored_path` only | ownership test |
| c | count a row with no `stored_path` as stale | row-ladder tests |
| d | naive `startsWith` in the scratch-containment check (`…/driveX` passes as outside `…/drive`) | `isUnder` test |
| e | select `stored_name` unconditionally | pre-#189-schema test |
| f | `openDatabase` against the drive | the read-only witness, on both branches |
| g | drop the id-based ownership rule (below) | phantom-orphan test |

**(a) is the dangerous one:** `<id><ext>.enc.new` is a live document mid-password-change, and a cleanup built on a count that includes it would delete user data.

**(g) came out of actually running the thing.** The first end-to-end operator smoke against a synthetic drive exposed a hole: a row whose recorded strings are corrupt (the safety guard refuses the leaf) names *nothing*, so its perfectly healthy `<id><ext>.enc` was reported as an orphan. Ownership now has a fourth source — the file's **leading id** — because the store's naming is `<documentId><ext>[.enc]` and the id is a never-reused UUID primary key. Over-counting orphans is the one error direction that can cost data, so ownership is deliberately over-generous.

## #190 checkbox 3 — REFUTED and replaced

**This PR originally argued that "Vorschau works" alongside the export failure was explained by one AUDIO document**, whose preview reads the stored CHUNKS via `audioSegmentsFromChunks` and never touches the file. The measured run killed it: **audio rows = 0.** There is no audio document on that drive — pdf 17 / docx 6 / md 1 is the whole corpus, and every one of those classes needs the file.

**The replacement was verified against the pre-#189 code rather than traced** (it was the same trace that produced the audio hypothesis). Walked directly on `2151e445`, the commit before the #189 fix — every path the Vorschau modal can reach and every path "Originaldatei exportieren" can reach:

| Path | Ladder, pre-#189 | Chunk-backed or cached? |
|---|---|---|
| `extractDocumentPreview` (non-audio) | `stored_path` → `original_path` → throw `main.docs.previewGone` | no |
| `extractDocumentPreview` (audio) | stored `chunks` only | **yes — the sole exception** |
| `extractDocumentPreviewPage` (what the modal actually calls) | thin slice wrapper over the above | no |
| `readStoredDocumentBytes` ("Originaldatei exportieren") | `stored_path` → `original_path` → throw `main.docs.exportGone` | no |
| `readStoredDocumentText` (`docs:export`) | same, after a text-extension gate | no |
| `buildDocumentSegmentReader` (skills / translate / compare) | `extractDocumentPreview` | no |

Three checks close the fan-in: the modal is opened by `setPreview(await previewDocument(id))`, so **a thrown preview never opens a modal** (the failure lands in the screen banner); the modal's only other sources are the persisted summary and coverage, both DB-only and reachable only once the preview resolved; and OCR'd PDFs do **not** qualify as a second exception — `ocrPages` feeds the parser, which still needs the file. The two German strings are near-identical too (`main.docs.previewGone` / `main.docs.exportGone` both open "Die Dokumentdatei ist nicht mehr vorhanden."), differing only in the trailing infinitive.

**So with 24/24 stale under pre-#189 code, preview failed for EVERY document on that drive** — including the generated `.md` row whose `original_path` is null. The two observations cannot be concurrent: the contradiction is **TEMPORAL** — two sessions, the "Vorschau works" observation predating the drive-letter change — not per-document. Nothing in the fix depends on this; it is recorded because the issue's narrative did.

## D4 rider — orphans are NOT inert

The record framed them as pure retention residue. They are also *participants*: `listEncryptedDocSidecars` addresses sidecars by **directory walk**, not by row.

- On a **v1** vault the first password change is the journaled v1→v2 migration, and `stageRekey` runs the full decrypt → re-encrypt → fsync → shred-old → rename cycle over **every orphan too**. Each orphan costs its bytes twice in I/O on the slowest medium the product targets, and the migration transiently needs free space for **every** orphan's `.enc.new` at once — an ENOSPC exposure that scales with orphaned bytes.
- On a **v2** vault a password change is the O(1) `rewrapVaultKey`, so orphans cost nothing there. **That asymmetry is why the report carries the descriptor version.**

(Small precision note on the brief: "every password change re-encrypts them" holds for a **v1** vault's migration, not for v2's O(1) re-wrap.)

None of this changes D4's refusal to build an automatic sweep. It changes what "leave them" costs.

---

# Operator run — DONE (2026-08-20, `G:\`)

The report, verbatim as it will be pasted into #190. **The read-only witness passed: the drive was byte-identical afterwards.**

```
workspace mode          encrypted
vault descriptor        v2
stored_name column      ABSENT (pre-#189 schema)
stored_name populated   0 / 24

(1) documents rows      24        all indexed
(2) stale stored_path   24
(3)   of those healable 24
      of those unnamed   0
(4) no copy anywhere     0
    never stored a copy  0
    resolved as recorded 0
(5) ORPHAN .enc files    1        115.2 KiB   token: 72957f7f pdf <1M
(6) file classes        stored-copy 25 (2.1 MiB); parse-transient 0; rekey-staged 0;
                        write-temp 0; unknown 0
(7) extension classes   pdf 17, docx 6, md 1     -> audio rows 0
(10) at rest            .recovery no, -wal no, -shm no, db .enc.new no
```

- **#188 confirmed outright.** 24/24 stale, 24/24 healable, 0 with no copy anywhere: the drive-letter relocation took the whole corpus stale in one step, every byte is still at the canonical location, and the #189 resolver heals all 24 on first read.
- **Field residue is one orphan, 115.2 KiB, on a v2 descriptor** — the cheap side of the D4-rider asymmetry (a v2 rekey is the O(1) key re-wrap, so it costs nothing at a password change). `documents/` also holds **zero** parse-transients and **zero** staged `.enc.new` files, so nothing is mid-flight.
- `stored_name` was **absent** — the pre-#189 schema the D8 probe exists for.
- One row (`48147f7f`, md) carries no `original_path`: a generated document, which `setDocumentOrigin` nulls by design.

## Phase 2 — the password prompt was broken, and the failure message made it worse

The harness prompted only `if (process.stdin.isTTY)`. **Vitest runs every test file in a forked worker whose stdin is a pipe**, so that branch is dead in the only process that ever executes it — the hidden prompt could not fire from a fully interactive PowerShell. Worse, the failure told the operator to *"re-run from an interactive shell"*, which cannot help; the run above worked only through the env-var fallback, the variant with the shell-history hazard.

**It now reads the console DEVICE directly**, so it works regardless of what vitest does to the worker's streams:

- `\\.\CONIN$` / `\\.\CONOUT$` on Windows, `/dev/tty` on POSIX. Two details are load-bearing and each cost a probe: the Windows path must be the **device form** (`//./CONIN$`) — libuv makes a bare `CONIN$` absolute against the cwd and turns it into ENOENT — and it must be opened **read-write** (`r+`), because `SetConsoleMode` needs `GENERIC_READ | GENERIC_WRITE` and a `'r'` open fails `setRawMode` with EPERM. The prompt is written to the console handle too, since vitest captures `process.stdout`.
- **Echo suppression is delegated, and its absence is fatal rather than degraded.** Node exposes no console-mode API, so raw mode comes from `tty.ReadStream.setRawMode(true)` — libuv's `uv_tty_set_mode(UV_TTY_MODE_RAW)`, which clears `ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT` on Windows and drops ECHO/ICANON on POSIX. Raw mode is **probed as part of opening**; if it is refused the opener returns `null` and the run **fails fast** with a copy-pasteable recipe. There is deliberately no cooked fallback — a half-hidden prompt echoes the workspace password onto the screen.

CI coverage is the defect's own witness rather than a simulation of it: `tests/unit/console-password.test.ts` runs **in that same forked worker**, so it asserts `process.stdin.isTTY` is falsy directly, then pins the fail-fast message (the recipe, the env var, the history hazard, and the *absence* of the "interactive shell" advice), the refusal to resolve from a console that could not be put into raw mode, and a source pin on the harness — mutation-checked by reinstating the `isTTY` gate, which turns it red.

### How to run it (corrected)

From `apps/desktop/`. **Not `npx`** — it is blocked by the PowerShell execution policy on this machine (its shim is a `.ps1`); the `.cmd` shim runs under any policy.

```powershell
cd apps\desktop
$env:HILBERTRAUM_STORED_COPY_AUDIT = "G:\"          # the drive ROOT — the folder holding config\ and workspace\
..\..\node_modules\.bin\vitest.cmd run tests/manual/stored-copy-diagnostic.test.ts
```

```bash
cd apps/desktop
HILBERTRAUM_STORED_COPY_AUDIT=/Volumes/HILBERTRAUM \
  ../../node_modules/.bin/vitest run tests/manual/stored-copy-diagnostic.test.ts
```

Optional: `HILBERTRAUM_STORED_COPY_AUDIT_OUT=<file>` also writes the report to a file you can copy from (refused if that path is on the drive). If there is no console at all (CI, a detached process), the run fails fast with the `Read-Host -AsSecureString` / `read -rs` recipe for `HILBERTRAUM_STORED_COPY_AUDIT_PASSWORD` — typed at a prompt, so it never enters the shell history. Clear it afterwards; while set it is readable in the process environment by anything running as you. A `plaintext_dev` workspace needs no password at all.

### It also doubles as the continuity check's evidence collector

For checkbox 4 / BUILD_STATE §5 item 1 — **the run above is already a valid "before" snapshot.** Re-run it after plugging the drive in under a different letter; the `stale` / `healable` / `stored_name populated` triple across the two reports is exactly the "rows self-heal after the first read" proof that check owes (it should read 0 stale / 24 populated once each document has been read once). It does not replace the functional walk (export original / preview / re-index / delete), but it turns the self-heal half into evidence instead of an eyeball.

# Continuity check — also DONE (2026-08-20, `G:\` → `K:\`)

The drive came back under a different letter mid-review, so #190 checkbox 4 was run too: diagnostic → functional walk in the app → diagnostic, with the app **quit cleanly in between** (load-bearing — the healed rows live in the plaintext working DB until `lockEncryptedVault` re-encrypts it, so an "after" run against a still-unlocked workspace reads the PRE-walk state and looks like nothing healed).

| | Before walk | After walk |
|---|---|---|
| `stored_name` column | ABSENT (pre-#189) | **present** |
| `stored_name` populated | **0 / 24** | **14 / 24** |
| stale `stored_path` | **24** | **10** |
| resolved as recorded | **0** | **14** |
| ORPHAN `.enc` files | 1 (115.2 KiB) | **1** — unchanged |
| documents rows | 24, all indexed | 24, all indexed |
| at rest | clean | clean |

Per-row tokens moved `EOPSH` → `ENOP` for exactly the 14 documents that were opened.

- **D3's lazy heal works on a relocated drive and heals only what is read** — no startup migration burst, which is what D3 traded a bulk migration away for.
- **D-1 is fixed on hardware.** An import + delete left **no new orphan**; pre-#189 that delete would have left a second one.
- The pre-walk baseline **reproduced the §9.1 report field for field under the new letter**, same orphan token included — so the canonical-location step is genuinely mount-independent, not accidentally right on one drive.
- The vault teardown is clean under the new letter.

**Residual, recorded not glossed:** the delete leg used a post-#189 throwaway row, so D-1's *original* condition — a legacy row whose absolute `stored_path` names the old mount point — is still not exercised directly. Ten such rows remain on that drive.

**Filed out of scope: #194.** The re-index leg succeeded but gave no feedback at all, so "it worked" and "nothing happened" were the same event. Single-document actions return silently from the shared `run()` helper while bulk "Re-index all" toasts and shows a progress bar; the failure path is the unnamed screen banner — **D-3 recurring on a neighbouring action**, which this wave fixed for export and never swept.

Record: `architecture.md` §6 (the "still owed" run is now done) and new **§9.4**.

## Gates

`typecheck` → `build` → `test`, in that order (the §8 bundler-landmine discipline). Full suite **5368 passed / 362 files**, 0 failures (the continuity commit is docs-only). BUILD_STATE.md is back to **1893** of its 2000-line budget: the four CLOSED waves of 2026-08-18/19 (#184 local API, #188, #182 MTP, #185/#186) were retired **verbatim, newest-first** to `docs/build-log.md` before this wave's entry was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


