### PR TITLE
fix(runtime): fail closed on a placeholder engine hash instead of installing unverified (RT-02)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -772,11 +772,13 @@ the offline/privacy guarantees:
   `tar`) of an archive whose source list (`runtime-sources.yaml`) lives on the user-writable
   drive. Current in-app posture: the archive's sha256 is verified **before** extraction
   (tampering needs drive write access to both the archive/URL and the matching hash; a
-  placeholder hash extracts flagged `unverified`), and the OS `tar` refuses `..` members by
-  default — containment rests on tar's *implicit* behavior rather than the explicit member
-  check this fix calls for; symlink members are the residual soft spot. (The skills importer
-  does NOT share this gap — it enumerates and validates every member's path/symlink before
-  inflating, arch §22-A2.) Fix: list/extract members with an explicit containment check.
+  placeholder hash extracted flagged `unverified` — RT-02, 2026-09-02, made that a hard
+  FAILURE: an unverifiable engine archive is discarded, never installed), and the OS `tar`
+  refuses `..` members by default — containment rests on tar's *implicit* behavior rather
+  than the explicit member check this fix calls for; symlink members are the residual soft
+  spot. (The skills importer does NOT share this gap — it enumerates and validates every
+  member's path/symlink before inflating, arch §22-A2.) Fix: list/extract members with an
+  explicit containment check.
   **Update (close-out 2026-07-12):** Phase 5 (`032b014`) added the explicit in-app containment
   check L-7's fix called for: `install()` now runs a post-extract symlink/junction containment
   sweep (`assertExtractedSymlinksContained`, over the final post-flatten layout — an escaping

--- a/apps/desktop/src/main/services/runtime-download.ts
+++ b/apps/desktop/src/main/services/runtime-download.ts
@@ -528,8 +528,9 @@ export class EngineDownloadManager {
 
   /**
    * Download → verify → clean → extract → flatten → marker for ONE family. Returns the
-   * outcome; on 'failed' it sets `job.status`/`job.error`. `job.unverified` is sticky (set
-   * if ANY family's hash is a placeholder).
+   * outcome; on 'failed' it sets `job.status`/`job.error`. `job.unverified` stays false for
+   * engines: RT-02 made a placeholder hash a hard FAILURE (the verify branch below), so there
+   * is no "installed but unverified" engine state — unlike model weights.
    */
   private async installOne(
     job: EngineDownloadJob,

--- a/apps/desktop/src/main/services/runtime-download.ts
+++ b/apps/desktop/src/main/services/runtime-download.ts
@@ -593,8 +593,23 @@ export class EngineDownloadManager {
         job.error = tMain('main.engine.fileMissing')
         return 'failed'
       }
-      // ok (verified) or placeholder (cannot verify): the bytes are complete either way.
-      if (verify.reason === 'placeholder') job.unverified = true
+      // RT-02: fail CLOSED on a placeholder (non-real) hash. This installs EXECUTABLE code —
+      // extract, chmod +x, and a marker that legitimizes later spawns — so an artifact that
+      // cannot be verified must never be installed, independent of the accepted
+      // trust-by-location signing residual (security-model.md S4 / §22-M2). The committed
+      // runtime-sources entries all carry real hashes (guarded by a committed-sources test),
+      // so this only ever fires on a mis-authored or tampered source, which is exactly when it
+      // should. Unlike model-weight downloads, there is no "unverified but usable" state for a
+      // binary we are about to execute.
+      if (verify.reason === 'placeholder') {
+        await rm(plan.zipDest, { force: true })
+        job.status = 'failed'
+        job.error = tMain('main.engine.unverifiablePlaceholder')
+        this.deps.log?.('Engine archive has a placeholder hash — refusing to install unverified executable', {
+          extractTo: plan.extractTo
+        })
+        return 'failed'
+      }
 
       job.status = 'extracting'
       // F-33: thread the job's abort signal into the extractor so a cancel actually kills the

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2179,6 +2179,8 @@ export const de: Record<keyof typeof en, string> = {
     'Die heruntergeladene Engine entsprach nicht ihrer erwarteten Prüfsumme und wurde verworfen. ' +
     'Bitte versuche es erneut.',
   'main.engine.fileMissing': 'Die heruntergeladene Engine fehlte, bevor sie geprüft werden konnte.',
+  'main.engine.unverifiablePlaceholder':
+    'Diese KI-Engine-Quelle hat keine echte Prüfsumme, daher konnte der Download nicht verifiziert und nicht installiert werden. Das Laufwerk ist möglicherweise fehlkonfiguriert.',
   'main.engine.binaryMissing':
     'Die Engine wurde heruntergeladen, konnte aber nicht entpackt werden (das Archivformat hat sich evtl. geändert).',
   'main.engine.extractFailed':

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2116,6 +2116,8 @@ export const en = {
   'main.engine.checksumMismatch':
     'The downloaded engine did not match its expected checksum, so it was discarded. Please try again.',
   'main.engine.fileMissing': 'The downloaded engine went missing before it could be verified.',
+  'main.engine.unverifiablePlaceholder':
+    'This AI-engine source has no real checksum, so the download could not be verified and was not installed. The drive may be misconfigured.',
   'main.engine.binaryMissing':
     'The engine downloaded but could not be unpacked (the archive layout may have changed).',
   'main.engine.extractFailed': 'The AI engine downloaded but could not be unpacked. Please try again.',

--- a/apps/desktop/tests/integration/engine-download.test.ts
+++ b/apps/desktop/tests/integration/engine-download.test.ts
@@ -254,13 +254,27 @@ describe('EngineDownloadManager install flow', () => {
     expect(captured as number).toBeLessThan(64 * GiB)
   })
 
-  it('completes but marks UNVERIFIED when the sources hash is a placeholder', async () => {
+  it('FAILS CLOSED on a placeholder hash — nothing extracted, no marker (RT-02)', async () => {
+    // A placeholder (non-real) hash means the archive cannot be verified. This installs
+    // EXECUTABLE code, so it must be refused rather than installed-as-unverified — independent
+    // of the accepted trust-by-location signing residual (security-model.md S4 / §22-M2). The
+    // committed pin never carries a placeholder (guarded by assets.test.ts), so this only fires
+    // on a mis-authored or tampered source, which is exactly when it should.
+    let extracted = false
     const { rootPath, manifestsDir } = makeDrive('REPLACE_WITH_REAL_HASH')
-    const mgr = new EngineDownloadManager({ fetchImpl: okFetch, extractImpl: fakeExtract })
+    const mgr = new EngineDownloadManager({
+      fetchImpl: okFetch,
+      extractImpl: async (...args: Parameters<typeof fakeExtract>) => {
+        extracted = true
+        return fakeExtract(...args)
+      }
+    })
     const started = await mgr.start({ rootPath, manifestsDir, gates: ALLOW })
     const job = await runToEnd(mgr, started.jobId)
-    expect(job.status).toBe('done')
-    expect(job.unverified).toBe(true)
+    expect(job.status).toBe('failed')
+    expect(extracted).toBe(false)
+    expect(existsSync(join(rootPath, 'runtime', 'llama.cpp', HOST_OS, BIN_NAME))).toBe(false)
+    expect(existsSync(runtimeMarkerPath(join(rootPath, 'runtime', 'llama.cpp', HOST_OS)))).toBe(false)
   })
 
   it('fails and discards the archive on a checksum mismatch', async () => {


### PR DESCRIPTION
## What

The engine installer treated a **placeholder** (non-real) archive hash as merely "unverified" and installed the executable anyway: extract, `chmod +x`, and an install marker that legitimizes later spawns. For code we are about to execute, an artifact that cannot be verified must never be installed. The installer now **fails closed** on `reason === 'placeholder'` (discarding the archive), mirroring the existing `missing` / `mismatch` branches, with a specific `main.engine.unverifiablePlaceholder` message (EN + DE).

## Scope / severity (honest)

This is a **defense-in-depth hardening**, not a new attack surface. It is independent of the accepted trust-by-location signing residual (`security-model.md` S4 / §22-M2): an attacker who can write the manifest would supply a *real* hash of their own binary, so they never need the placeholder path. The value is:

- the invariant **never install unverifiable executable code**, orthogonal to the (tracked, product-decision) signing question; and
- closing a **latent** mis-authored / tampered-source case. The committed `runtime-sources.yaml` pin already carries only real hashes (guarded by `assets.test.ts` "every build carries a REAL sha256"), so this never fires in normal operation.

Model-weight downloads keep their existing placeholder-tolerant behaviour — there is no code being executed there.

## Test

The engine-download placeholder case, which previously asserted `done + unverified`, now asserts fail-closed: **job failed, the extractor is never called, and no binary and no marker are written**.

## Validation

- `npm run typecheck` clean
- full suite: **5402 passed / 53 skipped**

## Not in scope (already-accepted residuals, reported alongside RT-02)

- **RT-01** (manipulable runtime manifest controls its own hash check) = `security-model.md` S4 / §22-M2 "trust by location, not signature"; the real fix is manifest signing, a tracked product decision.
- **RT-03** (legacy hash-less marker skips pre-spawn verification) = `known-limitations.md` "Sidecar binaries built by an OLD `fetch-runtime` carry no pre-spawn hash (accept + document)".

No code change for either here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MeYQAJD94b4oDFA7uTVUK