### PR TITLE
fix(tests): print-pdf step-timeout test — a turn count is not a time budget (master CI flake)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-08-22 — **Master CI flake FIXED (test-only): the evidence-pack print harness's step-timeout
+test waited for a REAL fs write by counting event-loop turns under a FAKE clock.**_ The PR #212
+merge left `master` red on the windows/24.x leg alone (`expected +0 to be 1`, everything else
+green). The wait was `1000 × advanceTimersByTimeAsync(0)`, whose yield is one real `setImmediate`
+— **measured: ~4 ms of wall clock for all 1000 turns** — so any print-source write slower than
+that (loaded runner, four forks, an AV scanner on a freshly created `.html`) failed the test.
+Reproduced deterministically by delaying the write 300 ms: pre-fix red with the exact CI
+assertion, post-fix green. Now a real-timer poll against a real 10 s deadline (both captured
+before the fake clock is installed), plus an honest error when the write itself rejects. The
+harness (`print-pdf.ts`) is unchanged — the wedged-renderer timeout it asserts always worked. Rule
+added to §7; the other `advanceTimersByTimeAsync(0)` loops in the suite drain mocked promise
+chains (no real I/O) and are unaffected.
+
 _2026-08-21 — **Encrypted vault destroyed in the field by a concurrent second instance — issue
 #208 root-caused, reproduced, guarded.**_ Mechanism (reproduced; pinned by tests): the 0.1.58
 first run's startup crash-sweep shredded the STILL-OPEN previous session's working DB — on Windows
@@ -169,23 +182,6 @@ byte-identical to `a166d511` — and the combined tree passed CI as one unit. Ci
 closed by **PR #199**, the successor wave above — so this issue has two landing points, one per
 stage.
 
-_2026-08-20 — **Single-document re-index/delete now give feedback — issue #194 CLOSED.**_ Found by
-the #190 continuity check on the relocated drive: the operator clicked re-index and got nothing —
-no success signal, no progress, no error — while the re-index had **succeeded** (all 24 rows still
-`indexed`). A feedback defect on the renderer's shared `run()` helper, which serves re-index AND
-delete and returned silently after its refresh, while the **bulk** twin has toasted and shown a
-determinate bar since M-U6. All three gaps fixed in that one helper: a **success toast naming the
-document** (`docs.reindexDone` / `docs.deleteDone`), a **per-row spinner** (the parent narrows the
-screen-global `busy` scalar to `rowBusy`, PERF-5-style, so the clicked row reads 'Re-indexing…' /
-'Wird gelöscht…' instead of every row's buttons just greying out), and the failure banner
-**prefixed with the title** — which is **#188's D-3 verbatim**, fixed there for export-original and
-never swept onto its neighbours. `run(key, fn)` → `run(kind, d, fn)`; the global `busy` scalar
-STAYS (DR-5 serialization), only its legibility changed. **Not built:** a per-row error surface
-(design-guidelines §6 keeps actionable errors off toasts and a second channel races the banner) and
-a main-owned cancellable job for one document. Record: `architecture.md` **§10** of the Portable
-stored copies record. Four renderer tests, each guard mutation-checked (drop the toast → 2 red;
-disable the `rowBusy` branch → 1 red; revert the title prefix → 1 red).
-
 _Older dated entries (the closed waves through 2026-08-20) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -193,7 +189,8 @@ retention budget), the 2026-07-11…2026-08-16 closed-wave block on 2026-08-18 (
 ritual), and the four CLOSED waves of 2026-08-18/19 (local API #184, portable stored copies #188,
 MTP speculative decoding #182, model occupancy #185/#186) on 2026-08-20 for the retention budget,
 and the four 2026-08-20 entries of the same now-CLOSED #188/#190 stored-copy wave at the #194
-close-out —
+close-out, and the #194 close-out entry itself on 2026-08-22 (preamble budget, making room for
+the CI-flake entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 
@@ -737,6 +734,9 @@ per-phase test inventories) lives in git history.
 - IDs: UUID v4 (`crypto.randomUUID()`). Timestamps: ISO-8601 UTC.
 - No network in core path. No telemetry. Models/workspace/logs are git-ignored.
 - Every service hides behind an interface from spec §9.2 to keep the Tauri/Rust swap open.
+- Tests: under fake timers, never wait for real I/O by counting event-loop turns — a turn is not
+  a unit of time (1000 `advanceTimersByTimeAsync(0)` ≈ 4 ms). Poll a real deadline with a real
+  timer captured before `useFakeTimers()` (2026-08-22 entry).
 
 ---
 ## 8. Post-MVP audits & hardening (2026-06-09 → 2026-06-10)

