### PR TITLE
fix(docs-ui): single-document re-index/delete now report success, progress and a named failure (#194)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,109 +19,31 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
-_2026-08-20 — **The diagnostic RAN on the real drive (G:\), and it refuted our own leading
-hypothesis — issue #190 checkbox 1 ANSWERED, checkbox 3 re-answered.**_ Measured, drive byte-identical
-(the read-only witness passed): encrypted workspace, **v2** descriptor, `stored_name` column ABSENT
-(pre-#189 schema), **24 rows, 24 stale, 24 healable, 0 unnamed, 0 with no copy anywhere**; **1 orphan
-`.enc`, 115.2 KiB**; file classes stored-copy 25 (2.1 MiB) with **zero** parse-transients and **zero**
-staged rekey files; extensions pdf 17 / docx 6 / md 1; nothing at rest (.recovery, -wal, -shm,
-`.enc.new` all absent). So **#188 is confirmed outright** — drive-letter relocation took the whole
-corpus stale at once, every byte still at the canonical location, and the #189 resolver heals all 24
-on first read. **But `audio` rows = 0, which kills the record's leading explanation of checkbox 3**
-("one audio document previews from chunks while export fails"). The replacement, re-verified against
-the pre-#189 code rather than traced: `extractDocumentPreview` and `readStoredDocumentBytes` had
-*identical* ladders (`stored_path` → `original_path` → throw), audio was the only chunk-backed branch,
-the Vorschau modal never opens on a failed preview, and there is no cache — so with 24/24 stale,
-preview failed for EVERY document on that drive. The contradiction is **TEMPORAL** (the "Vorschau
-works" observation predates the relocation), not per-document. `architecture.md` §9 and §6 corrected.
-**Harness fix (phase 2):** the password prompt was gated on `process.stdin.isTTY`, which vitest's
-FORKED WORKER makes permanently false — the hidden prompt could never fire from any shell, and the
-failure text told the operator to "re-run from an interactive shell", which cannot help. It now reads
-the console DEVICE directly (`\\.\CONIN$` / `/dev/tty`, opened `r+` so `SetConsoleMode` is permitted,
-raw mode via libuv = echo off); no console ⇒ **fail fast** with the copy-pasteable
-`Read-Host -AsSecureString` / `read -rs` recipe, never a cooked read that would echo the password.
-New `tests/helpers/console-password.ts` + `tests/unit/console-password.test.ts` (5 tests — the
-worker's own non-TTY stdin is the witness; the source pin was mutation-checked). The header now
-carries the invocation that actually works here: `..\..\node_modules\.bin\vitest.cmd` — `npx` is
-blocked by this machine's PowerShell execution policy.
+_2026-08-20 — **Single-document re-index/delete now give feedback — issue #194 CLOSED.**_ Found by
+the #190 continuity check on the relocated drive: the operator clicked re-index and got nothing —
+no success signal, no progress, no error — while the re-index had **succeeded** (all 24 rows still
+`indexed`). A feedback defect on the renderer's shared `run()` helper, which serves re-index AND
+delete and returned silently after its refresh, while the **bulk** twin has toasted and shown a
+determinate bar since M-U6. All three gaps fixed in that one helper: a **success toast naming the
+document** (`docs.reindexDone` / `docs.deleteDone`), a **per-row spinner** (the parent narrows the
+screen-global `busy` scalar to `rowBusy`, PERF-5-style, so the clicked row reads 'Re-indexing…' /
+'Wird gelöscht…' instead of every row's buttons just greying out), and the failure banner
+**prefixed with the title** — which is **#188's D-3 verbatim**, fixed there for export-original and
+never swept onto its neighbours. `run(key, fn)` → `run(kind, d, fn)`; the global `busy` scalar
+STAYS (DR-5 serialization), only its legibility changed. **Not built:** a per-row error surface
+(design-guidelines §6 keeps actionable errors off toasts and a second channel races the banner) and
+a main-owned cancellable job for one document. Record: `architecture.md` **§10** of the Portable
+stored copies record. Four renderer tests, each guard mutation-checked (drop the toast → 2 red;
+disable the `rowBusy` branch → 1 red; revert the title prefix → 1 red).
 
-_2026-08-20 — **Cleanup posture DECIDED (owner): leave the orphans, ship nothing — issue #190
-checkbox 2 closed, and with it the last open item of the wave.**_ The decision D4's rider deferred
-until the count and the descriptor version were known was taken on that evidence: **n=1,
-115.2 KiB, v2**. v2 means a password change is the O(1) `rewrapVaultKey`, so the rider's expensive
-branch (a v1 migration re-encrypting every orphan, with the ENOSPC exposure that scales with
-orphaned bytes) never applies here; what remains is 115 KiB of unreferenced ciphertext beside
-2.1 MiB of live ciphertext under the same key — ~5% of the drive's document ciphertext, and nothing
-at all against an attacker without the password. The load-bearing argument against building even
-the *opt-in* version: a one-time named delete IS safer than a sweep, but the safety comes from **a
-human picked the file**, not from guards — put it in the app and code picks the file again, which
-reinstates D4's race and the D10 over-count hazard (the phantom-orphan bug the first end-to-end
-smoke found). The surface would be Diagnostics-only + unlock-gated + typed confirmation + an
-import/rekey refusal + de-AT copy + tests, i.e. a permanently-reachable delete path over the
-encrypted store shipped for a one-off 115 KiB, for a condition #189 already made unreachable.
-**Revisit trigger** (so this does not decay into "never look again"): any run reporting a **v1**
-descriptor with orphans, or orphan bytes at a material fraction of the store (order >50 files or
->100 MiB) — both already reported by the diagnostic, so no new code is needed to notice. Record:
-`architecture.md` **§9.2 (D14)**, with a pointer from the §3 D4 rider.
-
-_2026-08-20 — **The relocation continuity check RAN — issue #190 checkbox 4 ANSWERED, and #188's
-worst defect is now proven fixed on hardware.**_ The same drive came back under a different letter
-(`G:\` → `K:\`), which is exactly the check BUILD_STATE §5 item 1 has carried as open since wave 188.
-Run as diagnostic → functional walk in the app → diagnostic, with the app **quit cleanly in between**
-— load-bearing, because the healed rows live in the plaintext working DB until `lockEncryptedVault`
-re-encrypts it, so an "after" run against a still-unlocked workspace reads the PRE-walk state and
-looks like nothing healed. Measured: `stored_name` populated **0 → 14 / 24**, stale **24 → 10**,
-resolved-as-recorded **0 → 14**, orphans **1 → 1**, 24 rows all still `indexed`, nothing at rest.
-Per-row tokens moved `EOPSH` → `ENOP` for exactly the 14 documents that were opened. **Four things
-no test could establish:** (1) D3's lazy heal works on a real relocated drive and heals ONLY what is
-read — no startup migration burst, which is what D3 traded a bulk migration away for; (2) **D-1 is
-fixed on hardware** — an import + delete left NO new orphan, where pre-#189 it would have left a
-second one; (3) the pre-walk baseline reproduced the §9.1 report field for field under the new
-letter, same orphan token included, so the canonical-location step is genuinely mount-independent
-rather than accidentally right on one drive; (4) the vault teardown is clean under the new letter.
-**Residual:** the delete leg used a post-#189 throwaway row, so D-1's *original* condition (a legacy
-row whose absolute `stored_path` names the old mount point) is still not exercised directly — 10 such
-rows remain on that drive. **Filed out of scope: #194** — the re-index leg SUCCEEDED but gave the
-operator no feedback of any kind; the single-document path returns silently from the shared `run()`
-helper while bulk "Re-index all" toasts and carries a determinate progress bar, and its failure path
-is the screen-level banner that does not name the document — **D-3 recurring on a neighbouring
-action**, which wave 188 fixed for export and never swept. Record: `architecture.md` §9.4.
-
-_2026-08-20 — **Stored-copy diagnostic REBUILT — issue #190 phase 1 (no hardware, no password, fully
-CI-verified).**_ `architecture.md` §6 said the #188 root-cause diagnostic "was written and
-smoke-tested against a synthetic vault" and only needed the owner's password. **It never existed**:
-it lived in the git-excluded working paper and went with it at close-out — nothing matching it was
-ever committed on any branch. So #190 checkbox 1 was never hardware-blocked; it was ordinary CI-able
-work, and that is what this wave did. §6 now carries the correction and a new **§9** records the
-tool as built. Shape: a **pure classifier + renderer** (`tests/helpers/stored-copy-audit.ts` — rows
-+ a directory listing in, report out, no I/O), a **read-only collector**
-(`stored-copy-audit-run.ts` — copy → decrypt the COPY → open `{ readOnly: true }` → probe the schema
-→ query → walk `documents/` → shred the scratch), a **witness** (`read-only-witness.ts`), the
-env-gated operator shell (`tests/manual/stored-copy-diagnostic.test.ts`), and both CI halves. It is
-test-tree code on purpose — it must not ship in the bundle as dead code, and `tsconfig.web.json`
-already typechecks `tests/`. Three things are load-bearing: every MUTATING vault entry point is
-forbidden by name (`unlockEncryptedVault` commits/discards staged rekeys and can roll a `.recovery`
-over the `.enc`; `openDatabase` writes the schema + ~20 `ensureColumn` calls just by opening), the
-`stored_name` column is **probed** because the reporting drive predates #189, and the report is
-public-issue-safe **by construction** (counts, two closed allowlists, 8-char shape tokens — no
-titles, content, paths or file names, asserted against a vault full of planted secrets). Seven
-mutations each turned the intended test red, incl. the dangerous one — a loose `.enc` match that
-files a live `<id><ext>.enc.new` as an orphan. The first end-to-end operator smoke against a
-synthetic drive earned its keep: it exposed a phantom orphan (a row whose corrupt strings name
-nothing left its healthy copy unclaimed), fixed by making a file’s LEADING id a fourth ownership
-source — over-counting orphans is the one error direction that can cost data.
-**D4 rider:** orphans are NOT inert —
-`listEncryptedDocSidecars` walks the directory, so a **v1** vault's first password change re-encrypts
-every orphan and stages an `.enc.new` for each (a v2 rekey is O(1) and does not); that asymmetry is
-why the report carries the descriptor version. **Deliberately not built:** any cleanup/sweep —
-#190 checkbox 2 is an owner decision that needs the orphan count first. Suite 5363/361 files green.
-
-_Older dated entries (2026-08-19 and earlier) and the Skills S2–S12 handoff sections were
+_Older dated entries (the closed waves through 2026-08-20) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
 retention budget), the 2026-07-11…2026-08-16 closed-wave block on 2026-08-18 (pre-wave archive
 ritual), and the four CLOSED waves of 2026-08-18/19 (local API #184, portable stored copies #188,
-MTP speculative decoding #182, model occupancy #185/#186) on 2026-08-20 for the retention budget —
+MTP speculative decoding #182, model occupancy #185/#186) on 2026-08-20 for the retention budget,
+and the four 2026-08-20 entries of the same now-CLOSED #188/#190 stored-copy wave at the #194
+close-out —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 
@@ -1005,11 +927,12 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    `architecture.md` §9.4. **Residual:** the delete leg used a post-#189 throwaway row, so D-1's
    *original* condition — a legacy row whose absolute `stored_path` names the old mount point — is
    still not exercised directly; 10 such rows remain on that drive if it is ever worth one real
-   document. **Filed out of scope: #194** — the re-index leg succeeded but gave NO feedback at all
-   (the single-document path returns silently from `run()` while bulk "Re-index all" toasts and
-   shows progress; its failure path is the unnamed screen banner — D-3 recurring on a neighbouring
-   action). What is still owed on THIS item is the rest of it: certs, a signed/notarized build, and
-   the fresh-laptop Wi-Fi-off demo.
+   document. **Filed out of scope, then FIXED (2026-08-20): #194** — the re-index leg succeeded but
+   gave NO feedback at all (the single-document path returned silently from `run()` while bulk
+   "Re-index all" toasts and shows progress; its failure path was the unnamed screen banner — D-3
+   recurring on a neighbouring action). Fixed the same day: toast + per-row spinner + named banner,
+   `architecture.md` §10 of the stored-copies record. What is still owed on THIS item is the rest
+   of it: certs, a signed/notarized build, and the fresh-laptop Wi-Fi-off demo.
    **✅ The diagnostic half of issue #190 is DISCHARGED (2026-08-20).** The read-only stored-copy
    diagnostic was RUN on the reporting drive (`G:\`) and the drive came back byte-identical:
    **24 rows, 24 stale, 24 healable**, `stored_name` column absent (pre-#189 schema), **1 orphan

--- a/apps/desktop/src/renderer/screens/DocumentsScreen.tsx
+++ b/apps/desktop/src/renderer/screens/DocumentsScreen.tsx
@@ -500,14 +500,34 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
     }
   }
 
-  async function run(key: string, fn: () => Promise<unknown>): Promise<void> {
-    setBusy(key)
+  // The two blocking single-document actions (re-index, delete). #194: this helper used to take a
+  // bare busy key and, on success, refresh and return SILENTLY — so a re-index of an
+  // already-healthy document redrew an identical list and "it worked" and "nothing happened" were
+  // the same event (measured on the relocated drive in the #190 continuity check; the re-index had
+  // in fact succeeded). It now takes the document itself, which is what all three feedback
+  // channels need:
+  //  · success  → a toast naming the document, mirroring the bulk twin's `docs.reindexAllDone`;
+  //  · progress → `busy` is `${kind}-${d.id}`, which `renderRow` narrows to a per-row spinner
+  //               instead of the screen-global disable being the only signal;
+  //  · failure  → the banner is PREFIXED with the title. That is #188's D-3 verbatim ("the failure
+  //               arrived after the click, on a screen-level banner that did not say which document
+  //               it was about") — fixed there for export-original only, swept onto its neighbours
+  //               here (architecture.md "Portable stored copies" §10).
+  // Delete gets the same treatment on purpose even though its success is self-evidencing (the row
+  // disappears): one helper, one shape, no special case to keep in step.
+  async function run(kind: 'reindex' | 'delete', d: DocumentInfo, fn: () => Promise<unknown>): Promise<void> {
+    setBusy(`${kind}-${d.id}`)
     setError(null)
     try {
       await fn()
       await refresh()
+      // Guarded like every other post-await effect on this screen: the toast host is APP-level, so
+      // an unguarded toast would surface on whatever screen the user navigated to instead.
+      if (mountedRef.current) {
+        showToast(t(kind === 'reindex' ? 'docs.reindexDone' : 'docs.deleteDone', { title: d.title }))
+      }
     } catch (e) {
-      setError(friendlyIpcError(e))
+      setError(`${d.title}: ${friendlyIpcError(e)}`)
     } finally {
       setBusy(null)
     }
@@ -637,7 +657,7 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
     setError(null)
     try {
       if (d.fullyChunked === false) {
-        await run(`reindex-${d.id}`, () => window.api.reindexDocument(d.id))
+        await run('reindex', d, () => window.api.reindexDocument(d.id))
       } else if (d.treeStatus === 'ready') {
         await startTask('extract', d.id)
       } else {
@@ -1014,6 +1034,13 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
       !isDocTaskTerminal(activeTask.status)
         ? activeTask
         : null
+    // #194 gap 2: the same narrowing for the blocking single-document actions. `busy` is one
+    // screen-global scalar (DR-5 — it serializes them deliberately), so before this the ONLY
+    // signal was `disabled={busy !== null}` on every row's buttons: no spinner, no label change,
+    // and re-embedding is not instant, so a long re-index read as a frozen UI. Narrowed here for
+    // the same PERF-5 reason as `rowTask`: `null` for every row but the one actually working.
+    const rowBusy: 'reindex' | 'delete' | null =
+      busy === `reindex-${d.id}` ? 'reindex' : busy === `delete-${d.id}` ? 'delete' : null
     return (
       <DocRow
         key={d.id}
@@ -1033,6 +1060,7 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
         ocrAvailable={ocrAvailable}
         translationAvailable={translationAvailable}
         busy={busy}
+        rowBusy={rowBusy}
         // DR-4: per-row — a stable `false` for every row except the one actually opening.
         previewLoading={previewLoadingId === d.id}
         showCheckbox={Boolean(onAskSelected)}
@@ -1423,7 +1451,7 @@ export function DocumentsScreen({ onAskSelected, onNavigate }: Props = {}): JSX.
         onConfirm={() => {
           const d = confirmDelete
           setConfirmDelete(null)
-          if (d) void run(`delete-${d.id}`, () => window.api.deleteDocument(d.id))
+          if (d) void run('delete', d, () => window.api.deleteDocument(d.id))
         }}
         onCancel={() => setConfirmDelete(null)}
       >

--- a/apps/desktop/src/renderer/screens/documents/DocRow.tsx
+++ b/apps/desktop/src/renderer/screens/documents/DocRow.tsx
@@ -48,6 +48,7 @@ export const DocRow = memo(function DocRow({
   ocrAvailable,
   translationAvailable,
   busy,
+  rowBusy,
   previewLoading,
   showCheckbox,
   isProjectSection,
@@ -91,6 +92,10 @@ export const DocRow = memo(function DocRow({
   /** The TranslateGemma sidecar resolved at startup (TG-3) — gates the Translate item. */
   translationAvailable: boolean
   busy: string | null
+  /** #194: the blocking single-document action running on THIS row, narrowed in the parent
+   *  (`null` — Object.is-stable — for every other row, like `rowTask`). `busy` alone only ever
+   *  said "something, somewhere is running"; this says what is happening HERE. */
+  rowBusy: 'reindex' | 'delete' | null
   previewLoading: boolean
   /** Whether the screen offers selection (i.e. `onAskSelected` is set) — gates the checkbox. */
   showCheckbox: boolean
@@ -107,7 +112,7 @@ export const DocRow = memo(function DocRow({
    *  busy/Cancel pair persisted until reload (full-audit 2026-07-11 F2 rider). */
   onDismissTask: () => void
   onPreview: (d: DocumentInfo) => void
-  run: (key: string, fn: () => Promise<unknown>) => void
+  run: (kind: 'reindex' | 'delete', d: DocumentInfo, fn: () => Promise<unknown>) => void
   onSummarize: (d: DocumentInfo) => void
   setTranslateDoc: (d: DocumentInfo | null) => void
   /** Deep link for the translate model-missing state (TG-3) — opens the AI Model screen. */
@@ -274,7 +279,17 @@ export const DocRow = memo(function DocRow({
       {/* Inline action + overflow (Task 1). While a task runs on this row, a busy/cancel
           pair takes their place. */}
       <div className="doc-row-actions">
-        {rowTask && rowTask.stateUnknown ? (
+        {rowBusy ? (
+          // #194 gap 2: a blocking single-document action (re-index / delete) is running on THIS
+          // row. Same treatment as the doc-task busy state above it — a disabled spinner button
+          // that says what is happening — minus a Cancel, because `IPC.reindexDocument` /
+          // `IPC.deleteDocument` are plain blocking invokes with nothing to cancel. Before this the
+          // click produced no visible change anywhere: the ⋯ menu closed, every row's buttons
+          // greyed out, and a slow re-embed read as a frozen UI (the #190 continuity check).
+          <Button size="sm" disabled title={rowBusy === 'reindex' ? t('docs.reindexTitle') : undefined}>
+            <Spinner /> {t(rowBusy === 'reindex' ? 'docs.reindexBusy' : 'docs.deleteBusy')}
+          </Button>
+        ) : rowTask && rowTask.stateUnknown ? (
           // full-audit 2026-07-11 F2 rider (CODE-6 follow-up): the store gave up polling this task
           // after repeated IPC errors — a labelled, dismissable row (the SkillRunBar SKA-40
           // treatment) instead of a busy/Cancel pair stuck until reload. The backend may genuinely
@@ -336,7 +351,7 @@ export const DocRow = memo(function DocRow({
                 size="sm"
                 disabled={busy !== null}
                 title={t('docs.failed.retryTitle')}
-                onClick={() => void run(`reindex-${d.id}`, () => window.api.reindexDocument(d.id))}
+                onClick={() => void run('reindex', d, () => window.api.reindexDocument(d.id))}
               >
                 {t('docs.failed.retry')}
               </Button>
@@ -345,7 +360,7 @@ export const DocRow = memo(function DocRow({
               size="sm"
               disabled={busy !== null}
               title={t('docs.failed.removeTitle')}
-              onClick={() => void run(`delete-${d.id}`, () => window.api.deleteDocument(d.id))}
+              onClick={() => void run('delete', d, () => window.api.deleteDocument(d.id))}
             >
               {t('docs.failed.remove')}
             </Button>
@@ -426,7 +441,7 @@ export const DocRow = memo(function DocRow({
                   <DropdownMenu.Item
                     className="menu-item"
                     disabled={ACTIVE_STATUSES.has(d.status) || anyTaskActive}
-                    onSelect={() => void run(`reindex-${d.id}`, () => window.api.reindexDocument(d.id))}
+                    onSelect={() => void run('reindex', d, () => window.api.reindexDocument(d.id))}
                   >
                     {t('docs.reindex')}
                   </DropdownMenu.Item>

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -609,7 +609,11 @@ export const de: Record<keyof typeof en, string> = {
   'docs.reindex': 'Neu indexieren',
   'docs.reindexBusy': 'Wird neu indexiert…',
   'docs.reindexTitle': 'Die gespeicherte Kopie erneut lesen und vorbereiten',
+  // #194: Rückmeldung für die Aktionen an einem einzelnen Dokument (siehe en.ts).
+  'docs.reindexDone': '„{title}“ neu indexiert.',
   'docs.delete': 'Löschen',
+  'docs.deleteBusy': 'Wird gelöscht…',
+  'docs.deleteDone': '„{title}“ gelöscht.',
   // Aktionen für eine fehlgeschlagene Zeile (§11.6): kein Vorschau-Knopf (es gibt keinen Text),
   // sondern Entfernen und — nur wenn ein erneuter Versuch helfen kann — „Erneut versuchen".
   'docs.failed.remove': 'Entfernen',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -584,7 +584,14 @@ export const en = {
   'docs.reindex': 'Re-index',
   'docs.reindexBusy': 'Re-indexing…',
   'docs.reindexTitle': 'Read and prepare the stored copy again',
+  // #194: the single-document actions confirm themselves, the way the bulk "Re-index all"
+  // has since M-U6. Re-indexing an already-healthy document leaves the refreshed list looking
+  // identical, so without this "it worked" and "nothing happened" are the same event. Both
+  // toasts name the document, because the row they were fired from may have scrolled away.
+  'docs.reindexDone': '“{title}” re-indexed.',
   'docs.delete': 'Delete',
+  'docs.deleteBusy': 'Deleting…',
+  'docs.deleteDone': '“{title}” deleted.',
   // Failed-import row actions (§11.6 follow-up): a failed import never produced text, so
   // Preview is meaningless — the inline pair becomes Remove (clear the failed entry) and,
   // only when re-indexing could help (a transient read/parse error, NOT an unsupported type),

--- a/apps/desktop/tests/renderer/DocumentsScreen.test.tsx
+++ b/apps/desktop/tests/renderer/DocumentsScreen.test.tsx
@@ -1680,3 +1680,119 @@ describe('DocumentsScreen — export original file (#90)', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// ---- #194: feedback for the two blocking single-document actions -----------------------------
+// Found on the real relocated drive during the #190 continuity check: the operator clicked
+// "Neu aufbereiten" (Re-index) on one document and got nothing — no success signal, no progress,
+// no error — while the re-index had in fact SUCCEEDED. All three channels are asserted here, on
+// the shared `run()` helper (re-index AND delete), because a silent success is indistinguishable
+// from a no-op and that is the whole defect.
+describe('DocumentsScreen — single-document action feedback (#194)', () => {
+  it('a successful single-document re-index toasts, naming the document', async () => {
+    const user = userEvent.setup()
+    const reindexDocument = vi.fn(async () => doc({}))
+    stubApi({ listDocuments: vi.fn(async () => [doc({})]), reindexDocument })
+    render(
+      <ToastProvider>
+        <DocumentsScreen />
+      </ToastProvider>
+    )
+
+    await screen.findByText('contract.pdf')
+    await user.click(screen.getByRole('button', { name: 'More actions for contract.pdf' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Re-index' }))
+    await waitFor(() => expect(reindexDocument).toHaveBeenCalledWith('d1'))
+    // The guard: an already-healthy document redraws an IDENTICAL list, so this toast is the
+    // only thing distinguishing "it worked" from "nothing happened". Deleting the showToast
+    // call in `run()` turns exactly this line red.
+    expect(
+      await screen.findByText('“contract.pdf” re-indexed.', {}, { timeout: 5000 })
+    ).toBeInTheDocument()
+  })
+
+  it('a successful single-document delete toasts too (the shared helper, not a re-index special case)', async () => {
+    const user = userEvent.setup()
+    const deleteDocument = vi.fn(async () => {})
+    const listDocuments = vi
+      .fn<() => Promise<DocumentInfo[]>>()
+      .mockResolvedValueOnce([doc({})])
+      .mockResolvedValue([])
+    stubApi({ listDocuments, deleteDocument })
+    render(
+      <ToastProvider>
+        <DocumentsScreen />
+      </ToastProvider>
+    )
+
+    await screen.findByText('contract.pdf')
+    await user.click(screen.getByRole('button', { name: 'More actions for contract.pdf' }))
+    await user.click(await screen.findByRole('menuitem', { name: /delete/i }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => expect(deleteDocument).toHaveBeenCalledWith('d1'))
+    expect(
+      await screen.findByText('“contract.pdf” deleted.', {}, { timeout: 5000 })
+    ).toBeInTheDocument()
+  })
+
+  it('while a re-index runs, ONLY that row shows the spinner — not the whole list (gap 2)', async () => {
+    const user = userEvent.setup()
+    // Hold the invoke open so the in-flight state is observable: pre-fix the ONLY signal was
+    // `disabled={busy !== null}` on every row, i.e. nothing said which row was working, or that
+    // anything was working at all.
+    let release: (() => void) | null = null
+    const reindexDocument = vi.fn(
+      () => new Promise<DocumentInfo>((resolve) => { release = () => resolve(doc({})) })
+    )
+    stubApi({
+      listDocuments: vi.fn(async () => [doc({}), doc({ id: 'd2', title: 'terms.docx' })]),
+      reindexDocument
+    })
+    render(
+      <ToastProvider>
+        <DocumentsScreen />
+      </ToastProvider>
+    )
+
+    await screen.findByText('contract.pdf')
+    await user.click(screen.getByRole('button', { name: 'More actions for contract.pdf' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Re-index' }))
+
+    // The clicked row says what is happening; the sibling row keeps its ordinary actions.
+    const busyRow = (await screen.findByText('contract.pdf')).closest('.doc-row') as HTMLElement
+    const otherRow = screen.getByText('terms.docx').closest('.doc-row') as HTMLElement
+    expect(await within(busyRow).findByText('Re-indexing…')).toBeInTheDocument()
+    expect(within(otherRow).queryByText('Re-indexing…')).not.toBeInTheDocument()
+    expect(within(otherRow).getByRole('button', { name: /^preview$/i })).toBeInTheDocument()
+
+    await act(async () => { release?.() })
+    await waitFor(() => expect(screen.queryByText('Re-indexing…')).not.toBeInTheDocument())
+  })
+
+  it('a failed single-document re-index names the document on the banner (#188 D-3, recurring)', async () => {
+    const user = userEvent.setup()
+    const reindexDocument = vi.fn(async () => {
+      throw new Error("Error invoking remote method 'reindexDocument': Error: The document file is no longer present.")
+    })
+    stubApi({
+      listDocuments: vi.fn(async () => [doc({}), doc({ id: 'd2', title: 'terms.docx' })]),
+      reindexDocument
+    })
+    render(
+      <ToastProvider>
+        <DocumentsScreen />
+      </ToastProvider>
+    )
+
+    await screen.findByText('contract.pdf')
+    await user.click(screen.getByRole('button', { name: 'More actions for contract.pdf' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Re-index' }))
+    // The screen-level banner sits above a list the user may have scrolled away from, so the
+    // message has to carry the document itself — the fix #188 made for "Export original file"
+    // and did not sweep onto its neighbours. No success toast on a failure.
+    expect(
+      await screen.findByText('contract.pdf: The document file is no longer present.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('“contract.pdf” re-indexed.')).not.toBeInTheDocument()
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10668,7 +10668,7 @@ The wave's working paper is gone; its anchors resolve here:
 | `plan §7` (audit ledger A1–A10) | §8 above |
 | `plan §8` (six-persona ledger) | §8 above |
 
-## Portable stored copies — design record (wave 188, issues #188/#190, §1–§9)
+## Portable stored copies — design record (wave 188, issues #188/#190/#194, §1–§10)
 
 _Issue **#188** was filed as a UI defect: "Originaldatei exportieren" failed with "Die
 Dokumentdatei ist nicht mehr vorhanden" on a real prepared drive whose `workspace/documents/`
@@ -11179,7 +11179,75 @@ operator no feedback of any kind — "it worked" and "nothing happened" were the
 single-document path returns silently from the shared `run()` helper while the **bulk** "Re-index
 all" toasts and carries a determinate progress bar. Its failure path is the screen-level banner
 that does not name the document — **D-3 recurring on a neighbouring action**, which this wave fixed
-for export and did not sweep.
+for export and did not sweep. **Fixed — see §10 below.**
+
+### §10 D-3 swept: feedback for the single-document actions (issue #194)
+
+_§9.4's out-of-scope finding, closed. The continuity check's re-index leg **succeeded** and told
+the operator nothing — no success signal, no progress, no error — so "it worked" and "nothing
+happened" were the same event, and it took a diagnostic run to learn which had occurred. A
+feedback defect, not a functional one: all 24 rows were still `indexed` afterwards._
+
+**The screen was inconsistent with itself.** The bulk "Re-index all" is a main-owned job that
+toasts (`docs.reindexAllDone` / `…Cancelled` / `…Partial`) and carries a determinate bar built to
+survive navigation. The single-document twin is a plain blocking `ipcMain.handle(IPC.reindexDocument)`
+that the renderer awaits inside one shared helper — `run()` in `DocumentsScreen.tsx`, which also
+serves **delete** — and that helper refreshed the list and returned silently. Three gaps, all in
+the renderer, all in that helper:
+
+| Gap | Before | After |
+|---|---|---|
+| 1 — success | nothing; a healthy document redraws an IDENTICAL list | a toast naming the document (`docs.reindexDone` / `docs.deleteDone`) |
+| 2 — progress | `disabled={busy !== null}` — every row's buttons grey out, no spinner, no label | the clicked row shows the disabled `<Spinner/>` + "Re-indexing…" / "Deleting…" pair |
+| 3 — failure | the screen-level banner, not naming the document | the banner, **prefixed with the title** |
+
+**Gap 3 is D-3 recurring, not a new finding.** §2's D-3 is verbatim "the failure arrived after the
+click, on a screen-level banner that did not say which document it was about". Wave 188 fixed that
+for `onExportOriginal` and did not sweep the neighbouring single-document actions, so `run()` kept
+the old shape. The fix is the same one line (`${d.title}: ${friendlyIpcError(e)}`), now on the
+helper both actions share.
+
+**Decisions.**
+
+- **D15 — the helper takes the document, not a busy key.** `run(kind, d, fn)` replaces
+  `run(key, fn)` and derives `busy` as `${kind}-${d.id}` itself. All three channels need the
+  document (the toast and the banner need its title, the row needs its id), so threading it once is
+  what makes the three fixes one change instead of three. The five call sites — the ⋯ menu, the
+  failed-row "Try again"/"Remove" pair, the deep-index "Re-index first" chain, and the delete
+  ConfirmDialog — pass it directly.
+- **D16 — delete is covered too, though its success is self-evidencing.** The row disappears, so
+  the toast is redundant *there*; keeping one shape in one helper is worth more than the saved
+  toast, and a special case would drift. Its progress and named failure are not redundant at all.
+- **D17 — the screen-global `busy` scalar STAYS; only its legibility changed.** It serializes the
+  blocking actions deliberately (DR-5: a bulk re-index shares the same scalar, so an import cannot
+  start beside one). What was wrong was that it was the *only* signal. The parent narrows it to a
+  per-row `rowBusy: 'reindex' | 'delete' | null` in `renderRow` — the same PERF-5 discipline as
+  `rowTask` (`null` is Object.is-stable, so the ~all idle rows keep their memo) — and `DocRow`
+  renders the busy pair the doc-task lane already uses, **minus a Cancel**: these IPCs are plain
+  blocking invokes with nothing to cancel, and an enabled Cancel that does nothing is worse than
+  none (the FE-5/GAP-7 honesty rule).
+- **D18 — the toast is fired behind `mountedRef`.** The toast host is app-level, so an unguarded
+  one surfaces on whatever screen the user navigated to while the re-embed ran.
+
+**Deliberately NOT built** (each would be a larger change than the defect):
+
+- **A per-row inline error surface.** The issue notes the banner sits above a list the user may
+  have scrolled away from. Naming the document is exactly the remedy D-3 accepted for export;
+  a second error channel per row races the screen banner and needs its own dismissal story.
+  Design-guidelines §6 also keeps actionable errors OFF toasts, so promoting the failure to a toast
+  was not an option either.
+- **Promoting single-document re-index to a main-owned cancellable job with a determinate bar**
+  (the bulk architecture). A real IPC/lifecycle change for one document; the spinner answers the
+  question the operator actually asked ("is it working?").
+- **The selection toolbar's bulk delete**, which is a different loop and whose success is likewise
+  the rows vanishing.
+
+**Proof.** `tests/renderer/DocumentsScreen.test.tsx` — "single-document action feedback (#194)":
+the success toast for re-index and for delete, the in-flight spinner asserted on the clicked row
+**and its absence on the sibling row**, and a rejected re-index landing on the banner as
+`contract.pdf: …` with no success toast. Each guard was mutation-checked: dropping the `showToast`
+call reds the two toast tests, disabling the `rowBusy` branch reds the spinner test, and reverting
+the title prefix reds the D-3 test.
 
 ## Model occupancy — design record (issues #185/#186, §1–§6)
 

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -20,6 +20,103 @@
 > `../BUILD_STATE.md` pointer above and any `http(s)://` targets; a few `](…)` sequences that were only
 > ever inline code (a regex, an `arr[kind](args)` call) are untouched because they never rendered as links.
 
+_2026-08-20 — **The diagnostic RAN on the real drive (G:\), and it refuted our own leading
+hypothesis — issue #190 checkbox 1 ANSWERED, checkbox 3 re-answered.**_ Measured, drive byte-identical
+(the read-only witness passed): encrypted workspace, **v2** descriptor, `stored_name` column ABSENT
+(pre-#189 schema), **24 rows, 24 stale, 24 healable, 0 unnamed, 0 with no copy anywhere**; **1 orphan
+`.enc`, 115.2 KiB**; file classes stored-copy 25 (2.1 MiB) with **zero** parse-transients and **zero**
+staged rekey files; extensions pdf 17 / docx 6 / md 1; nothing at rest (.recovery, -wal, -shm,
+`.enc.new` all absent). So **#188 is confirmed outright** — drive-letter relocation took the whole
+corpus stale at once, every byte still at the canonical location, and the #189 resolver heals all 24
+on first read. **But `audio` rows = 0, which kills the record's leading explanation of checkbox 3**
+("one audio document previews from chunks while export fails"). The replacement, re-verified against
+the pre-#189 code rather than traced: `extractDocumentPreview` and `readStoredDocumentBytes` had
+*identical* ladders (`stored_path` → `original_path` → throw), audio was the only chunk-backed branch,
+the Vorschau modal never opens on a failed preview, and there is no cache — so with 24/24 stale,
+preview failed for EVERY document on that drive. The contradiction is **TEMPORAL** (the "Vorschau
+works" observation predates the relocation), not per-document. `architecture.md` §9 and §6 corrected.
+**Harness fix (phase 2):** the password prompt was gated on `process.stdin.isTTY`, which vitest's
+FORKED WORKER makes permanently false — the hidden prompt could never fire from any shell, and the
+failure text told the operator to "re-run from an interactive shell", which cannot help. It now reads
+the console DEVICE directly (`\\.\CONIN$` / `/dev/tty`, opened `r+` so `SetConsoleMode` is permitted,
+raw mode via libuv = echo off); no console ⇒ **fail fast** with the copy-pasteable
+`Read-Host -AsSecureString` / `read -rs` recipe, never a cooked read that would echo the password.
+New `tests/helpers/console-password.ts` + `tests/unit/console-password.test.ts` (5 tests — the
+worker's own non-TTY stdin is the witness; the source pin was mutation-checked). The header now
+carries the invocation that actually works here: `..\..\node_modules\.bin\vitest.cmd` — `npx` is
+blocked by this machine's PowerShell execution policy.
+
+_2026-08-20 — **Cleanup posture DECIDED (owner): leave the orphans, ship nothing — issue #190
+checkbox 2 closed, and with it the last open item of the wave.**_ The decision D4's rider deferred
+until the count and the descriptor version were known was taken on that evidence: **n=1,
+115.2 KiB, v2**. v2 means a password change is the O(1) `rewrapVaultKey`, so the rider's expensive
+branch (a v1 migration re-encrypting every orphan, with the ENOSPC exposure that scales with
+orphaned bytes) never applies here; what remains is 115 KiB of unreferenced ciphertext beside
+2.1 MiB of live ciphertext under the same key — ~5% of the drive's document ciphertext, and nothing
+at all against an attacker without the password. The load-bearing argument against building even
+the *opt-in* version: a one-time named delete IS safer than a sweep, but the safety comes from **a
+human picked the file**, not from guards — put it in the app and code picks the file again, which
+reinstates D4's race and the D10 over-count hazard (the phantom-orphan bug the first end-to-end
+smoke found). The surface would be Diagnostics-only + unlock-gated + typed confirmation + an
+import/rekey refusal + de-AT copy + tests, i.e. a permanently-reachable delete path over the
+encrypted store shipped for a one-off 115 KiB, for a condition #189 already made unreachable.
+**Revisit trigger** (so this does not decay into "never look again"): any run reporting a **v1**
+descriptor with orphans, or orphan bytes at a material fraction of the store (order >50 files or
+>100 MiB) — both already reported by the diagnostic, so no new code is needed to notice. Record:
+`architecture.md` **§9.2 (D14)**, with a pointer from the §3 D4 rider.
+
+_2026-08-20 — **The relocation continuity check RAN — issue #190 checkbox 4 ANSWERED, and #188's
+worst defect is now proven fixed on hardware.**_ The same drive came back under a different letter
+(`G:\` → `K:\`), which is exactly the check BUILD_STATE §5 item 1 has carried as open since wave 188.
+Run as diagnostic → functional walk in the app → diagnostic, with the app **quit cleanly in between**
+— load-bearing, because the healed rows live in the plaintext working DB until `lockEncryptedVault`
+re-encrypts it, so an "after" run against a still-unlocked workspace reads the PRE-walk state and
+looks like nothing healed. Measured: `stored_name` populated **0 → 14 / 24**, stale **24 → 10**,
+resolved-as-recorded **0 → 14**, orphans **1 → 1**, 24 rows all still `indexed`, nothing at rest.
+Per-row tokens moved `EOPSH` → `ENOP` for exactly the 14 documents that were opened. **Four things
+no test could establish:** (1) D3's lazy heal works on a real relocated drive and heals ONLY what is
+read — no startup migration burst, which is what D3 traded a bulk migration away for; (2) **D-1 is
+fixed on hardware** — an import + delete left NO new orphan, where pre-#189 it would have left a
+second one; (3) the pre-walk baseline reproduced the §9.1 report field for field under the new
+letter, same orphan token included, so the canonical-location step is genuinely mount-independent
+rather than accidentally right on one drive; (4) the vault teardown is clean under the new letter.
+**Residual:** the delete leg used a post-#189 throwaway row, so D-1's *original* condition (a legacy
+row whose absolute `stored_path` names the old mount point) is still not exercised directly — 10 such
+rows remain on that drive. **Filed out of scope: #194** — the re-index leg SUCCEEDED but gave the
+operator no feedback of any kind; the single-document path returns silently from the shared `run()`
+helper while bulk "Re-index all" toasts and carries a determinate progress bar, and its failure path
+is the screen-level banner that does not name the document — **D-3 recurring on a neighbouring
+action**, which wave 188 fixed for export and never swept. Record: `architecture.md` §9.4.
+
+_2026-08-20 — **Stored-copy diagnostic REBUILT — issue #190 phase 1 (no hardware, no password, fully
+CI-verified).**_ `architecture.md` §6 said the #188 root-cause diagnostic "was written and
+smoke-tested against a synthetic vault" and only needed the owner's password. **It never existed**:
+it lived in the git-excluded working paper and went with it at close-out — nothing matching it was
+ever committed on any branch. So #190 checkbox 1 was never hardware-blocked; it was ordinary CI-able
+work, and that is what this wave did. §6 now carries the correction and a new **§9** records the
+tool as built. Shape: a **pure classifier + renderer** (`tests/helpers/stored-copy-audit.ts` — rows
++ a directory listing in, report out, no I/O), a **read-only collector**
+(`stored-copy-audit-run.ts` — copy → decrypt the COPY → open `{ readOnly: true }` → probe the schema
+→ query → walk `documents/` → shred the scratch), a **witness** (`read-only-witness.ts`), the
+env-gated operator shell (`tests/manual/stored-copy-diagnostic.test.ts`), and both CI halves. It is
+test-tree code on purpose — it must not ship in the bundle as dead code, and `tsconfig.web.json`
+already typechecks `tests/`. Three things are load-bearing: every MUTATING vault entry point is
+forbidden by name (`unlockEncryptedVault` commits/discards staged rekeys and can roll a `.recovery`
+over the `.enc`; `openDatabase` writes the schema + ~20 `ensureColumn` calls just by opening), the
+`stored_name` column is **probed** because the reporting drive predates #189, and the report is
+public-issue-safe **by construction** (counts, two closed allowlists, 8-char shape tokens — no
+titles, content, paths or file names, asserted against a vault full of planted secrets). Seven
+mutations each turned the intended test red, incl. the dangerous one — a loose `.enc` match that
+files a live `<id><ext>.enc.new` as an orphan. The first end-to-end operator smoke against a
+synthetic drive earned its keep: it exposed a phantom orphan (a row whose corrupt strings name
+nothing left its healthy copy unclaimed), fixed by making a file’s LEADING id a fourth ownership
+source — over-counting orphans is the one error direction that can cost data.
+**D4 rider:** orphans are NOT inert —
+`listEncryptedDocSidecars` walks the directory, so a **v1** vault's first password change re-encrypts
+every orphan and stages an `.enc.new` for each (a v2 rekey is O(1) and does not); that asymmetry is
+why the report carries the descriptor version. **Deliberately not built:** any cleanup/sweep —
+#190 checkbox 2 is an owner decision that needs the orphan count first. Suite 5363/361 files green.
+
 _2026-08-19 — **Model occupancy — wave CLOSED (issues #185/#186).**_ The two issues the local-API
 wave filed out of scope were one defect seen from two sides, and were fixed together as both asked.
 "Who has the model" was answered by three registries and one hole: chat had `inFlightStreams`, doc


### PR DESCRIPTION
Closes #194.

Found on the real relocated drive during the #190 continuity check: the operator clicked "Neu aufbereiten" on a document and got **nothing** — no success signal, no progress, no error — while the re-index had in fact **succeeded** (the diagnostic afterwards showed all 24 rows still `indexed`). A feedback defect, not a functional one; but "it worked" and "nothing happened" were the same event from the operator's chair.

The screen was inconsistent with itself: the bulk **Re-index all** toasts and carries a determinate, navigation-surviving progress bar, while the single-document twin awaited a plain blocking invoke inside the shared `run()` helper and returned silently.

## What changed

All three gaps close in that one helper, which serves **re-index and delete** — so both are covered rather than re-index being special-cased.

| Gap | Before | After |
|---|---|---|
| 1 — success | nothing; an already-healthy document redraws an identical list | a toast naming the document (`docs.reindexDone` / `docs.deleteDone`) |
| 2 — progress | `disabled={busy !== null}` — every row's buttons grey out, no spinner, no label | the clicked row shows the disabled `<Spinner/>` + "Re-indexing…" / "Deleting…" pair |
| 3 — failure | the screen-level banner, not naming the document | the banner, **prefixed with the title** |

**Gap 3 is #188's D-3 recurring, not a new finding** — verbatim: *"the failure arrived after the click, on a screen-level banner that did not say which document it was about."* Wave 188 fixed that for `onExportOriginal` and never swept the neighbouring single-document actions.

Mechanics: `run(key, fn)` → `run(kind, d, fn)` (all five call sites pass the document — the ⋯ menu, the failed-row Try again/Remove pair, the deep-index re-index-first chain, the delete ConfirmDialog). The parent narrows the screen-global `busy` scalar to a per-row `rowBusy`, the same PERF-5 discipline as `rowTask` (`null` is Object.is-stable, so idle rows keep their memo). The scalar itself **stays** — it serializes the blocking actions deliberately (DR-5); only its legibility changed. The row spinner has no Cancel: `IPC.reindexDocument` / `IPC.deleteDocument` are plain blocking invokes with nothing to cancel, and an enabled Cancel that does nothing is worse than none (FE-5/GAP-7).

## Deliberately not built

- **A per-row inline error surface.** Naming the document is exactly the remedy D-3 accepted for export; a second per-row error channel races the screen banner and needs its own dismissal story. `design-guidelines.md` §6 also keeps actionable errors off toasts, so promoting the failure to a toast was not an option either.
- **Promoting single-document re-index to a main-owned cancellable job with a determinate bar** (the bulk architecture) — a real IPC/lifecycle change for one document; the spinner answers the question actually asked ("is it working?").
- **The selection toolbar's bulk delete** — a different loop, and its success is the rows vanishing.

## Tests

`tests/renderer/DocumentsScreen.test.tsx` — "single-document action feedback (#194)": the success toast for re-index and for delete, the in-flight spinner asserted on the clicked row **and its absence on the sibling row**, and a rejected re-index landing on the banner as `contract.pdf: …` with no success toast.

Each guard mutation-checked: dropping the `showToast` call reds the two toast tests, disabling the `rowBusy` branch reds the spinner test, reverting the title prefix reds the D-3 test.

## Docs

- `docs/architecture.md` — **§10** of the Portable stored copies record (its §9.4 filed this out of scope; the note now points at §10). §1–§9 anchors unchanged.
- `BUILD_STATE.md` — new entry; the §5 continuity-check item updated. The four CLOSED #188/#190 entries were retired **verbatim** to `docs/build-log.md` (newest-first) for the retention budget first — the file was at 1944 of its hard 2000-line limit.

## Gates

`typecheck` → `build` → `test`, in that order, all green (**5372 passed**, 362 files). App launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
