### PR TITLE
fix(vault): a second running instance could destroy the encrypted workspace (#208)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,23 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-21 — **Encrypted vault destroyed in the field by a concurrent second instance — issue
+#208 root-caused, reproduced, guarded.**_ Mechanism (reproduced; pinned by tests): the 0.1.58
+first run's startup crash-sweep shredded the STILL-OPEN previous session's working DB — on Windows
+the overwrite lands while the unlink fails (SQLite holds no `FILE_SHARE_DELETE`), the live session
+notices nothing — and its lock-on-quit encrypted the noise over the good `.enc` (valid GCM tag
+forever after; every unlock then "wrong password"). No single-instance guard existed; dev + all
+portable builds share one `userData`. Shipped: `app.requestSingleInstanceLock()` + `-dev` userData
+suffix; SQLite-header refusal on EVERY encrypt-over-`.enc` (`lockEncryptedVault` + `stageRekey` —
+only the CODE-1b roll-forward had it); typed `VaultDamagedError` → `{reason:'vault_damaged'}` with
+backup copy (EN+DE); shred-on-failed-open of the decrypted leftover; `openDatabase` closes its
+native handle on a failed open (the leak blocked the shred). Record + full mechanism:
+`security-model.md` "Vault-overwrite guards & single instance"; also `troubleshooting.md`
+(damaged-vault entry), `known-limitations.md` (cross-`userData` residual — a workspace-level lock
+file is deliberately NOT built), `data-contracts.md`, CHANGELOG. Tests:
+`workspace-vault-destruction.test.ts` (two-controller repro, mutation-checked: guard off → 2 red
+on Windows) + `workspace-ipc.test.ts` mapping.
+
 _2026-08-20 — **gemma4-12b checkpoint repointed IN PLACE after the measurement wave — issue #201
 CLOSED.**_ Google superseded the pinned GGUF at the same URL on 2026-07-17 ("corrected
 vocabulary"), so a ~7 GB download ended in `checksum_failed`. Measured old vs corrected on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,28 @@ from its first public `1.0.0` release onward.
 
 ## [Unreleased]
 
-Nothing yet — the next release's entries accumulate here.
+### Fixed
+
+- **A second running copy of the app can no longer destroy your encrypted workspace
+  (issue #208).** Starting the app while another copy was already running — the natural
+  upgrade flow: launch the new version, then close the old one — could silently and
+  permanently corrupt an encrypted workspace on Windows, and the damage only surfaced at
+  the next unlock, looking like a wrong password. Three fixes ship together: the app now
+  refuses to start a second copy (the running copy's window comes to the front instead);
+  the workspace re-encryption on lock/quit refuses to overwrite the vault with anything
+  that is not actually your database; and a workspace whose encrypted data is damaged now
+  says so plainly at unlock — with backup guidance — instead of implying the password was
+  wrong. See the new troubleshooting entry "Your password is correct, but the workspace
+  data on the drive is damaged".
+- Failing to open the workspace database no longer leaves the decrypted file behind on the
+  drive, and no longer holds an invisible open file handle to it.
+
+### Changed
+
+- **Developer runs (`npm run dev`) now use their own app-data folder** (`…\@hilbertraum\
+  desktop-dev`) instead of sharing the released app's production workspace. A workspace
+  previously created from a dev run stays on disk under the old path; point the dev run at
+  it with `HILBERTRAUM_DRIVE_ROOT` if you still need it.
 
 ## [0.1.58] — 2026-08-20
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -76,6 +76,36 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const isDev = !app.isPackaged
 
+// #208: dev runs used to share the packaged app's PRODUCTION workspace — `npm run dev`
+// resolved the same userData fallback as every portable exe, so a dev build and a release
+// operated on one real vault (mixed-version access is exactly the window the destroyed
+// vault of issue #208 sat in). Give dev its own suffix BEFORE anything derives paths from
+// userData. Prepared drives (HILBERTRAUM_DRIVE_ROOT / exe-adjacent drive detection) are
+// unaffected — this only moves the no-drive fallback. Existing dev workspaces stay on
+// disk under the unsuffixed path (CHANGELOG notes the move).
+if (isDev) app.setPath('userData', `${app.getPath('userData')}-dev`)
+
+// #208: refuse to run a second instance on the same userData. Two live instances destroy
+// an encrypted vault: the second one's startup crash-sweep random-overwrites the first
+// one's plaintext working DB in place (on Windows the overwrite passes SQLite's share
+// modes while the unlink fails, so the noise keeps the file's name), the first instance
+// notices nothing, and its lock-on-quit encrypts the noise over the good `.enc`. The lock
+// is scoped to userData, so every portable release build AND dev (with its own suffix)
+// contend correctly; it must be taken BEFORE app-ready, ahead of initBackend()'s
+// workspace.init() sweep. The primary instance surfaces the attempt by focusing its
+// window (the standard single-instance UX).
+const isPrimaryInstance = app.requestSingleInstanceLock()
+if (!isPrimaryInstance) {
+  app.exit(0)
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+    }
+  })
+}
+
 // Re-hash sidecar binaries before spawn (vuln-scan B): enforce in packaged builds, skip in
 // dev. Set once here so every spawn seam (chat/embedder/reranker/vision sidecars, the GPU
 // probe, whisper-cli) shares one decision.
@@ -645,6 +675,10 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
+  // #208 belt: `app.exit` above is immediate, but if ready ever races it, a secondary
+  // instance must not reach initBackend() — its workspace.init() crash-sweep is the very
+  // thing that shreds the primary's live working DB.
+  if (!isPrimaryInstance) return
   perfMark('app_ready')
   // `app.getLocale()` is only meaningful after whenReady (R-L1: verified on Windows —
   // it returns a BCP-47 tag like "en-US"/"de"). Best guess until settings are readable.

--- a/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
+++ b/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
-import { VaultBusyError, WrongPasswordError, workspaceAdmitsWork } from '../services/workspace-vault'
+import { VaultBusyError, VaultDamagedError, WrongPasswordError, workspaceAdmitsWork } from '../services/workspace-vault'
 import { maybeRunFirstBenchmark } from './registerBenchmarkIpc'
 import { maybeAutoStartActiveModel } from './registerModelIpc'
 import { maybeStartLocalApi } from '../services/local-api/lifecycle'
@@ -126,6 +126,20 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
           ok: false,
           reason: 'wrong_password',
           message: tMain('main.workspace.wrongPassword')
+        }
+      }
+      // #208: the password VERIFIED but `.enc` did not decrypt to an openable database.
+      // This must never wear the wrong-password/openFailed copy: the reporter's vault was
+      // destroyed and three releases' worth of "check your password" pointed them at the
+      // troubleshooting step (create a new workspace) that would have erased the evidence.
+      // instanceof PLUS the name — same bundle-duplication quirk as WrongPasswordError.
+      if (err instanceof VaultDamagedError || (err instanceof Error && err.name === 'VaultDamagedError')) {
+        log.error('Workspace unlock failed: vault damaged (password verified, data unreadable)')
+        ctx.audit?.('workspace_unlock_failed', 'Workspace unlock failed (vault damaged)')
+        return {
+          ok: false,
+          reason: 'vault_damaged',
+          message: tMain('main.workspace.vaultDamaged')
         }
       }
       log.error('Workspace unlock failed', String(err))

