### PR TITLE
docs(build-state): record where the #196 fix actually landed (O6 citation correction)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -65,6 +65,13 @@ Records: `model-benchmarks.md` **§9.5**, `model-policy.md` "Withdrawn upstream 
 `architecture.md` In-app downloader ("a fourth refusal"). Tests: validator, planner, downloader,
 Models screen and both fetch twins, plus a general catalog invariant — *no committed manifest is
 both recommended and unobtainable*; the planner + renderer guards mutation-checked (5 red / 2 red).
+**Where it landed (O6 citation correction, 2026-08-20):** this fix has **no PR of its own**. Its
+branch (`fix/196-withdrawn-upstream-source`, local commit `a166d511`) was never pushed; the
+local-API documentation branch was cut from it by mistake instead of from `master`, so the squash
+of **PR #197** carried both change sets onto `master` as commit **`0324a55a`**, under a
+`docs(local-api)` title. Nothing was lost or altered — the #196 paths on `master` are
+byte-identical to `a166d511` — and the combined tree passed CI as one unit. Cite this work as
+**PR #197 / `0324a55a`**, not as a #196 PR; issue #196 itself is still open on GitHub.
 
 _2026-08-20 — **Single-document re-index/delete now give feedback — issue #194 CLOSED.**_ Found by
 the #190 continuity check on the relocated drive: the operator clicked re-index and got nothing —


### PR DESCRIPTION
Record-only follow-up to #197.

**What happened.** The #196 catalog fix (withdrawn upstream Qwen3.8 sources) has **no PR of its own**: its branch `fix/196-withdrawn-upstream-source` (local commit `a166d511`) was never pushed, and the local-API documentation branch was cut from it instead of from `master`. PR #197's squash therefore carried both change sets onto `master` as commit `0324a55a`, under a `docs(local-api)` title.

**What is and is not affected.**

- Nothing was lost or altered: `git diff a166d511 origin/master -- model-manifests scripts apps/desktop/src` is empty.
- The combined tree passed CI as one unit, so `master` is not in an untested state.
- The branch existed only locally, so nothing is orphaned or double-merged.
- The damage is to the record: the repo's O6 rule cites work as "PR# + phase prefix + record §", and a #196 citation would otherwise resolve to a docs PR.

**This PR** adds one note to the #196 `BUILD_STATE.md` entry stating where the work landed and how to cite it (**PR #197 / `0324a55a`**), and that issue #196 is still open on GitHub. No history rewrite — `master` is public.

`repo-hygiene.test.ts` green (link resolution, BOM/NUL scans, BUILD_STATE budget). Docs-only: no src or test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
