### PR TITLE
release: v0.1.59 — version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 from its first public `1.0.0` release onward.
 
 > **Pre-1.0.** HilbertRaum has been public since **2026-07-12** and has shipped releases
-> since that day: **v0.1.50** was the first, **v0.1.58** is current. Versions stay in the
+> since that day: **v0.1.50** was the first, **v0.1.59** is current. Versions stay in the
 > `0.1.x` line and SemVer applies from `1.0.0` on — a `0.1.x` bump is a release checkpoint,
 > not a compatibility promise. Tags below `v0.1.50` (and `v0.1.51`) are internal development
 > checkpoints with no GitHub release and no notes.
@@ -22,6 +22,10 @@ from its first public `1.0.0` release onward.
 > not for a contributor.
 
 ## [Unreleased]
+
+Nothing yet — the next release's entries accumulate here.
+
+## [0.1.59] — 2026-08-21
 
 ### Fixed
 
@@ -347,7 +351,8 @@ For what the product *is*, see the [README](README.md) and
 [`docs/known-limitations.md`](docs/known-limitations.md). Every release since has its own
 section in [`CHANGELOG.md`](CHANGELOG.md).
 
-[Unreleased]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.58...HEAD
+[Unreleased]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.59...HEAD
+[0.1.59]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.58...v0.1.59
 [0.1.58]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.57...v0.1.58
 [0.1.57]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.56...v0.1.57
 [0.1.56]: https://github.com/HilbertraumAI/HilbertRaum/compare/v0.1.55...v0.1.56

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hilbertraum/desktop",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "private": true,
   "description": "HilbertRaum desktop app (Electron).",
   "license": "GPL-3.0-or-later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilbertraum",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@hilbertraum/desktop",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilbertraum",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "private": true,
   "description": "Open-source offline AI workspace that runs local models from a portable drive. No cloud, no telemetry.",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
0.1.58 → 0.1.59 — a fix-only patch release carrying the #208 vault-destruction fix (PR #210): single-instance lock, the encrypt-over-`.enc` SQLite-header guard, the `vault_damaged` unlock result, and dev/prod `userData` separation. Every shipped version 0.1.55–0.1.58 is exposed to the destruction window, hence the immediate checkpoint.

Ritual (per #207):

- `package.json` + `apps/desktop/package.json` bumped; `package-lock.json` hand-edited on the three version fields only (issue #49 posture — no `npm install` rewrite).
- CHANGELOG: `[Unreleased]` renamed to `[0.1.59] — 2026-08-21` with its compare link; fresh `[Unreleased]` opened; "current" note updated. Verified by running release.yml's extraction step exactly as CI runs it: 0.1.59 selects its own 22-line section, and the fresh `[Unreleased]` is the fallback a later tag would see.

After merge: tag `v0.1.59` on the merge commit → release.yml builds the three legs + SHA256SUMS into a draft → owner smoke → Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
