### PR TITLE
release: v0.1.58 — version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 from its first public `1.0.0` release onward.
 
 > **Pre-1.0.** HilbertRaum has been public since **2026-07-12** and has shipped releases
-> since that day: **v0.1.50** was the first, **v0.1.57** is current. Versions stay in the
+> since that day: **v0.1.50** was the first, **v0.1.58** is current. Versions stay in the
 > `0.1.x` line and SemVer applies from `1.0.0` on — a `0.1.x` bump is a release checkpoint,
 > not a compatibility promise. Tags below `v0.1.50` (and `v0.1.51`) are internal development
 > checkpoints with no GitHub release and no notes.
@@ -22,6 +22,10 @@ from its first public `1.0.0` release onward.
 > not for a contributor.
 
 ## [Unreleased]
+
+Nothing yet — the next release's entries accumulate here.
+
+## [0.1.58] — 2026-08-20
 
 ### Added
 
@@ -322,7 +326,8 @@ For what the product *is*, see the [README](README.md) and
 [`docs/known-limitations.md`](docs/known-limitations.md). Every release since has its own
 section in [`CHANGELOG.md`](CHANGELOG.md).
 
-[Unreleased]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.57...HEAD
+[Unreleased]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.58...HEAD
+[0.1.58]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.57...v0.1.58
 [0.1.57]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.56...v0.1.57
 [0.1.56]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.55...v0.1.56
 [0.1.55]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.54...v0.1.55

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
0.1.57 → 0.1.58.

## What this release carries

Everything that had accumulated under `[Unreleased]`: the optional local API, the Qwen3.8 MTP
speed-up (#182), the #196 successor models, the #201 gemma4 checkpoint repoint, the #202 measured
`size_bytes`, the #188 and #194 fixes, and the Electron 39 → 43 wave.

## The four files

- `package.json`, `apps/desktop/package.json` — the `version` field. `release.yml`'s release job
  asserts **tag == `apps/desktop/package.json` version**, so both must move together.
- `package-lock.json` — the **three** version fields only, hand-edited to keep the diff exact
  (issue #49 posture: `npm ci` is lockfile-exact and must never rewrite it). Same shape as the
  v0.1.57 bump.
- `CHANGELOG.md` — `[Unreleased]` renamed to `## [0.1.58] — 2026-08-20` with its compare link, a
  fresh `[Unreleased]` opened above it, and the header's "current version" sentence updated.

## Why the CHANGELOG rename is not optional

It is the bump PR's obligation under the post-#200 ritual, and `repo-hygiene.test.ts` enforces it
("has a section for the version in package.json"). `release.yml` extracts `## [<version>]` and only
*falls back* to `[Unreleased]` — so bumping without the rename would publish whatever had
accumulated there under the new version's name, which is exactly the drift #200 fixed.

**Verified by running release.yml's extraction step as CI runs it**, not by reading it: with
`version = 0.1.58` it selects its own 67-line section (ending cleanly at the Electron entry), and
the fresh `[Unreleased]` is what a later un-renamed tag would fall back to.

## Verification

`npm test` (5,398 passed / 51 skipped) and `npm run typecheck` green, including the five
CHANGELOG-shape guards and the lockfile-discipline guard.

After merge: tag `v0.1.58` on master, which triggers `release.yml` to build the three packages and
open a **draft** release. The draft still needs the owner's manual post-package smoke
(`docs/packaging.md` "Manual pre-ship checklist") before Publish — this PR does not publish anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
