### PR TITLE
fix(main): Phase 0 — quit re-entry prevented + bounded teardown, cold-start abort for E5/reranker/vision, spellcheck off (audit 2026-09-02: SEC-12, GAP-2, REL-10, SEC-1)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,18 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-02 — **Audit 2026-09-02 Phase 0 — quit re-entry prevented, cold-start abort for
+E5/reranker/vision, spellcheck off (SEC-12, GAP-2, REL-10, SEC-1; PR #267; PR 0-a #265 drained the
+preamble).**_ The `will-quit`/`activate` handlers are one factory (`createAppLifecycleHandlers`,
+`main/shutdown.ts`) over one closure: every `will-quit` is prevented, the exit comes only from the
+teardown's finally (which now reaps registered sidecar children), `activate` is a no-op during a
+quit, and the awaited middle is bounded by `SHUTDOWN_OVERALL_DEADLINE_MS = 30_000` with the lock
+outside the race (record: `security-model.md` "App-shell gate & lifecycle"). E5/reranker/vision
+abort an in-flight cold start on lock/quit like translation (#159; `architecture.md` #159 note).
+`spellcheck: false` on every window (`security-model.md` "Chromium background fetches", which also
+records GAP-3 as a confirmed residual → follow-up SEC-14 #266). Decisions 1 and 13 ran on their
+plan defaults (#218, #230 unanswered). Tests: B1 (inverted) and B8 ported; suite 5,403 → 5,413.
+
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -553,6 +565,9 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     merged phase follows (outcome + PR + pointer; the narrative lives in the PR and the record):
     - **0-a** (2026-09-02, docs-only, PR #265): the eight closed 2026-08-20…08-22 dated entries
       drained to `docs/build-log.md`; this item opened.
+    - **0** (2026-09-02, PR #267): SEC-12 + GAP-2 (quit re-entry prevented, 30 s overall deadline,
+      lock outside the race), REL-10 (E5/reranker/vision cold-start abort), SEC-1 (spellcheck
+      off); GAP-3 confirmed residual → SEC-14 #266; decisions 1/13 on defaults — dated entry above.
 
 **Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
 the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ from its first public `1.0.0` release onward.
   embedding, reranking or image-understanding engine was still starting up (a slow USB read of a
   large model file, say), locking or quitting waited for the whole start-up window and the engine
   then refused to start again until the app was restarted. Locking now cancels the start and
-  finishes within a second; the engine starts normally after the next unlock.
+  finishes within a few seconds; the engine starts normally after the next unlock.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,25 @@ from its first public `1.0.0` release onward.
 
 ## [Unreleased]
 
-Nothing yet — the next release's entries accumulate here.
+### Fixed
+
+- **Quitting can no longer leave your workspace unencrypted.** Pressing Quit a second time while
+  the app was still shutting down (for example while it waited on a slow AI-engine start) used to
+  let the app exit before the workspace was re-encrypted, and the next start then discarded every
+  change since the last lock. A second Quit now waits for the shutdown to finish, and the shutdown
+  itself is capped at 30 seconds, after which the workspace is locked regardless.
+- **Lock now and Quit no longer wait up to three minutes on a stuck engine start.** If the
+  embedding, reranking or image-understanding engine was still starting up (a slow USB read of a
+  large model file, say), locking or quitting waited for the whole start-up window and the engine
+  then refused to start again until the app was restarted. Locking now cancels the start and
+  finishes within a second; the engine starts normally after the next unlock.
+
+### Changed
+
+- **Spell-checking in the message box is switched off.** The built-in browser engine would
+  otherwise download a spelling dictionary from a Google server on Windows and Linux the first
+  time you type — against the promise that nothing leaves the space. Shipping dictionaries on the
+  drive instead is under consideration.
 
 ## [0.1.59] — 2026-08-21
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -73,6 +73,9 @@ Even with that setting on, network access is only used if a drive **policy** per
 toggle allows. The effective state is `policy AND your setting`. Telemetry is **always off** and has
 no toggle. A startup self-check logs the offline posture and flags (logs, never sends) any attempt
 to reach a remote host while offline; local-only connections (`127.0.0.1`/`localhost`) are exempt.
+The built-in browser engine's own background fetches are switched off as well: spell-checking is
+disabled, because the engine would otherwise download a spelling dictionary from a Google-operated
+server on Windows and Linux the first time you type.
 
 ## Model downloads — the app's only use of the internet
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -63,7 +63,7 @@ import { resolveAppSkillsDir, resolveUserSkillsDir } from './services/drive'
 import { createSkillRegistry } from './services/skills/registry'
 import { composeServices, composeTranslator, shouldReplaceTranslator } from './services/compose-services'
 import { initBinaryVerification } from './services/binary-verifier'
-import { performShutdown } from './shutdown'
+import { createAppLifecycleHandlers, performShutdown } from './shutdown'
 import type { AppContext } from './services/context'
 
 // HilbertRaum — Electron main process (the "backend").
@@ -674,6 +674,21 @@ function createWindow(): void {
   }
 }
 
+// The `will-quit` / `activate` handlers live in `./shutdown` over ONE shared `isShuttingDown`
+// closure (SEC-12 + GAP-2, audit 2026-09-02): a second quit during the teardown is prevented
+// (the exit comes only from the teardown's finally), a Dock click during it opens no window, and
+// the teardown's awaited middle is bounded by `SHUTDOWN_OVERALL_DEADLINE_MS`. Its ORDERING is
+// unit-testable there (REL-4: abort in-flight streams BEFORE runtime.stop so a partial reply
+// persists, mirroring the lock path). `ctx` is read at call time, not here.
+const lifecycle = createAppLifecycleHandlers({
+  performShutdown: () => performShutdown(ctx),
+  exit: (code) => app.exit(code),
+  createWindow,
+  windowCount: () => BrowserWindow.getAllWindows().length,
+  killSidecarChildren: killRegisteredSidecarChildren,
+  log
+})
+
 app.whenReady().then(() => {
   // #208 belt: `app.exit` above is immediate, but if ready ever races it, a secondary
   // instance must not reach initBackend() — its workspace.init() crash-sweep is the very
@@ -698,21 +713,10 @@ app.whenReady().then(() => {
   })
   createWindow()
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
+  app.on('activate', lifecycle.onActivate)
 })
 
-let isShuttingDown = false
-
-app.on('will-quit', (event) => {
-  if (isShuttingDown) return // cleanup already ran → let the real quit proceed
-  event.preventDefault()
-  isShuttingDown = true
-  // Graceful quit teardown lives in `./shutdown` so its ORDERING is unit-testable (REL-4: abort
-  // in-flight streams BEFORE runtime.stop so a partial reply persists, mirroring the lock path).
-  void performShutdown(ctx).finally(() => app.exit(0))
-})
+app.on('will-quit', lifecycle.onWillQuit)
 
 // Last-resort crash safety: a hard `uncaughtException` skips `will-quit`, so try to lock the
 // vault (re-encrypt + shred the plaintext working DB) before the process dies. Best-effort

--- a/apps/desktop/src/main/services/embeddings/e5.ts
+++ b/apps/desktop/src/main/services/embeddings/e5.ts
@@ -1,5 +1,11 @@
 import type { Embedder, EmbedOptions } from './index'
-import { LlamaServer, combineSignals, isBindRaceError, type LlamaServerOptions } from '../runtime/sidecar'
+import {
+  LlamaServer,
+  combineSignals,
+  isBindRaceError,
+  isStartAbortError,
+  type LlamaServerOptions
+} from '../runtime/sidecar'
 import { truncateToContext } from '../runtime/context-budget'
 import { log } from '../logging'
 
@@ -208,6 +214,13 @@ export class E5Embedder implements Embedder {
    * replace the weight file and retry via lock/unlock without restarting the app.
    */
   private startFailed: Error | null = null
+  /**
+   * Aborts the IN-FLIGHT lazy start on lock/quit (REL-10, audit 2026-09-02 — the translation
+   * runtime's #159 / BE-1 pattern, ported): the child is killed inside the health wait and the
+   * start rejects with an AbortError, instead of the teardown awaiting the full health window
+   * (180 s by default) of a wedged cold start it is about to kill anyway. One per start.
+   */
+  private startAbort: AbortController | null = null
 
   constructor(private readonly opts: E5EmbedderOptions) {
     this.id = opts.id
@@ -223,6 +236,8 @@ export class E5Embedder implements Embedder {
     if (this.startFailed) throw this.startFailed
     if (this.server) return this.server
     if (!this.starting) {
+      const abort = new AbortController()
+      this.startAbort = abort
       const ctx = this.opts.contextTokens ?? DEFAULT_CONTEXT_TOKENS
       // RT-4: size the physical batch above the context so multiple in-context inputs of a
       // 32-input request co-decode per ubatch instead of the 512 embedding-mode default
@@ -255,7 +270,10 @@ export class E5Embedder implements Embedder {
         threads: this.opts.threads,
         healthTimeoutMs: this.opts.healthTimeoutMs,
         healthIntervalMs: this.opts.healthIntervalMs,
-        host: this.opts.host
+        host: this.opts.host,
+        // REL-10: let a lock/quit teardown abort this start mid-health-wait (the child is killed
+        // via the normal stop path; start() rejects AbortError — never latched below).
+        startAbortSignal: abort.signal
       })
       this.starting = server
         .start()
@@ -264,6 +282,9 @@ export class E5Embedder implements Embedder {
         })
         .catch((err) => {
           const error = err instanceof Error ? err : new Error(String(err))
+          // REL-10 (audit 2026-09-02): a teardown-ABORTED start is not a load fault — never latch
+          // `startFailed`; the next embed() after unlock must attempt a fresh start.
+          if (isStartAbortError(err) || abort.signal.aborted) throw error
           // F4 (post-merge audit): a TRANSIENT port-bind race must NOT arm the failed-start latch.
           // LlamaServer.start retries a bind race only ONCE (REL-1); losing the port twice during
           // the near-simultaneous chat+embedder+reranker+vision startup throws a bind-class error.
@@ -276,6 +297,7 @@ export class E5Embedder implements Embedder {
         })
         .finally(() => {
           this.starting = null
+          if (this.startAbort === abort) this.startAbort = null
         })
     }
     await this.starting
@@ -458,8 +480,12 @@ export class E5Embedder implements Embedder {
     try {
       // A lazy start may be IN FLIGHT (first embed() racing app quit): `this.server` is
       // only assigned after start() resolves, so returning here would let the spawned
-      // child outlive the app as an orphan. Wait for the start to settle, then stop
-      // whatever it produced.
+      // child outlive the app as an orphan. REL-10 (audit 2026-09-02): ABORT it rather than
+      // wait it out — the abort kills the child inside the health wait (the normal stop
+      // path, no orphan), the start rejects AbortError (never latches `startFailed`), and
+      // the await below settles in about one health-poll interval instead of the full
+      // 180 s health window of a wedged cold start.
+      this.startAbort?.abort()
       if (this.starting) {
         await this.starting.catch(() => undefined)
       }

--- a/apps/desktop/src/main/services/reranker/llama.ts
+++ b/apps/desktop/src/main/services/reranker/llama.ts
@@ -1,5 +1,11 @@
 import type { Reranker, RerankedHit, RerankOptions } from './index'
-import { LlamaServer, combineSignals, isBindRaceError, type LlamaServerOptions } from '../runtime/sidecar'
+import {
+  LlamaServer,
+  combineSignals,
+  isBindRaceError,
+  isStartAbortError,
+  type LlamaServerOptions
+} from '../runtime/sidecar'
 import { maxInputApproxTokens } from '../runtime/context-budget'
 import { truncateToApproxTokens, CHUNK_DEFAULTS } from '../ingestion/chunker'
 
@@ -100,6 +106,15 @@ export class LlamaReranker implements Reranker {
    * reranking for the whole session — leaving it null lets the next rerank() retry on a fresh port.
    */
   private startFailed: Error | null = null
+  /**
+   * Aborts the IN-FLIGHT lazy start on lock/quit (REL-10, audit 2026-09-02 — the translation
+   * runtime's #159 / BE-1 pattern, ported): the child is killed inside the health wait and the
+   * start rejects with an AbortError, instead of the teardown awaiting the full health window
+   * (180 s by default) of a wedged cold start it is about to kill anyway. Matters doubly here:
+   * the latch SURVIVES `suspend()`, so a timed-out start that latched would refuse every rerank
+   * for the rest of the session. One per start.
+   */
+  private startAbort: AbortController | null = null
 
   constructor(private readonly opts: LlamaRerankerOptions) {
     this.id = opts.id
@@ -122,6 +137,8 @@ export class LlamaReranker implements Reranker {
     if (this.startFailed) throw this.startFailed
     if (this.server) return this.server
     if (!this.starting) {
+      const abort = new AbortController()
+      this.startAbort = abort
       const contextTokens = this.opts.contextTokens ?? DEFAULT_CONTEXT_TOKENS
       const server = new LlamaServer({
         binPath: this.opts.binPath,
@@ -159,7 +176,10 @@ export class LlamaReranker implements Reranker {
         threads: this.opts.threads,
         healthTimeoutMs: this.opts.healthTimeoutMs,
         healthIntervalMs: this.opts.healthIntervalMs,
-        host: this.opts.host
+        host: this.opts.host,
+        // REL-10: let a lock/quit teardown abort this start mid-health-wait (the child is killed
+        // via the normal stop path; start() rejects AbortError — never latched below).
+        startAbortSignal: abort.signal
       })
       this.starting = server
         .start()
@@ -168,6 +188,9 @@ export class LlamaReranker implements Reranker {
         })
         .catch((err) => {
           const error = err instanceof Error ? err : new Error(String(err))
+          // REL-10 (audit 2026-09-02): a teardown-ABORTED start is not a load fault — never latch
+          // `startFailed` (it survives suspend(), so it would disable reranking for the session).
+          if (isStartAbortError(err) || abort.signal.aborted) throw error
           // F7 (post-merge audit): a TRANSIENT port-bind race must NOT arm the latch (same fix as
           // the embedder, F4). This latch is more persistent than the embedder's — `suspend()`
           // KEEPS it (a bad GGUF won't load after unlock either) — so arming it for a race killed
@@ -179,6 +202,7 @@ export class LlamaReranker implements Reranker {
         })
         .finally(() => {
           this.starting = null
+          if (this.startAbort === abort) this.startAbort = null
         })
     }
     await this.starting
@@ -267,8 +291,12 @@ export class LlamaReranker implements Reranker {
     // not, so this flag gives the lock path the same protection for the duration of the teardown.
     this.tearingDown = true
     try {
-      // A lazy start may be in flight (first rerank() racing app quit); wait for it to
-      // settle so the spawned child cannot outlive the app as an orphan.
+      // A lazy start may be in flight (first rerank() racing app quit). REL-10 (audit
+      // 2026-09-02): ABORT it rather than wait it out — the abort kills the child inside the
+      // health wait (the normal stop path, no orphan), the start rejects AbortError (never
+      // latches `startFailed`), and the await below settles in about one health-poll interval
+      // instead of the full 180 s health window of a wedged cold start.
+      this.startAbort?.abort()
       if (this.starting) {
         await this.starting.catch(() => undefined)
       }

--- a/apps/desktop/src/main/services/vision/runtime.ts
+++ b/apps/desktop/src/main/services/vision/runtime.ts
@@ -1,4 +1,4 @@
-import { LlamaServer, combineSignals, type LlamaServerOptions } from '../runtime/sidecar'
+import { LlamaServer, combineSignals, isStartAbortError, type LlamaServerOptions } from '../runtime/sidecar'
 import { readChatSSE } from '../runtime/llama'
 import type { VisionErrorCode } from '../../../shared/types'
 
@@ -195,6 +195,14 @@ export class VisionRuntime {
    *  so the latch is never cleared/reused — `ensureStarted` checks `stopped` first regardless
    *  (corrected from a stale "Cleared by stop()" note — BUG vuln-scan-2026-06-21). */
   private startFailed: Error | null = null
+  /**
+   * Aborts the IN-FLIGHT lazy start on lock/quit (REL-10, audit 2026-09-02 — the translation
+   * runtime's #159 / BE-1 pattern, ported): `stop()` no longer awaits the full health window
+   * (180 s by default) of a wedged cold start it is about to kill anyway — the child is killed
+   * inside the health wait and the start rejects with an AbortError, which never arms the
+   * (permanently sticky) `startFailed` latch above. One per start.
+   */
+  private startAbort: AbortController | null = null
   /** Number of analyses currently using the sidecar. Guards the idle teardown (RUNTIME-4):
    *  while >0 a job is running and the sidecar must NOT be torn down. */
   private inFlight = 0
@@ -220,10 +228,15 @@ export class VisionRuntime {
     if (this.startFailed) throw this.startFailed
     if (this.server) return this.server
     if (!this.starting) {
+      const abort = new AbortController()
+      this.startAbort = abort
       const server = new LlamaServer({
         binPath: this.opts.binPath,
         modelPath: this.opts.modelPath,
         contextTokens: this.opts.contextTokens ?? DEFAULT_VISION_CONTEXT_TOKENS,
+        // REL-10: let a lock/quit teardown abort this start mid-health-wait (the child is killed
+        // via the normal stop path; start() rejects AbortError — never latched below).
+        startAbortSignal: abort.signal,
         // V1-resolved: `--mmproj` loads multimodal; `--device none` CPU-pins. The b9585
         // default-on `--jinja` gives the multimodal chat-template path without inheriting
         // CHAT_SERVER_ARGS; `--reasoning-format` is left at default (non-reasoning VLM).
@@ -256,11 +269,16 @@ export class VisionRuntime {
           this.server = server
         })
         .catch((err) => {
+          // REL-10 (audit 2026-09-02): a teardown-ABORTED start is not a load fault — never latch
+          // `startFailed` (permanently sticky here; `stop()` has already latched `stopped`, and
+          // `isStartFailed()` must keep reporting the truth to the orchestrator).
+          if (isStartAbortError(err) || abort.signal.aborted) throw err
           this.startFailed = err instanceof Error ? err : new Error(String(err))
           throw this.startFailed
         })
         .finally(() => {
           this.starting = null
+          if (this.startAbort === abort) this.startAbort = null
         })
     }
     await this.starting
@@ -378,8 +396,12 @@ export class VisionRuntime {
   async stop(): Promise<void> {
     this.stopped = true
     this.cancelIdleTimer()
-    // Wait out an in-flight lazy start (e5.ts no-orphan precedent) AND an in-flight soft idle
-    // teardown, so neither leaves an orphaned child after the app quits.
+    // An in-flight lazy start is ABORTED (REL-10, audit 2026-09-02 — the #159 pattern): the
+    // child is killed inside the health wait (the normal stop path, no orphan) and the await
+    // settles in about one health-poll interval instead of the full 180 s health window of a
+    // wedged cold start. The in-flight soft idle teardown is still waited out, so neither
+    // leaves an orphaned child after the app quits.
+    this.startAbort?.abort()
     if (this.starting) await this.starting.catch(() => undefined)
     if (this.idleTeardownPromise) await this.idleTeardownPromise.catch(() => undefined)
     const server = this.server

--- a/apps/desktop/src/main/shutdown.ts
+++ b/apps/desktop/src/main/shutdown.ts
@@ -208,8 +208,9 @@ async function withOverallDeadline(
     }, SHUTDOWN_OVERALL_DEADLINE_MS)
     timer.unref()
   })
-  const raced = section()
-  raced.catch(() => undefined)
+  // The section cannot reject today (every step is try/caught or `allSettled`); the catch makes
+  // that structural, so neither a pre-deadline rejection nor an abandoned one can skip the lock.
+  const raced = section().catch((err) => log.error('quit: teardown section failed', String(err)))
   try {
     await Promise.race([raced, deadline])
   } finally {

--- a/apps/desktop/src/main/shutdown.ts
+++ b/apps/desktop/src/main/shutdown.ts
@@ -18,9 +18,24 @@ export interface ShutdownDeps {
   streamSettled?: Map<string, Promise<void>>
   /** Flush the encrypted diagnostics log before `lock()` zeroes the vault key. */
   detachVaultKey?: () => void
-  /** Logger (only `error` is used). */
-  log?: Pick<typeof realLog, 'error'>
+  /** Logger (`error`, plus `info` for the two quit-progress lines — SEC-12). */
+  log?: Pick<typeof realLog, 'error' | 'info'>
 }
+
+/**
+ * Overall bound on the AWAITED MIDDLE of `performShutdown` (SEC-12 rider 13, audit 2026-09-02;
+ * owner decision 13 unanswered → this default, #230): the local-API stop, the sidecar stops, the
+ * stream settle and the doc-task settle are raced as ONE section against this deadline. The
+ * per-step bounds sum to 20.5 s today (local API ≤ 0.5 s; sidecars ≤ 10 s — the transcriber's
+ * suspend timeout; streams 5 s; doc tasks 5 s), so 30 s only ever fires on a step that is not
+ * honouring its own bound. When it fires, the teardown logs, ABANDONS the parked promises and
+ * goes straight on to the log flush + the vault lock — the lock is never inside the race (a
+ * deadline that abandoned the lock would reproduce the hard-kill outcome it exists to prevent).
+ * Whatever a parked sidecar stop left behind is reaped synchronously right before `app.exit`
+ * (`killRegisteredSidecarChildren`, the CODE-11 crash-path reaper, now also run by the quit
+ * handler's finally — see `createAppLifecycleHandlers`).
+ */
+export const SHUTDOWN_OVERALL_DEADLINE_MS = 30_000
 
 /**
  * Stop the sidecars and AWAIT their exit so no orphaned `llama-server` survives, then re-encrypt +
@@ -50,8 +65,9 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
 
   // AUD-02 — arm the WORKSPACE lock latch FIRST, and in its OWN best-effort try (two latches
   // sharing one `catch` would make whichever runs second silently optional). The teardown below
-  // spends up to ~10 s in awaited windows (sidecar stops, the stream settles, the doc-task
-  // settle) during which the DB is still OPEN, so `isUnlocked()` is still true and every
+  // spends up to ~20.5 s in awaited windows (the local-API stop ≤ 0.5 s, the sidecar stops ≤ 10 s,
+  // the stream settle ≤ 5 s, the doc-task settle ≤ 5 s — bounded as a whole by
+  // `SHUTDOWN_OVERALL_DEADLINE_MS`) during which the DB is still OPEN, so `isUnlocked()` is still true and every
   // content-surface guard still admits. Most sidecars are safe here because QUIT uses the
   // permanently-latching `stop()` where lock uses the non-latching `suspend()` — a translate or
   // embed admitted now fails at `ensureStarted` instead of respawning. Two are not:
@@ -109,46 +125,54 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
   } catch (err) {
     log.error('Error aborting in-flight streams on quit', String(err))
   }
-  // The local API dies BEFORE the sidecars (local-api wave): stop() aborts active + queued
-  // external streams and closes every socket, so no outside caller holds the model while
-  // the children below are killed. In-process (no orphan class) — but awaited so its
-  // sockets are deterministically gone before the vault work.
-  try {
-    await (ctx?.localApi?.stop() ?? Promise.resolve())
-  } catch (err) {
-    log.error('Error stopping the local API on quit', String(err))
-  }
-  try {
-    await Promise.allSettled([
-      ctx?.runtime.stop() ?? Promise.resolve(),
-      ctx?.embedder.stop?.() ?? Promise.resolve(),
-      ctx?.reranker?.stop?.() ?? Promise.resolve(),
-      ctx?.transcriber?.stop?.() ?? Promise.resolve(),
-      ctx?.ocrEngine?.stop?.() ?? Promise.resolve(),
-      // The vision sidecar is a 4th co-resident llama-server (PROD-1) — kill it too so no
-      // child orphans on quit.
-      ctx?.vision?.stop() ?? Promise.resolve(),
-      // The TranslateGemma sidecar (TG wave) is a 5th co-resident llama-server — permanent stop()
-      // so its child + its KV cache of recent source/translation text never orphan on quit.
-      ctx?.translator?.stop?.() ?? Promise.resolve()
-    ])
-  } catch (err) {
-    log.error('Error stopping sidecars on quit', String(err))
-  }
-  // R1 (full-audit-2026-06-30, Phase C): deterministically await each aborted stream's SETTLE
-  // (its partial-reply persistence) before lock() closes the DB — the same guarantee the lock
-  // path now makes. The aborts above unwind each generation as an ABORT so the partial persists
-  // via `appendMessage` while `ctx.db` is open, but that runs in the stream's OWN promise this
-  // teardown never awaited; the REL-4 ordering only ensured the abort fired FIRST, still racing
-  // `runtime.stop()` vs the abort-unwind. Awaiting the settle makes persist-before-close the
-  // ordering. After the sidecar stop so a generation ignoring its signal is unwound by the dead
-  // sidecar (no quit stall). Best-effort (`allSettled`).
-  await awaitInFlightStreamsSettled(streamSettled)
-  // H1 (TA-1): await the cancelled doc-task's abort-unwind before lock() closes the DB. The
-  // translation handler persists/shreds its `.parse` transient synchronously during the unwind
-  // while ctx.db is open; awaiting the settle here makes cleanup-before-close the ORDERING, not a
-  // race. Bounded (~5 s) so a wedged handler can never hang quit. Mirrors the stream-settle above.
-  await awaitActiveDocTaskSettled(ctx, log)
+  // SEC-12 rider 13 (audit 2026-09-02): the four awaited steps below are bounded as a WHOLE by
+  // `SHUTDOWN_OVERALL_DEADLINE_MS` (see the constant). The log flush and the lock stay OUTSIDE.
+  await withOverallDeadline(async () => {
+    // The local API dies BEFORE the sidecars (local-api wave): stop() aborts active + queued
+    // external streams and closes every socket, so no outside caller holds the model while
+    // the children below are killed. In-process (no orphan class) — but awaited so its
+    // sockets are deterministically gone before the vault work.
+    try {
+      await (ctx?.localApi?.stop() ?? Promise.resolve())
+    } catch (err) {
+      log.error('Error stopping the local API on quit', String(err))
+    }
+    try {
+      await Promise.allSettled([
+        ctx?.runtime.stop() ?? Promise.resolve(),
+        ctx?.embedder.stop?.() ?? Promise.resolve(),
+        ctx?.reranker?.stop?.() ?? Promise.resolve(),
+        ctx?.transcriber?.stop?.() ?? Promise.resolve(),
+        ctx?.ocrEngine?.stop?.() ?? Promise.resolve(),
+        // The vision sidecar is a 4th co-resident llama-server (PROD-1) — kill it too so no
+        // child orphans on quit.
+        ctx?.vision?.stop() ?? Promise.resolve(),
+        // The TranslateGemma sidecar (TG wave) is a 5th co-resident llama-server — permanent stop()
+        // so its child + its KV cache of recent source/translation text never orphan on quit.
+        ctx?.translator?.stop?.() ?? Promise.resolve()
+      ])
+    } catch (err) {
+      log.error('Error stopping sidecars on quit', String(err))
+    }
+    // R1 (full-audit-2026-06-30, Phase C): deterministically await each aborted stream's SETTLE
+    // (its partial-reply persistence) before lock() closes the DB — the same guarantee the lock
+    // path now makes. The aborts above unwind each generation as an ABORT so the partial persists
+    // via `appendMessage` while `ctx.db` is open, but that runs in the stream's OWN promise this
+    // teardown never awaited; the REL-4 ordering only ensured the abort fired FIRST, still racing
+    // `runtime.stop()` vs the abort-unwind. Awaiting the settle makes persist-before-close the
+    // ordering. After the sidecar stop so a generation ignoring its signal is unwound by the dead
+    // sidecar (no quit stall). Best-effort (`allSettled`).
+    await awaitInFlightStreamsSettled(streamSettled)
+    // H1 (TA-1): await the cancelled doc-task's abort-unwind before lock() closes the DB. The
+    // translation handler persists/shreds its `.parse` transient synchronously during the unwind
+    // while ctx.db is open; awaiting the settle here makes cleanup-before-close the ORDERING, not a
+    // race. Bounded (~5 s) so a wedged handler can never hang quit. Mirrors the stream-settle above.
+    await awaitActiveDocTaskSettled(ctx, log)
+  }, log)
+  // SEC-12: by now no window is left (Windows/Linux quit after window-all-closed), so this line
+  // is the only visible state of a quit that is locking — and it lands in the encrypted log
+  // because it precedes the flush below.
+  log.info('quit: locking workspace')
   // Flush the encrypted diagnostics log to disk while the vault key is still live (lock() zeroes it).
   // No-op for plaintext_dev (that log is appended in real time).
   detachVaultKey()
@@ -160,6 +184,117 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
     ctx?.workspace.shutdown()
   } catch (err) {
     log.error('Failed to lock workspace on quit', String(err))
+  }
+}
+
+/**
+ * Race `section` against `SHUTDOWN_OVERALL_DEADLINE_MS` (SEC-12 rider 13). On the deadline the
+ * section's promise is abandoned (its rejection, if any, is swallowed so it can never surface as
+ * an unhandled rejection later) and the caller proceeds; on completion the timer is cleared so a
+ * finished teardown never holds a live handle. The timer is unref'd for the same reason.
+ */
+async function withOverallDeadline(
+  section: () => Promise<void>,
+  log: Pick<typeof realLog, 'error'>
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      log.error(
+        'quit: overall teardown deadline reached — abandoning the parked stops and locking the workspace now',
+        { deadlineMs: SHUTDOWN_OVERALL_DEADLINE_MS }
+      )
+      resolve()
+    }, SHUTDOWN_OVERALL_DEADLINE_MS)
+    timer.unref()
+  })
+  const raced = section()
+  raced.catch(() => undefined)
+  try {
+    await Promise.race([raced, deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+// ---- The Electron app-lifecycle handlers (SEC-12 / GAP-2, audit 2026-09-02) -------------------
+
+/** The subset of Electron's `will-quit` event the handler uses (kept electron-free for tests). */
+export interface WillQuitEventLike {
+  preventDefault(): void
+}
+
+/** The Electron surface the handlers touch — injected so `tests/unit/shutdown.test.ts` drives them. */
+export interface AppLifecycleDeps {
+  /** The graceful teardown; the real caller binds `performShutdown(ctx)`. Never expected to reject. */
+  performShutdown: () => Promise<void>
+  /** `app.exit` — the ONLY way the process leaves once a quit has begun. */
+  exit: (code: number) => void
+  /** `createWindow` (a macOS Dock click fires `activate` with no window open). */
+  createWindow: () => void
+  /** `BrowserWindow.getAllWindows().length`. */
+  windowCount: () => number
+  /**
+   * `killRegisteredSidecarChildren` — reaps, synchronously and right before `exit`, whatever a
+   * deadline-abandoned sidecar stop left behind (the CODE-11 crash-path reaper, reused). A no-op
+   * after a teardown that completed: every stopped child unregistered itself on exit.
+   */
+  killSidecarChildren: () => void
+  log: Pick<typeof realLog, 'error' | 'info'>
+}
+
+export interface AppLifecycleHandlers {
+  onWillQuit: (event: WillQuitEventLike) => void
+  onActivate: () => void
+  /** True from the first `will-quit` on (tests + diagnostics). */
+  isShuttingDown: () => boolean
+}
+
+/**
+ * ONE factory over ONE `isShuttingDown` closure (SEC-12 with GAP-2 folded in, audit 2026-09-02).
+ * Before this, `main/index.ts` held the flag inline: the `will-quit` re-entry branch returned
+ * WITHOUT `preventDefault()` — its comment assumed "cleanup already ran", but the flag is set
+ * BEFORE `performShutdown` starts, so a second quit while the teardown was still awaiting a
+ * sidecar stop (a wedged cold start held it up to 180 s — REL-10) let Electron's default quit
+ * proceed with the working DB still plaintext on the drive: the next launch found a live WAL,
+ * declined to preserve it and shredded it — every change since the last lock lost. On macOS a
+ * second ⌘Q while the app sits windowless in the Dock reaches exactly that branch. And a Dock
+ * click (`activate`) during the parked teardown opened a fresh window against a workspace whose
+ * runtime latch and lock latch were already armed.
+ *
+ * The two handlers must share the closure: a per-handler copy of the flag would freeze the
+ * activate guard at `false` in production while a test constructing it with `true` still passed.
+ * `main/index.ts` cannot be imported under vitest (it takes the single-instance lock and may call
+ * `app.exit` at module scope), so everything Electron is injected via `AppLifecycleDeps`.
+ */
+export function createAppLifecycleHandlers(deps: AppLifecycleDeps): AppLifecycleHandlers {
+  let shuttingDown = false
+  return {
+    onWillQuit: (event) => {
+      // SEC-12: EVERY will-quit is prevented — the first one starts the teardown, any later one
+      // arrives while it is still running (the DB is plaintext until `performShutdown` locks
+      // it). The teardown's own finally is the only exit; `app.exit` re-emits nothing.
+      event.preventDefault()
+      if (shuttingDown) return
+      shuttingDown = true
+      void deps
+        .performShutdown()
+        .catch((err) => deps.log.error('quit: teardown failed', String(err)))
+        .finally(() => {
+          try {
+            deps.killSidecarChildren()
+          } catch {
+            /* best-effort */
+          }
+          deps.exit(0)
+        })
+    },
+    onActivate: () => {
+      // GAP-2: no fresh window once a quit has begun.
+      if (shuttingDown) return
+      if (deps.windowCount() === 0) deps.createWindow()
+    },
+    isShuttingDown: () => shuttingDown
   }
 }
 

--- a/apps/desktop/src/main/window-security.ts
+++ b/apps/desktop/src/main/window-security.ts
@@ -25,7 +25,15 @@ export const SECURE_WINDOW_WEB_PREFERENCES = Object.freeze({
   contextIsolation: true,
   nodeIntegration: false,
   sandbox: true,
-  webSecurity: true
+  webSecurity: true,
+  // SEC-1 (audit 2026-09-02; owner decision 1 unanswered → this default, #218): Electron's
+  // spellchecker is ON by default and, on Windows and Linux, downloads Hunspell dictionaries
+  // from a Google-operated CDN on first typing — a BROWSER-PROCESS fetch that neither the page
+  // CSP nor the Node-socket offline tripwire (`offlineGuard.ts`) can see, and that the offline
+  // hard rule forbids. Off for all three windows; the composer loses red-underline spell-check
+  // (docs/known-limitations.md). If spell-check is wanted later: dictionaries on the drive +
+  // `setSpellCheckerDictionaryDownloadURL` to a no-op + a closed `setSpellCheckerLanguages`.
+  spellcheck: false
 }) satisfies Readonly<WebPreferences>
 
 /**

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -510,7 +510,7 @@ describe('admission during the QUIT teardown (AUD-02)', () => {
     inFlightStreams: new Map<string, AbortController>(),
     streamSettled: new Map<string, Promise<void>>(),
     detachVaultKey: (): void => {},
-    log: { error: (): undefined => undefined }
+    log: { error: (): undefined => undefined, info: (): undefined => undefined }
   }
 
   /** Park `performShutdown` inside its awaited sidecar-stop window (wrapped — see `parkedLock`). */

--- a/apps/desktop/tests/integration/runtime-manager.test.ts
+++ b/apps/desktop/tests/integration/runtime-manager.test.ts
@@ -715,7 +715,7 @@ describe('quit-path lifecycle (full-audit 2026-07-11 CODE-2/CODE-3)', () => {
         inFlightStreams: new Map(),
         streamSettled: new Map(),
         detachVaultKey: () => undefined,
-        log: { error: () => undefined }
+        log: { error: () => undefined, info: () => undefined }
       })
 
       expect(h.child.killed).toBe(true) // the loading child died with the teardown — no orphan

--- a/apps/desktop/tests/integration/sidecar-teardown-abort.test.ts
+++ b/apps/desktop/tests/integration/sidecar-teardown-abort.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { E5Embedder } from '../../src/main/services/embeddings/e5'
+import { LlamaReranker } from '../../src/main/services/reranker/llama'
+import { VisionRuntime } from '../../src/main/services/vision/runtime'
+import { TranslationRuntime } from '../../src/main/services/translation/runtime'
+import type { ChildProcessLike } from '../../src/main/services/runtime/sidecar'
+
+// REL-10 (audit 2026-09-02, port of the review's B8 reproduction): a lock or quit that lands
+// during a NEVER-HEALTHY cold start of a lazily-started llama-server must settle in about one
+// health-poll interval, not the full 180 s health window. Before the fix, only the translation
+// runtime (#159 / BE-1) aborted an in-flight start; the E5 embedder, the reranker and the vision
+// runtime awaited the whole spawn + health wait of a child they were about to kill anyway —
+// measured at 180 250 ms each (production defaults: 180 000 ms health timeout, 250 ms poll cap)
+// against 250 ms for translation — and the timed-out start then armed each wrapper's
+// `startFailed` latch, so the NEXT start after unlock was refused too (sticky for the reranker,
+// permanent for a vision instance).
+//
+// Production defaults on purpose: `base` carries NO `healthTimeoutMs` / `healthIntervalMs`, so
+// the bound this test measures is the one the product ships. Fake timers make the 180 s
+// reproducible in milliseconds; the settle time is read off the faked clock.
+//
+// Does not prove: the field likelihood of a wedged cold start (a slow USB read of a multi-GB
+// weight is the realistic trigger) — only that, when it happens, teardown is bounded.
+
+class FakeChild extends EventEmitter implements ChildProcessLike {
+  pid = 4242
+  killed = false
+  kill(): boolean {
+    this.killed = true
+    queueMicrotask(() => this.emit('exit', 0, null))
+    return true
+  }
+}
+
+/** A spawn() stub that records EVERY spawned child (a restart after an aborted start spawns a second). */
+function fakeSpawn() {
+  const children: FakeChild[] = []
+  const spawn = (): ChildProcessLike => {
+    const child = new FakeChild()
+    children.push(child)
+    return child
+  }
+  return { spawn, children }
+}
+
+/** `/health` never turns ready — a wedged cold start. Every other route is unreachable before health. */
+const neverHealthy = (async () =>
+  ({ ok: false, status: 503, json: async () => ({ status: 'loading' }) }) as Response) as typeof fetch
+
+/** Production defaults: no health timeout / interval override. `findPort` keeps the test off the network. */
+const base = {
+  binPath: '/bin/llama-server',
+  modelPath: '/models/model.gguf',
+  findPort: async () => 54321
+}
+
+/** Drain the microtask queue between fake-clock steps (promise chains settle without timers). */
+async function flush(n = 50): Promise<void> {
+  for (let i = 0; i < n; i++) await Promise.resolve()
+}
+
+/**
+ * Pump the fake clock in `step` ms slices until `done()` holds, and return the elapsed FAKE
+ * milliseconds — or null if `max` ms passed first. The health poll backs off up to the 250 ms
+ * production cap, so one slice is about one poll.
+ */
+async function advanceUntil(done: () => boolean, max = 200_000, step = 250): Promise<number | null> {
+  const t0 = Date.now()
+  await flush()
+  while (!done()) {
+    if (Date.now() - t0 >= max) return null
+    await vi.advanceTimersByTimeAsync(step)
+    await flush()
+  }
+  return Date.now() - t0
+}
+
+interface WrapperCase {
+  name: string
+  build: (spawn: () => ChildProcessLike) => {
+    /** Trigger the lazy cold start (the first user-facing call). */
+    kick: () => Promise<unknown>
+    /** The lock/quit teardown under test. */
+    teardown: () => Promise<void>
+    /** A second user-facing call after the teardown — must spawn a FRESH child (no stale latch). */
+    restart?: () => Promise<unknown>
+    /** The wrapper's own latch accessor where one exists. */
+    latched?: () => boolean
+    /** Permanent stop at the end so nothing is left parked. */
+    finalStop: () => Promise<void>
+  }
+}
+
+const cases: WrapperCase[] = [
+  {
+    name: 'E5Embedder.stop()',
+    build: (spawn) => {
+      const e5 = new E5Embedder({ ...base, id: 'e5', dimensions: 2, spawn, fetchImpl: neverHealthy })
+      return { kick: () => e5.embed(['a']), teardown: () => e5.stop(), finalStop: () => e5.stop() }
+    }
+  },
+  {
+    // suspend() clears the embedder's latch by design (L4), so the observable here is the
+    // lazy RESTART: a second embed() after the aborted start spawns a fresh child.
+    name: 'E5Embedder.suspend() then a lazy restart',
+    build: (spawn) => {
+      const e5 = new E5Embedder({ ...base, id: 'e5', dimensions: 2, spawn, fetchImpl: neverHealthy })
+      return {
+        kick: () => e5.embed(['a']),
+        teardown: () => e5.suspend(),
+        restart: () => e5.embed(['b']),
+        finalStop: () => e5.stop()
+      }
+    }
+  },
+  {
+    // The reranker KEEPS its latch across suspend() (F7 policy: a bad GGUF loads no better after
+    // unlock) — so an aborted start that wrongly latched would refuse every rerank for the
+    // session. The restart proves the aborted start did not latch.
+    name: 'LlamaReranker.suspend() then a lazy restart',
+    build: (spawn) => {
+      const rr = new LlamaReranker({ ...base, id: 'rr', spawn, fetchImpl: neverHealthy })
+      return {
+        kick: () => rr.rerank('q', ['d']),
+        teardown: () => rr.suspend(),
+        restart: () => rr.rerank('q', ['d']),
+        finalStop: () => rr.stop()
+      }
+    }
+  },
+  {
+    name: 'VisionRuntime.stop()',
+    build: (spawn) => {
+      const vis = new VisionRuntime({
+        ...base,
+        modelId: 'vis',
+        projectorPath: '/models/mmproj.gguf',
+        spawn,
+        fetchImpl: neverHealthy
+      })
+      return {
+        kick: () =>
+          vis.analyze({ imageBytes: new Uint8Array([1, 2, 3, 4]), mimeType: 'image/png', question: 'what?' }),
+        teardown: () => vis.stop(),
+        latched: () => vis.isStartFailed(),
+        finalStop: () => vis.stop()
+      }
+    }
+  },
+  {
+    // The #159 template — green before this change; kept as the control the three above must match.
+    name: 'TranslationRuntime.suspend() (control, #159)',
+    build: (spawn) => {
+      const tg = new TranslationRuntime({
+        ...base,
+        modelId: 'tg',
+        spawn,
+        fetchImpl: neverHealthy,
+        gpu: { getGpuMode: () => 'off', getGpuAutoDisabled: () => true }
+      })
+      return {
+        kick: () => tg.translate({ sourceLang: 'de', targetLang: 'en', text: 'Guten Tag.' }),
+        teardown: () => tg.suspend(),
+        latched: () => tg.isStartFailed(),
+        finalStop: () => tg.stop()
+      }
+    }
+  }
+]
+
+/** One health poll is ≤ 250 ms; anything near the 180 s health window is the finding. */
+const SETTLE_BOUND_MS = 5_000
+
+describe('REL-10 — lock/quit teardown during a never-healthy cold start (B8)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it.each(cases)('$name settles in < 5 s, kills the child, and leaves no stale latch', async ({ build }) => {
+    vi.useFakeTimers()
+    const { spawn, children } = fakeSpawn()
+    const w = build(spawn)
+
+    const inflight = w.kick()
+    inflight.catch(() => {}) // observed below; never unhandled
+    expect(await advanceUntil(() => children.length === 1, SETTLE_BOUND_MS)).not.toBeNull()
+    expect(children).toHaveLength(1) // the cold start spawned exactly one child
+
+    let settled = false
+    const teardown = w.teardown().then(() => {
+      settled = true
+    })
+    const at = await advanceUntil(() => settled)
+    expect(at).not.toBeNull() // the teardown settled inside the 200 s pump at all
+    expect(children[0].killed).toBe(true) // the mid-start child was killed, never orphaned
+    // The finding: 180 250 ms for E5 / reranker / vision before the fix, 250 ms for translation.
+    expect(at).toBeLessThan(SETTLE_BOUND_MS)
+    await teardown
+    await expect(inflight).rejects.toThrow() // the in-flight call rejects (aborted start)
+
+    if (w.latched) expect(w.latched()).toBe(false) // an aborted start is not a load fault
+    if (w.restart) {
+      const again = w.restart()
+      again.catch(() => {})
+      expect(await advanceUntil(() => children.length === 2, SETTLE_BOUND_MS)).not.toBeNull()
+      expect(children).toHaveLength(2) // a FRESH child — the aborted start left no latch behind
+    }
+
+    let stopped = false
+    void w.finalStop().then(() => {
+      stopped = true
+    })
+    expect(await advanceUntil(() => stopped, SETTLE_BOUND_MS)).not.toBeNull()
+    expect(children.every((c) => c.killed)).toBe(true)
+  })
+})

--- a/apps/desktop/tests/unit/inflight-settle-bound.test.ts
+++ b/apps/desktop/tests/unit/inflight-settle-bound.test.ts
@@ -50,7 +50,7 @@ describe('awaitInFlightStreamsSettled ceiling (full-audit 2026-07-12 REL-4)', ()
       inFlightStreams: new Map(),
       streamSettled: new Map<string, Promise<void>>([['c1', new Promise<void>(() => {})]]),
       detachVaultKey: () => order.push('detach'),
-      log: { error: () => undefined }
+      log: { error: () => undefined, info: () => undefined }
     })
 
     // Before the ceiling the teardown is parked on the wedged settle: lock() has not run.

--- a/apps/desktop/tests/unit/shutdown.test.ts
+++ b/apps/desktop/tests/unit/shutdown.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { performShutdown } from '../../src/main/shutdown'
+import { describe, it, expect, vi } from 'vitest'
+import { performShutdown, createAppLifecycleHandlers, SHUTDOWN_OVERALL_DEADLINE_MS } from '../../src/main/shutdown'
 import type { AppContext } from '../../src/main/services/context'
 
 // REL-4 (full-audit-2026-06-29 follow-up): the QUIT teardown must abort in-flight chat/RAG streams
@@ -220,5 +220,179 @@ describe('performShutdown ordering (REL-4)', () => {
     expect(order.indexOf('unwound')).toBeGreaterThan(order.indexOf('runtime.stop'))
     expect(order.indexOf('unwound')).toBeLessThan(order.indexOf('lock'))
     expect(order[order.length - 1]).toBe('lock')
+  })
+})
+
+// ---- SEC-12 / GAP-2 / rider 13 (audit 2026-09-02) — the quit handler itself ------------------
+//
+// B1 (the review's `o1-double-quit` reproduction, ported and INVERTED): `isShuttingDown` is set
+// before `performShutdown` starts, and the re-entry branch of the `will-quit` handler returned
+// WITHOUT `event.preventDefault()`, so a second quit while the teardown was parked (a wedged
+// sidecar stop — REL-10's 180 s) let Electron's default quit proceed with the working DB still
+// plaintext on the drive. The one parked point is `embedder.stop()`.
+//
+// Does not prove: that Electron re-emits `will-quit` after a prevented one (documentation-derived;
+// on macOS the default Quit role re-runs before-quit → will-quit for a second ⌘Q).
+
+/** A fake ctx whose every member resolves immediately EXCEPT `embedder.stop`, which parks. */
+function parkedCtx(order: string[]): { ctx: AppContext; release: () => void } {
+  let release: () => void = () => undefined
+  const ctx = fakeCtx(order) as unknown as { embedder: { stop: () => Promise<void> } }
+  ctx.embedder.stop = () => {
+    order.push('embedder.stop(parked)')
+    return new Promise<void>((r) => {
+      release = r
+    })
+  }
+  return { ctx: ctx as unknown as AppContext, release: () => release() }
+}
+
+/** The `{preventDefault, defaultPrevented}` subset of Electron's `will-quit` event. */
+function quitEvent(): { preventDefault: () => void; defaultPrevented: boolean } {
+  const ev = {
+    defaultPrevented: false,
+    preventDefault: () => {
+      ev.defaultPrevented = true
+    }
+  }
+  return ev
+}
+
+/** Let the parked teardown run up to its park point (the paper's 30-iteration drain). */
+async function drain(): Promise<void> {
+  for (let i = 0; i < 30; i++) await new Promise((r) => setImmediate(r))
+}
+
+const quietLog = { error: () => undefined, info: () => undefined }
+
+describe('will-quit re-entry during a parked teardown (SEC-12, B1 inverted)', () => {
+  it('prevents the SECOND will-quit too; the lock runs exactly once, after release, then exit', async () => {
+    const order: string[] = []
+    const exits: number[] = []
+    const { ctx, release } = parkedCtx(order)
+    // Characterisation form: the `will-quit` body copied from `main/index.ts` (which cannot be
+    // imported under vitest — it registers app handlers at import time) over an event stub.
+    // The fix commit rewrites this against `createAppLifecycleHandlers`.
+    let isShuttingDown = false
+    const onWillQuit = (event: { preventDefault: () => void }): void => {
+      if (isShuttingDown) return // cleanup already ran → let the real quit proceed
+      event.preventDefault()
+      isShuttingDown = true
+      void performShutdown(ctx, {
+        inFlightStreams: new Map(),
+        detachVaultKey: () => order.push('detach'),
+        log: quietLog
+      }).finally(() => exits.push(0))
+    }
+
+    const first = quitEvent()
+    onWillQuit(first)
+    await drain()
+    expect(first.defaultPrevented).toBe(true)
+    expect(order).toContain('embedder.stop(parked)') // the teardown is parked mid-sidecar-stop
+    expect(order).not.toContain('lock') // …so the working DB is still plaintext
+    expect(exits).toEqual([])
+
+    const second = quitEvent()
+    onWillQuit(second)
+    await drain()
+    // INVERTED B1: the re-entry must be prevented as well — nothing but the teardown's own
+    // completion may release the quit while the vault is unlocked.
+    expect(second.defaultPrevented).toBe(true)
+    expect(order).not.toContain('lock')
+    expect(exits).toEqual([])
+
+    release()
+    await drain()
+    expect(order.filter((l) => l === 'lock')).toHaveLength(1)
+    expect(order[order.length - 1]).toBe('lock')
+    expect(exits).toEqual([0]) // exit exactly once, from the teardown's finally
+  })
+})
+
+describe('activate during a parked teardown (GAP-2)', () => {
+  it('does not create a window once a quit began (Dock click while the teardown is parked)', async () => {
+    let windows = 0
+    let created = 0
+    const handlers = createAppLifecycleHandlers({
+      performShutdown: () => new Promise<void>(() => {}), // parked forever
+      exit: () => undefined,
+      createWindow: () => {
+        created++
+        windows++
+      },
+      windowCount: () => windows,
+      killSidecarChildren: () => undefined,
+      log: quietLog
+    })
+    handlers.onActivate()
+    expect(created).toBe(1) // a normal Dock click with no window creates one
+    windows = 0 // the user closed the window; the app stays in the Dock (macOS)
+    handlers.onWillQuit(quitEvent())
+    expect(handlers.isShuttingDown()).toBe(true)
+    handlers.onActivate()
+    expect(created).toBe(1) // no fresh window against a workspace whose lock latch is armed
+  })
+})
+
+describe('overall teardown deadline (SEC-12 rider 13)', () => {
+  it('bounds the awaited middle at SHUTDOWN_OVERALL_DEADLINE_MS and still locks AFTER it', async () => {
+    // §1.4: a REAL timer captured before the fake clock bounds the await below — never count
+    // event-loop turns as a time budget.
+    const realSetTimeout = setTimeout
+    vi.useFakeTimers()
+    try {
+      const order: string[] = []
+      const { ctx } = parkedCtx(order) // never released: the parked stop is abandoned
+      const p = performShutdown(ctx, {
+        inFlightStreams: new Map(),
+        detachVaultKey: () => order.push('detach'),
+        log: { error: (m) => order.push(`log:${m}`), info: (m) => order.push(`log:${m}`) }
+      })
+      let resolved = false
+      void p.then(() => {
+        resolved = true
+      })
+
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_OVERALL_DEADLINE_MS - 1)
+      expect(order).toContain('embedder.stop(parked)')
+      expect(order).not.toContain('lock') // one ms short of the deadline: still waiting
+      expect(resolved).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await Promise.race([
+        p,
+        new Promise<never>((_, reject) =>
+          realSetTimeout(() => reject(new Error('the lock did not run after the deadline')), 2_000)
+        )
+      ])
+      // The lock and the log flush sit OUTSIDE the raced section: they ran after the deadline
+      // fired, although the parked stop never resolved. (A fix that raced the whole tail would
+      // resolve on time while abandoning the lock — this ordering is what catches it.)
+      const deadlineLog = order.findIndex((l) => l.startsWith('log:') && /deadline/i.test(l))
+      expect(deadlineLog).toBeGreaterThan(order.indexOf('embedder.stop(parked)'))
+      expect(order.indexOf('detach')).toBeGreaterThan(deadlineLog)
+      expect(order[order.length - 1]).toBe('lock')
+      expect(order.filter((l) => l === 'lock')).toHaveLength(1)
+      expect(order.some((l) => /locking workspace/i.test(l))).toBe(true) // the "quit: locking" line
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves no deadline timer pending after a teardown that completes on its own', async () => {
+    vi.useFakeTimers()
+    try {
+      const order: string[] = []
+      await performShutdown(fakeCtx(order), {
+        inFlightStreams: new Map(),
+        detachVaultKey: () => order.push('detach'),
+        log: quietLog
+      })
+      expect(order[order.length - 1]).toBe('lock')
+      expect(vi.getTimerCount()).toBe(0) // the deadline timer was cleared, not left to fire
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/tests/unit/shutdown.test.ts
+++ b/apps/desktop/tests/unit/shutdown.test.ts
@@ -363,6 +363,7 @@ describe('overall teardown deadline (SEC-12 rider 13)', () => {
     // §1.4: a REAL timer captured before the fake clock bounds the await below — never count
     // event-loop turns as a time budget.
     const realSetTimeout = setTimeout
+    const realClearTimeout = clearTimeout
     vi.useFakeTimers()
     try {
       const order: string[] = []
@@ -383,12 +384,17 @@ describe('overall teardown deadline (SEC-12 rider 13)', () => {
       expect(resolved).toBe(false)
 
       await vi.advanceTimersByTimeAsync(1)
-      await Promise.race([
-        p,
-        new Promise<never>((_, reject) =>
-          realSetTimeout(() => reject(new Error('the lock did not run after the deadline')), 2_000)
-        )
-      ])
+      let bound: ReturnType<typeof setTimeout> | undefined
+      try {
+        await Promise.race([
+          p,
+          new Promise<never>((_, reject) => {
+            bound = realSetTimeout(() => reject(new Error('the lock did not run after the deadline')), 2_000)
+          })
+        ])
+      } finally {
+        if (bound) realClearTimeout(bound)
+      }
       // The lock and the log flush sit OUTSIDE the raced section: they ran after the deadline
       // fired, although the parked stop never resolved. (A fix that raced the whole tail would
       // resolve on time while abandoning the lock — this ordering is what catches it.)

--- a/apps/desktop/tests/unit/shutdown.test.ts
+++ b/apps/desktop/tests/unit/shutdown.test.ts
@@ -9,6 +9,9 @@ import type { AppContext } from '../../src/main/services/context'
 // ordering unit-testable with a fake ctx. The whole sequence: abort build + abort streams → stop
 // sidecars → detach log → lock.
 
+/** A logger the ordering tests do not care about (`error` + `info` — the quit path logs both). */
+const quietLog = { error: () => undefined, info: () => undefined }
+
 /** A fake AbortController that records when it is aborted, so the test can assert ordering. */
 function recordingController(order: string[], label: string): AbortController {
   const ctl = {
@@ -66,7 +69,7 @@ describe('performShutdown ordering (REL-4)', () => {
     await performShutdown(fakeCtx(order), {
       inFlightStreams: streams,
       detachVaultKey: () => order.push('detach'),
-      log: { error: () => undefined }
+      log: quietLog
     })
 
     // The stream WAS aborted (reds if the REL-4 abort loop is removed).
@@ -115,7 +118,7 @@ describe('performShutdown ordering (REL-4)', () => {
     await performShutdown(fakeCtx(order), {
       inFlightStreams: new Map([['c1', already]]),
       detachVaultKey: () => order.push('detach'),
-      log: { error: () => undefined }
+      log: quietLog
     })
 
     expect(order).not.toContain('should-not-fire') // not re-aborted
@@ -129,7 +132,7 @@ describe('performShutdown ordering (REL-4)', () => {
       performShutdown(null, {
         inFlightStreams: new Map(),
         detachVaultKey: () => order.push('detach'),
-        log: { error: () => undefined }
+        log: quietLog
       })
     ).resolves.toBeUndefined()
     expect(order).toEqual(['detach']) // only the always-runs detach fired; no ctx calls threw
@@ -159,7 +162,7 @@ describe('performShutdown ordering (REL-4)', () => {
       inFlightStreams: new Map([['c1', controller]]),
       streamSettled: settled,
       detachVaultKey: () => order.push('detach'),
-      log: { error: () => undefined }
+      log: quietLog
     })
 
     const tick = (): Promise<void> => new Promise((r) => setImmediate(r))
@@ -201,7 +204,7 @@ describe('performShutdown ordering (REL-4)', () => {
     const p = performShutdown(ctx as unknown as AppContext, {
       inFlightStreams: new Map(),
       detachVaultKey: () => order.push('detach'),
-      log: { error: () => undefined }
+      log: quietLog
     })
 
     const tick = (): Promise<void> => new Promise((r) => setImmediate(r))
@@ -263,30 +266,37 @@ async function drain(): Promise<void> {
   for (let i = 0; i < 30; i++) await new Promise((r) => setImmediate(r))
 }
 
-const quietLog = { error: () => undefined, info: () => undefined }
 
 describe('will-quit re-entry during a parked teardown (SEC-12, B1 inverted)', () => {
-  it('prevents the SECOND will-quit too; the lock runs exactly once, after release, then exit', async () => {
+  /** The real `will-quit` handler over the real `performShutdown`, parked on `embedder.stop()`. */
+  function harness() {
     const order: string[] = []
     const exits: number[] = []
     const { ctx, release } = parkedCtx(order)
-    // Characterisation form: the `will-quit` body copied from `main/index.ts` (which cannot be
-    // imported under vitest — it registers app handlers at import time) over an event stub.
-    // The fix commit rewrites this against `createAppLifecycleHandlers`.
-    let isShuttingDown = false
-    const onWillQuit = (event: { preventDefault: () => void }): void => {
-      if (isShuttingDown) return // cleanup already ran → let the real quit proceed
-      event.preventDefault()
-      isShuttingDown = true
-      void performShutdown(ctx, {
-        inFlightStreams: new Map(),
-        detachVaultKey: () => order.push('detach'),
-        log: quietLog
-      }).finally(() => exits.push(0))
-    }
+    const handlers = createAppLifecycleHandlers({
+      performShutdown: () =>
+        performShutdown(ctx, {
+          inFlightStreams: new Map(),
+          detachVaultKey: () => order.push('detach'),
+          log: quietLog
+        }),
+      exit: (code) => {
+        order.push('exit')
+        exits.push(code)
+      },
+      createWindow: () => order.push('createWindow'),
+      windowCount: () => 0,
+      killSidecarChildren: () => order.push('reap'),
+      log: quietLog
+    })
+    return { order, exits, release, handlers }
+  }
+
+  it('prevents the SECOND will-quit too; the lock runs exactly once, after release, then exit', async () => {
+    const { order, exits, release, handlers } = harness()
 
     const first = quitEvent()
-    onWillQuit(first)
+    handlers.onWillQuit(first)
     await drain()
     expect(first.defaultPrevented).toBe(true)
     expect(order).toContain('embedder.stop(parked)') // the teardown is parked mid-sidecar-stop
@@ -294,7 +304,7 @@ describe('will-quit re-entry during a parked teardown (SEC-12, B1 inverted)', ()
     expect(exits).toEqual([])
 
     const second = quitEvent()
-    onWillQuit(second)
+    handlers.onWillQuit(second)
     await drain()
     // INVERTED B1: the re-entry must be prevented as well — nothing but the teardown's own
     // completion may release the quit while the vault is unlocked.
@@ -305,8 +315,21 @@ describe('will-quit re-entry during a parked teardown (SEC-12, B1 inverted)', ()
     release()
     await drain()
     expect(order.filter((l) => l === 'lock')).toHaveLength(1)
-    expect(order[order.length - 1]).toBe('lock')
-    expect(exits).toEqual([0]) // exit exactly once, from the teardown's finally
+    // lock → (reap whatever a deadline-abandoned stop left) → exit, exactly once, from the finally.
+    expect(order.slice(-3)).toEqual(['lock', 'reap', 'exit'])
+    expect(exits).toEqual([0])
+  })
+
+  it('reaches the re-entry branch while the vault is still UNLOCKED and prevents there too (fresh closure)', async () => {
+    const { order, exits, handlers } = harness()
+    handlers.onWillQuit(quitEvent())
+    await drain()
+    expect(handlers.isShuttingDown()).toBe(true)
+    expect(order).not.toContain('lock') // the re-entry below happens with the DB open
+    const reentry = quitEvent()
+    handlers.onWillQuit(reentry)
+    expect(reentry.defaultPrevented).toBe(true)
+    expect(exits).toEqual([]) // never released by the re-entry
   })
 })
 

--- a/apps/desktop/tests/unit/window-security.test.ts
+++ b/apps/desktop/tests/unit/window-security.test.ts
@@ -18,11 +18,16 @@ import {
 describe('SECURE_WINDOW_WEB_PREFERENCES (both windows: main + OCR rasterizer)', () => {
   it('pins every hardening flag by name and value — and nothing else', () => {
     // toEqual is exact: a dropped flag, a flipped value, or a smuggled extra key fails.
+    // SEC-1 (audit 2026-09-02): `spellcheck: false` is the fifth flag — Chromium's spellchecker
+    // downloads Hunspell dictionaries from a Google CDN on Windows/Linux (a browser-process
+    // fetch that neither the CSP nor the Node-socket tripwire can see), and the offline hard
+    // rule forbids it. Closed by construction: this pin + the wiring pins below are the evidence.
     expect(SECURE_WINDOW_WEB_PREFERENCES).toEqual({
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
-      webSecurity: true
+      webSecurity: true,
+      spellcheck: false
     })
   })
 
@@ -187,6 +192,7 @@ describe('call-site wiring (the flags cannot be re-inlined)', () => {
       expect(src).not.toMatch(/nodeIntegration\s*:/)
       expect(src).not.toMatch(/\bsandbox\s*:/)
       expect(src).not.toMatch(/webSecurity\s*:/)
+      expect(src).not.toMatch(/spellcheck\s*:/i) // SEC-1: the flag lives ONLY in the shared constant
       expect(src).not.toContain('default-src') // the CSP is not re-inlined either
     }
   })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2424,7 +2424,13 @@ Per-finding disposition (F-1…F-8):
   fires with a runtime up. **(#159)** `LlamaServer` gained an opt-in `startAbortSignal`; the
   translation teardown aborts an in-flight cold start (child killed inside the health wait,
   start rejects `AbortError`, never latches `startFailed`, never walks the CPU rung
-  mid-teardown) — lock/quit no longer block up to the 180 s health timeout. **(#160)** the F-2
+  mid-teardown) — lock/quit no longer block up to the 180 s health timeout. *(Audit 2026-09-02
+  REL-10, #244: the E5 embedder, the reranker and the vision runtime now carry the same per-start
+  `AbortController` + `startAbortSignal` + `isStartAbortError` latch bypass, abort-first in their
+  teardowns — every lazily-started llama-server wrapper aborts an in-flight cold start on
+  lock/quit; `tests/integration/sidecar-teardown-abort.test.ts` measures all four at one
+  health-poll under production defaults, where the three used to take the full 180 s and then
+  latch.)* **(#160)** the F-2
   retry classification splits the per-request timeout by tokens-flowed (live-decode timeout =
   deterministic, no retry; wedged = one retry) in BOTH consumers; the view paste is bounded by
   `TRANSLATE_MAX_TEXT_CHARS` (`'tooLong'`); `run()` defers a microtask so no terminal can emit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2428,9 +2428,10 @@ Per-finding disposition (F-1…F-8):
   REL-10, #244: the E5 embedder, the reranker and the vision runtime now carry the same per-start
   `AbortController` + `startAbortSignal` + `isStartAbortError` latch bypass, abort-first in their
   teardowns — every lazily-started llama-server wrapper aborts an in-flight cold start on
-  lock/quit; `tests/integration/sidecar-teardown-abort.test.ts` measures all four at one
-  health-poll under production defaults, where the three used to take the full 180 s and then
-  latch.)* **(#160)** the F-2
+  lock/quit; `tests/integration/sidecar-teardown-abort.test.ts` bounds all four at < 5 s under
+  production defaults — typically one health-poll, ≈ 5 s worst case with the 3 s probe timeout
+  and the 2 s SIGTERM grace — where the three used to take the full 180 s and then latch.)*
+  **(#160)** the F-2
   retry classification splits the per-request timeout by tokens-flowed (live-decode timeout =
   deterministic, no retry; wedged = one retry) in BOTH consumers; the view paste is bounded by
   `TRANSLATE_MAX_TEXT_CHARS` (`'tooLong'`); `run()` defers a microtask so no terminal can emit

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -17,6 +17,12 @@ password recovery — are documented in
   app-wide risks breaking loopback IPC and the sidecars). Electron's own `net` module would bypass
   it. The offline guarantee is a property of the code + CSP + deny-by-default policy; the guard is
   a tripwire, not an enforcement layer.
+- **In-app spell-checking is off by design (SEC-1, audit 2026-09-02).** Chromium's spellchecker
+  downloads Hunspell dictionaries from a Google-operated CDN on Windows and Linux on first typing —
+  a browser-process fetch that neither the CSP nor the offline tripwire above can see, and one the
+  offline hard rule forbids — so `spellcheck: false` is pinned for every window and the composer
+  shows no red underlines. Re-enabling needs dictionaries shipped on the drive plus a no-op
+  download URL (owner decision #218; `security-model.md` "Chromium background fetches").
 - **`importDocuments` picker imports are token-bound; drag-drop trusts caller paths (accepted).**
   A PICKER import is bound to a one-time `pickDocuments` capability token (main imports exactly what
   it returned), so a compromised renderer can't forge a picker-origin read of an arbitrary file

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -338,6 +338,37 @@ OS-level network blocking remains explicitly **out of scope** (see "Out of scope
 offline is by design + policy/UX, not a kernel-level block. If a hard block is ever wanted, the
 right layer is the OS firewall / a sandbox profile, not an in-process `connect` shim.
 
+### 3. Chromium background fetches (`window-security.ts`; SEC-1 / GAP-3, audit 2026-09-02)
+The two layers above see **Node-side** sockets and **page-governed** loads. A third class exists:
+fetches the **browser process itself** makes, which neither the CSP (it governs what the page
+loads) nor the socket tripwire (it patches Node's `net.Socket`, not Chromium's network service)
+can observe. Both earlier audit rounds enumerated Node sinks and the renderer CSP; neither
+enumerated this class.
+
+- **Spell-check dictionaries (SEC-1) — closed by construction.** Electron's spellchecker is on by
+  default and, on Windows and Linux, downloads a Hunspell `.bdic` for the current locale from a
+  Google-operated CDN on first typing (macOS uses the OS spellchecker). No policy, setting or CSP
+  gated it. `SECURE_WINDOW_WEB_PREFERENCES` now carries `spellcheck: false` for all three windows,
+  which disables the spellchecker and with it the download. The closure is by construction, not by
+  measurement — observing the fetch would need a network capture on a packaged build, which the
+  offline test posture forbids — and the evidence is the five-flag pin in
+  `tests/unit/window-security.test.ts` plus its call-site scan (no inline `spellcheck:` anywhere).
+  The composer loses red-underline spell-check (`docs/known-limitations.md`). Owner decision 1
+  (#218) can reverse this: dictionaries shipped on the drive + `setSpellCheckerDictionaryDownloadURL`
+  pointed at a no-op + a closed `setSpellCheckerLanguages`.
+- **Channels the CSP does not govern (GAP-3) — confirmed residual, documented.** Investigated
+  (documentation-based, no probing): (i) **WebRTC** is outside CSP; the renderer never calls
+  `RTCPeerConnection`, but a compromised renderer could — the candidate switches
+  (`disableBlinkFeatures`, `disable-features`, `setWebRTCIPHandlingPolicy`) need a verification the
+  offline posture cannot give this round, so no flag was added; (ii) `<link rel="dns-prefetch">` /
+  `preconnect` hints are outside CSP3 (`prefetch-src` was withdrawn) — metadata egress only if
+  injected, and no CSP mitigation exists; (iii) found on the way: the production header carries
+  `object-src 'none'`, `base-uri 'none'` and `frame-ancestors 'none'` while the baked meta does
+  not, and neither carries `form-action` — that parity + `form-action 'none'` hardening is
+  follow-up SEC-14 (#266). Both channels require a compromised renderer first (`script-src
+  'self'`, sandbox, context isolation, no `window.open` into the app), which is the boundary the
+  rest of this section rests on.
+
 ## Logs are local-only AND encrypted at rest (spec §7.11, §3.5)
 `services/logging.ts` writes a rotating diagnostics log under the workspace `logs/` directory and
 never uploads. Diagnostics surfaces local data only; it transmits nothing off-device.
@@ -942,6 +973,26 @@ in-flight generations and stops BOTH sidecars (chat runtime + E5 embedder; a lla
 recent prompts in its in-memory KV cache), then locks. Unlock restarts the chat runtime in the
 background (the active-model auto-start); the embedder restarts lazily on the next embed.
 `will-quit` likewise locks (re-encrypt + shred) alongside stopping the sidecars.
+- **Quit re-entry and the overall deadline (SEC-12 with GAP-2 folded in, audit 2026-09-02).** Both
+  app-lifecycle handlers are built by `createAppLifecycleHandlers` (`main/shutdown.ts`) over ONE
+  `isShuttingDown` closure. *Re-entry rule:* **every** `will-quit` is `preventDefault()`ed — the
+  first starts `performShutdown`; any later one (a second ⌘Q while the app sits windowless in the
+  macOS Dock — the default Quit role re-runs before-quit → will-quit) arrives while the teardown is
+  still running and the working DB is still plaintext, so it must not release Electron's default
+  quit. The process leaves only through the teardown's own `finally` (`app.exit(0)`, which
+  re-emits nothing). Before this rule the re-entry branch returned unprevented: a second quit
+  during a parked sidecar stop exited with the DB unencrypted on the drive, and the next launch
+  found a live WAL and shredded it — REL-11's loss, produced by the app's own quit path. A Dock
+  click (`activate`) during the teardown opens no window. *Overall deadline:* the teardown's
+  awaited middle — the local-API stop (≤ 0.5 s), the sidecar stops (≤ 10 s, the transcriber's
+  suspend timeout), the stream settle (≤ 5 s) and the doc-task settle (≤ 5 s) — is raced as one
+  section against `SHUTDOWN_OVERALL_DEADLINE_MS` (30 s; owner decision 13's default, #230). When
+  it fires, the teardown logs, abandons the parked promises and proceeds to the log flush + the
+  lock; **the lock is never inside the race**. Whatever an abandoned sidecar stop left behind is
+  reaped synchronously right before `app.exit` (`killRegisteredSidecarChildren`, the crash-path
+  reaper). A `quit: locking workspace` log line precedes the lock — with no window left, it is the
+  only visible state of a quit. Pinned by `tests/unit/shutdown.test.ts` (B1 inverted, the
+  activate guard, the deadline with the lock outside it).
 - **Doc-task pipeline is flushed on lock/quit (TA-1).** The lock/quit handlers call
   `ctx.docTasks.cancelAllDocTasks()` — cancelling the running task **and every queued task** —
   not just the active one. The DB stays *open* while the handler awaits the sidecar suspends, so


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 0: quit path, cold-start abort, spellcheck
Closes #238 #244 #239
Refs #254 (GAP-3 investigation outcome recorded there — confirmed residual, no code), #266 (SEC-14 follow-up opened from it)
Tracker: #217

### What
- **SEC-12 (+ GAP-2 folded), `main/shutdown.ts` + `main/index.ts`:** the `will-quit` / `activate` handlers become one factory `createAppLifecycleHandlers({ performShutdown, exit, createWindow, windowCount, killSidecarChildren, log })` over ONE `isShuttingDown` closure (Electron injected, so the unit test drives the real handler). Every `will-quit` is `preventDefault()`ed — the re-entry branch used to return unprevented while the teardown was parked and the working DB plaintext; the process leaves only from the teardown's `finally`, which now also reaps registered sidecar children (`killRegisteredSidecarChildren`) before `app.exit(0)`. `activate` is a no-op once a quit began.
- **Rider 13 (default):** `SHUTDOWN_OVERALL_DEADLINE_MS = 30_000` races the teardown's awaited middle (local-API stop, sidecar `allSettled`, stream settle, doc-task settle) as one section; on the deadline it logs, abandons the parked promises and proceeds to the log flush + the lock — the lock is never inside the race. New `quit: locking workspace` info line before the lock; `ShutdownDeps.log` widened to `'error' | 'info'`; the stale "~10 s" comment now states the real 20.5 s worst case.
- **REL-10, `embeddings/e5.ts`, `reranker/llama.ts`, `vision/runtime.ts`:** the translation runtime's #159 pattern ported — per-start `AbortController` → `startAbortSignal`, an `isStartAbortError` bypass ahead of each `startFailed` latch, abort-first in `teardown()` / `stop()`.
- **SEC-1, `window-security.ts`:** `spellcheck: false` in `SECURE_WINDOW_WEB_PREFERENCES` (all three windows spread it).
- **GAP-3:** investigation only (documentation-based, no probing) — outcome on #254; side-hardening filed as SEC-14 #266; no code in this PR.

### Why (finding IDs + the promise each restores)
- SEC-12 / GAP-2 — `security-model.md` "the clean quit path is the named mitigation for the accepted mid-session-durability trade-off": a second ⌘Q while windowless in the Dock no longer exits with the DB unencrypted (which the next launch would then shred: REL-11's loss via the app's own quit).
- REL-10 — the Lock contract ("Lock now … must leave nothing user-derived running"): lock/quit no longer wait up to the 180 s health window on a wedged E5/reranker/vision cold start, and the aborted start no longer latches `startFailed` (sticky for the reranker, permanent for a vision instance).
- SEC-1 — the offline hard rule: Chromium's dictionary download from a Google CDN on Windows/Linux is a browser-process fetch neither the CSP nor the socket tripwire can see; closed by construction (the flag + the pins), not by measurement (plan §1.4).

### Tests
- characterisation (red before, commit `ae3ebee4`): B1 ported to `tests/unit/shutdown.test.ts` and inverted (second `will-quit` prevented) — red; activate-during-teardown — red; overall deadline (a real timer captured before the fake clock bounds the await) — red; B8 → new `tests/integration/sidecar-teardown-abort.test.ts`, parametrised over four wrappers under production defaults — red at **180 250 ms** for E5 / reranker / vision, translation control 250 ms; five-flag pin + inline-`spellcheck:` scan — red.
- regression / inverted: all of the above green after the fix; B1 rewritten against the factory; re-entry-while-unlocked over a fresh closure; the `lock → reap → exit` order; no deadline timer left pending after a normal teardown; B8 measures **250 ms** for all four wrappers and proves the lazy restart (a fresh second child) after an aborted start for E5 and the reranker, `isStartFailed() === false` for vision and translation.
- `npm test`: 364 files passed / 23 skipped; **5,413 passed / 52 skipped** (baseline 363 / 5,403 / 52 — +1 file, +10 tests). `npm run typecheck` clean (three other tests widened their fake logger for the new `info` dep). `npm run build` green.
- Launch gate: see the comment below.

### Docs + BUILD_STATE
`docs/security-model.md` (quit contract bullet under "App-shell gate & lifecycle"; new "3. Chromium background fetches" subsection under "Offline posture" — SEC-1 record + GAP-3 residual), `PRIVACY.md` (one sentence), `docs/architecture.md` (#159 note: three more wrappers), `CHANGELOG.md` [Unreleased], `docs/known-limitations.md` (spell-check off by design). `BUILD_STATE.md`: one dated entry (≤ 12 lines) + one line under §5 item 19 — in the last commit.

### Owner decisions relied on
- #218 (decision 1, SEC-1): unanswered → **default: disable** (`spellcheck: false`).
- #230 (decision 13, rider): unanswered → **default: 30 s behind a constant** (`SHUTDOWN_OVERALL_DEADLINE_MS`; 20.5 s worst case today, 25.5 s after Phase 4).
- #226 (decision 9, GAP-1): unanswered → default: document (PR 0-c not scheduled).
A default is a planning assumption, not a ruling.

### Landed differently from the plan
- The plan said the deadline-abandoned children "are killed by the existing exit path (`killRegisteredSidecarChildren`)" — at HEAD that reaper ran only on the `uncaughtException` path, not on `will-quit`. The factory's `finally` now calls it (injected as `killSidecarChildren`) before `app.exit(0)`, which makes the plan's claim true; tested (`lock → reap → exit`).

### Reviewer pass
Fable tier — see the review comment below.

### Rollback
Revert the PR. No on-disk format change. The deadline abandons parked sidecar stops (children reaped at exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