--- a/apps/desktop/src/main/services/db.ts
+++ b/apps/desktop/src/main/services/db.ts
@@ -975,6 +975,27 @@ function seedCollections(db: Db): void {
 /** Open (or create) the database at `path` and run migrations. */
 export function openDatabase(path: string): Db {
   const db = new DatabaseSync(path)
+  // #208: everything below the constructor can throw (the very first PRAGMA does, with
+  // "file is not a database", when the file's bytes are not SQLite — the destroyed-vault
+  // unlock path). Without the close, the native handle LEAKED open: on Windows that open
+  // handle then blocks the caller's cleanup unlink (EPERM, no FILE_SHARE_DELETE), so the
+  // vault code could not even shred the not-a-database file it had just decrypted.
+  try {
+    applyPragmasAndMigrations(db)
+  } catch (err) {
+    try {
+      db.close()
+    } catch {
+      /* the open itself may be broken past closing — the throw below is the story */
+    }
+    throw err
+  }
+  return db
+}
+
+/** The PRAGMA + additive-migration body of {@link openDatabase}. Throws on a file whose
+ *  bytes are not a SQLite database; the caller owns closing the handle on failure. */
+function applyPragmasAndMigrations(db: Db): void {
   db.exec('PRAGMA journal_mode = WAL;')
   db.exec('PRAGMA foreign_keys = ON;')
   // DB-2 — portable-drive performance PRAGMAs (perf audit 2026-06-18). HilbertRaum runs from a
@@ -1203,7 +1224,6 @@ export function openDatabase(path: string): Db {
   ensureMessagesFtsUpdateKindFilter(db)
   ensureFtsRowidSync(db)
   seedCollections(db)
-  return db
 }
 
 /** List of table names — used by tests/diagnostics to confirm migration ran. */

--- a/apps/desktop/src/main/services/workspace-vault.ts
+++ b/apps/desktop/src/main/services/workspace-vault.ts
@@ -122,6 +122,26 @@ export class VaultLockError extends Error {
 }
 
 /**
+ * Thrown by `unlockEncryptedVault` when the password is CORRECT (verifier passed, GCM tag
+ * on `.enc` authenticated) but the decrypted bytes are not an openable SQLite database —
+ * the vault ciphertext itself is damaged (issue #208: the app had re-encrypted a
+ * shred-survivor of random noise over the good `.enc`, so every layer of crypto verified
+ * and only `openDatabase` could tell). Structurally NOT a password problem: the IPC layer
+ * must surface it as its own `vault_damaged` result (backup/recovery guidance), never as
+ * the wrong-password copy — three releases telling the reporter "check your password" is
+ * what nearly buried the forensic evidence. The decrypted non-database working file is
+ * shredded before this is thrown (the shred-on-failure in `decryptFile` covers only TAG
+ * failures; without this, noise — or, for a merely-corrupt real database, authentic
+ * plaintext user data — stayed on disk while the workspace reported locked).
+ */
+export class VaultDamagedError extends Error {
+  constructor() {
+    super('The workspace decrypted but is not a database — the vault is damaged')
+    this.name = 'VaultDamagedError'
+  }
+}
+
+/**
  * Thrown by a `DocumentCipher` closure invoked AFTER `lock()` zeroed the vault key
  * (full-audit 2026-07-12 SEC-1). The closures re-read the live key per invocation, so a
  * cipher captured by an in-flight import fails CLOSED when "Lock now" lands mid-job —
@@ -717,6 +737,21 @@ function stagedRekeyFiles(vaultPaths: VaultPaths): string[] {
  */
 export function stageRekey(vaultPaths: VaultPaths, db: Db, oldKey: Buffer, dataKey: Buffer): void {
   db.exec('PRAGMA wal_checkpoint(TRUNCATE);')
+  // #208 — same guard as the lock path: the staged file replaces `.enc` right after the
+  // descriptor commit, so encrypting a shred-survivor (or anything else that is not the
+  // checkpointed database) here would destroy the vault through the rekey journal instead.
+  let sourceIsDatabase = false
+  try {
+    sourceIsDatabase = fileHasSqliteHeader(vaultPaths.dbPath)
+  } catch {
+    /* unreadable working file → refuse below */
+  }
+  if (!sourceIsDatabase) {
+    throw new Error(
+      'Refusing to stage the password change: the working database file is not a SQLite ' +
+        'database (it may have been overwritten).'
+    )
+  }
   encryptFile(vaultPaths.dbPath, `${vaultPaths.encPath}${REKEY_SUFFIX}`, dataKey)
   fsyncPath(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
   for (const enc of listEncryptedDocSidecars(vaultPaths)) {
@@ -1025,7 +1060,20 @@ export function unlockEncryptedVault(vaultPaths: VaultPaths, password: string): 
     decryptMs: perfMs(decryptT0),
     dbBytes: fileSizeOrNull(vaultPaths.dbPath)
   })
-  const db = openDatabase(vaultPaths.dbPath)
+  // #208: the decrypt above verified the GCM tag, so a failure to OPEN what came out means
+  // the vault ciphertext itself is damaged (it authenticates — it is our own ciphertext —
+  // but its plaintext is not a database). Distinguish that from a wrong password, and never
+  // leave the decrypted output at rest: for a damaged-but-real database those bytes are
+  // authentic plaintext user data sitting on disk while the workspace reports locked.
+  let db: Db
+  try {
+    db = openDatabase(vaultPaths.dbPath)
+  } catch {
+    shredFile(vaultPaths.dbPath)
+    cleanSidecars(vaultPaths.dbPath)
+    fileKey.fill(0)
+    throw new VaultDamagedError()
+  }
   seedSettings(db)
   return { db, key: fileKey, descriptor }
 }
@@ -1054,6 +1102,31 @@ export function lockEncryptedVault(
   db.close()
   const checkpointMs = perfMs(checkpointT0)
   const dbBytes = fileSizeOrNull(vaultPaths.dbPath)
+  // #208 — NEVER encrypt a non-database over `.enc`. The CODE-1b roll-forward has carried
+  // this guard since 2026-07-11; the plain lock path did not, and that is exactly how a
+  // real vault died: a second app instance's startup sweep random-overwrote this session's
+  // working file in place (Windows lets the overwrite through SQLite's share modes while
+  // the unlink fails without FILE_SHARE_DELETE, so the noise keeps the original name), the
+  // session noticed nothing (reads ride the page cache), and lock-on-quit encrypted the
+  // noise over the only good snapshot — GCM verifying fine forever after, because it is
+  // our own ciphertext. Whatever put garbage under dbPath, refusing here keeps the stale
+  // `.enc` (a recoverable vault) instead of replacing it with authenticated noise; the
+  // session's unsaved delta is already lost either way. An UNREADABLE source is refused
+  // too — encrypting bytes we cannot even probe over the vault is never the safe branch.
+  // The controller maps the throw like any lock failure (CODE-1a), and the next launch's
+  // sweep shreds the garbage (no SQLite header ⇒ preserveNewerPlaintext ignores it).
+  let sourceIsDatabase = false
+  try {
+    sourceIsDatabase = fileHasSqliteHeader(vaultPaths.dbPath)
+  } catch {
+    /* unreadable/missing working file → refuse the encrypt below */
+  }
+  if (!sourceIsDatabase) {
+    throw new Error(
+      'Refusing to lock: the working database file is not a SQLite database (it may have ' +
+        'been overwritten). Keeping the previous encrypted snapshot.'
+    )
+  }
   const encryptT0 = performance.now()
   encryptFileImpl(vaultPaths.dbPath, vaultPaths.encPath, key)
   const encryptMs = perfMs(encryptT0)

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1999,6 +1999,11 @@ export const de: Record<keyof typeof en, string> = {
     'Dieses Passwort hat deinen Arbeitsbereich nicht entsperrt. Prüf es und versuch es ' +
     'noch einmal.',
   'main.workspace.openFailed': 'Der Arbeitsbereich konnte nicht geöffnet werden.',
+  'main.workspace.vaultDamaged':
+    'Dein Passwort ist richtig, aber die Daten des Arbeitsbereichs auf dem Laufwerk sind ' +
+    'beschädigt und konnten nicht geöffnet werden. Das Passwort erneut einzugeben hilft ' +
+    'nicht. Lege keinen neuen Arbeitsbereich an — lass die Dateien unverändert und stelle ' +
+    'den Ordner „workspace“ aus einem Backup wieder her.',
   'main.workspace.createFailed': 'Der Arbeitsbereich konnte nicht erstellt werden.',
   'main.workspace.passwordTooShort': 'Das Passwort muss mindestens {min} Zeichen lang sein.',
   'main.workspace.newPasswordTooShort':

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1959,6 +1959,10 @@ export const en = {
   'main.workspace.wrongPassword':
     "That password didn't unlock your workspace. Check it and try again.",
   'main.workspace.openFailed': 'Could not open the workspace.',
+  'main.workspace.vaultDamaged':
+    'Your password is correct, but the workspace data on the drive is damaged and could ' +
+    'not be opened. Retyping the password will not help. Do not create a new workspace — ' +
+    'keep the files as they are and restore the workspace folder from a backup.',
   'main.workspace.createFailed': 'Could not create the workspace.',
   'main.workspace.passwordTooShort': 'Password must be at least {min} characters.',
   'main.workspace.newPasswordTooShort': 'The new password must be at least {min} characters.',

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -190,10 +190,13 @@ export interface WorkspaceStateInfo {
   encryptionRequired: boolean
 }
 
-/** Result of an unlock/create action (a wrong password is a normal, non-throwing result). */
+/** Result of an unlock/create action (a wrong password is a normal, non-throwing result).
+ *  `vault_damaged` (#208): the password verified but the vault ciphertext did not decrypt
+ *  to an openable database — structurally NOT a password problem, and the copy must say so
+ *  (retyping the password cannot help; restoring from a backup can). */
 export type WorkspaceActionResult =
   | { ok: true; state: WorkspaceStateInfo }
-  | { ok: false; reason: 'wrong_password' | 'refused' | 'error'; message: string }
+  | { ok: false; reason: 'wrong_password' | 'vault_damaged' | 'refused' | 'error'; message: string }
 
 export interface DriveStatus {
   /** Root directory that holds models + workspace (drive root or app-data fallback). */

--- a/apps/desktop/tests/integration/workspace-ipc.test.ts
+++ b/apps/desktop/tests/integration/workspace-ipc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mkdtempSync, mkdirSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -29,7 +29,7 @@ vi.mock('../../src/main/services/embeddings', async (importOriginal) => {
   return { ...actual, purgeResidentVectors: purgeSpy }
 })
 
-import { randomUUID } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import { encodeVector, getResidentVectors } from '../../src/main/services/embeddings'
 import { inFlightStreams, streamSettled } from '../../src/main/ipc/inflight'
 import { registerWorkspaceIpc } from '../../src/main/ipc/registerWorkspaceIpc'
@@ -40,6 +40,9 @@ import {
   WorkspaceController,
   vaultPathsFrom,
   createEncryptedVaultOnDisk,
+  unlockEncryptedVault,
+  lockEncryptedVault,
+  encryptFile,
   type VaultPaths
 } from '../../src/main/services/workspace-vault'
 import type { KdfParams } from '../../src/main/services/security/crypto'
@@ -113,6 +116,36 @@ describe('registerWorkspaceIpc', () => {
 
     const { result } = await invoke(handlers, IPC.unlockWorkspace, 'wrong-password')
     expect(result).toMatchObject({ ok: false, reason: 'wrong_password' })
+    expect(ctrl.isUnlocked()).toBe(false)
+  })
+
+  // #208: a vault whose `.enc` authenticates but does not decrypt to a database must NOT
+  // wear the wrong-password (or generic openFailed) copy — the reporter's destroyed vault
+  // looked like a forgotten password across three releases, and the troubleshooting step
+  // that suggests ("create a new workspace") erases the recovery evidence.
+  it('maps a damaged vault to { ok:false, reason:"vault_damaged" }, distinct from wrong_password', async () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'right-password', FAST_KDF)
+    const { db, key } = unlockEncryptedVault(vp, 'right-password')
+    lockEncryptedVault(vp, db, key)
+    // The incident's on-disk state: our own encryption of pure noise, under the real key.
+    const noise = `${vp.dbPath}.noise-src`
+    writeFileSync(noise, randomBytes(64 * 1024))
+    encryptFile(noise, vp.encPath, key)
+
+    const ctrl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    ctrl.init()
+    registerWorkspaceIpc(ctxWith(ctrl))
+
+    const wrong = await invoke(handlers, IPC.unlockWorkspace, 'wrong-password')
+    expect(wrong.result).toMatchObject({ ok: false, reason: 'wrong_password' })
+
+    const { result } = await invoke(handlers, IPC.unlockWorkspace, 'right-password')
+    expect(result).toMatchObject({ ok: false, reason: 'vault_damaged' })
+    // The copy must carry the damage + backup guidance, not the "check it and try again"
+    // retry framing of the wrong-password copy.
+    expect((result as { message: string }).message).toMatch(/damaged/i)
+    expect((result as { message: string }).message).toMatch(/backup/i)
     expect(ctrl.isUnlocked()).toBe(false)
   })
 

--- a/apps/desktop/tests/integration/workspace-vault-destruction.test.ts
+++ b/apps/desktop/tests/integration/workspace-vault-destruction.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  vaultPathsFrom,
+  createEncryptedVaultOnDisk,
+  unlockEncryptedVault,
+  lockEncryptedVault,
+  encryptFile,
+  stageRekey,
+  VaultDamagedError,
+  VaultLockError,
+  WorkspaceController,
+  WrongPasswordError,
+  REKEY_SUFFIX,
+  type VaultPaths
+} from '../../src/main/services/workspace-vault'
+import { getSettings, updateSettings } from '../../src/main/services/settings'
+import { DEFAULT_POLICY } from '../../src/main/services/policy'
+import type { PrivacyPolicy } from '../../src/shared/types'
+import type { Db } from '../../src/main/services/db'
+import type { KdfParams } from '../../src/main/services/security/crypto'
+
+// Issue #208 — an encrypted workspace was destroyed ON DISK: `.enc` ended up holding the
+// app's own encryption of a 483 kB random-noise file (a shred survivor), so every unlock
+// decrypted — valid GCM tag — to noise and died in openDatabase, presenting as a wrong
+// password. Root cause: a SECOND app instance's startup crash-sweep random-overwrote the
+// first instance's live plaintext working DB in place (on Windows the overwrite passes
+// SQLite's share modes while the unlink fails without FILE_SHARE_DELETE, so the noise
+// keeps the file's name; the first instance keeps reading from its page cache and notices
+// NOTHING), and the first instance's lock-on-quit then encrypted the noise over the only
+// good `.enc`. These tests pin the three guards that close the loss:
+//   • lock/stage NEVER encrypt a non-SQLite source over the vault (the stale `.enc` is a
+//     recoverable workspace; authenticated noise is not);
+//   • an unlock that decrypts fine but cannot OPEN the result throws the typed
+//     `VaultDamagedError` (not the wrong-password shape) and shreds the leftover;
+//   • the whole two-instance scenario, end to end: the vault must survive it.
+// (The fourth guard — app.requestSingleInstanceLock in main/index.ts — is Electron-level
+// and covered by the release smoke, not unit-testable here.)
+
+const FAST_KDF: KdfParams = { algo: 'scrypt', N: 1024, r: 8, p: 1, keyLen: 32 }
+
+const ENCRYPTION_REQUIRED: PrivacyPolicy = {
+  ...DEFAULT_POLICY,
+  workspace: { encryptionRequired: true, allowPlaintextDevMode: false }
+}
+
+function freshVault(): VaultPaths {
+  const root = mkdtempSync(join(tmpdir(), 'hilbertraum-vault-208-'))
+  mkdirSync(join(root, 'config'), { recursive: true })
+  mkdirSync(join(root, 'workspace'), { recursive: true })
+  return vaultPathsFrom({
+    configPath: join(root, 'config'),
+    dbPath: join(root, 'workspace', 'hilbertraum.sqlite')
+  })
+}
+
+/** A stub whose checkpoint/close are irrelevant to the guard under test. */
+const closedDbStub = { exec: () => {}, close: () => {} } as unknown as Db
+
+describe('issue #208 — the vault must never be overwritten with authenticated garbage', () => {
+  it('end to end: a second instance startup sweep + first instance lock-on-quit must not destroy the vault', () => {
+    const vp = freshVault()
+
+    // Instance A: create + unlock the workspace and write session data (stays open, like
+    // a user-visible session — WAL sidecars live on disk).
+    const a = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    a.init()
+    a.create('correct horse battery', 'encrypted')
+    updateSettings(a.requireDb(), { contextTokens: 4096 })
+    const encBefore = readFileSync(vp.encPath)
+
+    // Instance B: the incident's 0.1.58 first run — same paths, full startup init() while
+    // A is live. Its crash-sweep shreds A's working file (on Windows the overwrite lands
+    // and the unlink fails, leaving noise under the DB's name; on POSIX the unlink wins
+    // and the file is simply gone).
+    const b = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    b.init()
+
+    // Instance A quits: lock-on-quit re-encrypts the working file over `.enc`. Pre-fix
+    // (Windows) this SUCCEEDED silently and `.enc` became authenticated noise — the
+    // destroyed vault of #208. The guard must refuse instead (mapped to VaultLockError
+    // by the controller, like any failed lock).
+    expect(() => a.lock()).toThrowError(VaultLockError)
+
+    // The at-rest snapshot survived, byte for byte.
+    expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+
+    // "Next launch": a fresh controller sweeps the garbage and the ORIGINAL password
+    // still opens the workspace — the session delta is lost (it was destroyed in place,
+    // nothing can save it), but everything up to the last good lock is intact.
+    const c = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    c.init()
+    expect(c.getState().state).toBe('locked')
+    c.unlock('correct horse battery')
+    expect(c.getState().state).toBe('unlocked')
+    expect(getSettings(c.requireDb()).workspaceMode).toBe('encrypted')
+    c.lock()
+  })
+
+  it('lockEncryptedVault refuses to encrypt a non-SQLite working file over .enc (guard pin)', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    const { db, key } = unlockEncryptedVault(vp, 'pw')
+    lockEncryptedVault(vp, db, key) // a good lock; `.enc` is the reference snapshot
+    const encBefore = readFileSync(vp.encPath)
+
+    // A shred survivor: the working file exists under its real name but is pure noise.
+    writeFileSync(vp.dbPath, randomBytes(64 * 1024))
+    expect(() => lockEncryptedVault(vp, closedDbStub, key)).toThrowError(/not a SQLite database/)
+    expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+
+    // A MISSING working file (the POSIX arm of the same incident: the sweep's unlink
+    // WINS there) is refused through the same guard — the header probe cannot read it,
+    // and un-probe-able is never the safe branch to encrypt over the vault.
+    rmSync(vp.dbPath, { force: true })
+    expect(() => lockEncryptedVault(vp, closedDbStub, key)).toThrowError(/not a SQLite database/)
+    expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+  })
+
+  it('stageRekey refuses a non-SQLite working file (the rekey journal must not stage garbage)', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    const { db, key } = unlockEncryptedVault(vp, 'pw')
+    lockEncryptedVault(vp, db, key)
+
+    writeFileSync(vp.dbPath, randomBytes(4096))
+    const dataKey = randomBytes(32)
+    expect(() => stageRekey(vp, closedDbStub, key, dataKey)).toThrowError(/not a SQLite database/)
+    expect(existsSync(`${vp.encPath}${REKEY_SUFFIX}`)).toBe(false)
+  })
+
+  it('unlocking a destroyed vault throws VaultDamagedError (not wrong-password) and shreds the leftover', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    const { db, key } = unlockEncryptedVault(vp, 'pw')
+    lockEncryptedVault(vp, db, key)
+
+    // Reproduce the reporter's exact on-disk state: `.enc` = the app's own encryption of
+    // random noise under the REAL data key (valid tag, decrypts fine, not a database).
+    const noise = `${vp.dbPath}.noise-src`
+    writeFileSync(noise, randomBytes(483_328))
+    encryptFile(noise, vp.encPath, key)
+
+    // A wrong password is still rejected by the verifier FIRST — the two failures must
+    // stay distinguishable (that is the whole point of the typed error).
+    expect(() => unlockEncryptedVault(vp, 'not-the-password')).toThrowError(WrongPasswordError)
+
+    // The correct password reaches the decrypt, authenticates, cannot open — and the
+    // failure says "damaged", not "wrong password".
+    expect(() => unlockEncryptedVault(vp, 'pw')).toThrowError(VaultDamagedError)
+
+    // The decrypted noise must NOT stay on disk (for a merely-corrupt REAL database those
+    // bytes would be authentic plaintext user data resting beside a "locked" workspace).
+    expect(existsSync(vp.dbPath)).toBe(false)
+    expect(existsSync(`${vp.dbPath}.tmp`)).toBe(false)
+
+    // And the damaged `.enc` is left untouched as evidence/recovery material.
+    expect(statSync(vp.encPath).size).toBeGreaterThan(483_328)
+  })
+})

