### PR TITLE
docs(local-api): document the local API as a first-class release feature (O2 lifted)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,29 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-20 — **Upstream deleted the three Qwen3.8 GGUFs — issue #196, catalog + product fix
+landed, the successor measurement wave stays OPEN.**_ Unsloth restructured
+`unsloth/Qwen3.8-27B-GGUF` for Dynamic 3.0 and removed the static K-quants: all three pinned URLs
+return **404** (re-verified here 2026-08-20 with `HEAD`). Blast radius measured, not assumed —
+**all 28 committed `download.url`s re-checked: only these three are dead**, and the Qwen3.6 pair is
+intact (URL alive AND upstream LFS OIDs still equal the committed hashes). Drives that already
+carry a Qwen3.8 weight are unaffected (local SHA-256 still verifies; MTP unchanged). Shipped: a new
+optional manifest field **`download.withdrawn`** (a dated note) that the planner turns into a
+`source-withdrawn` task ahead of the license gate, so the in-app downloader refuses by name before
+any request, the AI-Model card shows the reason instead of a Download button, and both
+`fetch-models` twins skip with a loud line instead of burning retries on a known-dead link. Catalog:
+`qwen3.8-27b-q4/-q5` **rank 3 → 0** (selectable, never auto-recommended — the existing rank-0
+convention) and the §9.4 generational handover **reverted**: `qwen3.6-27b-q4` retakes 24 GB,
+`qwen3.6-27b-q5` retakes ≥32 GB, both at rank 3. **Not built (deliberate):** the `UD-*` successor
+manifests — numbers are measured, never estimated, so they need the per-quant rig wave (§9.4
+method) **plus** a per-file MTP re-verification, since Dynamic 3.0 publishes the draft head as a
+SEPARATE file while `speculative_decoding: mtp` asserts an in-GGUF head. Verified upstream
+size/OID data for the three candidates is recorded in the §9.5 record so the wave starts from data.
+Records: `model-benchmarks.md` **§9.5**, `model-policy.md` "Withdrawn upstream sources",
+`architecture.md` In-app downloader ("a fourth refusal"). Tests: validator, planner, downloader,
+Models screen and both fetch twins, plus a general catalog invariant — *no committed manifest is
+both recommended and unobtainable*; the planner + renderer guards mutation-checked (5 red / 2 red).
+
 _2026-08-20 — **Single-document re-index/delete now give feedback — issue #194 CLOSED.**_ Found by
 the #190 continuity check on the relocated drive: the operator clicked re-index and got nothing —
 no success signal, no progress, no error — while the re-index had **succeeded** (all 24 rows still

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -19,6 +19,30 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-20 — **Local API documented as a first-class feature for the release — docs-only, O2
+lifted.**_ The local-API wave shipped under owner option **O2 "not promoted"** (one CHANGELOG
+line, no README push, ship one release quietly first). With the release now being prepared, the
+owner lifted that hold; this pass writes the feature up properly **without touching a line of its
+behaviour** (still default-off, loopback-only, consent-gated, policy-restrictable). New:
+**[`docs/local-api.md`](docs/local-api.md)** — §1–§12, a user tutorial (turn-on flow, the exact
+`127.0.0.1` vs `localhost` trap, port conflicts) plus a **client-author contract** (curl /
+PowerShell / Python + Node `openai` SDK / plain `fetch` examples, the supported-ignored-refused
+field table, both response shapes, the full error-code table with `Retry-After` semantics, the
+timeout/limit table, the concurrency + pre-emption rules, the security-control table, and the
+privacy statement). Updated: `README.md` (feature bullet, docs-table row, an inbound-door
+paragraph under Privacy & security), `PRIVACY.md` (port named; the `local_api_toggled` audit entry
+disclosed as the ONE thing recorded — state only; "completions only, no other model features"),
+`SECURITY.md` (constant-time compare, key at rest + rotation aborting in-flight streams, the 1 MB
+counted-byte body cap and 16-connection ceiling), `known-limitations.md` (a new **Local API**
+section: v1 scope, refused capabilities, ignored sampling extras, absent `usage`, single-slot
+concurrency, no per-connection visibility, the same-machine residual, the upstream
+`/health`+`/v1/models` auth exemption), plus cross-pointers from `user-guide.md`,
+`troubleshooting.md`, `security-model.md`, and `data-contracts.md` (whose §"P3 exposed HTTP
+contract" now names `local-api.md` §6 as the twin that must move with it). The design record's O2
+row carries a dated **superseded** note, which also promotes the wire shape to **externally
+documented**: a status/code-mapping or frame-order change is now a breaking change needing a
+CHANGELOG note. Docs-only — no src/test change, `npm test` unaffected.
+
 _2026-08-20 — **Upstream deleted the three Qwen3.8 GGUFs — issue #196, catalog + product fix
 landed, the successor measurement wave stays OPEN.**_ Unsloth restructured
 `unsloth/Qwen3.8-27B-GGUF` for Dynamic 3.0 and removed the static K-quants: all three pinned URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,14 @@ first public release. Consciously-accepted gaps are tracked in
   for now; bulk export is a possible follow-up.
 - **Local API (optional, off by default)**. Other programs on the same computer
   can be allowed to use the running chat model over a loopback-only,
-  OpenAI-compatible endpoint. It is off until switched on behind a consent
-  dialog, requires an access key by default, never reaches the internet, exposes
-  no documents or conversations, keeps no record of what was asked or answered,
-  exists only while the workspace is unlocked, and can be forbidden by drive
-  policy.
+  OpenAI-compatible endpoint (`http://127.0.0.1:4980/v1` — `GET /v1/models` and
+  `POST /v1/chat/completions`, streaming or not, with JSON-schema-constrained
+  output). It is off until switched on behind a consent dialog, requires an
+  access key by default, never reaches the internet, exposes no documents or
+  conversations, keeps no record of what was asked or answered, exists only
+  while the workspace is unlocked, gives the user's own chat priority over any
+  outside caller, and can be forbidden by drive policy. Full tutorial, client
+  examples, and the wire contract: [`docs/local-api.md`](docs/local-api.md).
 
 ### Changed
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -100,9 +100,9 @@ text to the model you have running and read its answers. It is **off until you t
 turning it on asks you to confirm what it means.
 
 - **It never reaches the internet.** The endpoint listens only on this computer's loopback address
-  (`127.0.0.1` / `::1`). It cannot be reached from your network, and the app has no mode, setting,
-  or policy that would let it be. Web pages are structurally locked out (browser requests are
-  refused and no CORS headers are ever sent).
+  (`127.0.0.1` / `::1`, port 4980 by default). It cannot be reached from your network, and the app
+  has no mode, setting, or policy that would let it be. Web pages are structurally locked out
+  (browser requests are refused and no CORS headers are ever sent).
 - **It is answers only.** Connected apps can ask the model for text. They cannot read your
   documents, your conversations, your search index, or anything else in your workspace — the
   endpoint has no route to any of it.
@@ -110,6 +110,13 @@ turning it on asks you to confirm what it means.
   held in memory for the length of the request and then dropped. They are **never** written to your
   chat history, your documents, or the logs. The app keeps counts only — how many requests were
   answered or refused — so you can see the feature is being used without a record of what was said.
+- **Only the switch itself is recorded.** Turning the feature on or off writes a single entry to
+  your local activity log saying which way you set it (`{ enabled: true }` / `{ enabled: false }`)
+  and nothing else — no port, no caller, no content. That is the same treatment every other
+  privacy-relevant setting gets, and the record never leaves your drive.
+- **It answers with the model you already started.** A connected app cannot start, stop, or switch
+  a model, and it gets no access to embeddings, image analysis, transcription, or translation —
+  only chat completions.
 - **It only exists while your workspace is unlocked**, and it stops the moment you lock or quit.
 - **An access key is required by default**, so another program has to be given the key before it can
   use your model. You can switch that off; the app tells you what that means when you do.
@@ -124,6 +131,9 @@ sync it to its own cloud service as part of its normal behaviour. That would be 
 sending your data somewhere — not HilbertRaum — but the effect on your privacy is the same. Before
 you point a program at your model, check its own logging and sync behaviour, exactly as you would
 before pasting confidential text into it.
+
+The complete description — how to turn it on, what a connected app can and cannot ask for, and
+every control that bounds it — is in [`docs/local-api.md`](docs/local-api.md).
 
 ## Deleting your data
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ leave your device.
 - 🛠️ **Document tasks & skills** — summarize, translate, and compare documents; install reusable
   **skills** for structured extraction (bank statements, invoices, meeting protocols, redaction) —
   see the [skills overview](docs/skills-overview.md) for what each bundled skill can do.
+- 🔌 **Local API (opt-in)** — let other programs *on the same computer* use your running model
+  through an OpenAI-compatible loopback endpoint: point any client at `http://127.0.0.1:4980/v1`.
+  Off by default, never touches the internet, exposes only completions (no documents, no
+  conversations), and keeps no record of what was asked — see **[`docs/local-api.md`](docs/local-api.md)**.
 - 🧳 **Portable & encrypted** — keep models + a password-encrypted workspace on an external drive;
   move between laptops.
 - 🪟 **Cross-platform** — Windows-first, with macOS/Linux supported in the architecture.
@@ -283,6 +287,7 @@ are in **[`docs/model-benchmarks.md`](docs/model-benchmarks.md)**.
 | [`docs/architecture.md`](docs/architecture.md) | System design, services, IPC, runtimes, design records |
 | [`docs/rag-design.md`](docs/rag-design.md) | Retrieval pipeline: ingestion, chunking, hybrid search, rerank |
 | [`docs/security-model.md`](docs/security-model.md) | Threat model, encrypted vault, offline guard, audit log |
+| [`docs/local-api.md`](docs/local-api.md) | The opt-in local API: tutorial, client examples, the full HTTP contract, security & privacy posture |
 | [`docs/design-guidelines.md`](docs/design-guidelines.md) | Design system: tokens, components, UI/UX design records |
 | [`docs/skills-overview.md`](docs/skills-overview.md) | The bundled skills at a glance — what each can do; reviewed on every skill change |
 | [`docs/model-policy.md`](docs/model-policy.md) | Manifest schema, roles, license policy, runtime pinning |
@@ -338,6 +343,13 @@ Nothing you type or import is sent anywhere. The workspace can be **password-enc
 (AES-256-GCM, Argon2id key derivation), an **offline guard** logs (never blocks) any attempt to
 reach a remote host while offline — local `127.0.0.1`/`localhost` connections are exempt — and a
 local audit log records activity **for you** (ids/counts only — never content).
+
+The one inbound door is the **local API**, and it is opt-in: off by default behind a consent
+dialog, loopback-only (`127.0.0.1`/`::1` — no LAN mode exists), alive only while your workspace is
+unlocked, protected by an access key by default, structurally closed to browser JavaScript, and
+limited to chat completions — there is no route to your documents or conversations. A drive policy
+can forbid it outright. Details in [`docs/local-api.md`](docs/local-api.md).
+
 See [`PRIVACY.md`](PRIVACY.md) and [`docs/security-model.md`](docs/security-model.md); report
 vulnerabilities per [`SECURITY.md`](SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,13 @@ HilbertRaum is a **local-first, offline** application. Full details live in
   so browser JavaScript is structurally locked out. It serves **chat completions plus a
   one-model listing and nothing else**: there is no route to documents, conversations, or any
   other workspace data. There is no LAN mode and no setting
-  that could produce one.
+  that could produce one. The access key is compared in constant time, is stored in the workspace
+  database (encrypted at rest with everything else, never in renderer state, never crossing IPC in
+  full), and **rotating it aborts every in-flight request the old key admitted** — auth is checked
+  once at admission, so a live stream must not outlive the credential that let it in. Request
+  bodies are capped at 1 MB counted as bytes arrive (`Content-Length` is never trusted) and
+  connections at 16. The full posture, the wire contract, and the accepted residuals are in
+  [`docs/local-api.md`](docs/local-api.md).
 - **The model sidecars authenticate their own requests** — each `llama-server` spawn is given a
   fresh random API key through its **environment** (never argv, so it is not visible in a process
   list), and the key is redacted from captured stderr before that text can reach an error message,

--- a/apps/desktop/src/main/services/assets.ts
+++ b/apps/desktop/src/main/services/assets.ts
@@ -38,6 +38,7 @@ export type ModelTaskStatus =
   | 'present-verified' // present + real expected hash matches → skip
   | 'present-unverified' // present but the manifest carries a placeholder hash → skip + warn
   | 'license-blocked' // needs fetch but license not approved and no override → refuse
+  | 'source-withdrawn' // needs fetch but the manifest declares the upstream file gone (#196)
 
 export interface ModelDownloadTask {
   id: string
@@ -56,6 +57,8 @@ export interface ModelDownloadTask {
   license: string
   licenseUrl: string | null
   licenseApproved: boolean
+  /** The manifest's `download.withdrawn` note — set exactly when the source is gone (#196). */
+  withdrawn?: string
   status: ModelTaskStatus
 }
 
@@ -73,7 +76,9 @@ export interface PlanModelOptions {
  * are considered (the rest have no upstream source). Filesystem is read (to skip
  * present+verified weights) but the NETWORK IS NOT touched. The license gate refuses to
  * plan a fetch whose manifest `license_review.status` is not `approved` unless
- * `acceptLicense` is set; a present-but-placeholder weight is skipped with a warning.
+ * `acceptLicense` is set; a present-but-placeholder weight is skipped with a warning; a
+ * manifest whose `download.withdrawn` says the upstream file is gone (#196) plans
+ * `source-withdrawn` instead of `download`, so no caller ever requests a known-dead URL.
  */
 export async function planModelDownloads(
   rootPath: string,
@@ -155,6 +160,12 @@ async function planOneFile(
   } else if (check.exists && check.matched === null) {
     // Present but the manifest hash is a placeholder — can't verify, don't re-fetch.
     status = 'present-unverified'
+  } else if (download.withdrawn) {
+    // Absent (or stale) AND the upstream file is gone (#196). Checked BEFORE the license
+    // gate: "this file can no longer be fetched from anywhere" is the fact the caller acts
+    // on, and accepting a license would not conjure the bytes back. A file already present
+    // + verified never reaches here — a withdrawn source never disturbs an installed drive.
+    status = 'source-withdrawn'
   } else {
     // Absent, or present-but-mismatched → must (re)fetch. Gate on the license first.
     status = licenseApproved || opts.acceptLicense ? 'download' : 'license-blocked'
@@ -172,6 +183,7 @@ async function planOneFile(
     license: manifest.license,
     licenseUrl: download.licenseUrl,
     licenseApproved,
+    ...(download.withdrawn ? { withdrawn: download.withdrawn } : {}),
     status
   }
 }
@@ -783,9 +795,11 @@ export function formatAssetPlan(
           ? 'present (placeholder hash — cannot verify) — skip'
           : t.status === 'license-blocked'
             ? `BLOCKED: license "${t.license}" not approved (use --accept-license)`
-            : t.placeholderHash
-              ? `fetch (⚠ placeholder hash — verify with verify-models --generate)`
-              : 'fetch + verify'
+            : t.status === 'source-withdrawn'
+              ? `SKIP: upstream source withdrawn — ${t.withdrawn ?? ''}`
+                : t.placeholderHash
+                  ? `fetch (⚠ placeholder hash — verify with verify-models --generate)`
+                  : 'fetch + verify'
     lines.push(`  · ${t.id}  [${t.status}]`)
     lines.push(`      url:  ${t.url}`)
     lines.push(`      dest: ${t.relPath}`)

--- a/apps/desktop/src/main/services/downloads.ts
+++ b/apps/desktop/src/main/services/downloads.ts
@@ -172,6 +172,19 @@ export class DownloadManager {
       if (tasks.length === 0) {
         throw new Error(tMain('main.download.noSource', { modelId: opts.manifest.id }))
       }
+      // #196: the upstream publisher deleted the exact file this manifest pins. Checked BEFORE
+      // the license gate (the planner orders them the same way) because no acknowledgement can
+      // make a deleted file fetchable — and refused HERE, not only in the renderer, so the
+      // known-dead URL is never requested even if a card offers the button.
+      const withdrawn = tasks.find((t) => t.status === 'source-withdrawn')
+      if (withdrawn) {
+        throw new Error(
+          tMain('main.download.sourceWithdrawn', {
+            modelId: opts.manifest.id,
+            reason: withdrawn.withdrawn ?? ''
+          })
+        )
+      }
       // The license gate is the MODEL's (a vision projector inherits its GGUF's review), so a single
       // blocked file blocks the whole model.
       const blocked = tasks.find((t) => t.status === 'license-blocked')

--- a/apps/desktop/src/main/services/models.ts
+++ b/apps/desktop/src/main/services/models.ts
@@ -911,7 +911,10 @@ function toModelInfo(
         url: manifest.download.url,
         sizeBytes: manifest.download.sizeBytes,
         licenseUrl: manifest.download.licenseUrl,
-        licenseApproved: manifest.licenseReview.status === 'approved'
+        licenseApproved: manifest.licenseReview.status === 'approved',
+        // #196: a known-dead upstream source. Surfaced so the card explains WHY there is no
+        // Download button, instead of offering one that can only end in an HTTP 404.
+        ...(manifest.download.withdrawn ? { withdrawn: manifest.download.withdrawn } : {})
       }
     : undefined
   return {

--- a/apps/desktop/src/renderer/screens/ModelsScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ModelsScreen.tsx
@@ -408,13 +408,26 @@ export function ModelsScreen(): JSX.Element {
     : !(policy?.allowNetworkSetting ?? false)
       ? t('models.downloads.enableInSettings')
       : null
+  // A withdrawn source (#196) is NOT downloadable — the network-gate banner above the list
+  // must not appear for a screen whose only "missing" models can never be fetched anyway.
   const anyDownloadable = models.some(
-    (m) => m.download && (m.state === 'missing' || m.state === 'checksum_failed')
+    (m) => m.download && !m.download.withdrawn && (m.state === 'missing' || m.state === 'checksum_failed')
   )
 
   function downloadSection(m: ModelInfo): JSX.Element | null {
     if (!m.download) return null
     if (m.state !== 'missing' && m.state !== 'checksum_failed') return null
+    // #196: the publisher removed the pinned file. Explain instead of offering a button that
+    // can only end in an HTTP 404 — the main process refuses the start regardless.
+    if (m.download.withdrawn) {
+      return (
+        <div className="download-progress">
+          <Banner tone="info">
+            {t('models.download.withdrawn', { reason: m.download.withdrawn })}
+          </Banner>
+        </div>
+      )
+    }
     const mine = job && job.modelId === m.id ? job : null
     if (mine && JOB_LIVE.has(mine.status)) {
       const pct =

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1111,6 +1111,11 @@ export const de: Record<keyof typeof en, string> = {
   'models.download.titled': '{name} herunterladen ({size})',
   'models.download.resume': 'Download fortsetzen',
   'models.download.start': 'Herunterladen',
+  // #196: Der Anbieter hat genau diese Datei entfernt.
+  'models.download.withdrawn':
+    'Nicht mehr zum Download verfügbar: Der Anbieter hat genau diese Datei entfernt ' +
+    '({reason}). Bereits auf einem Laufwerk vorhandene Kopien funktionieren weiterhin und ' +
+    'bleiben verifizierbar.',
   // In-App-Engine-(llama.cpp + whisper.cpp)-Installer-Banner — sichtbar, wenn eine Engine fehlt.
   'models.engine.title': 'KI-Engine installieren',
   'models.engine.explain':
@@ -2135,6 +2140,10 @@ export const de: Record<keyof typeof en, string> = {
   'main.download.alreadyRunning':
     'Es läuft bereits ein Download. Modelle werden einzeln heruntergeladen.',
   'main.download.noSource': 'Das Modell „{modelId}“ hat keine Download-Quelle in seinem Manifest.',
+  'main.download.sourceWithdrawn':
+    'Der Anbieter von „{modelId}“ hat genau diese Datei entfernt, sie kann daher nicht mehr ' +
+    'heruntergeladen werden ({reason}). Bereits auf diesem Laufwerk vorhandene Modelle ' +
+    'funktionieren weiterhin.',
   'main.download.alreadyVerified': 'Dieses Modell ist bereits heruntergeladen und verifiziert.',
   'main.download.presentUnverified':
     'Die Datei dieses Modells ist bereits vorhanden. Ihr Manifest enthält noch keine echte ' +

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1080,6 +1080,11 @@ export const en = {
   'models.download.titled': 'Download {name} ({size})',
   'models.download.resume': 'Resume download',
   'models.download.start': 'Download',
+  // #196: the publisher removed the exact file this manifest pins. Sentence case, no blame,
+  // and it says what still works — this card is read by someone deciding what to install.
+  'models.download.withdrawn':
+    'No longer available for download: the publisher removed this exact file ({reason}). ' +
+    'Copies already on a drive keep working and stay verifiable.',
   // In-app engine (llama.cpp + whisper.cpp) installer banner — shown when an engine is missing.
   'models.engine.title': 'Install the AI engine',
   'models.engine.explain':
@@ -2080,6 +2085,9 @@ export const en = {
     'downloads and updates” in Settings first.',
   'main.download.alreadyRunning': 'Another download is already running. One model downloads at a time.',
   'main.download.noSource': 'Model "{modelId}" has no download source in its manifest.',
+  'main.download.sourceWithdrawn':
+    'The publisher of "{modelId}" removed this exact file, so it can no longer be ' +
+    'downloaded ({reason}). Models already on this drive keep working.',
   'main.download.alreadyVerified': 'This model is already downloaded and verified.',
   'main.download.presentUnverified':
     'This model’s file is already present. Its manifest carries no real checksum ' +

--- a/apps/desktop/src/shared/manifest.ts
+++ b/apps/desktop/src/shared/manifest.ts
@@ -52,6 +52,22 @@ export interface DownloadSpec {
   sizeBytes: number | null
   /** URL of the model license, shown at the license-acceptance prompt. */
   licenseUrl: string | null
+  /**
+   * WITHDRAWN UPSTREAM SOURCE (issue #196, model-policy.md "Withdrawn upstream sources"):
+   * a short dated note saying the `url` above is known-dead — the publisher deleted or
+   * replaced the exact file this manifest pins. Absent (the normal case) = the source is
+   * live. Present = the app must NOT offer or attempt the fetch: `planModelDownloads`
+   * reports `source-withdrawn` instead of `download`, the in-app downloader refuses to
+   * start with that reason, and the fetch scripts skip the model with a loud line —
+   * instead of everyone rediscovering an HTTP 404 the long way.
+   *
+   * The rest of the block is deliberately KEPT (url, hash, size, license): a manifest whose
+   * weight is already on a drive stays fully usable — the pinned SHA-256 still verifies the
+   * local file — and the dead URL remains the provenance record of what that file is. Such
+   * a manifest also carries `recommendation_rank: 0`, so the picker never recommends a model
+   * a fresh drive can no longer obtain (pinned in `committed-catalog.test.ts`).
+   */
+  withdrawn?: string
 }
 
 /**
@@ -211,11 +227,24 @@ function validateDownloadSubBlock(
   if (licenseUrlRaw !== undefined && licenseUrlRaw !== null && typeof licenseUrlRaw !== 'string') {
     errors.push(`"${label}.license_url" must be a string when present`)
   }
+  // Optional withdrawal note (#196). A non-empty STRING, never a bare `true`: the note is
+  // shown to the user and read by a maintainer months later, so "withdrawn" without a date
+  // and a reason is worse than no field at all.
+  const withdrawnRaw = dl['withdrawn']
+  let withdrawn: string | undefined
+  if (withdrawnRaw !== undefined && withdrawnRaw !== null) {
+    if (typeof withdrawnRaw !== 'string' || withdrawnRaw.trim() === '') {
+      errors.push(`"${label}.withdrawn" must be a non-empty string (a dated reason) when present`)
+    } else {
+      withdrawn = withdrawnRaw.trim()
+    }
+  }
   return {
     url: typeof url === 'string' ? url.trim() : '',
     sha256: dlSha,
     sizeBytes,
-    licenseUrl: typeof licenseUrlRaw === 'string' ? licenseUrlRaw.trim() : null
+    licenseUrl: typeof licenseUrlRaw === 'string' ? licenseUrlRaw.trim() : null,
+    ...(withdrawn ? { withdrawn } : {})
   }
 }
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -528,6 +528,13 @@ export interface ModelDownloadInfo {
    * in-app mirror of the fetch scripts' `--accept-license`).
    */
   licenseApproved: boolean
+  /**
+   * The manifest's `download.withdrawn` note (issue #196) — present only when the pinned
+   * upstream file is gone. The Models screen then shows the note INSTEAD of a Download
+   * button; the main process refuses the start anyway (a renderer bug can only cost the
+   * user a friendly error, never a doomed multi-GB request).
+   */
+  withdrawn?: string
 }
 
 // ---- In-app model downloader (architecture.md "In-app model downloader") ----

--- a/apps/desktop/tests/integration/assets.test.ts
+++ b/apps/desktop/tests/integration/assets.test.ts
@@ -183,6 +183,62 @@ describe('planModelDownloads', () => {
     expect(tasks[0].licenseApproved).toBe(true)
   })
 
+  // Issue #196: unsloth deleted the exact Qwen3.8 files three manifests pinned. The planner is
+  // the ONE place that decides "this file has to come off the network", so the withdrawal is
+  // decided here and every caller (in-app downloader, dry-run report) inherits it.
+  describe('a withdrawn upstream source (issue #196)', () => {
+    const withdrawn = (extra: Record<string, unknown> = {}): ModelManifest =>
+      manifest({
+        license_review: { status: 'approved', reviewed_by: 'me', reviewed_at: '2026-01-01', notes: '' },
+        download: {
+          url: 'https://example.test/qwen3-4b.gguf',
+          sha256: 'REPLACE_WITH_REAL_HASH',
+          size_bytes: 2700000000,
+          license_url: 'https://example.test/license',
+          withdrawn: '2026-08-20: upstream deleted the file'
+        },
+        ...extra
+      })
+
+    it('plans source-withdrawn instead of download when the weight is absent', async () => {
+      const root = tempDir('hilbertraum-assets-')
+      const tasks = await planModelDownloads(root, [withdrawn()], { acceptLicense: true })
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0].status).toBe('source-withdrawn')
+      expect(tasks[0].withdrawn).toContain('2026-08-20')
+    })
+
+    it('outranks the license gate — no acknowledgement can conjure a deleted file back', async () => {
+      const root = tempDir('hilbertraum-assets-')
+      const pending = withdrawn({
+        license_review: { status: 'pending', reviewed_by: null, reviewed_at: null, notes: '' }
+      })
+      const tasks = await planModelDownloads(root, [pending])
+      expect(tasks[0].status).toBe('source-withdrawn')
+    })
+
+    it('never disturbs a drive that already carries the weight', async () => {
+      const root = tempDir('hilbertraum-assets-')
+      const content = 'real-weights'
+      const hash = sha256(content)
+      const m = manifest({
+        sha256: hash,
+        download: { url: 'https://x/y.gguf', sha256: hash, size_bytes: 1, license_url: null, withdrawn: 'gone' }
+      })
+      writeWeight(root, m, content)
+      const tasks = await planModelDownloads(root, [m], { acceptLicense: true })
+      expect(tasks[0].status).toBe('present-verified')
+    })
+
+    it('says so in the dry-run report instead of promising a fetch', async () => {
+      const root = tempDir('hilbertraum-assets-')
+      const tasks = await planModelDownloads(root, [withdrawn()], { acceptLicense: true })
+      const report = formatAssetPlan(tasks, null)
+      expect(report).toContain('source-withdrawn')
+      expect(report).toContain('upstream source withdrawn')
+    })
+  })
+
   it('skips a present + verified weight (real hash matches)', async () => {
     const root = tempDir('hilbertraum-assets-')
     const content = 'real-weights'

--- a/apps/desktop/tests/integration/benchmark.test.ts
+++ b/apps/desktop/tests/integration/benchmark.test.ts
@@ -231,8 +231,8 @@ describe('recommendation per profile', () => {
     expect(recommendModelIdByRam(m, 12, 'chat')).toBe('gemma4-e2b-it-qat-q4') // #153 sub-16 band
     expect(recommendModelIdByRam(m, 16, 'chat')).toBe('qwen3.5-9b-ud-q4kxl') // 8B-class tier
     expect(recommendModelIdByRam(m, 20, 'chat')).toBe('qwen3.5-9b-ud-q4kxl') // 24 GB tier starts at 24
-    expect(recommendModelIdByRam(m, 24, 'chat')).toBe('qwen3.8-27b-q4') // §9.4 handover (Q4)
-    expect(recommendModelIdByRam(m, 32, 'chat')).toBe('qwen3.8-27b-q5') // §9.4 handover (Q5)
+    expect(recommendModelIdByRam(m, 24, 'chat')).toBe('qwen3.6-27b-q4') // §9.5 revert (#196)
+    expect(recommendModelIdByRam(m, 32, 'chat')).toBe('qwen3.6-27b-q5') // §9.5 revert (#196)
   })
 
   it('never auto-recommends the opt-in 30B MoE or the benchmark-loser Granite (real manifests)', () => {

--- a/apps/desktop/tests/integration/committed-catalog.test.ts
+++ b/apps/desktop/tests/integration/committed-catalog.test.ts
@@ -133,9 +133,12 @@ describe('committed catalog — Qwen3.5 Unsloth wave', () => {
 // The Qwen3.6 27B pair: productized from local-test stubs and promoted to rank 3 in the
 // newest-Qwen decision (owner, 2026-07-12, model-benchmarks.md §6.4). These are the #48 tester
 // eval's top quality scorers, and the only promoted models whose promotion the eval AGREES
-// with — pin the full promotion facts so a mis-edit fails CI, not a user's drive.
-describe('committed catalog — Qwen3.6 27B pair (2026-07-12 promotion; rank 1 since the 2026-08-16 §9.4 handover)', () => {
-  it('both Qwen3.6 manifests hold the productization + demoted-rank invariants', () => {
+// with — pin the full promotion facts so a mis-edit fails CI, not a user's drive. The pair
+// carries rank 3 AGAIN since 2026-08-20 (issue #196, §9.5): the Qwen3.8 wave that took the two
+// tiers on 2026-08-16 lost its upstream files, and the tiers came back to the best-measured
+// models that can still be downloaded.
+describe('committed catalog — Qwen3.6 27B pair (2026-07-12 promotion; rank 3 again since #196)', () => {
+  it('both Qwen3.6 manifests hold the productization + tier-pick invariants', () => {
     const byId = Object.fromEntries(committedManifests().map((m) => [m.id, m]))
     for (const id of ['qwen3.6-27b-q4', 'qwen3.6-27b-q5']) {
       const m = byId[id]
@@ -144,9 +147,12 @@ describe('committed catalog — Qwen3.6 27B pair (2026-07-12 promotion; rank 1 s
       expect(m.runtime, `${id} runtime`).toBe('llama_cpp')
       expect(m.format, `${id} format`).toBe('gguf')
       expect(m.family, `${id} family`).toBe('qwen3.6')
-      // Rank 1 since the 2026-08-16 Qwen3.8 handover (owner decision, §6.4 newest-generation
-      // preference; model-benchmarks.md §9.4) — ranked + selectable, below the gemma rank-2s.
-      expect(m.recommendationRank, `${id} rank`).toBe(1)
+      // Rank 3 again since 2026-08-20 (issue #196, §9.5): the 2026-08-16 handover to the
+      // Qwen3.8 pair is reverted because those files are gone from upstream. This pair's own
+      // source is live (URL + LFS OID re-verified 2026-08-20), so it holds the two big tiers.
+      expect(m.recommendationRank, `${id} rank`).toBe(3)
+      // …and its own source must still be fetchable — the whole point of taking the tier back.
+      expect(m.download!.withdrawn, `${id} source live`).toBeUndefined()
       expect(m.recommendedProfiles, `${id} profiles`).toEqual([])
       expect(m.license, `${id} license`).toBe('apache-2.0')
       expect(m.licenseReview.status, `${id} review`).toBe('approved')
@@ -164,17 +170,19 @@ describe('committed catalog — Qwen3.6 27B pair (2026-07-12 promotion; rank 1 s
 })
 
 // The Qwen3.8 wave (2026-08-16 promotion; model-benchmarks.md §9.4): three unsloth quants of
-// Qwen3.8-27B, productized with real HF-LFS hashes on day one. Ranks per the owner's §9.4
-// ratification (full generational handover): q4 rank 3 takes 24 GB, q5 rank 3 takes ≥32 GB,
-// q6 rank 0 BY DESIGN (the "24 GB GPU quality ceiling" selectable — its VRAM-fit niche is not
-// expressible in the RAM-tier picker; the gemma4-31b selectable-ceiling precedent). No
-// UD-Q4_K_XL manifest: measured slower than q5 at equal quality (§9.4).
+// Qwen3.8-27B, productized with real HF-LFS hashes on day one. All three carry rank 0 SINCE
+// 2026-08-20 (issue #196, §9.5): unsloth deleted the static K-quants in their Dynamic 3.0
+// restructure, so the pinned files 404 and a fresh drive cannot obtain them. The MEASUREMENTS
+// are unchanged and the manifests stay as installed-base records — rank 0 only stops the picker
+// from recommending what can no longer be downloaded (q6 was rank 0 by design anyway: the
+// "24 GB GPU quality ceiling" selectable, the gemma4-31b precedent). No UD-Q4_K_XL manifest:
+// measured slower than q5 at equal quality (§9.4).
 const QWEN38_WAVE_FACTS: Record<
   string,
   { rank: number; minRam: number; recRam: number; displayName: string }
 > = {
-  'qwen3.8-27b-q4': { rank: 3, minRam: 21, recRam: 24, displayName: 'Qwen3.8 27B Q4_K_M' },
-  'qwen3.8-27b-q5': { rank: 3, minRam: 23, recRam: 32, displayName: 'Qwen3.8 27B Q5_K_M' },
+  'qwen3.8-27b-q4': { rank: 0, minRam: 21, recRam: 24, displayName: 'Qwen3.8 27B Q4_K_M' },
+  'qwen3.8-27b-q5': { rank: 0, minRam: 23, recRam: 32, displayName: 'Qwen3.8 27B Q5_K_M' },
   'qwen3.8-27b-q6': { rank: 0, minRam: 26, recRam: 32, displayName: 'Qwen3.8 27B Q6_K' }
 }
 
@@ -225,13 +233,49 @@ describe('committed catalog — Qwen3.8 wave (2026-08-16 promotion, §9.4)', () 
     expect(claiming).toEqual(['qwen3.8-27b-q4', 'qwen3.8-27b-q5'])
   })
 
-  it('the rank-3 pair owns exactly the 24 GB and ≥32 GB tiers (no-signal mapping)', () => {
-    const chat = committedManifests()
-    expect(recommendModelIdByRam(chat, 24, 'chat')).toBe('qwen3.8-27b-q4')
-    for (const ram of [32, 48, 64, 128]) {
-      expect(recommendModelIdByRam(chat, ram, 'chat'), `ram=${ram}`).toBe('qwen3.8-27b-q5')
+  // Issue #196: upstream deleted all three pinned files. The catalog says so IN THE MANIFEST
+  // (`download.withdrawn`) rather than leaving everyone to rediscover an HTTP 404 — the
+  // planner, the in-app downloader and both fetch scripts all key off this one field.
+  it('all three manifests declare the withdrawn upstream source, block intact', () => {
+    const byId = Object.fromEntries(committedManifests().map((m) => [m.id, m]))
+    for (const id of Object.keys(QWEN38_WAVE_FACTS)) {
+      const dl = byId[id].download!
+      expect(dl.withdrawn, `${id} withdrawn note`).toMatch(/^2026-08-20: unsloth removed/)
+      // The dead URL + hash + size are KEPT: they are the provenance record of the file that
+      // existing drives carry, and that copy still verifies against this manifest.
+      expect(dl.url, `${id} url kept`).toContain('huggingface.co/unsloth/Qwen3.8-27B-GGUF')
+      expect(dl.sizeBytes, `${id} size kept`).toBeGreaterThan(0)
+      // The fetch scripts read this value with a flat-YAML parser that strips inline comments
+      // at " #" — a note containing one would be silently truncated mid-sentence.
+      expect(dl.withdrawn, `${id} no " #" in the note`).not.toContain(' #')
     }
-    // Below 24 the wave changes nothing (min-21 q4 must not leak into the 16-20 band).
+  })
+
+  // The general rule, not just this wave: a model the app cannot obtain must never be the
+  // auto-pick. Rank 0 is the established "selectable, never recommended" convention.
+  it('no committed manifest is both recommended and unobtainable', () => {
+    const offenders = committedManifests()
+      .filter((m) => m.download?.withdrawn && m.recommendationRank > 0)
+      .map((m) => m.id)
+    expect(offenders).toEqual([])
+  })
+
+  it('hands the 24 GB and ≥32 GB tiers back to the Qwen3.6 pair (no-signal mapping)', () => {
+    const chat = committedManifests()
+    // #196: with the Qwen3.8 pair at rank 0, the tiers return to their pre-§9.4 holders — the
+    // best-measured models whose upstream source is still live.
+    expect(recommendModelIdByRam(chat, 24, 'chat')).toBe('qwen3.6-27b-q4')
+    for (const ram of [32, 48, 64, 128]) {
+      expect(recommendModelIdByRam(chat, ram, 'chat'), `ram=${ram}`).toBe('qwen3.6-27b-q5')
+    }
+    // No Qwen3.8 manifest may be the auto-pick at ANY realistic RAM level any more.
+    for (const ram of [8, 12, 14, 16, 20, 24, 26, 32, 48, 64, 128]) {
+      expect(
+        Object.keys(QWEN38_WAVE_FACTS),
+        `ram=${ram}`
+      ).not.toContain(recommendModelIdByRam(chat, ram, 'chat'))
+    }
+    // Below 24 nothing changed (min-21 q4 never leaked into the 16-20 band either).
     expect(recommendModelIdByRam(chat, 16, 'chat')).toBe('qwen3.5-9b-ud-q4kxl')
     expect(recommendModelIdByRam(chat, 20, 'chat')).toBe('qwen3.5-9b-ud-q4kxl')
   })
@@ -401,21 +445,22 @@ describe('committed catalog — §6.5 speed-signal stepped picks (issue #95)', (
     expect(recommendModelIdByRam(chat, 20, 'chat', slowOnOwnPick(chat, 20))).toBe('gemma4-e2b-it-qat-q4')
     // 24 GB: 27B Q4 crawling steps to the 16-band winner.
     expect(recommendModelIdByRam(chat, 24, 'chat', slowOnOwnPick(chat, 24))).toBe('qwen3.5-9b-ud-q4kxl')
-    // ≥32 GB: 27B Q5 crawling steps to the 24-band winner (qwen3.8 since the §9.4 handover).
-    expect(recommendModelIdByRam(chat, 32, 'chat', slowOnOwnPick(chat, 32))).toBe('qwen3.8-27b-q4')
-    expect(recommendModelIdByRam(chat, 48, 'chat', slowOnOwnPick(chat, 48))).toBe('qwen3.8-27b-q4')
-    expect(recommendModelIdByRam(chat, 128, 'chat', slowOnOwnPick(chat, 128))).toBe('qwen3.8-27b-q4')
+    // ≥32 GB: 27B Q5 crawling steps to the 24-band winner (qwen3.6 again since issue #196 —
+    // the §9.4 handover to qwen3.8 was reverted when upstream deleted those files).
+    expect(recommendModelIdByRam(chat, 32, 'chat', slowOnOwnPick(chat, 32))).toBe('qwen3.6-27b-q4')
+    expect(recommendModelIdByRam(chat, 48, 'chat', slowOnOwnPick(chat, 48))).toBe('qwen3.6-27b-q4')
+    expect(recommendModelIdByRam(chat, 128, 'chat', slowOnOwnPick(chat, 128))).toBe('qwen3.6-27b-q4')
   })
 
   it('an oversized crawl never moves the pick (the #52 lesson, real manifests)', () => {
     const chat = committedManifests()
     // 24 GB box, crawl measured on the manually-started 32 GB-tier Q5: pick unchanged.
     expect(
-      recommendModelIdByRam(chat, 24, 'chat', { tokensPerSecond: 2.0, measuredModelId: 'qwen3.8-27b-q5' })
-    ).toBe('qwen3.8-27b-q4')
+      recommendModelIdByRam(chat, 24, 'chat', { tokensPerSecond: 2.0, measuredModelId: 'qwen3.6-27b-q5' })
+    ).toBe('qwen3.6-27b-q4')
     // 16 GB box, crawl on the 24 GB-tier Q4: pick unchanged.
     expect(
-      recommendModelIdByRam(chat, 16, 'chat', { tokensPerSecond: 2.0, measuredModelId: 'qwen3.8-27b-q4' })
+      recommendModelIdByRam(chat, 16, 'chat', { tokensPerSecond: 2.0, measuredModelId: 'qwen3.6-27b-q4' })
     ).toBe('qwen3.5-9b-ud-q4kxl')
   })
 

--- a/apps/desktop/tests/integration/downloads.test.ts
+++ b/apps/desktop/tests/integration/downloads.test.ts
@@ -220,6 +220,43 @@ describe('download gates', () => {
     ).rejects.toThrow(/no download source/)
   })
 
+  // Issue #196: the publisher deleted the exact file. The main process refuses BEFORE any
+  // request — the Models screen already hides the button, but a renderer bug must never cost
+  // the user a multi-GB request into a known 404.
+  it('a withdrawn upstream source is refused by NAME and never reaches fetch', async () => {
+    const fetchSpy = vi.fn()
+    const mgr = new DownloadManager({ fetchImpl: fetchSpy as unknown as FetchFn })
+    const gone = manifest({
+      download: {
+        url: 'https://example.test/qwen3-4b.gguf',
+        sha256: 'REPLACE_WITH_REAL_HASH',
+        size_bytes: 1000,
+        license_url: 'https://example.test/license',
+        withdrawn: '2026-08-20: upstream deleted the file'
+      }
+    })
+    await expect(mgr.start({ rootPath: tempRoot(), manifest: gone, gates: OPEN })).rejects.toThrow(
+      /removed this exact file/
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('the withdrawal message names the model and the reason (not a bare "nothing to fetch")', async () => {
+    const mgr = new DownloadManager({ fetchImpl: vi.fn() as unknown as FetchFn })
+    const gone = manifest({
+      download: {
+        url: 'https://example.test/qwen3-4b.gguf',
+        sha256: 'REPLACE_WITH_REAL_HASH',
+        size_bytes: 1000,
+        license_url: 'https://example.test/license',
+        withdrawn: '2026-08-20: Dynamic 3.0 restructure'
+      }
+    })
+    await expect(
+      mgr.start({ rootPath: tempRoot(), manifest: gone, gates: OPEN })
+    ).rejects.toThrow(/qwen3-4b-instruct-q4[\s\S]*Dynamic 3\.0 restructure/)
+  })
+
   it('a present + verified weight is refused (nothing to download)', async () => {
     const body = 'verified-weights'
     const m = verifiedManifest(body)

--- a/apps/desktop/tests/integration/script-drift.test.ts
+++ b/apps/desktop/tests/integration/script-drift.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parse as parseYaml } from 'yaml'
@@ -487,6 +487,54 @@ describe('fetch-models — the mismatch re-download deletes only when resume can
         /^"\$[a-z0-9_]*size[a-z0-9_]*"$/i
       )
     }
+  })
+})
+
+describe('fetch-models — a withdrawn upstream source is skipped, never requested (issue #196)', () => {
+  // `assets.ts` (planModelDownloads → 'source-withdrawn') is the source of truth; the two
+  // self-contained scripts re-implement it for machines with no Node. If a twin loses the check,
+  // a drive build spends its retry budget on a URL the manifest already knows is dead — and
+  // reports a download FAILURE for a model nobody can fetch any more.
+  //
+  // Asserted structurally per twin: the `withdrawn` field is read from the manifest, and the
+  // skip branch appears BEFORE the license gate (the planner orders them the same way — no
+  // acknowledgement can bring a deleted file back) and before the download call.
+  it('fetch-models.sh reads download.withdrawn and skips ahead of the license gate', () => {
+    const src = read('scripts/fetch-models.sh')
+    const read_ = src.indexOf('withdrawn="$(field "$mf" withdrawn)"')
+    const skip = src.indexOf('-n "$withdrawn"')
+    const licenseGate = src.indexOf('$ACCEPT_LICENSE -eq 0')
+    const fetchCall = src.indexOf('handle_file "$id" ""')
+    expect(read_, 'fetch-models.sh no longer reads download.withdrawn').toBeGreaterThanOrEqual(0)
+    expect(skip, 'fetch-models.sh no longer branches on a withdrawn source').toBeGreaterThan(read_)
+    expect(skip, 'the withdrawn skip must precede the license gate').toBeLessThan(licenseGate)
+    expect(skip, 'the withdrawn skip must precede the download call').toBeLessThan(fetchCall)
+  })
+
+  it('fetch-models.ps1 reads download.withdrawn and skips ahead of the license gate', () => {
+    const src = read('scripts/fetch-models.ps1')
+    const read_ = src.indexOf("$withdrawn = Get-ManifestField $text 'withdrawn'")
+    const skip = src.indexOf('$needsFetch -and $withdrawn')
+    const licenseGate = src.indexOf('-not $AcceptLicense')
+    const fetchCall = src.indexOf("Invoke-HandleFile $id ''")
+    expect(read_, 'fetch-models.ps1 no longer reads download.withdrawn').toBeGreaterThanOrEqual(0)
+    expect(skip, 'fetch-models.ps1 no longer branches on a withdrawn source').toBeGreaterThan(read_)
+    expect(skip, 'the withdrawn skip must precede the license gate').toBeLessThan(licenseGate)
+    expect(skip, 'the withdrawn skip must precede the download call').toBeLessThan(fetchCall)
+  })
+
+  // Both twins parse flat YAML and strip an inline comment at " #", so a note containing one
+  // would reach the operator truncated mid-sentence. Pinned on the committed manifests because
+  // that is where a maintainer writes the next note.
+  it('no committed manifest hides part of its withdrawal note behind a " #"', () => {
+    const dir = join(REPO_ROOT, 'model-manifests', 'chat')
+    const notes = readdirSync(dir)
+      .filter((f) => f.endsWith('.yaml'))
+      .map((f) => parseYaml(readFileSync(join(dir, f), 'utf8')) as Record<string, unknown>)
+      .map((m) => (m.download as Record<string, unknown> | undefined)?.withdrawn)
+      .filter((n): n is string => typeof n === 'string')
+    expect(notes.length, 'expected the issue-#196 notes').toBeGreaterThan(0)
+    for (const n of notes) expect(n, 'truncated by the scripts\' inline-comment strip').not.toContain(' #')
   })
 })
 

--- a/apps/desktop/tests/renderer/ModelsScreen.test.tsx
+++ b/apps/desktop/tests/renderer/ModelsScreen.test.tsx
@@ -108,6 +108,49 @@ describe('ModelsScreen — download gates (plan §6.1: explain WHY, policy vs Se
     await screen.findByText('Qwen3 4B Instruct')
     expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument()
   })
+
+  // Issue #196: unsloth deleted the Qwen3.8 files three manifests pin. A Download button there
+  // could only end in an HTTP 404 that reads like a broken connection — so the card explains
+  // instead, and says what still works.
+  describe('a withdrawn upstream source (#196)', () => {
+    const gone = (over: Partial<ModelInfo> = {}): ModelInfo =>
+      model({
+        download: {
+          url: 'https://example.test/qwen3-4b.gguf',
+          sizeBytes: 2_900_000_000,
+          licenseUrl: 'https://example.test/license',
+          licenseApproved: true,
+          withdrawn: '2026-08-20: upstream deleted the file'
+        },
+        ...over
+      })
+
+    it('replaces the Download button with the reason, naming what still works', async () => {
+      stub({ models: [gone()] })
+      render(<ModelsScreen />)
+      await screen.findByText('Qwen3 4B Instruct')
+      expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument()
+      expect(screen.getByText(/No longer available for download/)).toBeInTheDocument()
+      expect(screen.getByText(/2026-08-20: upstream deleted the file/)).toBeInTheDocument()
+      expect(screen.getByText(/Copies already on a drive keep working/)).toBeInTheDocument()
+    })
+
+    it('does not raise the network-gate banner when the only "missing" model is unfetchable', async () => {
+      // Downloads disabled by policy + nothing downloadable ⇒ the banner would blame the drive
+      // policy for a model the policy has nothing to do with.
+      stub({ models: [gone()], policy: policyStatus({ downloadsAllowed: false, settingOn: true }) })
+      render(<ModelsScreen />)
+      await screen.findByText('Qwen3 4B Instruct')
+      expect(screen.queryByText(/disabled by this drive’s policy/)).not.toBeInTheDocument()
+    })
+
+    it('says nothing on a card whose weight is already installed', async () => {
+      stub({ models: [gone({ state: 'installed' })] })
+      render(<ModelsScreen />)
+      await screen.findByText('Qwen3 4B Instruct')
+      expect(screen.queryByText(/No longer available for download/)).not.toBeInTheDocument()
+    })
+  })
 })
 
 describe('ModelsScreen — "AI Model" reframe (Phase 26, guidelines §2)', () => {

--- a/apps/desktop/tests/unit/manifest.test.ts
+++ b/apps/desktop/tests/unit/manifest.test.ts
@@ -214,6 +214,52 @@ describe('validateManifest — optional download block (Phase 12)', () => {
     expect(res.ok).toBe(true)
     expect(res.manifest?.download?.sha256).toBe(hash)
   })
+
+  // Issue #196: the publisher deleted the exact file a manifest pins. The block stays (it is the
+  // provenance record of the weight existing drives carry); `withdrawn` marks the URL as dead so
+  // no code path requests it.
+  describe('download.withdrawn (issue #196)', () => {
+    it('is absent by default — every existing manifest keeps a live source', () => {
+      const res = validateManifest(rawManifest({ download: downloadBlock() }))
+      expect(res.ok).toBe(true)
+      expect(res.manifest?.download?.withdrawn).toBeUndefined()
+    })
+
+    it('accepts a dated note and trims it', () => {
+      const note = '2026-08-20: upstream deleted the file (Dynamic 3.0 restructure)'
+      const res = validateManifest(rawManifest({ download: downloadBlock({ withdrawn: `  ${note}  ` }) }))
+      expect(res.ok).toBe(true)
+      expect(res.manifest?.download?.withdrawn).toBe(note)
+    })
+
+    it('rejects an empty note — "withdrawn" with no reason is worse than no field', () => {
+      const res = validateManifest(rawManifest({ download: downloadBlock({ withdrawn: '   ' }) }))
+      expect(res.ok).toBe(false)
+      expect(res.errors.some((e) => e.includes('download.withdrawn'))).toBe(true)
+    })
+
+    it('rejects a boolean — the note is shown to the user, not a flag', () => {
+      const res = validateManifest(rawManifest({ download: downloadBlock({ withdrawn: true }) }))
+      expect(res.ok).toBe(false)
+      expect(res.errors.some((e) => e.includes('download.withdrawn'))).toBe(true)
+    })
+
+    it('applies to an mmproj.download block too (one definition, both slots)', () => {
+      const res = validateManifest(
+        rawManifest({
+          download: downloadBlock(),
+          role: 'vision',
+          mmproj: {
+            local_path: 'models/vision/x-mmproj.gguf',
+            sha256: 'REPLACE_WITH_REAL_HASH',
+            download: downloadBlock({ withdrawn: 5 })
+          }
+        })
+      )
+      expect(res.ok).toBe(false)
+      expect(res.errors.some((e) => e.includes('mmproj.download.withdrawn'))).toBe(true)
+    })
+  })
 })
 
 describe('validateManifest — vision role + mmproj projector (image-understanding §8.1)', () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3304,6 +3304,14 @@ all enforced in MAIN and re-checked per call:**
    or 2 fails the AI Model screen says *why* (policy vs Settings toggle), reusing the
    `PolicyStatus` distinction.
 
+**A fourth refusal, not a gate (issue #196, 2026-08-20):** a manifest whose `download.withdrawn`
+records that the publisher deleted the pinned file is refused BEFORE any request, with copy naming
+the model and the reason — the planner reports `source-withdrawn` ahead of the license gate, the AI
+Model card shows the note instead of a Download button, and the `fetch-models` twins skip such a
+model with a loud line. Nothing about an already-installed weight changes: it verifies and runs as
+before. Schema + rules: model-policy.md "Withdrawn upstream sources"; the case that produced it:
+model-benchmarks.md §9.5.
+
 **Mechanics:** `services/downloads.ts` `DownloadManager` — a job state machine over the
 REUSED `assets.ts` seams (`planModelDownloads` + optional `hashStore`; `downloadToFile`,
 extended additively with `signal`/`headers`/`append`/`onResponse`; `verifyDownloadedFile`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10477,6 +10477,16 @@ embeddings, no workspace data, and the endpoint never starts, stops, or switches
 | O5 | Loopback family | **Bind both `127.0.0.1` and `::1`** — Windows resolves `localhost` to `::1` first and many Electron/Node clients do not address-iterate. The UI still prints the unambiguous `127.0.0.1` form |
 | O6 | Citations under squash-merge | PR# + phase prefix + record §, never a branch SHA |
 
+> **O2 superseded 2026-08-20 (owner decision, pre-release documentation pass).** The "ship one
+> release quietly first" hold is lifted: the feature is now documented as a first-class capability
+> — a dedicated user + client-author reference at [`local-api.md`](local-api.md), a README feature
+> bullet and docs-table row, the `PRIVACY.md`/`SECURITY.md` sections deepened, and its accepted
+> scope limits written up in [`known-limitations.md`](known-limitations.md). Nothing about the
+> feature's behaviour, defaults, or policy posture changed with it: still default-off, still
+> loopback-only, still consent-gated. §5's contract is now **externally documented**, so a change
+> to a status/code mapping or the streaming frame order is a breaking change and needs a
+> `CHANGELOG.md` note (`local-api.md` §12).
+
 ### §4 The generation gate (P1)
 
 The admission decision needs one true answer to "is the model busy?", and generation reaches the

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -113,11 +113,12 @@ that fits the measured RAM, breaking ties on each manifest's `recommendation_ran
 | < 12 GB | `qwen3.5-4b-ud-q4kxl` |
 | 12–15 GB | `gemma4-e2b-it-qat-q4` |
 | 16–20 GB | `qwen3.5-9b-ud-q4kxl` |
-| 24 GB | `qwen3.8-27b-q4` |
-| ≥ 32 GB | `qwen3.8-27b-q5` |
+| 24 GB | `qwen3.6-27b-q4` |
+| ≥ 32 GB | `qwen3.6-27b-q5` |
 
-(This is the newest-Qwen promotion, owner decision 2026-07-12, handed over to the Qwen3.8 pair
-2026-08-16 — see `model-benchmarks.md` §6.4 and the §9.4 wave record — plus the E2B promotion,
+(This is the newest-Qwen promotion, owner decision 2026-07-12; handed to the Qwen3.8 pair 2026-08-16
+and handed BACK on 2026-08-20 when upstream deleted the Qwen3.8 files — see `model-benchmarks.md`
+§6.4, the §9.4 wave record and §9.5 (issue #196) — plus the E2B promotion,
 owner decision 2026-08-09, issue #153 (the 12–15 GB row; §6.5 "#153 amendment"). The **bundled** default on a preconfigured drive stays `qwen3-4b-instruct-q4` — the
 promotions deliberately did NOT change the bundled model; the tiers above are the RAM-best-fit
 recommendation the picker offers, not the bundled pick.)

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -174,7 +174,9 @@ New audit event `local_api_toggled` (metadata `{ enabled: boolean }` ONLY — th
 writes metadata verbatim to plaintext outside the vault); `localApiEnabled` +
 `localApiTokenRequired` join the `privacyKeys` settings_changed allowlist (booleans only, port
 excluded).
-**Local-api wave P3 — the exposed HTTP contract (what external apps code against):**
+**Local-api wave P3 — the exposed HTTP contract (what external apps code against; the
+client-facing rendering of this same contract is [`local-api.md`](local-api.md) §6, which must be
+updated in the same change whenever anything below moves):**
 `LocalApiServer` (`services/local-api/server.ts` + `handlers.ts`) binds **127.0.0.1 AND ::1**
 (O5; never 0.0.0.0; no-IPv6 machines degrade to v4-only), default port **4980** (O1).
 Every response carries `Server: HilbertRaum/<version>`. Pipeline order (security contract):

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -652,7 +652,10 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 
 ### Provisioning / asset loader (Phase 12 live)
 ✅ **Schema** — `shared/manifest.ts` `DownloadSpec` + optional `ModelManifest.download` (validated only
-  when present; real `download.sha256` must equal a real top-level `sha256`). `shared/runtime-sources.ts`
+  when present; real `download.sha256` must equal a real top-level `sha256`). Optional
+  `download.withdrawn?: string` (issue #196) — a dated note that the pinned upstream file is GONE;
+  non-empty string or reject, and it applies to `mmproj.download` too (model-policy.md "Withdrawn
+  upstream sources"). `shared/runtime-sources.ts`
   `RuntimeBuild`/`RuntimeSources` + `validateRuntimeSources` (mirror `validateManifest`). The committed
   model manifests (the original six, incl. the later 14B/30B-A3B) carry real upstream URLs + placeholder hashes.
   **(Updated since Phase 12 — see `model-policy.md` for the live catalog and its authoritative
@@ -668,7 +671,9 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 ✅ **`services/assets.ts`** — the canonical, unit-tested asset logic (mirrors `drive.ts`; NO real network):
 - `planModelDownloads(root, manifests, {only?, acceptLicense?}) → ModelDownloadTask[]` — only manifests
   with a `download` block; reads fs to mark `present-verified`/`present-unverified`/`download`/
-  `license-blocked` (license gate ∧ `acceptLicense`); reuses `weightPath`/`verifyChecksum`.
+  `license-blocked` (license gate ∧ `acceptLicense`)/`source-withdrawn` (#196 — `download.withdrawn`
+  is set and the file would have to be fetched; decided BEFORE the license gate, and the task
+  carries the note as `withdrawn`); reuses `weightPath`/`verifyChecksum`.
 - `selectRuntimeBuild(sources, {os, arch, backend?}) → RuntimeBuild | null` (default = first os/arch
   match = the CPU build) · `planRuntimeDownload(root, build, version) → {url, zipDest, extractTo,
   binaryPath, sha256, ...}` (escape-guarded) · `runtimeBinaryName(os)`.
@@ -705,7 +710,9 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 ✅ **Types** (`shared/types.ts`): `DownloadJobStatus = 'queued'|'downloading'|'verifying'|'done'|
   'failed'|'cancelled'`; `DownloadJob { jobId, modelId, status, receivedBytes, totalBytes,
   unverified, error }` (`unverified` = placeholder-hash download, the model stays UNVERIFIED);
-  `ModelInfo.download?: ModelDownloadInfo { url, sizeBytes, licenseUrl, licenseApproved }`.
+  `ModelInfo.download?: ModelDownloadInfo { url, sizeBytes, licenseUrl, licenseApproved,
+  withdrawn? }` (`withdrawn` = the manifest's #196 note; the card shows it INSTEAD of a Download
+  button, and `DownloadManager.start` refuses such a manifest before any request).
 ✅ **`services/downloads.ts`** — `DownloadGates { policyAllows, settingAllows }`,
   `assertDownloadAllowed(gates)` (friendly, cause-specific refusals: policy vs. Settings),
   `partPath(dest)`, `DownloadManager({ fetchImpl?, log? })` with `start({rootPath, manifest,

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2133,6 +2133,37 @@ _The **`audit §N.M`** citations in the skills/extraction residuals below refer 
   error — and the trade (an edge-case refusal vs. a silently mislabelled signed-off pack) is
   deliberate. Recovery: save under a shorter path.
 
+## Local API ([`local-api.md`](local-api.md) · [`architecture.md`](architecture.md) "Local API endpoint — design record")
+
+All of these are decided scope, not oversights; the design record's §7 carries the reasoning.
+
+- **v1 serves chat completions and a one-model listing — nothing else.** No embeddings, vision,
+  transcription, or translation route, and no way to start/stop/switch a model from outside. The
+  endpoint borrows the model the user already started; if none is running, callers get
+  `model_not_loaded` until a human acts.
+- **No tool/function calling, no image or audio content parts, no `n > 1`.** These are refused by
+  name (400 `unsupported_field`) rather than silently ignored, so a client fails loudly at setup
+  instead of quietly getting a degraded answer.
+- **Sampling extras are accepted and ignored** (`top_p`, `stop`, penalties, `seed`, …).
+  `RuntimeChatOptions` carries no such fields; extending the runtime contract mid-wave was
+  rejected in favour of documenting the omission. Honoured today: `max_tokens` (clamped to the
+  context window), `temperature`, and `response_format.json_schema`.
+- **`usage` token counts are absent from responses.** The streaming reader discards them, so
+  surfacing them means extending the runtime contract; documented-as-absent beats fabricated
+  numbers. A post-v1 candidate — clients that require usage accounting will not work.
+- **One outside request generates at a time** (plus one waiter, ~30 s cap), and in-app use
+  pre-empts it. A deeper queue on ~2 tok/s CPU hardware is a silent multi-minute hang, so the
+  refusal is fast and explicit (429 + `Retry-After`) instead.
+- **No per-connection visibility** — the card shows counts only. Naming who connected and what
+  they asked would require keeping exactly the record the feature promises never to keep.
+- **A loopback endpoint cannot distinguish one local program from another.** The access key is a
+  boundary against casual use by other programs, not against code already running with the user's
+  rights; a same-user debugger can read it out of the unlocked workspace. Recorded in
+  [`security-model.md`](security-model.md) and [`../SECURITY.md`](../SECURITY.md).
+- **The pinned sidecar build leaves `/health` and `/v1/models` auth-exempt on its own port**, so a
+  local process can read liveness and the loaded model's file path (metadata, never content) —
+  upstream behaviour, unrelated to the app's own endpoint but part of the same threat surface.
+
 ## Internationalization ([`architecture.md`](architecture.md) i18n record)
 
 - **Task/summary output language follows the model, not the UI (D-L6 — RESOLVED as

--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -1,0 +1,534 @@
+# Local API — using your HilbertRaum model from other apps
+
+HilbertRaum can make the chat model you already have running available to **other programs on the
+same computer** — an editor plugin, a note-taking app, a shell script, a small tool you wrote —
+over a small **OpenAI-compatible HTTP endpoint** bound to loopback.
+
+It is **off by default**, it **never touches the internet**, it exposes **nothing but completions**
+(no documents, no conversations, no search index), and it **keeps no record** of what was asked or
+answered. Everything below explains how to turn it on, how to point a client at it, exactly what
+the wire contract is, and where its edges are.
+
+> **One sentence for the impatient:** switch it on in **Settings → Privacy & data → Local API**,
+> then point any OpenAI-compatible client at `http://127.0.0.1:4980/v1` with the access key the
+> card gives you.
+
+**Audience.** §1–§5 and §7–§11 are for anyone connecting an app. §6 is the wire contract for
+people writing a client. §12 points maintainers at the design records.
+
+## Table of contents
+
+- [§1 What it is — and what it is not](#1-what-it-is--and-what-it-is-not)
+- [§2 Before you start](#2-before-you-start)
+- [§3 Turning it on](#3-turning-it-on)
+- [§4 Your first request](#4-your-first-request)
+- [§5 Connecting real clients](#5-connecting-real-clients)
+- [§6 The HTTP contract](#6-the-http-contract)
+- [§7 Sharing one model with yourself](#7-sharing-one-model-with-yourself)
+- [§8 Security posture](#8-security-posture)
+- [§9 Privacy](#9-privacy)
+- [§10 Settings and policy reference](#10-settings-and-policy-reference)
+- [§11 Troubleshooting](#11-troubleshooting)
+- [§12 For maintainers](#12-for-maintainers)
+
+---
+
+## §1 What it is — and what it is not
+
+```
+your app  ──HTTP──▶  127.0.0.1:4980  (HilbertRaum, opt-in)
+                          │  Host check · Origin policy · no CORS · JSON only
+                          │  Bearer access key (on by default)
+                          │  admission: one outside request at a time
+                          ▼
+                     the chat model you already started
+```
+
+**It is:** a two-route HTTP endpoint that answers chat completions with the model **currently
+running** in HilbertRaum, in the OpenAI request/response shape, streaming or all at once.
+
+**It is not:**
+
+| Not | Why |
+|---|---|
+| A document/RAG API | There is no route to your documents, chunks, embeddings, or citations. Retrieval stays inside the app. |
+| A workspace API | Conversations, settings, the activity log, and the vector index are unreachable — not "protected", *unreachable*: no route exists. |
+| A model manager | The endpoint never starts, stops, or switches a model. If nothing is running, callers get an honest error and a human has to start one. |
+| A network service | Loopback only (`127.0.0.1` and `::1`). No LAN mode, no `0.0.0.0`, no proxy, no setting that could produce one. |
+| An embeddings / vision / audio / translation API | Those features exist in the app, not on this endpoint. |
+| A tool-calling backend | `tools` / `functions` are refused by name (see [§6.4](#64-request-fields)). |
+
+## §2 Before you start
+
+Four things must be true before an outside app can get an answer:
+
+1. **Your drive's policy permits it.** A managed or commercial drive can forbid the feature
+   outright; the card then appears greyed out *with that reason* rather than disappearing. See
+   [§10](#10-settings-and-policy-reference).
+2. **You switched it on** and confirmed the consent dialog. Off is the default.
+3. **Your workspace is unlocked.** The endpoint exists only while it is — the settings and the
+   access key live inside the encrypted workspace. Lock or quit stops the listener; the next
+   unlock starts it again if the switch is still on.
+4. **A chat model is running** (the **AI Model** screen). The endpoint borrows the model you
+   started; it never starts one for a caller.
+
+## §3 Turning it on
+
+1. Open **Settings → Privacy & data** and find the **Local API** card.
+2. Switch on **Allow other apps on this computer to use my AI model**.
+3. Read the dialog, tick the acknowledgement, and choose **Turn on**. Nothing is saved until you do.
+4. The card now reads **Listening on port 4980** and shows a **Connect another app** block with
+   the two values every client asks for:
+
+| The card shows | Your client probably calls it |
+|---|---|
+| **Server address** — `http://127.0.0.1:4980/v1` | "Base URL", "API base", "endpoint", "OpenAI-compatible URL" |
+| **Access key** — starts with `hr-` | "API key", "token", "secret key" |
+
+Use the **Copy** buttons rather than retyping. The key is only ever *displayed* shortened
+(`hr-…7f3q`); copying puts the real value on your clipboard, and the app clears the clipboard
+again after about a minute if you have not copied something else since.
+
+**Use the literal `127.0.0.1` string from the card, not `localhost`.** HilbertRaum binds both
+loopback addresses, but on Windows 11 `localhost` resolves to the IPv6 address `::1` first and
+some clients try only one of the two — and on a machine with IPv6 disabled the `::1` listener
+cannot be created at all. The printed address is unambiguous; a typed `localhost` is not.
+
+**If the port is taken**, the card says so and the endpoint does not start — the switch stays on,
+only the bind failed. Type another number (4981, for example) and press **Apply**. Treat an
+unexpected conflict seriously: a program squatting on the port could be posing as HilbertRaum to
+collect the key you are about to paste somewhere. Find out what is listening first
+(`netstat -ano | findstr :4980` on Windows, `lsof -i :4980` on macOS/Linux).
+
+## §4 Your first request
+
+Start a model, then check the endpoint answers before you configure anything else.
+
+**Is it up, and which model is loaded?**
+
+```bash
+curl -s http://127.0.0.1:4980/v1/models -H "Authorization: Bearer hr-YOURKEY"
+```
+
+```json
+{"object":"list","data":[{"id":"gemma4-e2b-it-qat-q4","object":"model","owned_by":"hilbertraum","context_window":8192}]}
+```
+
+**Ask something** (non-streaming — the default of every SDK):
+
+```bash
+curl -s http://127.0.0.1:4980/v1/chat/completions \
+  -H "Authorization: Bearer hr-YOURKEY" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"Say hello in five words."}]}'
+```
+
+**The same on Windows PowerShell** — PowerShell's `curl` is an alias for `Invoke-WebRequest`, so
+use the cmdlet properly rather than pasting a bash line:
+
+```powershell
+$key = 'hr-YOURKEY'
+Invoke-RestMethod -Uri 'http://127.0.0.1:4980/v1/chat/completions' -Method Post `
+  -Headers @{ Authorization = "Bearer $key" } -ContentType 'application/json' `
+  -Body '{"messages":[{"role":"user","content":"Say hello in five words."}]}' |
+  ForEach-Object { $_.choices[0].message.content }
+```
+
+**Streaming** (server-sent events):
+
+```bash
+curl -N http://127.0.0.1:4980/v1/chat/completions \
+  -H "Authorization: Bearer hr-YOURKEY" \
+  -H "Content-Type: application/json" \
+  -d '{"stream":true,"messages":[{"role":"user","content":"Count to five."}]}'
+```
+
+You will see a role-first chunk, then content deltas, then a `finish_reason` chunk, then
+`data: [DONE]`.
+
+> A first request against a cold CPU model can take a while to produce its first token — prefill
+> is silent. That is normal, and the endpoint deliberately does not time it out; see
+> [§6.7](#67-limits-and-timeouts).
+
+## §5 Connecting real clients
+
+### Any OpenAI-compatible client
+
+Most tools that speak "OpenAI-compatible" need exactly three values:
+
+| Field | Value |
+|---|---|
+| Base URL / API base | `http://127.0.0.1:4980/v1` (exactly what the card shows) |
+| API key | the `hr-…` key from the card (any non-empty string if you turned the key requirement off) |
+| Model name | **anything** — HilbertRaum always answers with the model you have running. Use the id from `GET /v1/models` if the client validates it. |
+
+Turn **off** any client feature that maps to a refused capability: tool/function calling, vision
+attachments, and "n > 1" completions (see [§6.4](#64-request-fields)). Clients that insist on
+token-usage numbers will find `usage` absent ([§6.5](#65-responses)).
+
+### Python (`openai` SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:4980/v1", api_key="hr-YOURKEY")
+
+resp = client.chat.completions.create(
+    model="hilbertraum",                      # ignored; any value works
+    messages=[{"role": "user", "content": "Summarize this in one sentence: ..."}],
+)
+print(resp.choices[0].message.content)
+
+# streaming
+for chunk in client.chat.completions.create(
+    model="hilbertraum",
+    messages=[{"role": "user", "content": "Count to five."}],
+    stream=True,
+):
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="", flush=True)
+```
+
+### Node / TypeScript (`openai` SDK)
+
+```ts
+import OpenAI from 'openai'
+
+const client = new OpenAI({ baseURL: 'http://127.0.0.1:4980/v1', apiKey: 'hr-YOURKEY' })
+
+const resp = await client.chat.completions.create({
+  model: 'hilbertraum',
+  messages: [{ role: 'user', content: 'Say hello in five words.' }]
+})
+console.log(resp.choices[0].message.content)
+```
+
+### Plain `fetch` (Node, an Electron main process, a plugin host)
+
+```ts
+const res = await fetch('http://127.0.0.1:4980/v1/chat/completions', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: 'Bearer hr-YOURKEY' },
+  body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
+})
+if (!res.ok) {
+  const { error } = await res.json() // { message, type, code }
+  throw new Error(`${res.status} ${error.code}: ${error.message}`)
+}
+```
+
+**Browser JavaScript cannot use this endpoint, by design** — see [§8](#8-security-posture). A
+plugin running in an Electron/VS Code *main* or extension-host process can (its requests carry no
+`http(s)` origin, or a custom-scheme one such as `vscode-webview://`, both of which pass); a web
+page's `fetch` cannot.
+
+### Asking for JSON in a fixed shape
+
+`response_format: { type: 'json_schema', json_schema: { name, schema } }` is supported and mapped
+onto grammar-constrained decoding, so the model's output conforms to your schema:
+
+```json
+{
+  "messages": [{ "role": "user", "content": "Extract the invoice total." }],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "invoice",
+      "schema": {
+        "type": "object",
+        "properties": { "total": { "type": "number" }, "currency": { "type": "string" } },
+        "required": ["total", "currency"]
+      }
+    }
+  }
+}
+```
+
+`response_format: { type: 'json_object' }` is **not** supported (400) — pass a schema instead.
+
+### A retry rule worth writing once
+
+Two answers mean "ask again shortly", and both carry `Retry-After` (seconds):
+
+- **429 `busy`** — the model is answering something else (yours, or another caller's).
+- **`preempted_by_user`** — you were interrupted because the user started their own chat. See
+  [§7](#7-sharing-one-model-with-yourself).
+
+Everything else is either a client mistake (4xx) or a state a human must fix (503
+`model_not_loaded`, `workspace_locked`).
+
+## §6 The HTTP contract
+
+The authoritative, maintained version of this contract lives in
+[`data-contracts.md`](data-contracts.md) ("Local-api wave P3 — the exposed HTTP contract"); this
+section is the same thing written for a client author.
+
+### 6.1 Base URL, headers, authentication
+
+- Base URL: `http://127.0.0.1:4980/v1` (the port is configurable, 1024–65535).
+- Every response carries `Server: HilbertRaum/<app version>`.
+- **`Authorization: Bearer <key>`** is required on **both** routes while *Require an access key*
+  is on (the default). The comparison is constant-time. With the requirement off, a present
+  `Authorization` header is ignored rather than validated (SDKs always send one).
+- `Content-Type: application/json` is required on POST; a `; charset=utf-8` suffix is fine.
+- The `Host` header must name a loopback address **and the port actually bound**; an absent or
+  empty `Host` is refused. Send the URL as printed and any normal HTTP client does this for you.
+
+### 6.2 `GET /v1/models`
+
+Lists the **one** model currently running. It is the cheap "is it up?" probe and never occupies
+the model.
+
+```json
+{ "object": "list",
+  "data": [{ "id": "<model id>", "object": "model", "owned_by": "hilbertraum",
+             "context_window": 8192 }] }
+```
+
+`context_window` is a non-standard extra so a client can size its prompts. Three distinct
+outcomes: **200** (running) · **503 `model_starting`** + `Retry-After` (loading — pace yourself) ·
+**503 `model_not_loaded`** (a human must start a model).
+
+### 6.3 `POST /v1/chat/completions`
+
+The only generation route. Minimal body:
+
+```json
+{ "messages": [{ "role": "user", "content": "…" }] }
+```
+
+Roles: `system`, `user`, `assistant`. `content` is a string, or an array of **text-only** content
+parts (they are flattened); image/audio parts are refused.
+
+### 6.4 Request fields
+
+| Field | Behaviour |
+|---|---|
+| `messages` | **Required**, non-empty. Roles above; text content only. |
+| `stream` | `true` → SSE, otherwise a single JSON object (the SDK default). |
+| `max_tokens` | Honoured, clamped to the launched context window. |
+| `temperature` | Honoured. |
+| `response_format.type: "json_schema"` | **Supported** — grammar-constrained decoding against `json_schema.schema`. |
+| `response_format.type: "text"` | Accepted (the default behaviour). |
+| `model` | **Ignored** — the running model answers. Any value works. |
+| `top_p`, `presence_penalty`, `frequency_penalty`, `stop`, `seed`, `user`, `stream_options`, `n: 1` | **Accepted and ignored.** v1 does not pass sampling extras through to the runtime. If your prompt depends on `stop` or `top_p`, handle it client-side. |
+| `tools`, `tool_choice`, `functions` | **400** `unsupported_field` — no tool calling. |
+| `audio`, `modalities` | **400** `unsupported_field`. |
+| `n` > 1 | **400** `unsupported_field` — one answer per request. |
+| `response_format.type: "json_object"` | **400** `unsupported_field` — use `json_schema`. |
+| image / audio content parts | **400** `unsupported_field` — the endpoint has no vision surface. |
+
+External requests run at answer depth **balanced, with thinking off**, so a client's first-token
+timeout does not sit through a silent reasoning phase. There is no RAG, no document context, and
+no chat history — the endpoint sends exactly the messages you passed.
+
+### 6.5 Responses
+
+**Non-streaming** — one `chat.completion` object:
+
+```json
+{ "id": "chatcmpl-…", "object": "chat.completion", "created": 1755600000,
+  "model": "<model id>",
+  "choices": [{ "index": 0,
+                "message": { "role": "assistant", "content": "…" },
+                "finish_reason": "stop" }] }
+```
+
+**Streaming** — `text/event-stream`, in this order: a role-first `chat.completion.chunk`
+(`delta: {"role":"assistant"}`), content chunks (`delta: {"content":"…"}`), a final chunk carrying
+`finish_reason`, then `data: [DONE]`.
+
+> **`usage` is deliberately absent in v1.** The runtime's streaming reader discards token counts,
+> and fabricating numbers would be worse than omitting them. Do not read `usage.total_tokens` — it
+> is not there. (A post-v1 candidate.)
+
+> **A truncated stream never ends with `[DONE]`.** If a generation is interrupted you get an
+> in-band error frame and the stream closes *without* the terminator. Treat "no `[DONE]`" as "not
+> a complete answer" — that distinction is the whole point of omitting it.
+
+### 6.6 Errors
+
+All errors are OpenAI-shaped: `{"error": {"message": …, "type": …, "code": …}}`. Branch on `code`.
+
+| HTTP | `code` | Meaning | What a client should do |
+|---|---|---|---|
+| 400 | `invalid_body`, `invalid_messages`, `invalid_json`, `invalid_response_format` | Malformed request | Fix the request |
+| 400 | `unsupported_field` | A capability this endpoint does not have (named in the message) | Disable that client feature |
+| 400 | `context_overflow` | Prompt + answer do not fit the context window | Send less text |
+| 401 | `invalid_api_key` | Missing or wrong access key | Re-copy the key from the card |
+| 403 | `forbidden_host` | `Host` was absent, or not a loopback name for this port | Use the printed base URL |
+| 403 | `forbidden_origin` | A web-page origin (or `Origin: null`) | Browsers are locked out by design |
+| 403 | `no_cors` | An `OPTIONS` preflight | Same |
+| 404 | `unknown_route` | Only the two routes above exist | — |
+| 413 | `body_too_large` | Body exceeded 1 MB (counted as bytes arrive) | Send less |
+| 415 | `unsupported_content_type` | POST was not `application/json` | Set the header |
+| 429 | `busy` | The model is answering something else | Retry after `Retry-After` |
+| 429 | `preempted_by_user` | The user's own chat interrupted this request before any bytes were sent | Retry after `Retry-After` |
+| 500 | `internal_error` | An unexpected failure inside the endpoint (for example the workspace locking mid-request) | Retry; if it persists, check Diagnostics |
+| 502 | `runtime_unresponsive` | The model runtime did not answer | Check the app — the model may have crashed |
+| 503 | `model_not_loaded` | No model is running | A human must start one |
+| 503 | `model_starting` | A model is loading | Retry after `Retry-After` |
+| 503 | `workspace_locked` | The workspace is locked | Retry once it is unlocked |
+| 503 / in-band | `server_stopped` | The endpoint is shutting down (lock or quit) | Reconnect later |
+
+`Retry-After` on `busy` / `model_starting` / `preempted_by_user` is derived from the machine's
+**measured** tokens-per-second when one is available for the running model, and is 30 s otherwise;
+it is clamped to 5–180 s.
+
+**Mid-stream failures** arrive as an in-band frame with the same body shape (`preempted_by_user`,
+`server_stopped`, or `runtime_error`), and the stream then closes **without** `[DONE]`.
+
+### 6.7 Limits and timeouts
+
+| Bound | Value | Why |
+|---|---|---|
+| Request body | **1 MB**, counted as bytes arrive (`Content-Length` is never trusted) | A chunked body makes a header check meaningless |
+| Header phase | 10 s | Slow-loris |
+| Body idle | 30 s (body phase only) | A stalled upload should not hold a socket |
+| Generation | **no timeout** | A legitimate CPU generation can run for minutes; Node's 300 s default would kill it. Wedge detection is done app-side instead |
+| SSE reader stall | 15 s of unrelieved backpressure → the request is aborted and the slot reclaimed | One stalled reader must not wedge the model |
+| Concurrent connections | 16 | Cheap flood ceiling |
+| Outside requests generating at once | **1** (plus one waiting up to ~30 s) | [§7](#7-sharing-one-model-with-yourself) |
+
+**A client disconnect aborts the generation** in both modes — an abandoned request never burns a
+multi-minute answer nobody will read.
+
+## §7 Sharing one model with yourself
+
+There is one model and one machine, so the rules are explicit rather than emergent:
+
+- **One outside request generates at a time.** A second one waits up to about 30 seconds; if the
+  first is still going it gets **429 `busy`** with a `Retry-After`. A third is refused immediately
+  rather than left hanging — on slow CPU hardware a deeper queue is a silent multi-minute stall,
+  not politeness.
+- **Your own use always wins.** If you start an in-app chat while an outside request is
+  generating, that request is interrupted: it receives `preempted_by_user` (in-band if the stream
+  had started, 429 otherwise) and the Settings card tells you it happened. The reverse never
+  occurs — an outside caller cannot interrupt you.
+- **Background work counts as busy.** Document tasks (summaries, whole-document translation,
+  comparisons, extraction), skill runs, and the hardware benchmark hold the model for their whole
+  multi-step run; the endpoint waits or answers `busy` honestly instead of slipping into the gap
+  between two steps of a background job.
+- **Lock and quit stop the endpoint first**, before the model sidecars come down. A stream running
+  at that moment ends with `server_stopped`.
+- **Switching models** while a caller waits is safe: a promoted waiter re-checks which model is
+  running and never generates against a stopped one.
+
+## §8 Security posture
+
+The full threat analysis is in [`security-model.md`](security-model.md) ("The fifth threat:
+same-machine processes"). The controls, in the order a request meets them:
+
+| Control | Stops |
+|---|---|
+| **Off by default, behind a consent dialog** | The door existing before you knowingly open it |
+| **Policy ceiling `network.allow_local_api`** (restrict-only) | A managed/commercial drive forbidding it outright; your setting can never override the policy |
+| **Exists only while the workspace is unlocked** | Anything being served out of a locked vault |
+| **Binds `127.0.0.1` + `::1` only** | Everything off-machine. No LAN mode, no `0.0.0.0`, no forwarding — and no setting that could create one |
+| **`Host` validation (absent ⇒ 403)** | DNS rebinding: a page resolving an attacker domain to 127.0.0.1 still fails the check |
+| **Origin policy + `OPTIONS` refused + no CORS header ever emitted + JSON required** | Drive-by access from browser JavaScript, structurally |
+| **Bearer access key, on by default, constant-time compared** | Casual use by any other program on the machine |
+| **Two routes and no others** | Documents, conversations, embeddings, settings, the activity log — there is no route to authorize |
+| **Counts-only accounting** | A record of what was asked or answered existing at all |
+| **Single-slot admission + user pre-emption** | An outside caller starving your own use |
+
+**Rotating the key.** *Create a new key* re-mints it and **immediately** aborts every outside
+request the old key admitted — including one that is mid-stream. Apps holding the old key need the
+new one pasted in. Use it whenever a key may have leaked, or simply to cut an app off.
+
+**Turning the key off** is a confirmed choice, not a click: without it, *any* program running as
+you can use your model. The Host / Origin / content-type checks stay unconditional in that mode,
+so browsers remain locked out either way.
+
+**Honest residuals** (also recorded in [`../SECURITY.md`](../SECURITY.md)):
+
+- A loopback endpoint **cannot tell one local program from another**. The access key is the
+  boundary, and any program that can read your unlocked workspace could read the key. That is why
+  the feature is off by default and why the key requirement stays on unless you turn it off.
+- A debugger running **as you** can read process memory; so can a full-memory crash dump. On
+  Windows, leaving crash dumps at the **minidump** default is recommended.
+- What a connected app does with an answer is outside HilbertRaum's control — see [§9](#9-privacy).
+
+## §9 Privacy
+
+- **Nothing about a request is recorded.** The prompt and the answer are held in memory for the
+  length of the request and then dropped. They are never written to your chat history, your
+  documents, or the logs. The app keeps **counts only** — how many requests were answered and how
+  many refused — visible on the card and in **Settings → Diagnostics**.
+- **Nothing reaches the internet.** The listener is loopback-bound; connecting an app adds no
+  outbound traffic of any kind.
+- **The switch itself is recorded, minimally.** Turning the feature on or off writes one entry to
+  your local activity log with the new state (`{ enabled: true | false }`) and nothing else — the
+  same treatment other privacy-relevant settings get. The port number is not recorded.
+- **The access key lives in your workspace database**, so it is encrypted at rest exactly like the
+  rest of your data and unreadable before you unlock. It never crosses to the app's UI process in
+  full — the interface only ever displays `hr-…<last four>`, and copying happens inside the
+  privileged process.
+
+**Your responsibility.** Once a connected app has an answer, that answer is in that app's hands.
+An editor plugin or note app may store the text in its own files, index it, or sync it to its own
+cloud service as part of normal behaviour. That would be **that app** sending your data somewhere,
+not HilbertRaum — but the effect on your privacy is identical. Check a program's own logging and
+sync behaviour before you point it at confidential material, exactly as you would before pasting
+confidential text into it.
+
+See [`../PRIVACY.md`](../PRIVACY.md) for the full statement.
+
+## §10 Settings and policy reference
+
+**Settings → Privacy & data → Local API**
+
+| Setting | Default | Notes |
+|---|---|---|
+| Allow other apps on this computer to use my AI model | **off** | Consent dialog required; the change is audited (state only) |
+| Require an access key | **on** | Turning it off is a confirmed choice |
+| Port number | **4980** | Range 1024–65535, clamped. 4980 avoids the ports Ollama (11434) and LM Studio (1234) use |
+
+Changing any of these applies immediately — the listener starts, stops, or re-binds to the new
+port without a restart.
+
+**Drive policy** (`config/policy.json`, key `network.allow_local_api`) is a **ceiling**: the
+effective state is `policy AND your setting`. A policy can only restrict, never enable.
+
+| Drive kind | `allow_local_api` |
+|---|---|
+| Commercial / prepared drive (`prepare-drive`) | explicit **`false`** — the card shows "Turned off by your drive's policy" |
+| `--dev` prepared drive | `true` |
+| Standalone install (a GitHub release, app-data fallback) | `true` — the setting is still off until you turn it on |
+| A policy file written **before** the key existed | inherits the permissive default (an absent key means "not yet decided", so drives already in the field are not silently denied). An explicit `false` denies; a junk value or a malformed policy file fails closed |
+
+## §11 Troubleshooting
+
+Symptom-by-symptom fixes — connection refused, port conflicts, firewall/EDR questions, and a
+plain-language table of the HTTP status codes — live in
+[`troubleshooting.md`](troubleshooting.md). The three that catch almost everyone:
+
+1. **`localhost` instead of `127.0.0.1`** — paste the exact address from the card
+   ([§3](#3-turning-it-on)).
+2. **Workspace locked, or no model running** — the endpoint is alive only with the former, and
+   useful only with the latter ([§2](#2-before-you-start)).
+3. **A client with tool calling enabled** — turn it off; it is refused by name
+   ([§6.4](#64-request-fields)).
+
+**Windows Firewall does not prompt for this**: it filters traffic crossing the network stack, and
+a loopback listener never does. Some endpoint-protection (EDR) products *do* alert on any process
+opening a listening socket — that alert is accurate, and if your organization's tooling objects,
+the honest answer is to leave the feature off. Nothing else in the app depends on it.
+
+## §12 For maintainers
+
+| Where | What |
+|---|---|
+| [`architecture.md`](architecture.md) — "Local API endpoint — design record (wave local-api, PR #184, §1–§9)" | The design: framing decisions D1–D9, owner options O1–O6, the generation gate, the HTTP surface, deliberate omissions, what the audits changed, and the verification (incl. the real-model smoke) |
+| [`data-contracts.md`](data-contracts.md) | The authoritative wire + IPC + settings + policy contract |
+| [`security-model.md`](security-model.md) | "The fifth threat: same-machine processes" — controls and accepted residuals |
+| [`user-guide.md`](user-guide.md) | The end-user walkthrough ("Use HilbertRaum from other apps") |
+| `apps/desktop/src/main/services/local-api/` | `server.ts` (listener + lifecycle), `handlers.ts` (pipeline checks, parsing, envelopes), `admission.ts` (the single external slot), `token.ts` (access key), `lifecycle.ts` (start seams) |
+| `apps/desktop/src/shared/local-api.ts` | The shared derivations: `localApiEffectivelyEnabled`, `localApiServerAddress`, `isStrictLoopbackHostname`, the port clamp, `LOCAL_API_SETTINGS_KEYS` |
+| `apps/desktop/tests/**/local-api-*.test.ts` | The pinned behaviour: bind posture, the check matrix in both auth modes, zero CORS headers, streaming and non-streaming paths, error mapping, pre-emption closing without `[DONE]`, the counted-byte body cap, drain-timeout reclaim, lock/quit ordering, rotation aborting live streams, and a no-content sentinel grepped out of every log and status surface |
+
+**Contract stability.** The wire shape above is what external apps code against; treat it as
+public API. Additive changes (a new optional field, a new error `code`) are fine; changing an
+existing status/code mapping or the streaming frame order is a breaking change and needs a note in
+[`../CHANGELOG.md`](../CHANGELOG.md).

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -1123,6 +1123,61 @@ gate); (4) draft depths n=3/4 neither break nor help (n=4 acceptance falls to 64
 "n=4 emits junk" claim circulating publicly did not reproduce on this stack; n=2 is the pick.
 `-np 1` showed no throughput effect at ctx 8192 (default `n_slots=4`, unified KV).
 
+### 9.5 The Qwen3.8 wave lost its upstream files (2026-08-20, issue #196)
+
+**What happened.** Four days after the §9.4 promotion, unsloth restructured
+`unsloth/Qwen3.8-27B-GGUF` for their Dynamic 3.0 rollout and **deleted the plain static
+K-quants**. All three files the wave pins return HTTP 404 (verified 2026-08-20 with `HEAD`
+requests on the exact manifest URLs); the repo now publishes `UD-*` files plus legacy
+`Q4_0/Q4_1/Q8_0` — different weights, different hashes. Hash pinning did its job: we can never
+silently receive substituted weights. We also cannot fetch these exact files again.
+
+**Blast radius, measured not assumed.** Every committed `download.url` in the catalog was
+re-checked the same day (28 URLs, `HEAD` + redirects): **only the three Qwen3.8 manifests are
+dead.** The Qwen3.6 pair is intact — URL alive AND the upstream LFS OIDs still equal the
+committed hashes (`5ed60d0a…` / `cfecab16…`), so the tier fallback below rests on a live,
+unchanged source. Drives that already carry a Qwen3.8 weight are unaffected in every way: the
+local file still matches the pinned SHA-256, verification passes, the model starts, and MTP
+speculative decoding (§9.4 addendum) still applies.
+
+**Decision (interim, 2026-08-20).** The measurements of §9.4 stand — nothing about the models
+changed, only their obtainability — so the manifests are **kept as installed-base records** with
+the dead URL, hash and size intact (option 2 of issue #196, the posture prior waves used for
+weight changes), plus a new machine-readable `download.withdrawn` note. Two consequences:
+
+1. **Ranks.** `qwen3.8-27b-q4` and `-q5` go **rank 3 → 0** (selectable, never auto-recommended —
+   the existing rank-0 convention, cf. the q6 sibling and gemma4-31b). The §9.4 generational
+   handover is **reverted**: `qwen3.6-27b-q4` retakes 24 GB and `qwen3.6-27b-q5` retakes ≥32 GB
+   at **rank 3**. Rationale: a recommendation the user cannot act on is worse than a
+   slightly-older recommendation they can — and the Qwen3.6 pair is the best-measured pair on
+   this harness whose weights can still be downloaded (q5 still holds the all-time F1 record
+   .3573). The §6.5 stepped picks move with it (≥32 GB crawl now lands on `qwen3.6-27b-q4`).
+2. **No estimated successors.** The `UD-Q4_K_M` / `UD-Q5_K_M` / `UD-Q6_K` candidates are NOT
+   productized here. Manifest numbers are measured, never estimated, and the successor files
+   need the full per-quant wave on the i9-9900X + RTX 3090 rig (§9.4 method): SHA-256 on disk,
+   §2 grounded-QA vs the committed baseline, §3/§4 speed + peak VRAM/RSS at ctx 8192, §9.1
+   in-app smokes on the b9849 pin. **One extra gate for the successors:** Dynamic 3.0 publishes
+   the MTP module as a SEPARATE file (`MTP/mtp-Qwen3.8-27B-Q4_0.gguf`, 1.37 GB), so the
+   `speculative_decoding: mtp` claim — which asserts a draft head *inside the same GGUF*, with
+   no `--model-draft` — must be re-verified per successor file and dropped if the modules are
+   no longer in-GGUF. Verified upstream facts as of 2026-08-20 (HF LFS metadata), so the wave
+   starts from data rather than a re-lookup:
+
+   | successor candidate | size (bytes) | LFS OID (= SHA-256) |
+   |---|---|---|
+   | `Qwen3.8-27B-UD-Q4_K_M.gguf` | 16,464,440,224 | `322e194ff79741c7baa497c240f677f54b201b0efab44ca8e50f122b39123482` |
+   | `Qwen3.8-27B-UD-Q5_K_M.gguf` | 19,771,509,664 | `2de73110cb254cbf09b54b717578dadff12ef1194e7271527e68202f39ba4bfd` |
+   | `Qwen3.8-27B-UD-Q6_K.gguf`   | 21,983,677,344 | `c9c206812fbe4ac7b76a729e25928b63f2ae89d37f69da7a71c20aec763cd436` |
+
+   These are upstream metadata, NOT a promotion: a hash only becomes a manifest pin after the
+   file is downloaded and hashed on disk (model-policy.md's checksum-honesty rule).
+
+**Product change shipped with this record** (so the failure is legible instead of an HTTP 404):
+the manifest field `download.withdrawn` — see model-policy.md "Withdrawn upstream sources
+(`download.withdrawn`)" for the schema, the planner status, the in-app copy and the fetch-script
+behaviour. License posture is unchanged (same upstream repo, apache-2.0); nothing was
+redistributed, so no DRIVE-NOTICES regeneration is implied.
+
 ---
 
 ## 10. Skills extraction & real-model smoke (skills-remediation T1, audit §7)

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -25,11 +25,11 @@
 | Chat (new 4B) | Qwen3.5 4B (UD-Q4_K_XL) | ~2.9 GB | 8 GB | — (rank 3) | **Recommended ≤12 GB since the newest-Qwen promotion (owner decision 2026-07-12, `model-benchmarks.md` §6.4).** unsloth Dynamic-2.0 quant; thinking-by-default (Deep applies). §9 eval standing recorded honestly in the manifest (F1 under the Qwen3-4B incumbent, EM comparable); b9849 load observed through the app 2026-07-12. Vision model run text-only. |
 | Chat (Qwen3.5 9B) | Qwen3.5 9B (UD-Q4_K_XL) | ~6.0 GB | 12 GB | — (rank 3) | **Recommended 16–20 GB since the newest-Qwen promotion (2026-07-12, §6.4).** unsloth Dynamic-2.0 quant. §9 eval standing recorded in the manifest (edges Ministral on F1/EM within cross-run tolerance, ranked under it only on the hallucination-trap axis); ran on the b9849 binary in the #48 tester eval; **§9.1 in-app smoke PASSED all legs 2026-07-30** (peak RSS 6.57 GiB vulkan). Text-only, not bundled. |
 | Chat (Qwen3.5 27B) | Qwen3.5 27B (UD-Q4_K_XL) | ~17.6 GB | 24 GB | — (rank 0) | **Qwen3.5 wave (2026-07-01).** High-end dense challenger; superseded at its tier by the Qwen3.6 27B pair (below) before ever being promoted. Text-only, opt-in (not bundled). |
-| Chat (Qwen3.6 27B Q4) | Qwen3.6 27B Q4_K_M | ~16.8 GB | 20 GB | — (rank 1) | **Was the recommended 24 GB pick 2026-07-12..2026-08-16 (§6.4); rank 1 since the Qwen3.8 handover (§9.4).** Productized 2026-07-12 from a local-test stub: unsloth Q4_K_M, real HF-LFS hash, apache-2.0 review; hallucinations 0 on the v3 rescore; **§9.1 in-app smoke PASSED all legs 2026-07-30** (peak RSS 16.87 GiB vulkan). Still ranked + selectable. Text-only, not bundled. |
-| Chat (Qwen3.6 27B Q5) | Qwen3.6 27B Q5_K_M | ~19.5 GB | 24 GB | — (rank 1) | **Was the recommended ≥32 GB pick 2026-07-12..2026-08-16; rank 1 since the Qwen3.8 handover (§9.4).** Still the all-time top scorer of the grounded-QA harness (F1 .3573, zero unanswerable-set hallucinations) — the handover is the §6.4 generational call, not a quality verdict. **§9.1 smoke PASSED 2026-07-30** (peak RSS 19.38 GiB vulkan). Text-only, not bundled. |
-| Chat (Qwen3.8 27B Q4) | Qwen3.8 27B Q4_K_M | ~17.1 GB | 21 GB | — (rank 3) | **Recommended 24 GB since the Qwen3.8 handover (owner decision 2026-08-16, §6.4 + §9.4).** unsloth Q4_K_M, real HF-LFS hash confirmed on-disk, apache-2.0 review (private/legal addendum 2026-08-16). §9.4 eval: F1 .3500 (ties the 3.6-Q4 inside cross-run noise), EM .9765, ZERO hallucinations, perfect abstention; tg 39.9 t/s vulkan / 2.83 cpu (b10430 basis). Text-only, not bundled. |
-| Chat (Qwen3.8 27B Q5) | Qwen3.8 27B Q5_K_M | ~19.8 GB | 23 GB | — (rank 3) | **Recommended ≥32 GB since the Qwen3.8 handover (2026-08-16, §6.4 + §9.4).** Same productization posture as the Q4. §9.4 eval: F1 .3523, zero hallucinations; tg 35.9 t/s vulkan — out-decodes the smaller UD-Q4_K_XL, which therefore got no manifest. Text-only, not bundled. |
-| Chat (Qwen3.8 27B Q6) | Qwen3.8 27B Q6_K | ~22.9 GB | 26 GB | — (rank 0) | **Qwen3.8 wave (2026-08-16, §9.4): the 24 GB-GPU quality ceiling — rank 0 BY DESIGN** (the q5 sibling wins the ≥32 GB RAM tier; this quant's niche — fully fits a 24 GB GPU at ctx 8192, 22.7 GiB peak VRAM, no spill — is not expressible in the RAM-tier picker; gemma4-31b selectable-ceiling precedent). F1 .3503, zero hallucinations. Text-only, not bundled. |
+| Chat (Qwen3.6 27B Q4) | Qwen3.6 27B Q4_K_M | ~16.8 GB | 20 GB | — (rank 3) | **The recommended 24 GB pick again since 2026-08-20 (issue #196, §9.5): it held the tier 2026-07-12..2026-08-16, lost it to the Qwen3.8 handover (§9.4), and took it back when upstream deleted the Qwen3.8 files — its own URL + LFS hash re-verified live 2026-08-20.** Productized 2026-07-12 from a local-test stub: unsloth Q4_K_M, real HF-LFS hash, apache-2.0 review; hallucinations 0 on the v3 rescore; **§9.1 in-app smoke PASSED all legs 2026-07-30** (peak RSS 16.87 GiB vulkan). Still ranked + selectable. Text-only, not bundled. |
+| Chat (Qwen3.6 27B Q5) | Qwen3.6 27B Q5_K_M | ~19.5 GB | 24 GB | — (rank 3) | **The recommended ≥32 GB pick again since 2026-08-20 (issue #196, §9.5) — same story as the Q4 sibling, and it never stopped being the harness top scorer.** Still the all-time top scorer of the grounded-QA harness (F1 .3573, zero unanswerable-set hallucinations) — the handover is the §6.4 generational call, not a quality verdict. **§9.1 smoke PASSED 2026-07-30** (peak RSS 19.38 GiB vulkan). Text-only, not bundled. |
+| Chat (Qwen3.8 27B Q4) | Qwen3.8 27B Q4_K_M | ~17.1 GB | 21 GB | — (rank 0) | **UPSTREAM FILE DELETED 2026-08-20 (issue #196, §9.5): `download.withdrawn`, rank 3 → 0 — installed copies keep working and verifying, but a fresh drive cannot obtain it, so it is never auto-recommended (the 24 GB tier went back to Qwen3.6 Q4). Was the recommended 24 GB pick 2026-08-16..2026-08-20 (§6.4 + §9.4).** unsloth Q4_K_M, real HF-LFS hash confirmed on-disk, apache-2.0 review (private/legal addendum 2026-08-16). §9.4 eval: F1 .3500 (ties the 3.6-Q4 inside cross-run noise), EM .9765, ZERO hallucinations, perfect abstention; tg 39.9 t/s vulkan / 2.83 cpu (b10430 basis). Text-only, not bundled. |
+| Chat (Qwen3.8 27B Q5) | Qwen3.8 27B Q5_K_M | ~19.8 GB | 23 GB | — (rank 0) | **UPSTREAM FILE DELETED 2026-08-20 (issue #196, §9.5): `download.withdrawn`, rank 3 → 0; the ≥32 GB tier went back to Qwen3.6 Q5. Was the recommended ≥32 GB pick 2026-08-16..2026-08-20 (§6.4 + §9.4).** Same productization posture as the Q4. §9.4 eval: F1 .3523, zero hallucinations; tg 35.9 t/s vulkan — out-decodes the smaller UD-Q4_K_XL, which therefore got no manifest. Text-only, not bundled. |
+| Chat (Qwen3.8 27B Q6) | Qwen3.8 27B Q6_K | ~22.9 GB | 26 GB | — (rank 0) | **UPSTREAM FILE DELETED 2026-08-20 (issue #196, §9.5): `download.withdrawn` — selectable only where the weight is already on the drive. Qwen3.8 wave (2026-08-16, §9.4): the 24 GB-GPU quality ceiling — rank 0 BY DESIGN** (the q5 sibling wins the ≥32 GB RAM tier; this quant's niche — fully fits a 24 GB GPU at ctx 8192, 22.7 GiB peak VRAM, no spill — is not expressible in the RAM-tier picker; gemma4-31b selectable-ceiling precedent). F1 .3503, zero hallucinations. Text-only, not bundled. |
 | Chat (Qwen3.5 35B-A3B) | Qwen3.5 35B-A3B (UD-Q4_K_XL) MoE | ~22.2 GB | 24 GB | — (rank 1) | **Qwen3.5 wave (2026-07-01); rank 1 since the 2026-08-03 ratification (`model-benchmarks.md` §9.3).** ~35B total / ~3B active MoE (256 experts, 8+1 active); beat the incumbent MoE `qwen3-30b-a3b-q4` on hallucinations (0 real vs 2, EM parity) with the speed case confirmed (140.9 t/s vulkan / 12.1 cpu tg). Ranked alternative for ≥32 GB — never the auto-pick (the Qwen3.8 Q5 holds ≥32 since 2026-08-16). Text-only, not bundled; §9.1 in-app smoke PASSED 2026-08-09 (§9.3 smokes record). |
 | Chat (Gemma E2B) | Gemma 4 E2B Instruct QAT Q4_0 | ~3.3 GB | 8 GB | 12–15 GB boxes + the §6.5 step-down landing tier (rank 3) | **Gemma 4 QAT wave (2026-07-23, issue #82); eval ratified 2026-08-03 (§9.3); PROMOTED 2026-08-09 (issue #153).** Official Google QAT; MatFormer effective-2B. Eval: F1 .3373 edges the bundled Qwen3 4B with equal hallucinations (3) and the fastest cpu decode measured (24.3 t/s); the #153 weak-16 GB-box leg confirmed 17.0 tok/s settled vs the prior 12 GB pick's 9.0 (iGPU basis) → rank 3, rec-RAM retuned to 12 (`model-benchmarks.md` §6.5 #153 amendment). Text-only. In-app b9849 smoke PASSED 2026-07-23. |
 | Chat (Gemma E4B) | Gemma 4 E4B Instruct QAT Q4_0 | ~5.2 GB | 12 GB | — (rank 0) | **Gemma 4 QAT wave; eval ratified 2026-08-03 (§9.3): F1 .2999 misses the 8B bar — no promotion.** MatFormer effective-4B. Text-only; thinks by default, `enable_thinking: false` suppression verified per size. In-app b9849 smoke PASSED 2026-07-23. |
@@ -64,11 +64,12 @@ Sizes/RAM come from each manifest
 > (higher = preferred) that the picker now uses as the tiebreak among models that fit the
 > machine's RAM (the **quality-aware recommender** follow-up — `model-benchmarks.md` §6.2, tiers
 > since recalibrated by §6.3). Net effect on real hardware (newest-Qwen promotion, owner decision
-> 2026-07-12, handed to the Qwen3.8 pair 2026-08-16, `model-benchmarks.md` §6.4 + §9.4; asserted
+> 2026-07-12, handed to the Qwen3.8 pair 2026-08-16 and handed BACK 2026-08-20 when upstream
+> deleted the Qwen3.8 files (issue #196), `model-benchmarks.md` §6.4 + §9.4 + §9.5; asserted
 > in `benchmark.test.ts`): **≤12 GB → Qwen3.5 4B, 12–15 GB → Gemma 4 E2B (#153),
-> 16–20 GB → Qwen3.5 9B, 24 GB → Qwen3.8 27B Q4, ≥32 GB → Qwen3.8 27B Q5**; Granite, both MoEs,
-> and the superseded former winners (Ministral, Gemma 4 12B, the Qwen3.6 27B pair — all still
-> ranked and selectable) are never auto-recommended. The "Auto-tier" column above is the declared `recommended_profiles`
+> 16–20 GB → Qwen3.5 9B, 24 GB → Qwen3.6 27B Q4, ≥32 GB → Qwen3.6 27B Q5**; Granite, both MoEs,
+> the withdrawn Qwen3.8 trio, and the superseded former winners (Ministral, Gemma 4 12B — all
+> still ranked and selectable) are never auto-recommended. The "Auto-tier" column above is the declared `recommended_profiles`
 > (kept as-is); the live recommendation is `recommendation_rank` + RAM-best-fit.
 Min-RAM values were **recalibrated from measured peak RSS** in the Phase-29 run (8B: 16→12,
 12–14B: 16→14). Adding a model is
@@ -262,6 +263,9 @@ vision role + mmproj projector" below). Unknown extra keys (e.g. `supports_tools
   today by `qwen3.8-27b-q4` and `qwen3.8-27b-q5`; deliberately NOT by `qwen3.8-27b-q6`, whose
   22.7 GiB VRAM fit on a 24 GB card is its whole reason to exist. Design record:
   `architecture.md` "MTP speculative decoding"; measured evidence: `model-benchmarks.md` §9.4.
+  **Do not copy the flag onto a Qwen3.8 successor manifest on family resemblance** (issue #196):
+  upstream's Dynamic 3.0 rebuild publishes the MTP module as a SEPARATE file, and this enum member
+  means an in-GGUF head with no second model file — re-verify per file (§9.5).
 
 ## Model states (spec §7.4)
 Computed by `services/models.ts` with this precedence:
@@ -343,6 +347,52 @@ Leave `sha256` as the placeholder until a real drive is built; fetch the weight,
 `verify-models --generate` to capture the real hash **and the exact `size_bytes`** and promote them
 into the manifest. A 64-hex value the code treats as a **verified** hash, so never transcribe a hash
 you have not computed from the actual downloaded file — an unverified guess hard-fails the checksum.
+
+### Withdrawn upstream sources (`download.withdrawn`, issue #196)
+
+Publishers delete and restructure their repos. On 2026-08-20 unsloth removed the static K-quants
+from `Qwen3.8-27B-GGUF` (their Dynamic 3.0 rollout) and the three files our Qwen3.8 manifests pin
+began returning HTTP 404 (model-benchmarks.md §9.5). Hash pinning means we can never be handed
+substituted weights — but everyone downstream rediscovers the dead link the expensive way: a
+multi-GB request that ends in an error reading like a broken connection.
+
+An optional string inside the `download` block records the fact once, in the manifest:
+
+```yaml
+download:
+  url: https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/Qwen3.8-27B-Q4_K_M.gguf?download=true
+  sha256: 7e78da5d…
+  size_bytes: 17106775008
+  withdrawn: "2026-08-20: unsloth removed the static K-quants … (HTTP 404 verified 2026-08-20)."
+```
+
+Rules and behaviour:
+- **A non-empty, dated string** — never a bare `true`. The note is shown to the user and read by a
+  maintainer months later; the validator rejects an empty value or a boolean.
+- **The rest of the block stays.** `url`/`sha256`/`size_bytes`/`license_url` remain the provenance
+  record of the file existing drives carry, and that local copy keeps verifying normally. A
+  withdrawn source **never** disturbs an installed weight (the planner still reports
+  `present-verified`).
+- **Planner** (`assets.ts` `planModelDownloads`, the source of truth): a file that would need
+  fetching plans **`source-withdrawn`** instead of `download` — checked *before* the license gate,
+  since no acknowledgement can conjure a deleted file back.
+- **In-app**: the AI Model card shows the reason in place of the Download button, and the main
+  process refuses `downloadModel` for such a manifest anyway (a renderer bug must never cost the
+  user a doomed multi-GB request). The network-gate banner does not fire for a model that is
+  unfetchable for reasons that have nothing to do with the drive's policy.
+- **Fetch scripts**: `fetch-models.{ps1,sh}` print a loud `SKIP … upstream source withdrawn` line
+  and continue — one retired file must not fail a whole drive build. Both twins are pinned against
+  the TS behaviour by `script-drift.test.ts`. Their flat-YAML parser strips inline comments at
+  `" #"`, so **a withdrawal note must not contain `" #"`** (write "issue 196", not "issue #196") —
+  also asserted in CI.
+- **Ranking**: a withdrawn manifest carries `recommendation_rank: 0` — selectable, never
+  auto-recommended. `committed-catalog.test.ts` pins the general invariant ("no committed manifest
+  is both recommended and unobtainable"), so a fresh drive is never pointed at a model it cannot
+  obtain. Hand the tier to the best-measured model whose source is still live.
+
+When a successor file is eventually measured and productized, the withdrawn manifest is retired
+(or kept as an installed-base record) per the wave that promotes the successor — that decision
+belongs to the wave, not to this field.
 
 ### The DIY download flow + license gate (spec §13)
 `scripts/fetch-models.{ps1,sh}` downloads each weight with a `download` block, **resumes** partials,

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -106,6 +106,13 @@ Two of the spec's original exclusions were later **reversed by shipping**: local
 (Whisper transcription + dictation, Phase 36/37 — voice *output*/TTS remains out of scope) and
 scanned-PDF OCR ("Make searchable", Phase 38).
 
+**The one boundary the product deliberately opened — inward, not outward.** The opt-in
+[local API](local-api.md) lets other programs *on the user's own machine* use the running model
+(loopback only, off by default, completions only). It widens who may ask the model a question
+from "this app" to "this computer" — and nothing further: it is not a network service, not a
+multi-user surface, and not a step toward serving anyone else's requests. "The space" is the
+user's machine, and that is exactly where the door stops.
+
 ## Growth directions
 
 ### Future editions (spec §19)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -275,6 +275,9 @@ exposure, not against a same-user debugger reading the child's environment.
 
 #### The fifth threat: same-machine processes (local-api wave)
 
+_User-facing counterpart: [`local-api.md`](local-api.md) — the same controls written for someone
+deciding whether to switch the feature on, plus the wire contract a client author needs._
+
 Loopback binding answers "can the network reach it?" — it says nothing about the **other programs
 running as you**. Two doors exist:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -433,7 +433,8 @@ What to do:
 ## Connecting another app to HilbertRaum (local API)
 
 These cover the optional **Settings → Privacy & data → Local API** feature. If you have not turned
-it on, none of them apply.
+it on, none of them apply. Setup instructions, client examples, and the full HTTP contract are in
+[`local-api.md`](local-api.md).
 
 ### The app I connected says "connection refused"
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -875,6 +875,10 @@ See [`PRIVACY.md`](../PRIVACY.md) for the full statement.
 running model and read the answers — an editor plugin, a note-taking app, a script you wrote. It is
 **off until you turn it on**, and turning it on asks you to confirm what that means.
 
+> Setting up a specific client — curl, the Python/Node `openai` SDKs, any "OpenAI-compatible"
+> tool — plus the complete request/response contract for people writing one: see
+> [`local-api.md`](local-api.md).
+
 **Turn it on**
 
 1. Open **Settings → Privacy & data** and find the **Local API** card.

--- a/model-manifests/chat/qwen3.6-27b-q4.yaml
+++ b/model-manifests/chat/qwen3.6-27b-q4.yaml
@@ -17,16 +17,17 @@ recommended_min_ram_gb: 20
 # the 12-14B pair (gemma4-12b / qwen3-14b, both 24), so the §6.2 rank decides the tier winner
 # instead of capacity alone. Weight is ~16.8 GB (15.7 GiB); 24 GB is the honest comfortable floor.
 recommended_ram_gb: 24
-# Rank 1 (owner decision 2026-08-16, §6.4 full generational handover to the Qwen3.8 wave;
-# model-benchmarks.md §9.4): qwen3.8-27b-q4 takes the 24 GB tier on a quality tie inside
-# cross-run noise (F1 .3523 vs .3500, EM parity) at the same speed envelope, per the standing
-# newest-generation preference. Deliberately ranked BELOW gemma4-12b (rank 2) per the owner's
-# handover call — ranked, still selectable, no longer the alternative of record.
-# HISTORY — rank 3 2026-07-12..2026-08-16 (owner decision, newest-generation preference §6.4):
-# the #48 tester eval (i9-9900X + RTX 3090, b9849 binary) put Qwen3.6 27B Q4/Q5 at the top of
-# the quality table (F1 .3523/.3573, EM .9765, zero unanswerable-set hallucinations for Q5),
-# sweeping the 20-24 GB tier; won the 24 GB tier from gemma4-12b.
-recommendation_rank: 1
+# Rank 3 — the 24 GB tier pick again SINCE 2026-08-20 (issue 196; model-benchmarks.md §9.5).
+# The §9.4 handover gave the tier to qwen3.8-27b-q4 on a quality tie inside cross-run noise;
+# upstream then deleted that file, so it can no longer be obtained and dropped to rank 0. This
+# model's own measurements are untouched and its source is live (URL + LFS hash re-verified
+# 2026-08-20), so it takes the tier back rather than leaving 24 GB boxes to gemma4-12b (rank 2,
+# a 12B) or to an undownloadable pick.
+# HISTORY — rank 3 2026-07-12..2026-08-16: the #48 tester eval (i9-9900X + RTX 3090, b9849
+# binary) put Qwen3.6 27B Q4/Q5 at the top of the quality table (F1 .3523/.3573, EM .9765, zero
+# unanswerable-set hallucinations for Q5), sweeping the 20-24 GB tier; won the 24 GB tier from
+# gemma4-12b. Rank 1 2026-08-16..2026-08-20 (the §9.4 generational handover, now reverted).
+recommendation_rank: 3
 # Safe LOCAL runtime budget (catalog convention for the big additions, not the native window).
 # The earlier local-test value 16384 assumed a 24 GB RTX 3090; 8192 is the honest default for
 # a generic 24 GB machine (KV cache + sidecars need headroom). Raise per-machine in Settings.

--- a/model-manifests/chat/qwen3.6-27b-q5.yaml
+++ b/model-manifests/chat/qwen3.6-27b-q5.yaml
@@ -13,15 +13,16 @@ size_on_disk_gb: 19.5
 # 2026-07-30 (the §6.4 residual for this model).
 recommended_min_ram_gb: 24
 recommended_ram_gb: 32
-# Rank 1 (owner decision 2026-08-16, §6.4 full generational handover to the Qwen3.8 wave;
-# model-benchmarks.md §9.4): qwen3.8-27b-q5 takes the ≥32 GB tier per the standing
-# newest-generation preference. This model still holds the all-time harness F1 record (.3573)
-# — recorded honestly; the handover is the generational call, not a quality verdict. Ranked
-# below gemma4-26b-a4b (rank 2) per the owner's handover call; still selectable.
+# Rank 3 — the ≥32 GB tier pick again SINCE 2026-08-20 (issue 196; model-benchmarks.md §9.5).
+# The §9.4 handover gave the tier to qwen3.8-27b-q5; upstream then deleted that file, so it can
+# no longer be obtained and dropped to rank 0. This model holds the all-time harness F1 record
+# (.3573) and its source is live (URL + LFS hash re-verified 2026-08-20) — the tier comes back
+# to the best-measured model that can actually be downloaded.
 # HISTORY — rank 3 2026-07-12..2026-08-16: top scorer of the #48 tester eval (F1 .3573,
 # EM .9765, zero unanswerable-set hallucinations, b9849 binary). The ~19.5 GB (18.2 GiB)
-# weight needs the 32 GB tier to be comfortable; the Q4 sibling covered 24 GB.
-recommendation_rank: 1
+# weight needs the 32 GB tier to be comfortable; the Q4 sibling covered 24 GB. Rank 1
+# 2026-08-16..2026-08-20 (the §9.4 generational handover, now reverted).
+recommendation_rank: 3
 # Safe LOCAL runtime budget (catalog convention for the big additions), not the native window.
 recommended_context_tokens: 8192
 supports_thinking_mode: true

--- a/model-manifests/chat/qwen3.8-27b-q4.yaml
+++ b/model-manifests/chat/qwen3.8-27b-q4.yaml
@@ -15,12 +15,18 @@ size_on_disk_gb: 17.1
 # VmHWM 17.14 GiB, thinking suppression + Deep verified, clean stop/quit teardowns — §9.4).
 recommended_min_ram_gb: 21
 recommended_ram_gb: 24
-# Rank 3 (owner decision 2026-08-16, newest-generation preference; model-benchmarks.md §6.4 +
-# the §9.4 wave record): quality ties the former 24 GB pick qwen3.6-27b-q4 inside cross-run
-# noise (F1 .3500 vs .3523, EM parity .9765) with ZERO hallucinations and perfect
-# unanswerable-abstention, at the same speed envelope. Takes the 24 GB tier; qwen3.6-27b-q4
-# drops to rank 1 (full generational handover, owner decision at the §9.4 ratification).
-recommendation_rank: 3
+# Rank 0 SINCE 2026-08-20 (issue 196): unsloth deleted this exact file in their Dynamic 3.0
+# restructure, so a drive that does not already carry the weight can no longer obtain it (see
+# download.withdrawn below). Rank 0 = selectable, never auto-recommended — the same "never the
+# auto-pick" convention the q6 sibling and gemma4-31b use — so the picker stops handing the
+# 24 GB tier to a model a fresh drive cannot get. The 24 GB tier goes back to qwen3.6-27b-q4
+# (rank 3 again); model-benchmarks.md §9.5.
+# HISTORY — rank 3 2026-08-16..2026-08-20 (owner decision, newest-generation preference;
+# model-benchmarks.md §6.4 + the §9.4 wave record): quality ties the former 24 GB pick
+# qwen3.6-27b-q4 inside cross-run noise (F1 .3500 vs .3523, EM parity .9765) with ZERO
+# hallucinations and perfect unanswerable-abstention, at the same speed envelope. The
+# measured verdict is UNCHANGED — only the obtainability is gone.
+recommendation_rank: 0
 # Safe LOCAL runtime budget (catalog convention for the big additions), not the native window.
 recommended_context_tokens: 8192
 supports_thinking_mode: true
@@ -50,6 +56,11 @@ download:
   sha256: 7e78da5d7e3ae28d178121f58646953305f3e5bd3cb46f4a75584e8b6c6fe169
   size_bytes: 17106775008
   license_url: https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/LICENSE
+  # DEAD URL — kept as the provenance record of the file this manifest pins, never fetched
+  # again (issue 196; model-policy.md "Withdrawn upstream sources"). The url/sha256/size above
+  # still describe the weight already on existing drives, which keeps verifying normally.
+  # No " #" in this value: the fetch scripts' flat-YAML parser strips inline comments.
+  withdrawn: "2026-08-20: unsloth removed the static K-quants from Qwen3.8-27B-GGUF in their Dynamic 3.0 restructure (HTTP 404 verified 2026-08-20). Successor candidate UD-Q4_K_M awaits the measurement wave of issue 196."
 bundled_on_preconfigured_drive: false
 # TEXT-ONLY USE: upstream Qwen3.8 is a vision-language model, but this chat manifest ships only
 # the language GGUF and no mmproj/projector, which is all our chat pipeline uses.

--- a/model-manifests/chat/qwen3.8-27b-q5.yaml
+++ b/model-manifests/chat/qwen3.8-27b-q5.yaml
@@ -14,12 +14,18 @@ size_on_disk_gb: 19.8
 # sha256 verify 76 s, VmHWM 19.68 GiB, thinking suppression + Deep verified, clean teardowns).
 recommended_min_ram_gb: 23
 recommended_ram_gb: 32
-# Rank 3 (owner decision 2026-08-16, newest-generation preference; model-benchmarks.md §6.4 +
-# §9.4): F1 .3523 exactly ties the former 24 GB pick qwen3.6-27b-q4; the all-time harness
-# record stays with qwen3.6-27b-q5 (.3573), but the 3.8 wave's zero-hallucination + perfect-
-# abstention profile across ALL quants plus the newest-generation preference takes the ≥32 GB
-# tier; qwen3.6-27b-q5 drops to rank 1 (full generational handover).
-recommendation_rank: 3
+# Rank 0 SINCE 2026-08-20 (issue 196): unsloth deleted this exact file in their Dynamic 3.0
+# restructure, so a drive that does not already carry the weight can no longer obtain it (see
+# download.withdrawn below). Rank 0 = selectable, never auto-recommended, so the picker stops
+# handing the ≥32 GB tier to a model a fresh drive cannot get; the tier goes back to
+# qwen3.6-27b-q5 (rank 3 again, and the all-time harness F1 record holder). §9.5.
+# HISTORY — rank 3 2026-08-16..2026-08-20 (owner decision, newest-generation preference;
+# model-benchmarks.md §6.4 + §9.4): F1 .3523 exactly ties the former 24 GB pick
+# qwen3.6-27b-q4; the all-time harness record stays with qwen3.6-27b-q5 (.3573), but the 3.8
+# wave's zero-hallucination + perfect-abstention profile across ALL quants plus the
+# newest-generation preference took the ≥32 GB tier. The measured verdict is UNCHANGED — only
+# the obtainability is gone.
+recommendation_rank: 0
 # Safe LOCAL runtime budget (catalog convention for the big additions), not the native window.
 recommended_context_tokens: 8192
 supports_thinking_mode: true
@@ -48,6 +54,11 @@ download:
   sha256: 07deb7fa91bf751d3000774fe5bb8afae5ffb41255fd19980147468052e07177
   size_bytes: 19834055648
   license_url: https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/LICENSE
+  # DEAD URL — kept as the provenance record of the file this manifest pins, never fetched
+  # again (issue 196; model-policy.md "Withdrawn upstream sources"). The url/sha256/size above
+  # still describe the weight already on existing drives, which keeps verifying normally.
+  # No " #" in this value: the fetch scripts' flat-YAML parser strips inline comments.
+  withdrawn: "2026-08-20: unsloth removed the static K-quants from Qwen3.8-27B-GGUF in their Dynamic 3.0 restructure (HTTP 404 verified 2026-08-20). Successor candidate UD-Q5_K_M awaits the measurement wave of issue 196."
 bundled_on_preconfigured_drive: false
 # TEXT-ONLY USE: upstream Qwen3.8 is a vision-language model, but this chat manifest ships only
 # the language GGUF and no mmproj/projector, which is all our chat pipeline uses.

--- a/model-manifests/chat/qwen3.8-27b-q6.yaml
+++ b/model-manifests/chat/qwen3.8-27b-q6.yaml
@@ -18,6 +18,8 @@ recommended_ram_gb: 32
 # the q5 sibling wins the ≥32 GB RAM tier (faster at equal quality: F1 .3523 vs .3503, tg 35.9
 # vs 31.7). Stays selectable as the "24 GB GPU, quality ceiling" option (the gemma4-31b
 # selectable-ceiling precedent) for boxes where VRAM, not RAM, is the binding constraint.
+# SINCE 2026-08-20 (issue 196) rank 0 is also the obtainability answer: upstream deleted this
+# file (download.withdrawn below), so only drives that already carry the weight can select it.
 recommendation_rank: 0
 # Safe LOCAL runtime budget (catalog convention for the big additions), not the native window.
 recommended_context_tokens: 8192
@@ -41,6 +43,11 @@ download:
   sha256: 562fbf760503008f118e5df38de5b3e97992d1f693f475815631198547486727
   size_bytes: 22884408288
   license_url: https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/LICENSE
+  # DEAD URL — kept as the provenance record of the file this manifest pins, never fetched
+  # again (issue 196; model-policy.md "Withdrawn upstream sources"). The url/sha256/size above
+  # still describe the weight already on existing drives, which keeps verifying normally.
+  # No " #" in this value: the fetch scripts' flat-YAML parser strips inline comments.
+  withdrawn: "2026-08-20: unsloth removed the static K-quants from Qwen3.8-27B-GGUF in their Dynamic 3.0 restructure (HTTP 404 verified 2026-08-20). Successor candidate UD-Q6_K awaits the measurement wave of issue 196."
 bundled_on_preconfigured_drive: false
 # TEXT-ONLY USE: upstream Qwen3.8 is a vision-language model, but this chat manifest ships only
 # the language GGUF and no mmproj/projector, which is all our chat pipeline uses.

--- a/scripts/fetch-models.ps1
+++ b/scripts/fetch-models.ps1
@@ -253,6 +253,11 @@ foreach ($mf in $manifestFiles) {
   $license = Get-ManifestField $text 'license'
   $licenseUrl = Get-ManifestField $text 'license_url'
   $reviewStatus = Get-ManifestField $text 'status'
+  # Optional download.withdrawn (issue 196): the publisher deleted the exact file this manifest
+  # pins, so the URL above is known-dead. Mirrors planModelDownloads' 'source-withdrawn' task
+  # status (assets.ts is the source of truth; script-drift.test.ts pins both twins). Note values
+  # must not contain ' #' -- Get-ManifestField strips inline YAML comments.
+  $withdrawn = Get-ManifestField $text 'withdrawn'
 
   if (-not $url -or -not $localPath) { continue }      # no download block -> skip
   if ($Only -and $id -ne $Only) { continue }
@@ -278,6 +283,16 @@ foreach ($mf in $manifestFiles) {
   # skipped WITHOUT a license prompt (the license is only relevant to an actual download).
   $needsFetch = ($ggufState -eq 'absent' -or $ggufState -eq 'mismatch') -or
     ($hasMmproj -and ($mmprojState -eq 'absent' -or $mmprojState -eq 'mismatch'))
+
+  # Withdrawn upstream source (issue 196) -- only relevant when something WOULD be fetched: a
+  # drive that already carries the weight is unaffected and verifies as usual. Skipped, not
+  # failed: one publisher retiring a file must not break a whole drive build.
+  if ($needsFetch -and $withdrawn) {
+    Write-Host ("  SKIP   {0}: upstream source withdrawn -- {1}" -f $id, $withdrawn) -ForegroundColor Yellow
+    Write-Host '         Nothing to fetch; copies already on a drive keep verifying.'
+    $skipped++
+    continue
+  }
 
   if ($needsFetch) {
     # License gate (spec section 13) -- only when something will actually be fetched.

--- a/scripts/fetch-models.sh
+++ b/scripts/fetch-models.sh
@@ -216,6 +216,11 @@ for mf in "${MANIFEST_FILES[@]}"; do
   license="$(field "$mf" license)"
   license_url="$(field "$mf" license_url)"
   review_status="$(field "$mf" status)"
+  # Optional `download.withdrawn` (issue 196): the publisher deleted the exact file this
+  # manifest pins, so the URL above is known-dead. Mirrors planModelDownloads' 'source-
+  # withdrawn' task status (assets.ts is the source of truth; script-drift.test.ts pins both
+  # twins). Note values must not contain " #" — `field` strips inline YAML comments.
+  withdrawn="$(field "$mf" withdrawn)"
 
   [[ -z "$url" || -z "$local_path" ]] && continue       # no download block → skip
   [[ -n "$ONLY" && "$id" != "$ONLY" ]] && continue
@@ -244,6 +249,15 @@ for mf in "${MANIFEST_FILES[@]}"; do
   needs_fetch=0
   [[ "$gguf_state" == absent || "$gguf_state" == mismatch ]] && needs_fetch=1
   [[ $has_mmproj -eq 1 && ( "$mmproj_state" == absent || "$mmproj_state" == mismatch ) ]] && needs_fetch=1
+
+  # Withdrawn upstream source (issue 196) — only relevant when something WOULD be fetched: a
+  # drive that already carries the weight is unaffected and verifies as usual. Skipped, not
+  # failed: one publisher retiring a file must not break a whole drive build.
+  if [[ $needs_fetch -eq 1 && -n "$withdrawn" ]]; then
+    printf '  SKIP   %s: upstream source withdrawn — %s\n' "$id" "$withdrawn"
+    printf '         Nothing to fetch; copies already on a drive keep verifying.\n'
+    skipped=$((skipped + 1)); continue
+  fi
 
   if [[ $needs_fetch -eq 1 ]]; then
     # License gate (spec §13) — only when something will actually be fetched.


### PR DESCRIPTION
The local-API wave (PR #184) shipped under owner option **O2 "not promoted"** — one CHANGELOG line, no README push, ship one release quietly first. With the first release being prepared, that hold is lifted.

**Docs-only. No behaviour changed**: the feature is still default-off, loopback-only, consent-gated, and policy-restrictable.

## New — `docs/local-api.md` (§1–§12)

One document serving both audiences:

- **Tutorial** (§2–§5): what must be true first, the turn-on flow, the `127.0.0.1`-vs-`localhost` trap and why it bites on Windows 11, port conflicts (and why an unexpected one is a security question), then working examples — curl, PowerShell `Invoke-RestMethod`, the Python and Node `openai` SDKs, plain `fetch`, and JSON-schema-constrained output.
- **Wire contract** (§6): base URL/headers/auth, both routes, the supported / accepted-and-ignored / refused field table, streaming and non-streaming response shapes (incl. why `usage` is absent and why a truncated stream never ends with `[DONE]`), the full error-code table with `Retry-After` semantics, and the timeout/limit table.
- **Behaviour and posture** (§7–§10): how one model is shared (single slot, ~30 s waiter, user pre-emption, background lanes, lock/quit), the security-control table, the privacy statement, and the settings + drive-policy reference.
- **§12** points maintainers at the design record, data contracts, source layout, and the pinned tests.

## Updated

- **`README.md`** — feature bullet, docs-table row, and an "inbound door" paragraph under Privacy & security.
- **`PRIVACY.md`** — port named; the `local_api_toggled` audit entry disclosed as the *one* thing recorded (state only — no port, no caller, no content); explicit "completions only, no other model features".
- **`SECURITY.md`** — constant-time compare, key at rest, rotation aborting in-flight streams, the 1 MB counted-byte body cap and 16-connection ceiling.
- **`docs/known-limitations.md`** — a new **Local API** section: v1 scope, refused capabilities, ignored sampling extras, absent `usage`, single-slot concurrency, no per-connection visibility, the same-machine residual, and the upstream `/health` + `/v1/models` auth exemption.
- **`docs/product-vision.md`** — the one deliberately opened boundary, and where it stops.
- Cross-pointers from `user-guide.md`, `troubleshooting.md`, `security-model.md`, and `data-contracts.md` — the last now names `local-api.md` §6 as the twin that must move with the contract.
- **`docs/architecture.md`** — the O2 row carries a dated *superseded* note, which also promotes the wire shape to **externally documented**: a status/code-mapping or streaming-frame-order change is now a breaking change needing a CHANGELOG note.
- `CHANGELOG.md` + `BUILD_STATE.md` per the per-phase ritual.

## Verification

Every documented fact was read out of the implementation (`services/local-api/*`, `shared/local-api.ts`, `shared/types.ts` defaults, the policy merge rules, the i18n card copy), not from the wave's prose.

`repo-hygiene.test.ts` green (link resolution, BOM/NUL scans, BUILD_STATE budget). Full `npm test`: 5390 passed, 1 pre-existing flake in `evidence-pack-print-pdf.test.ts` under full-suite parallel load — it passes in isolation and this branch touches no source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
