### PR TITLE
fix(catalog): measured size_bytes for four Qwen3 manifests, and scope the field (#202)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -53,6 +53,16 @@ hash equality for two manifests; **[#202]** four manifests carry rounded `size_b
 landed here: `model-policy.md` "Re-verifying the catalog against upstream" makes the drift check
 compare the upstream LFS OID, not just the status code.
 
+_2026-08-20 — **Four rounded `size_bytes` replaced with measured ones, and the field scoped —
+issue #202 CLOSED.**_ Both options, which were never alternatives. (a) `qwen3-4b/8b/14b-instruct-q4`
+and `qwen3-30b-a3b-q4` now carry the real byte counts (2497280256 / 5027783488 / 9001752960 /
+18556685824), re-derived by both methods of the `model-policy.md` drift check; `size_on_disk_gb`
+followed on the 4B and 14B to hold the committed F-16 decimal-GB invariant, and the two test
+fixtures carrying the old 4B number moved with them. All four `sha256` values were and remain exact
+matches — only the declared sizes were estimates. (b) `model-policy.md` now scopes the field:
+**declare it exactly, consume it tolerantly**, tying `assets.ts`'s 25 %/128 MiB cap headroom to the
+reason it exists and citing #201 (a checkpoint that arrived 1,568 bytes larger at the same URL) as
+the proof. Audit ledger B-3 closed.
 _2026-08-20 — **Local API documented as a first-class feature for the release — docs-only, O2
 lifted.**_ The local-API wave shipped under owner option **O2 "not promoted"** (one CHANGELOG
 line, no README push, ship one release quietly first). With the release now being prepared, the

--- a/apps/desktop/tests/integration/assets.test.ts
+++ b/apps/desktop/tests/integration/assets.test.ts
@@ -46,7 +46,7 @@ function manifest(overrides: Record<string, unknown> = {}): ModelManifest {
     format: 'gguf',
     runtime: 'llama_cpp',
     license: 'apache-2.0',
-    size_on_disk_gb: 2.7,
+    size_on_disk_gb: 2.5,
     recommended_min_ram_gb: 8,
     recommended_ram_gb: 16,
     recommended_context_tokens: 4096,
@@ -57,7 +57,7 @@ function manifest(overrides: Record<string, unknown> = {}): ModelManifest {
     download: {
       url: 'https://example.test/qwen3-4b.gguf',
       sha256: 'REPLACE_WITH_REAL_HASH',
-      size_bytes: 2700000000,
+      size_bytes: 2497280256,
       license_url: 'https://example.test/license'
     },
     ...overrides
@@ -193,7 +193,7 @@ describe('planModelDownloads', () => {
         download: {
           url: 'https://example.test/qwen3-4b.gguf',
           sha256: 'REPLACE_WITH_REAL_HASH',
-          size_bytes: 2700000000,
+          size_bytes: 2497280256,
           license_url: 'https://example.test/license',
           withdrawn: '2026-08-20: upstream deleted the file'
         },

--- a/apps/desktop/tests/unit/manifest.test.ts
+++ b/apps/desktop/tests/unit/manifest.test.ts
@@ -145,7 +145,7 @@ describe('validateManifest — optional download block (Phase 12)', () => {
   const downloadBlock = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
     url: 'https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf?download=true',
     sha256: 'REPLACE_WITH_REAL_HASH',
-    size_bytes: 2700000000,
+    size_bytes: 2497280256,
     license_url: 'https://huggingface.co/Qwen/Qwen3-4B-GGUF/blob/main/LICENSE',
     ...overrides
   })
@@ -161,7 +161,7 @@ describe('validateManifest — optional download block (Phase 12)', () => {
     expect(res.ok).toBe(true)
     expect(res.manifest?.download?.url).toContain('Qwen3-4B-Q4_K_M.gguf')
     expect(res.manifest?.download?.sha256).toBe('replace_with_real_hash')
-    expect(res.manifest?.download?.sizeBytes).toBe(2700000000)
+    expect(res.manifest?.download?.sizeBytes).toBe(2497280256)
     expect(res.manifest?.download?.licenseUrl).toContain('LICENSE')
   })
 

--- a/docs/audits/docs-code-comment-audit.md
+++ b/docs/audits/docs-code-comment-audit.md
@@ -29,7 +29,7 @@ record of what was true when the pass ran. This table is the ledger.
 | **A-8** five stale manifest rank comments | **fixed** | Phase 4 |
 | **B-1** `gemma4-12b-it-qat-q4` upstream re-upload | **FILED, not fixed — needs a measurement wave** | [#201](https://github.com/HilbertraumAI/HilbertRaum/issues/201) |
 | **B-2** the drift check verified liveness, not byte-identity | **fixed** (the ritual is now written down) | Phase 5 |
-| **B-3** four rounded `size_bytes` | **FILED — owner's call between a measured correction and a policy sentence** | [#202](https://github.com/HilbertraumAI/HilbertRaum/issues/202) |
+| **B-3** four rounded `size_bytes` | **fixed 2026-08-20 — BOTH options, they were never alternatives.** (a) The four values corrected to the measured byte counts (re-derived by both drift-check methods; `size_on_disk_gb` followed on two of them to hold the F-16 decimal-GB invariant). (b) `model-policy.md` now scopes `size_bytes` as drift-TOLERANT where it is consumed and exact where it is declared, tying the tolerance to `assets.ts`'s 25 %/128 MiB headroom and citing #201 as the proof it was right. (a) alone left the headroom looking arbitrary; (b) alone left four wrong numbers | [#202](https://github.com/HilbertraumAI/HilbertRaum/issues/202) |
 | **C-1 … C-5** the Node floor | **fixed** | Phase 1 |
 | **D-1** four unresolvable links in the archive | **fixed** (de-linkified as the 2026-07-12 pass did; header records the completed sweep) | Phase 5 |
 | **D-2 D-3 D-4** | **no action — recorded so a later sweep does not "fix" them** | — |

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -336,7 +336,7 @@ stay valid, and the validator only checks the sub-fields when the block is prese
 download:
   url: https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf?download=true
   sha256: REPLACE_WITH_REAL_HASH   # when a real hash, MUST equal the top-level sha256 (same file)
-  size_bytes: 2700000000           # optional; progress + a DRIFT-TOLERANT in-app download body cap
+  size_bytes: 2497280256           # optional; progress + a DRIFT-TOLERANT in-app download body cap
   license_url: https://huggingface.co/Qwen/Qwen3-4B-GGUF/blob/main/LICENSE   # optional
 ```
 
@@ -348,11 +348,22 @@ Rules (validated in `shared/manifest.ts`):
 
 `size_bytes` feeds the progress bar AND the in-app downloader's disk-fill body cap
 (`modelWeightMaxBytes`). The cap is **drift-tolerant** — `size_bytes` grown by a comfortable headroom
-(BUG dl-size-cap-2026-07-03) — so a file a little larger than the declared size still downloads; the
-SHA verify is the integrity control. Do **not** understate `size_bytes` by more than the headroom:
-an exact cap keyed to a too-small `size_bytes` previously truncated a legitimate download near ~95%
-and then failed the checksum on resume. It is informational, not a hard integrity gate — the **real**
-trust anchor is `sha256`.
+(25 %, floor 128 MiB; BUG dl-size-cap-2026-07-03) — so a file a little larger than the declared size
+still downloads; the SHA verify is the integrity control.
+
+**Field scope: `size_bytes` is DRIFT-TOLERANT by design — it is the one manifest number the code
+does not assume is exact.** Everywhere else the rule holds without qualification (manifest numbers
+are measured, never estimated), and `size_bytes` should still be the real byte count: capture it with
+`verify-models --generate`, and correct it when a drift check finds it stale — four Qwen3 manifests
+carried hand-rounded values until issue #202 replaced them with measured ones on 2026-08-20. But the
+downloader must survive the case where it is *not* exact, because upstream can change the file's size
+underneath a pinned manifest without our knowing: **issue #201 is the proof** — Google's corrected
+gemma4-12B checkpoint arrived 1,568 bytes larger at the same URL. That is why `assets.ts`'s cap
+carries headroom rather than being keyed exactly to `size_bytes`, and the headroom is not arbitrary:
+an exact cap is what truncated a legitimate download at ~95 % once already. Integrity is enforced by
+`sha256` regardless, so a wrong `size_bytes` costs a wrong progress estimate, never a wrong file.
+Keep the two facing directions straight: **declare it exactly, consume it tolerantly** — and never
+understate it by more than the headroom, which is the failure the cap was widened to end.
 
 Leave `sha256` as the placeholder until a real drive is built; fetch the weight, then run
 `verify-models --generate` to capture the real hash **and the exact `size_bytes`** and promote them

--- a/model-manifests/chat/qwen3-14b-instruct-q4.yaml
+++ b/model-manifests/chat/qwen3-14b-instruct-q4.yaml
@@ -5,7 +5,9 @@ role: chat
 format: gguf
 runtime: llama_cpp
 license: apache-2.0
-size_on_disk_gb: 9.3
+# size_on_disk_gb follows size_bytes (decimal GB, the F-16 catalog convention): both were
+# derived from the same rounded estimate before the 2026-08-20 measured correction (issue 202).
+size_on_disk_gb: 9.0
 # recommended_min_ram_gb recalibrated 16->14 from the Phase-29 measured ~10.6 GiB peak RSS.
 recommended_min_ram_gb: 14
 # recommended_ram_gb recalibrated 32→24 with the tier winner Gemma 4 (issue #48, model-benchmarks.md
@@ -22,7 +24,11 @@ sha256: 500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0
 download:
   url: https://huggingface.co/Qwen/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf?download=true
   sha256: 500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0
-  size_bytes: 9300000000
+  # MEASURED 2026-08-20 (issue 202), was the hand-entered 9300000000. Real byte count from the
+  # upstream LFS metadata, confirmed by both methods of the model-policy.md drift check (the HF
+  # tree API lfs.size AND x-linked-size off a redirect-manual HEAD). The sha256 was and stays an
+  # exact match, so only the declared size was ever an estimate.
+  size_bytes: 9001752960
   license_url: https://huggingface.co/Qwen/Qwen3-14B-GGUF/blob/main/LICENSE
 bundled_on_preconfigured_drive: false
 # The spec §7.3 PRO model ("Qwen3 8B or 14B"). A clear quality step up for 32 GB+ laptops;

--- a/model-manifests/chat/qwen3-30b-a3b-q4.yaml
+++ b/model-manifests/chat/qwen3-30b-a3b-q4.yaml
@@ -18,7 +18,11 @@ sha256: 0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5
 download:
   url: https://huggingface.co/Qwen/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf?download=true
   sha256: 0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5
-  size_bytes: 18600000000
+  # MEASURED 2026-08-20 (issue 202), was the hand-entered 18600000000. Real byte count from the
+  # upstream LFS metadata, confirmed by both methods of the model-policy.md drift check (the HF
+  # tree API lfs.size AND x-linked-size off a redirect-manual HEAD). The sha256 was and stays an
+  # exact match, so only the declared size was ever an estimate.
+  size_bytes: 18556685824
   license_url: https://huggingface.co/Qwen/Qwen3-30B-A3B-GGUF/blob/main/LICENSE
 bundled_on_preconfigured_drive: false
 # Mixture-of-Experts: ~30B total params but only ~3.3B ACTIVE per token (8 of 128 experts),

--- a/model-manifests/chat/qwen3-4b-instruct-q4.yaml
+++ b/model-manifests/chat/qwen3-4b-instruct-q4.yaml
@@ -5,7 +5,9 @@ role: chat
 format: gguf
 runtime: llama_cpp
 license: apache-2.0
-size_on_disk_gb: 2.7
+# size_on_disk_gb follows size_bytes (decimal GB, the F-16 catalog convention): both were
+# derived from the same rounded estimate before the 2026-08-20 measured correction (issue 202).
+size_on_disk_gb: 2.5
 recommended_min_ram_gb: 8
 recommended_ram_gb: 16
 recommendation_rank: 2  # Phase-29: the chosen 4B default (preferred over 2507 to keep Deep)
@@ -20,7 +22,11 @@ sha256: 7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5
 download:
   url: https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf?download=true
   sha256: 7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5
-  size_bytes: 2700000000
+  # MEASURED 2026-08-20 (issue 202), was the hand-entered 2700000000. Real byte count from the
+  # upstream LFS metadata, confirmed by both methods of the model-policy.md drift check (the HF
+  # tree API lfs.size AND x-linked-size off a redirect-manual HEAD). The sha256 was and stays an
+  # exact match, so only the declared size was ever an estimate.
+  size_bytes: 2497280256
   license_url: https://huggingface.co/Qwen/Qwen3-4B-GGUF/blob/main/LICENSE
 bundled_on_preconfigured_drive: true
 # Target default; recommended for LITE hardware (spec §7.3). Also covers TINY + UNKNOWN

--- a/model-manifests/chat/qwen3-8b-instruct-q4.yaml
+++ b/model-manifests/chat/qwen3-8b-instruct-q4.yaml
@@ -23,7 +23,11 @@ sha256: d98cdcbd03e17ce47681435b5150e34c1417f50b5c0019dd560e4882c5745785
 download:
   url: https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf?download=true
   sha256: d98cdcbd03e17ce47681435b5150e34c1417f50b5c0019dd560e4882c5745785
-  size_bytes: 5000000000
+  # MEASURED 2026-08-20 (issue 202), was the hand-entered 5000000000. Real byte count from the
+  # upstream LFS metadata, confirmed by both methods of the model-policy.md drift check (the HF
+  # tree API lfs.size AND x-linked-size off a redirect-manual HEAD). The sha256 was and stays an
+  # exact match, so only the declared size was ever an estimate.
+  size_bytes: 5027783488
   license_url: https://huggingface.co/Qwen/Qwen3-8B-GGUF/blob/main/LICENSE
 bundled_on_preconfigured_drive: false
 # Better answers on 16 GB+ machines (spec §7.3 BALANCED). PRO auto-recommends the 14B; the


### PR DESCRIPTION
Closes #202.

Both options from the issue, because they were never alternatives: (a) alone leaves `assets.ts`'s
download-cap headroom looking arbitrary, (b) alone leaves four wrong numbers.

## (a) The four values

Re-derived on this branch by **both** methods of `model-policy.md`'s drift check — the HF tree API
(`lfs.size`) and `x-linked-size` off a `redirect: manual` HEAD — which agree with each other and
with the issue's table:

| manifest | committed | measured | delta |
|---|---|---|---|
| `qwen3-4b-instruct-q4` | 2700000000 | **2497280256** | −7.5 % |
| `qwen3-8b-instruct-q4` | 5000000000 | **5027783488** | +0.6 % |
| `qwen3-14b-instruct-q4` | 9300000000 | **9001752960** | −3.2 % |
| `qwen3-30b-a3b-q4` | 18600000000 | **18556685824** | −0.2 % |

All four `sha256` values were, and remain, exact matches against upstream — the *weights* were never
in question, only the declared size. The AI-Model card's download-size estimate comes from
`size_bytes` (`fmtGb` prefers it over `size_on_disk_gb`), so this is the user-visible number the
issue was about.

**One consequence worth calling out**, because it is a manifest change beyond the four lines:
`size_on_disk_gb` moved on the 4B (2.7 → 2.5) and the 14B (9.3 → 9.0). Those two were derived from
the same rounded estimate, and `committed-catalog.test.ts`'s **F-16** invariant requires
`size_on_disk_gb == size_bytes / 1e9` within 0.15 GB — correcting `size_bytes` alone would redden it.
That is the committed test being **satisfied**, not changed. The 8B and 30B already sat inside the
tolerance and are untouched. Neither value crosses a `plainHintKey` threshold, and both previously
*over*stated the size, so no free-space check was ever short.

The two synthetic fixtures carrying the old 4B number (`assets.test.ts`, `manifest.test.ts`) moved
with it — they are fixtures, not pins, but leaving `2700000000` in the tree means the next person
greps it and finds a stale value. `modelWeightMaxBytes`'s cap test uses a different declared size and
is unaffected.

## (b) The field scope

`docs/model-policy.md`'s manifest-field docs now say what `size_bytes` actually is, in both
directions: **declare it exactly, consume it tolerantly.** It is the one manifest number the code
does not assume is exact — which is why `assets.ts` grows the download body cap by 25 % (floor
128 MiB) instead of keying it to the declared size. The paragraph names that headroom and ties it to
the two facts that justify it: the BUG `dl-size-cap-2026-07-03` truncation at ~95 %, and **#201 as
the proof the tolerance was right** — Google's corrected gemma4-12B checkpoint arrived 1,568 bytes
larger at the same URL, under a pinned manifest, without anything on our side changing.

That keeps the repo's "manifest numbers are measured, never estimated" rule intact rather than
carving an exception out of it: the field must still be declared exactly, and this PR makes all four
so; what is tolerated is the *consumer*, because upstream can move the number underneath us.

## Also

- `docs/audits/docs-code-comment-audit.md` — ledger row **B-3** closed
- `BUILD_STATE.md` — short dated entry
- The `size_bytes` example in the field docs used the stale 4B number; corrected.

## Verification

`npm test` (5,398 passed / 51 skipped) and `npm run typecheck` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