--- a/apps/desktop/tests/manual/issue-208-drive-check.test.ts
+++ b/apps/desktop/tests/manual/issue-208-drive-check.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  vaultPathsFrom,
+  VaultLockError,
+  WorkspaceController
+} from '../../src/main/services/workspace-vault'
+import { getSettings, updateSettings } from '../../src/main/services/settings'
+import { DEFAULT_POLICY } from '../../src/main/services/policy'
+import type { PrivacyPolicy } from '../../src/shared/types'
+
+// MANUAL issue-#208 drive check — NOT CI.
+//
+// Re-runs the two-instance vault-destruction scenario (the CI pin is
+// `tests/integration/workspace-vault-destruction.test.ts`) against a REAL drive's
+// filesystem, because the incident mechanism is filesystem-semantic: the second instance's
+// startup sweep overwrites the live working DB through SQLite's Windows share modes while
+// the unlink fails without FILE_SHARE_DELETE, and NTFS vs exFAT vs FAT32 behave
+// differently around open-handle deletes. CI proves the guards on the dev box's temp dir;
+// this proves them where the product actually lives.
+//
+// SAFE BY CONSTRUCTION: everything happens inside a fresh `_issue208-check/` scratch
+// directory at the given root, created here and removed at the end. The drive's real
+// `config/` + `workspace/` are never read or written.
+//
+// RUN IT — from `apps/desktop/` (the `.cmd` form; `npx` is blocked on this machine):
+//   $env:HILBERTRAUM_ISSUE208_DRIVE = "K:\"
+//   ..\..\node_modules\.bin\vitest.cmd run tests/manual/issue-208-drive-check.test.ts
+
+const root = process.env.HILBERTRAUM_ISSUE208_DRIVE
+const gate = root ? describe : describe.skip
+
+const ENCRYPTION_REQUIRED: PrivacyPolicy = {
+  ...DEFAULT_POLICY,
+  workspace: { encryptionRequired: true, allowPlaintextDevMode: false }
+}
+
+gate('issue #208 on the real drive — two-instance overlap must not destroy the vault', () => {
+  it('create → second-instance init → lock refused → vault still unlocks', () => {
+    const scratch = join(root!, '_issue208-check')
+    rmSync(scratch, { recursive: true, force: true })
+    mkdirSync(join(scratch, 'config'), { recursive: true })
+    mkdirSync(join(scratch, 'workspace'), { recursive: true })
+    const vp = vaultPathsFrom({
+      configPath: join(scratch, 'config'),
+      dbPath: join(scratch, 'workspace', 'hilbertraum.sqlite')
+    })
+    try {
+      // Instance A: live unlocked session with a working file + WAL on the drive.
+      const a = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+      a.init()
+      a.create('issue-208-check', 'encrypted')
+      updateSettings(a.requireDb(), { contextTokens: 4096 })
+      const encBefore = readFileSync(vp.encPath)
+
+      // Instance B: full startup init() over the same paths — the incident's second exe.
+      new WorkspaceController(vp, ENCRYPTION_REQUIRED, false).init()
+      const dbShredded = !existsSync(vp.dbPath) || !readFileSync(vp.dbPath).subarray(0, 16).toString('latin1').startsWith('SQLite format 3')
+      console.log(
+        `[208-drive] after second-instance sweep: working file ${existsSync(vp.dbPath) ? 'SURVIVES as noise (Windows-style hold)' : 'unlinked (POSIX-style)'}; shredded=${dbShredded}`
+      )
+
+      // Instance A quits: the guard must refuse to encrypt garbage over `.enc`.
+      expect(() => a.lock()).toThrowError(VaultLockError)
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+
+      // Relaunch: the vault still opens with the original password.
+      const c = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+      c.init()
+      c.unlock('issue-208-check')
+      expect(c.getState().state).toBe('unlocked')
+      expect(getSettings(c.requireDb()).workspaceMode).toBe('encrypted')
+      c.lock()
+      console.log('[208-drive] PASS: lock refused over garbage, .enc byte-identical, vault unlocks after relaunch')
+    } finally {
+      rmSync(scratch, { recursive: true, force: true })
+    }
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -579,8 +579,10 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
   `lock()` (no-op for plaintext).
 ✅ **IPC** `ipc/registerWorkspaceIpc.ts` — `getWorkspaceState` (`workspace:getState`) →
   `WorkspaceStateInfo`; `unlockWorkspace(password)` / `createWorkspace(password, mode)` →
-  **`WorkspaceActionResult`** (`{ok:true,state}` | `{ok:false, reason:'wrong_password'|'refused'|
-  'error', message}` — a wrong password / policy refusal is a normal result, not a throw);
+  **`WorkspaceActionResult`** (`{ok:true,state}` | `{ok:false, reason:'wrong_password'|
+  'vault_damaged'|'refused'|'error', message}` — a wrong password / policy refusal is a normal
+  result, not a throw; `vault_damaged` (#208) is the password-verified-but-undecryptable-to-a-
+  database unlock failure, deliberately distinct from `wrong_password`);
   `lockWorkspace` → `WorkspaceStateInfo`. Registered in `initBackend()`; exposed on preload `api` +
   `PreloadApi`.
 - **Types** (`shared/types.ts`): `WorkspaceStateName` (`uninitialized|locked|unlocked`),

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -26,6 +26,18 @@ password recovery — are documented in
 - **Archive extraction trusts verified archives.** `fetch-runtime` rejects `extract_to` escapes,
   and archives are SHA-256-verified before extraction — but member paths inside an archive are only
   as trustworthy as the pinned hash in `runtime-sources.yaml`.
+- **The single-instance guard is `userData`-scoped, not workspace-scoped (#208).**
+  `app.requestSingleInstanceLock()` refuses a second app instance on the same `userData` —
+  which covers the incident class (two portable release builds, or two runs of the same
+  build), and dev builds keep their own `-dev` suffix. It does NOT cover two processes with
+  *different* `userData` pointed at one drive workspace (e.g. an `npm run dev` with
+  `HILBERTRAUM_DRIVE_ROOT` racing a portable exe launched from that drive). In that corner
+  the second instance's startup sweep can still destroy the live session's **working file**
+  (its delta since the last lock); the lock-path SQLite-header guard then refuses to
+  re-encrypt the garbage, so the at-rest `.enc` — the vault itself — survives and the next
+  unlock recovers the last locked snapshot. A workspace-level cross-process lock file would
+  close the corner fully; not built (stale-lock handling on hard-killed processes needs its
+  own design).
 - **A pre-envelope build cannot open a v2 (envelope) vault.** New vaults — and any vault after
   its first password change — use the descriptor-v2 envelope (`security-model.md`). An older
   app version derives the correct KEK and even passes the verifier, but then tries to decrypt

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -687,6 +687,50 @@ explicitly:
   is chosen over mid-session durability here; the mitigations are the clean quit path
   (lock-on-quit + the `uncaughtException` crash lock) and the safe-eject guidance above.
 
+### Vault-overwrite guards & single instance (issue #208)
+
+A real vault was destroyed in the field by a **concurrent second app instance** — the exact
+upgrade flow the portable product invites (download the new exe, launch it, then close the
+old one). The second instance's startup crash-sweep (`shredStalePlaintext`) treated the
+first instance's **live** working DB as a crash leftover: on Windows the random-overwrite
+goes through (SQLite's open handle shares read+write) while the unlink fails (no
+`FILE_SHARE_DELETE`), so the noise keeps the file's name; the first instance notices
+nothing (reads ride its page cache, the best-effort checkpoint failure is swallowed) and
+its lock-on-quit **encrypted the noise over the good `.enc`** — which then authenticated
+forever after (it is the app's own ciphertext) and presented at every unlock as a wrong
+password. Four guards close this:
+
+- **Single instance (Electron).** `app.requestSingleInstanceLock()` before any workspace
+  path is touched; a second instance exits immediately and the primary's window is
+  focused. The lock is scoped to `userData`, which every portable release build shares —
+  so old-exe + new-exe overlap (the incident) is refused at the door. Dev builds get their
+  own `userData` suffix (`-dev`), so `npm run dev` no longer operates on the production
+  vault at all (mixed dev/release access to one vault is what widened the incident
+  window). Residual: two processes with *different* `userData` pointed at one drive
+  workspace (e.g. a dev run with `HILBERTRAUM_DRIVE_ROOT` beside a portable exe on that
+  drive) bypass the Electron lock — the write guard below bounds the damage there.
+- **Never encrypt a non-database over `.enc`.** The CODE-1b roll-forward has carried a
+  SQLite-header guard since 2026-07-11; the incident proved the **plain lock path** — the
+  most-travelled write to `.enc` — did not. `lockEncryptedVault` (and `stageRekey`, whose
+  staged file replaces `.enc` after the descriptor commit) now refuse to encrypt a working
+  file that does not start with the SQLite header, or that cannot be probed at all. A
+  refused lock keeps the stale `.enc` — a recoverable workspace — instead of replacing it
+  with authenticated garbage; the session delta is already lost either way.
+- **"Vault damaged" is not "wrong password".** An unlock that passes the descriptor
+  verifier and authenticates the `.enc` GCM tag but cannot `openDatabase` the decrypted
+  bytes throws a typed `VaultDamagedError`, surfaced as its own
+  `{ reason: 'vault_damaged' }` result with backup/recovery copy. Structurally it cannot
+  be a password problem, and telling the user to retype the password (or worse, follow
+  the forgotten-password advice to create a fresh workspace) destroys the evidence and
+  any recovery option.
+- **No decrypted leftover after a failed open.** `decryptFile` always shredded its output
+  on a **tag** failure; the incident showed the gap after a *successful* decrypt whose
+  result fails to open — that output stayed on disk while the workspace reported locked
+  (for a merely-corrupt real database it would be authentic plaintext user data at rest).
+  The damaged-vault unlock path now shreds the working file + sidecars before throwing
+  (`openDatabase` also closes its native handle when the open fails, so the shred's
+  unlink is not blocked by the app's own leaked fd).
+
 ### Encrypted document cache (spec §3.5: "database AND document cache")
 Imports copy each file into `workspace/documents/` so the drive is self-contained. In an encrypted
 workspace those copies rest **encrypted** too — encrypting only the DB would leave the raw bytes of

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,6 +156,35 @@ Encrypted workspaces are protected by your password, which is **never stored**. 
 it, the data **cannot be recovered** — this is by design. Create a new workspace to start over
 (your old encrypted data remains on the drive but unreadable).
 
+Before you do: read the message on the unlock screen carefully. "That password didn't unlock
+your workspace" means the password was wrong. If it instead says the workspace data is
+**damaged**, your password is fine and creating a new workspace is the wrong move — see the
+next section.
+
+---
+
+## "Your password is correct, but the workspace data on the drive is damaged"
+
+This message (issue #208) means the app verified your password and decrypted the workspace,
+but what came out is not a readable database — the encrypted file itself was damaged at some
+earlier point. Retyping the password cannot help, and this is deliberately **not** worded as
+a password problem.
+
+What to do:
+
+- **Do not create a new workspace** and do not delete anything — that overwrites the evidence
+  and any recovery option.
+- Quit the app and copy the whole `workspace/` and `config/` folders somewhere safe.
+- Restore `workspace/hilbertraum.sqlite.enc` (and the rest of the `workspace/` folder) from a
+  backup, then unlock normally with your usual password.
+- If you have no backup, keep the copied files and report the issue — the damaged file still
+  proves what happened, and your imported documents' encrypted copies under
+  `workspace/documents/` may be individually recoverable.
+
+Never run two copies of the app at the same time against the same drive. Current versions
+refuse a second instance on their own; when upgrading, quit the old version **before**
+starting the new one.
+
 ---
 
 ## "Could not lock the workspace"


### PR DESCRIPTION
Closes #208.

## Root cause — confirmed, not hypothesized

The reporter's forensics were exact. The destroying write is the **quit teardown of the pre-0.1.58 session**, and the destroyer of its working file was the **first run of the 0.1.58 exe, started while that session was still open** — the natural upgrade flow (download the new exe, launch it, then close the old one). Nothing in the app prevented two live instances.

Mechanism, reproduced on this machine and on a real prepared drive (NTFS):

1. Instance B (0.1.58 first run) starts. `WorkspaceController.init()` sees an encrypted descriptor and runs the startup crash-sweep. `preserveNewerPlaintext` correctly skips A's live working DB (live `-wal`/`-shm`), but `shredStalePlaintext` then shreds it: on Windows the **random-overwrite succeeds** (SQLite's open handle shares read+write) while the **unlink fails with EPERM** (SQLite holds no `FILE_SHARE_DELETE`) — so 483 kB of noise survives under `hilbertraum.sqlite`. The WAL/SHM get the same treatment.
2. Instance A notices **nothing**: reads are served from SQLite's page cache, and the lock path's checkpoint failure is swallowed (`try/catch`, best-effort by design).
3. Instance A quits at 11:58:42. `performShutdown` → `detachVaultKey()` (rewrites `logs/app.log.enc`) → `lock()` → `encryptFile(noise → .enc)` — both files rewritten in the same second, exactly as the report's timeline shows. The result authenticates forever after (it is the app's own ciphertext), decrypts to 8.000-bits/byte noise, and dies in `openDatabase` — surfacing as "wrong password" on 0.1.56, 0.1.58 and dev master alike (deterministic, as observed).
4. Aftermath, also as reported: the failed unlock leaves the full-size decrypted noise on disk — `decryptFile` shreds its output only on **tag** failures, and `openDatabase` additionally **leaked its native handle** on a failed open, which would have blocked any cleanup unlink.

The empirical linchpin (live-DB overwrite lands, unlink fails, holder sees nothing, checkpoint "ok") was verified with a scratch script before any code was written, and the end-to-end destruction reproduces in the new test suite on Windows when the guard is disabled (mutation-checked).

## Why the existing guards missed it

The CODE-1b roll-forward and `preserveNewerPlaintext` have carried a SQLite-header guard against exactly this shred-survivor shape since 2026-07-11 — but the **plain lock path**, the most-travelled write to `.enc`, never had it. The audits guarded the recovery lane and left the main lane open.

## Fixes

- **Single instance** (`main/index.ts`): `app.requestSingleInstanceLock()` before anything touches workspace paths; a second instance exits immediately and the primary's window is focused. Scoped to `userData`, which all portable release builds share — the incident class is refused at the door. Verified live: two launches of the built app, second exits 0, first unaffected.
- **Dev/prod separation** (issue suggestion 4): dev runs get `userData` + `-dev`, so `npm run dev` no longer operates on the production vault.
- **Never encrypt a non-database over `.enc`**: `lockEncryptedVault` and `stageRekey` now refuse a working file without the SQLite header (or one that cannot be probed). A refused lock keeps the stale `.enc` — a recoverable vault — instead of authenticated noise; the controller maps it like any failed lock (CODE-1a). With this guard alone, the reporter's vault would have survived with only the last session's delta lost.
- **"Vault damaged" ≠ "wrong password"** (issue suggestion 2): verifier-pass + decrypt-OK + open-fail now throws typed `VaultDamagedError` → `{ reason: 'vault_damaged' }` with its own EN/DE copy (password is correct; do not create a new workspace; restore from backup). Previously this wore the generic `openFailed` copy on the password prompt, and `troubleshooting.md`'s forgotten-password advice ("create a new workspace") would have destroyed the evidence.
- **No decrypted leftover** (issue suggestion 3): the damaged-vault unlock path shreds the working file + sidecars before throwing — for a merely-corrupt *real* database those bytes are authentic plaintext user data resting beside a "locked" workspace.
- **`openDatabase` closes its native handle on a failed open** — the leak is what pinned the noise file against the shred's unlink in testing, and it existed on every failed-open path.

## Blast radius audited

All writers to `.enc` are now guarded: lock ✔ (new), rekey staging ✔ (new), roll-forward ✔ (pre-existing CODE-1b), creation ✔ (pre-existing exists-refusal). `shredStalePlaintext` has exactly one call site (`init()`), now behind the instance lock. A concurrent second instance could additionally have disturbed a mid-flight password change (`recoverPendingRekey` racing the primary's staging) and shredded the live session's transient import/preview/OCR plaintext — all closed by the same instance lock.

**Residual (documented in `known-limitations.md`):** the instance lock is `userData`-scoped; two processes with *different* userData pointed at one drive workspace (dev + `HILBERTRAUM_DRIVE_ROOT` beside a portable exe on that drive) bypass it. The header guard bounds that corner to session-delta loss — the vault itself survives. A workspace-level cross-process lock file would close it fully; deliberately not built here (stale-lock handling needs its own design).

## Tests

- `tests/integration/workspace-vault-destruction.test.ts` — end-to-end two-controller repro (create → second-instance `init()` → lock refused → `.enc` byte-identical → original password unlocks after "relaunch"), plus direct pins for the lock guard, the `stageRekey` guard, and the `VaultDamagedError` path (wrong password still wins at the verifier; leftover shredded; `.enc` untouched as evidence). Mutation-checked: disabling the lock guard turns 2 tests red on Windows (the destruction actually reproduces).
- `tests/integration/workspace-ipc.test.ts` — `vault_damaged` mapping, distinct from `wrong_password`, on the reporter's exact on-disk state.
- `tests/manual/issue-208-drive-check.test.ts` — env-gated manual re-run of the scenario against a real drive's filesystem (sandboxed scratch dir; never touches the drive's real vault). **Run of record: 2026-08-21 on `K:\` (NTFS): working file survives as noise (Windows-hold), lock refused, `.enc` byte-identical, vault unlocks after relaunch.**
- Full suite green: 363 files / 5403 tests. `npm run typecheck` and `npm run build` clean; launch smoke done (single-instance verified on the built app).

## Docs

`security-model.md` (new "Vault-overwrite guards & single instance" record), `troubleshooting.md` (damaged-vault entry + forgotten-password cross-reference), `known-limitations.md` (residual), `data-contracts.md` (`WorkspaceActionResult` union), `CHANGELOG.md` (Unreleased), `BUILD_STATE.md` (dated entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