--- a/apps/desktop/tests/unit/evidence-pack-print-pdf.test.ts
+++ b/apps/desktop/tests/unit/evidence-pack-print-pdf.test.ts
@@ -123,6 +123,16 @@ import { SECURE_WINDOW_WEB_PREFERENCES } from '../../src/main/window-security'
 const HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>pack</body></html>'
 const PACK_ID = '00000000-0000-4000-8000-00000000e9a1'
 
+// Captured at module scope, before any test installs the fake clock: the step-timeout test
+// has to wait for a REAL filesystem write while `setTimeout`/`Date` are faked, and only the
+// originals can buy real wall-clock time. `sleepReal` is the yield; `realNow` the deadline.
+const realSetTimeout = globalThis.setTimeout
+const realNow = Date.now
+const sleepReal = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    realSetTimeout(resolve, ms)
+  })
+
 let root = ''
 let sourceHtmlPath = ''
 
@@ -287,21 +297,42 @@ describe('print flow (hidden window lifecycle)', () => {
     fake.state.loadFile = () => new Promise<void>(() => {}) // never finishes loading
     const printing = printEvidencePackHtmlToPdf(HTML, { packId: PACK_ID, sourceHtmlPath })
     const failed = expect(printing).rejects.toThrow(/load step took too long/)
+    // A print whose SOURCE write fails never reaches the load step at all. Record that
+    // rejection so the wait below ends on it with an honest message instead of spinning to
+    // its deadline and reporting a bare window-count mismatch. Both handlers are attached
+    // up front: `failed` is only awaited at the end, and an early `throw` here must not
+    // leave it as an unhandled rejection.
+    let printError: unknown = null
+    void printing.catch((err: unknown) => {
+      printError = err
+    })
+    void failed.catch(() => {})
     // The print SOURCE is written asynchronously (a multi-MB synchronous write on the main
     // thread used to stall the whole process), so the window — and with it the load step's
-    // timeout timer — only exists once that write has landed. Yield real event-loop turns
-    // until it does; advancing the fake clock before the timer is armed would leave the
-    // step waiting on a deadline that is already in the past. `advanceTimersByTimeAsync(0)`
-    // is the yield: it hands one real turn back before flushing the (empty) fake queue.
-    for (let turns = 0; fake.state.windows.length === 0 && turns < 1000; turns++) {
-      await vi.advanceTimersByTimeAsync(0)
+    // timeout timer — only exists once that write has landed. Wait for it in REAL time, and
+    // never on the fake clock: advancing that before the timer is armed would leave the step
+    // waiting on a deadline that is already in the past.
+    //
+    // A turn COUNT is not a budget (2026-08-22, master CI windows leg: "expected +0 to be
+    // 1"). This loop used to spin 1000 × `advanceTimersByTimeAsync(0)`, whose yield is one
+    // real `setImmediate` — ~4 µs — so the whole budget was ~4 ms of wall clock. Locally the
+    // write lands in a fraction of that; a loaded CI runner (four forks, an antivirus
+    // scanner on a freshly created .html) can take longer, and the test then failed for
+    // reasons that had nothing to do with the print harness. Real sleeps against a real
+    // deadline are the fix: the same fast path when the write is quick, ~10 s of patience
+    // when it is not, and still far inside the 15 s local / 60 s CI test budget.
+    const deadline = realNow() + 10_000
+    while (fake.state.windows.length === 0 && printError === null && realNow() < deadline) {
+      await sleepReal(1)
     }
+    if (printError !== null) throw new Error(`the print source write failed: ${printError}`)
     expect(fake.state.windows.length).toBe(1)
     await vi.advanceTimersByTimeAsync(PRINT_STEP_TIMEOUT_MS + 1)
     await failed
     expect(lastWin().destroyed).toBe(true)
-    // The removal is async too — let it settle before asserting the source file is gone.
-    await vi.advanceTimersByTimeAsync(0)
+    // The removal is awaited inside the harness's `finally`, so the rejection above already
+    // implies it has settled — no extra yield needed (and a fake-clock turn could not buy
+    // one anyway, per the note above).
     expect(existsSync(sourceHtmlPath)).toBe(false)
   })
 })

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -1309,6 +1309,23 @@ tag triggers the release workflow's draft build).
 
 ---
 
+_2026-08-20 — **Single-document re-index/delete now give feedback — issue #194 CLOSED.**_ Found by
+the #190 continuity check on the relocated drive: the operator clicked re-index and got nothing —
+no success signal, no progress, no error — while the re-index had **succeeded** (all 24 rows still
+`indexed`). A feedback defect on the renderer's shared `run()` helper, which serves re-index AND
+delete and returned silently after its refresh, while the **bulk** twin has toasted and shown a
+determinate bar since M-U6. All three gaps fixed in that one helper: a **success toast naming the
+document** (`docs.reindexDone` / `docs.deleteDone`), a **per-row spinner** (the parent narrows the
+screen-global `busy` scalar to `rowBusy`, PERF-5-style, so the clicked row reads 'Re-indexing…' /
+'Wird gelöscht…' instead of every row's buttons just greying out), and the failure banner
+**prefixed with the title** — which is **#188's D-3 verbatim**, fixed there for export-original and
+never swept onto its neighbours. `run(key, fn)` → `run(kind, d, fn)`; the global `busy` scalar
+STAYS (DR-5 serialization), only its legibility changed. **Not built:** a per-row error surface
+(design-guidelines §6 keeps actionable errors off toasts and a second channel races the banner) and
+a main-owned cancellable job for one document. Record: `architecture.md` **§10** of the Portable
+stored copies record. Four renderer tests, each guard mutation-checked (drop the toast → 2 red;
+disable the `rowBusy` branch → 1 red; revert the title prefix → 1 red).
+
 _2026-08-20 — **The diagnostic RAN on the real drive (G:\), and it refuted our own leading
 hypothesis — issue #190 checkbox 1 ANSWERED, checkbox 3 re-answered.**_ Measured, drive byte-identical
 (the read-only witness passed): encrypted workspace, **v2** descriptor, `stored_name` column ABSENT


### PR DESCRIPTION
`master` went red after the PR #212 merge ([run 32583674842](https://github.com/HilbertraumAI/HilbertRaum/actions/runs/32583674842)) on the **windows-latest / 24.x leg only**:

```
FAIL tests/unit/evidence-pack-print-pdf.test.ts > print flow (hidden window lifecycle)
     > a wedged renderer fails the step timeout instead of hanging the export
AssertionError: expected +0 to be 1   (evidence-pack-print-pdf.test.ts:299)
Test Files  1 failed | 361 passed | 24 skipped
```

The other three matrix legs and the other 5401 tests were green on the same tree, and the change under it was README prose — a flake, not a regression.

## Root cause (test-only)

The test installs fake timers and then waits for the harness's **real** print-source write to land by spinning `1000 × vi.advanceTimersByTimeAsync(0)`. That yield is one real `setImmediate`, so the entire "budget" is **~4 ms of wall clock** — measured locally: 1000 turns = 4 ms, while the write itself needed 58 turns (< 1 ms) on an idle box. A loaded CI runner (four forks, an AV scanner on a freshly created `.html`) only has to be ~20× slower for the window never to appear inside the budget, and the next assertion goes red.

Reproduced deterministically by delaying the write 300 ms with a mocked `writeFile`: the pre-fix test fails with the exact CI assertion (`expected +0 to be 1`), the post-fix test passes in 313 ms.

## Blast radius

- **Production code is not affected.** `print-pdf.ts` is unchanged; the wedged-renderer step timeout it asserts always worked (the fixed test proves it against a slow write).
- **One test, one wait.** The other `advanceTimersByTimeAsync(0)` loops in the suite (renderer tests) drain mocked promise chains with no real I/O, so a handful of microtask turns is deterministic there. This was the only test mixing a real filesystem wait with a fake clock; the two other fake-timer + `node:fs` files (`local-api-ipc`, `gpu`) advance fake time over in-memory state.
- **Any tree, any leg, at any time** — a probabilistic ~4 ms race, not something PR #212 introduced.

## Fix

- Wait in **real** time: poll a real 10 s deadline with a real timer, both captured at module scope before the fake clock is installed. The fake clock still must not be advanced before the load step arms its timer — that constraint is why the original avoided it — and 10 s stays far inside the 15 s local / 60 s CI budget while costing nothing on the fast path.
- A write that **rejects** now ends the wait with its own error instead of a bare window-count mismatch (verified: an injected `ENOSPC` reports `the print source write failed: Error: ENOSPC…` immediately).
- Dropped the redundant fake-clock "let the removal settle" turn — the removal is awaited inside the harness's own `finally`, so the rejection already implies it.

Rule added to `BUILD_STATE` §7 so the next author doesn't reach for a turn count; dated entry included, and the closed #194 entry moved verbatim to `docs/build-log.md` to stay inside the preamble retention budget.

## Verification

- Full suite locally: **5403 passed / 52 skipped**, `npm run typecheck` clean.
- Pre-fix vs post-fix under an artificially slow (300 ms) write: red → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)