### PR TITLE
fix(packaging): REL-6 asarUnpack closure derived from the tesseract worker's require graph (audit 2026-09-02 Phase 1, PR 1-b)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,17 +29,17 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
-_2026-09-02 — **Audit 2026-09-02 Phase 1, PR 1-a — packaged OCR fails per document instead of
-killing the app; `ocrAvailable` reads execution state (REL-6; PR #268).**_ tesseract.js sets the
-inert browser `worker.onerror` on its Node Worker and never settles `createWorker()` on a load
-failure, so the packaged `asarUnpack` gap surfaced as `uncaughtException`. `ocr/tesseract.ts` now
-captures the raw worker via Node's `process.on('worker')` hook, bounds the start (30 s), passes
-tesseract's `errorHandler`, rejects the pending page and latches `'unavailable'`; packaged builds
-run a startup execution probe (one bounded start, released on success) and report OCR unavailable
-until it passes; `AppStatus.ocrState` (additive) tells the renderer why. Decision 2 (#219) on its
-DEFAULT: a photo imports without text + a NEW per-document note (Q22 copy drafted in the PR body,
-owner review pending). Packaged OCR still does NOT work — the closure is PR 1-b; §5 16(b)/18(b)/18(c)
-stay open. +11 tests (5,424 / 52); tesseract boundary tests use REAL eval-Workers, no module mock.
+_2026-09-02 — **Audit 2026-09-02 Phase 1 — packaged OCR: worker failures degrade per document,
+`ocrAvailable` reads execution state, the `asarUnpack` closure is derived by a test (REL-6; PRs
+#268 + #269).**_ tesseract.js sets the inert browser `worker.onerror` on its Node Worker and never
+settles `createWorker()` on a load failure, so the packaged `asarUnpack` gap surfaced as
+`uncaughtException`. 1-a: `ocr/tesseract.ts` captures the raw worker via `process.on('worker')`,
+bounds the start, passes `errorHandler`, rejects the page, re-arms once after a live death;
+packaged builds run a startup execution probe and report OCR unavailable until it passes
+(`AppStatus.ocrState`); decision 2 (#219) on its DEFAULT — photos import without text + a new
+per-document note (Q22 copy in the PR body, owner review pending). 1-b: `asar-unpack-closure.test.ts`
+walks the worker's require graph (+5 globs); packaged Windows probe `ok` in 277 ms. Open: the
+interactive recognition leg (§5 18(c)). Suite 5,413 → 5,427; boundary tests use REAL eval-Workers.
 
 _2026-09-02 — **Audit 2026-09-02 Phase 0 — quit re-entry prevented, cold-start abort for
 E5/reranker/vision, spellcheck off (SEC-12, GAP-2, REL-10, SEC-1; PR #267; PR 0-a #265 drained the
@@ -513,7 +513,11 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     `asarUnpack` the tesseract.js worker's hoisted deps, add graceful task-failure degradation,
     make `ocrAvailable` honest, and re-check the OCR window's header∩meta `blob:` intersection
     once the packaged path is reachable again (a pre-existing, version-independent crash found
-    by the P4 packaged smoke). (c) **`test:coverage` parallelism cap or a documented RAM floor**
+    by the P4 packaged smoke). **⟶ 2026-09-02 (audit 2026-09-02 Phase 1, PRs #268 + #269): the
+    three code items LANDED — hoisted deps unpacked per the require-graph closure test, worker
+    failures degrade per document, `ocrAvailable` reads execution state; packaged Windows startup
+    probe passed (277 ms). Residual → 18(c): the `blob:` header∩meta re-check + the interactive
+    recognition leg.** (c) **`test:coverage` parallelism cap or a documented RAM floor**
     — full-width coverage starves this 16 GB machine; `--maxWorkers=2` is the current workaround
     (script/CI unchanged). (d) **Recommend `.github/dependabot.yml`** with grouped weekly npm
     updates so the next wave arrives as PRs, not an audit (recommendation only — not
@@ -528,12 +532,18 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     land as its **own PR**; this was the fourth hand-rolled dependency batch. Supersedes item
     16(d).
     (b) **Packaged-OCR fix bundle** — unchanged, still open; see item 16(b). DEP-4 did not touch
-    it (the defect is an `asarUnpack` gap, not a runtime-version effect).
+    it (the defect is an `asarUnpack` gap, not a runtime-version effect). **⟶ LANDED 2026-09-02
+    (audit Phase 1, PRs #268 + #269; see 16(b)); what remains is the 18(c) measurement.**
     (c) **OCR assets on a build machine** — two DEP-4 measurement gaps exist ONLY because this
     machine carries no `*.traineddata`: dev-mode OCR recognize, and the OCR window's RUNTIME
     CSP leg (its baked meta WAS verified byte-exact from the shipped asar; the header is
     page-agnostic, so the mechanism is proven by the main window). Running the packaged
-    measurement on an asset-carrying drive closes both.
+    measurement on an asset-carrying drive closes both. **⟶ 2026-09-02 (audit Phase 1, PR #269):
+    the packaged Windows build's startup OCR execution probe PASSED against a scratch root with
+    `deu`+`eng` files (`ok: true`, 277 ms) — worker script, hoisted deps, WASM core and language
+    init load from `app.asar.unpacked`. STILL OPEN (owner-runnable on the packaged build): the
+    interactive recognition leg (photo import + "Make searchable (OCR)" on a scanned PDF) and the
+    OCR window's runtime CSP leg; record machine/date/outcome here when run.**
     (d) ⚠️ **Electron 44 is a CUSTOMER-FACING decision, not a routine bump** — it removes macOS 12
     support and drops 32-bit Windows (ia32) + Linux armv7l. **E43 is the last series shipping
     prebuilt 32-bit binaries, supported until January 2027.** Decide deliberately with the drive
@@ -583,6 +593,9 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     - **1-a** (2026-09-02, PR #268): REL-6 worker boundary + packaged execution probe + honest
       `ocrAvailable`/`ocrState`; interim degrade on decision 2's default (Q22 copy pending owner
       review). Closure (`asarUnpack` require-graph test + globs) and the packaged smoke = PR 1-b.
+    - **1-b** (2026-09-02, PR #269): `asarUnpack` closure derived by `asar-unpack-closure.test.ts`
+      (+5 globs); packaged Windows probe passed (277 ms); interactive recognition leg still open
+      (18(c)); #232 closed — Phase 1 complete.
 
 **Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
 the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,12 @@ from its first public `1.0.0` release onward.
   photo or running "Make searchable (OCR)" could exit the whole app when the recognizer failed to
   start. Such a failure now affects only that document: the photo is stored without readable text
   and its row says why, and the app checks once at start-up whether recognition can run at all —
-  when it cannot, OCR is not offered and the Documents screen says so. (Packaged text recognition
-  itself is still being repaired; this change makes the failure safe, not the feature work.)
+  when it cannot, OCR is not offered and the Documents screen says so.
+- **Text recognition (OCR) starts again in the packaged app.** The packaged app was missing some
+  of the files the recognizer needs at start-up, which is why it failed (and, before the fix above,
+  closed the app). Those files are now shipped, and a test keeps the list complete. Verified on a
+  Windows build with the German and English language files; if recognition still cannot start on
+  your machine, the app now tells you instead of closing.
 
 ### Changed
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -115,7 +115,10 @@ files:
   - '!**/node_modules/@upsetjs/**'
 # NOTE: `includeSubNodeModules: true` was REMOVED in electron-builder 26 (it now errors as an
 # unknown property). v26's reworked dependency collector already follows hoisted/nested
-# node_modules trees by default, so mammoth's transitive deps still come along. If a hoisted
+# node_modules trees by default, so mammoth's transitive deps still come along — and it lays
+# a source-NESTED package out at TOP level inside app.asar (measured 2026-09-02: node-fetch's
+# nested whatwg-url/tr46/webidl-conversions became node_modules/<name>), which is why any
+# `asarUnpack` glob must be written against that flattened layout too. If a hoisted
 # externalized dep ever goes missing from app.asar, build from apps/desktop or disable hoisting
 # (see docs/packaging.md "Portable build"). ALWAYS smoke-test a PDF/DOCX/CSV import + encrypted
 # workspace from the produced .exe — a missing dep surfaces only at runtime.
@@ -174,9 +177,14 @@ asarUnpack:
   - 'node_modules/is-url/**'
   - 'node_modules/bmp-js/**'
   - 'node_modules/wasm-feature-detect/**'
-  # node-fetch carries its own nested node_modules (tr46, webidl-conversions, whatwg-url) —
-  # the recursive glob covers them.
+  # node-fetch's own deps (tr46, webidl-conversions, whatwg-url) are NESTED under it in the
+  # source tree but the electron-builder 26 collector FLATTENS them to top level inside the
+  # asar (measured on the 2026-09-02 win-unpacked artifact) — the closure test checks both
+  # destinations, so all four are listed.
   - 'node_modules/node-fetch/**'
+  - 'node_modules/whatwg-url/**'
+  - 'node_modules/tr46/**'
+  - 'node_modules/webidl-conversions/**'
 
 # CODE SIGNING (Phase 13). Signing turns a scary OS gatekeeper dialog into a clean launch
 # for a non-technical buyer; it is the single most important non-code task for the

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -151,21 +151,32 @@ asar: true
 # see inside the asar archive (Phase 38, R-O2). Unpack both packages; the engine
 # rewrites app.asar → app.asar.unpacked in the resolved workerPath.
 #
-# ⚠️ KNOWN INSUFFICIENT — this list does not cover the worker's require graph (measured
-# 2026-07-19 on a real packaged Windows build, DEP-1 P4; pre-existing and
-# version-independent). The unpacked worker still `require`s HOISTED deps
-# (regenerator-runtime, is-url, …) that are NOT listed here, so they stay inside app.asar
-# and cannot be resolved from app.asar.unpacked. Since audit 2026-09-02 Phase 1 PR 1-a
-# (REL-6) that failure no longer kills the app: the engine catches the worker's load
-# error (`process.on('worker')` hook + bounded start, ocr/tesseract.ts), a packaged
-# build proves the worker at startup (execution probe) and reports OCR unavailable until
-# it passes, photos import without text + a per-document note. Packaged OCR still does
-# NOT WORK until the closure lands (PR 1-b: a require-graph test + the missing globs);
-# the manual packaged smoke (BUILD_STATE §5 item 18(c)) remains the exit criterion.
-# Dev-mode OCR is unaffected. User-facing text: docs/known-limitations.md.
+# The list is the worker's REQUIRE-GRAPH CLOSURE, derived — not guessed — by
+# tests/integration/asar-unpack-closure.test.ts (audit 2026-09-02 Phase 1, PR 1-b, REL-6):
+# the test resolves `tesseract.js/src/worker-script/node/index.js` and walks its literal
+# `require()` graph, and every resolved module path must match a glob below. History: with
+# only the two tesseract packages listed (measured 2026-07-19 on a real packaged Windows
+# build, DEP-1 P4) the worker's HOISTED deps stayed inside app.asar, could not be resolved
+# from app.asar.unpacked, and the load failure killed the whole app while ocrAvailable
+# reported true. PR 1-a (REL-6) contained the failure (the engine catches the worker's
+# load error through the `process.on('worker')` hook + a bounded start, a packaged build
+# proves the worker at startup and reports OCR unavailable until it passes); this list
+# closes the gap. The manual packaged smoke (BUILD_STATE §5 item 18(c)) is the executable
+# proof — a static walk misses computed requires (tesseract.js 7.0.0 has none on the
+# worker path). `node-fetch` is on the graph only behind `global.fetch ||` (never taken on
+# Electron's Node) — unpacked anyway: the static graph is the contract. Dev-mode OCR is
+# unaffected. User-facing text: docs/known-limitations.md.
 asarUnpack:
   - 'node_modules/tesseract.js/**'
   - 'node_modules/tesseract.js-core/**'
+  # the worker's hoisted runtime deps (require-graph closure, PR 1-b):
+  - 'node_modules/regenerator-runtime/**'
+  - 'node_modules/is-url/**'
+  - 'node_modules/bmp-js/**'
+  - 'node_modules/wasm-feature-detect/**'
+  # node-fetch carries its own nested node_modules (tr46, webidl-conversions, whatwg-url) —
+  # the recursive glob covers them.
+  - 'node_modules/node-fetch/**'
 
 # CODE SIGNING (Phase 13). Signing turns a scary OS gatekeeper dialog into a clean launch
 # for a non-technical buyer; it is the single most important non-code task for the

--- a/apps/desktop/src/main/services/ocr/tesseract.ts
+++ b/apps/desktop/src/main/services/ocr/tesseract.ts
@@ -65,6 +65,13 @@ function resolveOcrPageTimeoutMs(explicit?: number): number {
   return Number.isFinite(env) && env > 0 ? env : DEFAULT_OCR_PAGE_TIMEOUT_MS
 }
 
+/**
+ * The tesseract.js Node worker entry this engine spawns. Exported so the packaging closure test
+ * (`tests/integration/asar-unpack-closure.test.ts`, REL-6) walks the SAME entry's require graph —
+ * a path change here turns that test's walk red instead of leaving it validating a stale entry.
+ */
+export const TESSERACT_WORKER_ENTRY = 'tesseract.js/src/worker-script/node/index.js'
+
 function toError(err: unknown, fallback: string): Error {
   if (err instanceof Error) return err
   const text = typeof err === 'string' ? err : ''
@@ -238,7 +245,7 @@ export class TesseractOcrEngine implements OcrEngine {
     let workerPath: string | undefined
     try {
       workerPath = resolveWorkerScriptPath(
-        require.resolve('tesseract.js/src/worker-script/node/index.js')
+        require.resolve(TESSERACT_WORKER_ENTRY)
       )
     } catch {
       workerPath = undefined // fake module in tests / exotic layout: use its default

--- a/apps/desktop/tests/helpers/globs.ts
+++ b/apps/desktop/tests/helpers/globs.ts
@@ -1,0 +1,18 @@
+/**
+ * Translate a minimatch-style electron-builder `files`/`asarUnpack` glob to a coarse RegExp.
+ * Shared by `packaging.test.ts` (L18 canvas exclusion) and `asar-unpack-closure.test.ts`
+ * (REL-6 worker closure) so the two pins cannot drift apart. Coarse on purpose: `**​/` →
+ * any directory prefix, `**` → anything, a single `*` → one path segment; enough for the
+ * `node_modules/<pkg>/**` shapes both tests check, not a full minimatch.
+ */
+export function globToRegExp(glob: string): RegExp {
+  return new RegExp(
+    '^' +
+      glob
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*\*\//g, '(?:.*/)?')
+        .replace(/\*\*/g, '.*')
+        .replace(/(?<!\.)\*/g, '[^/]*') +
+      '$'
+  )
+}

--- a/apps/desktop/tests/integration/asar-unpack-closure.test.ts
+++ b/apps/desktop/tests/integration/asar-unpack-closure.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { builtinModules, createRequire } from 'node:module'
+import { join, relative, sep } from 'node:path'
+import { parse } from 'yaml'
+
+// REL-6 (audit 2026-09-02 Phase 1, PR 1-b) — the `asarUnpack` CLOSURE, derived instead of
+// guessed. `worker_threads` loads the tesseract.js worker script and everything it `require`s
+// through real filesystem reads, which cannot see inside `app.asar`; electron-builder copies
+// the unpacked globs to `app.asar.unpacked` and the engine rewrites the workerPath there. A
+// module the worker requires that is NOT covered by an unpack glob stays inside the archive and
+// cannot be resolved from the unpacked directory — measured 2026-07-19 on a real packaged
+// Windows build: only `tesseract.js/**` and `tesseract.js-core/**` were listed, the worker's
+// hoisted deps (`regenerator-runtime`, `is-url`, …) were not, and the load failure killed the
+// app (PR 1-a made that failure a per-document error; this test + the globs make OCR WORK).
+//
+// Method: resolve the worker entry (`tesseract.js/src/worker-script/node/index.js`) from the
+// app package exactly as Node would, walk its STATIC `require('<literal>')` graph with
+// `createRequire(file).resolve`, and assert every resolved module path (relative to the first
+// `node_modules/` segment — the layout electron-builder reproduces inside the asar) matches at
+// least one `asarUnpack` glob. Specifiers that do not resolve in this tree (an optional dep
+// such as node-fetch's `encoding`, required inside a try/catch) are tolerated: a package that
+// is not installed cannot be packed either, so it cannot be missing from the unpacked copy.
+//
+// watch-item: a static walk misses computed `require(expr)` calls; tesseract.js 7.0.0 has none
+// on the worker path (its `getCore.js` variants are all literal), and the manual packaged smoke
+// (BUILD_STATE §5 item 18(c)) remains the executable exit criterion for the closure.
+
+const APP_DIR = join(__dirname, '..', '..')
+const BUILDER_YML = join(APP_DIR, 'electron-builder.yml')
+const WORKER_ENTRY = 'tesseract.js/src/worker-script/node/index.js'
+
+interface BuilderConfig {
+  asarUnpack?: string[]
+}
+
+/** Translate a minimatch-style glob to a coarse RegExp (same rules as `packaging.test.ts`). */
+function globToRegExp(glob: string): RegExp {
+  return new RegExp(
+    '^' +
+      glob
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*\*\//g, '(?:.*/)?')
+        .replace(/\*\*/g, '.*')
+        .replace(/(?<!\.)\*/g, '[^/]*') +
+      '$'
+  )
+}
+
+const isBuiltin = (spec: string): boolean =>
+  spec.startsWith('node:') || builtinModules.includes(spec)
+
+/** Every file reachable from `entry` through literal CJS requires, plus the specs that did not resolve. */
+export function resolveRequireGraph(entry: string): { files: string[]; unresolved: string[] } {
+  const seen = new Set<string>()
+  const unresolved: string[] = []
+  const walk = (file: string): void => {
+    if (seen.has(file)) return
+    seen.add(file)
+    if (!/\.(c?js|json)$/.test(file)) return
+    const src = readFileSync(file, 'utf8')
+    const req = createRequire(file)
+    for (const m of src.matchAll(/require\(\s*['"]([^'"]+)['"]\s*\)/g)) {
+      const spec = m[1]
+      if (isBuiltin(spec)) continue
+      try {
+        walk(req.resolve(spec))
+      } catch {
+        unresolved.push(`${relative(APP_DIR, file).split(sep).join('/')} -> ${spec}`)
+      }
+    }
+  }
+  walk(entry)
+  return { files: [...seen].sort(), unresolved }
+}
+
+/** `…/node_modules/a/node_modules/b/x.js` → `node_modules/a/node_modules/b/x.js` (asar-relative). */
+function asarRelative(file: string): string {
+  const posix = file.split(sep).join('/')
+  const i = posix.indexOf('node_modules/')
+  return i >= 0 ? posix.slice(i) : posix
+}
+
+describe('asarUnpack closure — the tesseract.js worker require graph (REL-6, PR 1-b)', () => {
+  const config = parse(readFileSync(BUILDER_YML, 'utf8')) as BuilderConfig
+  const globs = config.asarUnpack ?? []
+  const matchers = globs.map(globToRegExp)
+  const appRequire = createRequire(join(APP_DIR, 'package.json'))
+  const entry = appRequire.resolve(WORKER_ENTRY)
+  const { files, unresolved } = resolveRequireGraph(entry)
+
+  it('resolves the worker entry and a non-trivial graph (the walk itself works)', () => {
+    expect(asarRelative(entry)).toBe(`node_modules/${WORKER_ENTRY}`)
+    // The WASM core and the hoisted runtime deps are on the path — if this shrinks to just
+    // tesseract.js, the regex walk is broken, not the closure.
+    const packages = new Set(
+      files.map((f) => {
+        const m = asarRelative(f).match(/node_modules\/((?:@[^/]+\/)?[^/]+)/g)
+        return m ? m[m.length - 1].replace('node_modules/', '') : f
+      })
+    )
+    expect(packages).toContain('tesseract.js')
+    expect(packages).toContain('tesseract.js-core')
+    expect(packages).toContain('regenerator-runtime')
+    expect(packages).toContain('is-url')
+  })
+
+  it('every module the worker can require is covered by an asarUnpack glob (fails on the DEP-1 P4 gap)', () => {
+    expect(globs.length).toBeGreaterThan(0)
+    const uncovered = files
+      .map(asarRelative)
+      .filter((rel) => !matchers.some((re) => re.test(rel)))
+    // Print the offenders by package so the fix is a glob per line, not a guess.
+    const offendingPackages = [
+      ...new Set(
+        uncovered.map((rel) => {
+          const m = rel.match(/^node_modules\/((?:@[^/]+\/)?[^/]+)/)
+          return m ? m[1] : rel
+        })
+      )
+    ].sort()
+    expect(offendingPackages, `uncovered by asarUnpack: ${uncovered.join(', ')}`).toEqual([])
+  })
+
+  it('unresolved specifiers are only optional deps guarded by try/catch (nothing packed is missing)', () => {
+    // node-fetch 2.x: `require('encoding')` inside a try/catch (an optional peer that is not
+    // installed here). Anything else unresolved means the graph walk hit a real gap.
+    const allowed = new Set(['encoding'])
+    const unexpected = unresolved.filter((u) => !allowed.has(u.split(' -> ')[1]))
+    expect(unexpected).toEqual([])
+  })
+})

--- a/apps/desktop/tests/integration/asar-unpack-closure.test.ts
+++ b/apps/desktop/tests/integration/asar-unpack-closure.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { builtinModules, createRequire } from 'node:module'
-import { join, relative, sep } from 'node:path'
+import { join, sep } from 'node:path'
 import { parse } from 'yaml'
+import { globToRegExp } from '../helpers/globs'
+import { TESSERACT_WORKER_ENTRY } from '../../src/main/services/ocr/tesseract'
 
 // REL-6 (audit 2026-09-02 Phase 1, PR 1-b) — the `asarUnpack` CLOSURE, derived instead of
 // guessed. `worker_threads` loads the tesseract.js worker script and everything it `require`s
@@ -14,41 +16,57 @@ import { parse } from 'yaml'
 // hoisted deps (`regenerator-runtime`, `is-url`, …) were not, and the load failure killed the
 // app (PR 1-a made that failure a per-document error; this test + the globs make OCR WORK).
 //
-// Method: resolve the worker entry (`tesseract.js/src/worker-script/node/index.js`) from the
-// app package exactly as Node would, walk its STATIC `require('<literal>')` graph with
-// `createRequire(file).resolve`, and assert every resolved module path (relative to the first
-// `node_modules/` segment — the layout electron-builder reproduces inside the asar) matches at
-// least one `asarUnpack` glob. Specifiers that do not resolve in this tree (an optional dep
-// such as node-fetch's `encoding`, required inside a try/catch) are tolerated: a package that
-// is not installed cannot be packed either, so it cannot be missing from the unpacked copy.
+// Method: resolve the worker entry (the engine's own `TESSERACT_WORKER_ENTRY`) from the app
+// package exactly as Node would, walk its STATIC `require('<literal>')` graph with
+// `createRequire(file).resolve`, and assert every resolved module is covered at EVERY
+// destination electron-builder may give it inside the asar:
+//   - the source-tree path from the first `node_modules/` segment
+//     (`node_modules/node-fetch/node_modules/whatwg-url/lib/URL.js`), and
+//   - the FLATTENED path (`node_modules/whatwg-url/lib/URL.js`): electron-builder derives the
+//     in-asar location from the dependency tree, and in this npm workspace its collector
+//     flattens a source-nested package to top level (reviewer measurement on the 2026-09-02
+//     `win-unpacked` artifact: `node-fetch` had no nested `node_modules` inside `app.asar`,
+//     `whatwg-url`/`tr46`/`webidl-conversions` sat at top level, packed).
+// Requiring both keeps the pin true whichever layout a builder version produces.
+// Specifiers that do not resolve in this tree (an optional dep such as node-fetch's `encoding`,
+// required inside a try/catch) are tolerated only from the exact `file -> spec` allow-list: a
+// package that is not installed cannot be packed either, so it cannot be missing from the
+// unpacked copy — but a NEW unresolvable specifier fails the walk.
 //
-// watch-item: a static walk misses computed `require(expr)` calls; tesseract.js 7.0.0 has none
-// on the worker path (its `getCore.js` variants are all literal), and the manual packaged smoke
-// (BUILD_STATE §5 item 18(c)) remains the executable exit criterion for the closure.
+// watch-item: a static walk misses computed `require(expr)`, `import()`, `require.resolve` and
+// ESM `import` legs (an `.mjs`/`.node`/`.wasm` file that resolves is coverage-checked but not
+// walked); tesseract.js 7.0.0 has none of these on the worker path (grep-verified by the PR 1-b
+// review), and `tesseract.js-core` reads its `.wasm` beside its `.js` via `fs` — covered because
+// the glob is package-wide. The manual packaged smoke (BUILD_STATE §5 item 18(c)) remains the
+// executable exit criterion for the closure.
 
 const APP_DIR = join(__dirname, '..', '..')
 const BUILDER_YML = join(APP_DIR, 'electron-builder.yml')
-const WORKER_ENTRY = 'tesseract.js/src/worker-script/node/index.js'
 
 interface BuilderConfig {
   asarUnpack?: string[]
 }
 
-/** Translate a minimatch-style glob to a coarse RegExp (same rules as `packaging.test.ts`). */
-function globToRegExp(glob: string): RegExp {
-  return new RegExp(
-    '^' +
-      glob
-        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-        .replace(/\*\*\//g, '(?:.*/)?')
-        .replace(/\*\*/g, '.*')
-        .replace(/(?<!\.)\*/g, '[^/]*') +
-      '$'
-  )
-}
-
 const isBuiltin = (spec: string): boolean =>
   spec.startsWith('node:') || builtinModules.includes(spec)
+
+/** `…/node_modules/a/node_modules/b/x.js` → `node_modules/a/node_modules/b/x.js` (source layout). */
+export function asarRelative(file: string): string {
+  const posix = file.split(sep).join('/')
+  const i = posix.indexOf('node_modules/')
+  return i >= 0 ? posix.slice(i) : posix
+}
+
+/**
+ * Every in-asar destination a resolved file may have: the source-nested path and, when the
+ * package is nested, the flattened top-level form electron-builder's collector produces.
+ */
+export function asarCandidates(file: string): string[] {
+  const nested = asarRelative(file)
+  const segments = nested.split('node_modules/')
+  const flattened = `node_modules/${segments[segments.length - 1]}`
+  return flattened === nested ? [nested] : [nested, flattened]
+}
 
 /** Every file reachable from `entry` through literal CJS requires, plus the specs that did not resolve. */
 export function resolveRequireGraph(entry: string): { files: string[]; unresolved: string[] } {
@@ -57,7 +75,7 @@ export function resolveRequireGraph(entry: string): { files: string[]; unresolve
   const walk = (file: string): void => {
     if (seen.has(file)) return
     seen.add(file)
-    if (!/\.(c?js|json)$/.test(file)) return
+    if (!/\.(c?js|json)$/.test(file)) return // resolved but not walked (ESM/native/wasm legs)
     const src = readFileSync(file, 'utf8')
     const req = createRequire(file)
     for (const m of src.matchAll(/require\(\s*['"]([^'"]+)['"]\s*\)/g)) {
@@ -66,7 +84,7 @@ export function resolveRequireGraph(entry: string): { files: string[]; unresolve
       try {
         walk(req.resolve(spec))
       } catch {
-        unresolved.push(`${relative(APP_DIR, file).split(sep).join('/')} -> ${spec}`)
+        unresolved.push(`${asarRelative(file)} -> ${spec}`)
       }
     }
   }
@@ -74,59 +92,52 @@ export function resolveRequireGraph(entry: string): { files: string[]; unresolve
   return { files: [...seen].sort(), unresolved }
 }
 
-/** `…/node_modules/a/node_modules/b/x.js` → `node_modules/a/node_modules/b/x.js` (asar-relative). */
-function asarRelative(file: string): string {
-  const posix = file.split(sep).join('/')
-  const i = posix.indexOf('node_modules/')
-  return i >= 0 ? posix.slice(i) : posix
+/** `node_modules/@scope/name/x.js` / `node_modules/name/x.js` → the package name. */
+function packageOf(asarPath: string): string {
+  const m = asarPath.match(/^node_modules\/((?:@[^/]+\/)?[^/]+)/)
+  return m ? m[1] : asarPath
 }
 
 describe('asarUnpack closure — the tesseract.js worker require graph (REL-6, PR 1-b)', () => {
   const config = parse(readFileSync(BUILDER_YML, 'utf8')) as BuilderConfig
   const globs = config.asarUnpack ?? []
   const matchers = globs.map(globToRegExp)
+  const covered = (asarPath: string): boolean => matchers.some((re) => re.test(asarPath))
   const appRequire = createRequire(join(APP_DIR, 'package.json'))
-  const entry = appRequire.resolve(WORKER_ENTRY)
+  const entry = appRequire.resolve(TESSERACT_WORKER_ENTRY)
   const { files, unresolved } = resolveRequireGraph(entry)
 
-  it('resolves the worker entry and a non-trivial graph (the walk itself works)', () => {
-    expect(asarRelative(entry)).toBe(`node_modules/${WORKER_ENTRY}`)
+  it('resolves the engine’s worker entry and a non-trivial graph (the walk itself works)', () => {
+    expect(asarRelative(entry)).toBe(`node_modules/${TESSERACT_WORKER_ENTRY}`)
     // The WASM core and the hoisted runtime deps are on the path — if this shrinks to just
     // tesseract.js, the regex walk is broken, not the closure.
-    const packages = new Set(
-      files.map((f) => {
-        const m = asarRelative(f).match(/node_modules\/((?:@[^/]+\/)?[^/]+)/g)
-        return m ? m[m.length - 1].replace('node_modules/', '') : f
-      })
-    )
+    const packages = new Set(files.map((f) => packageOf(asarRelative(f))))
     expect(packages).toContain('tesseract.js')
     expect(packages).toContain('tesseract.js-core')
     expect(packages).toContain('regenerator-runtime')
     expect(packages).toContain('is-url')
+    // The flattening rule is exercised by node-fetch's nested deps (a nested source path yields
+    // two candidates; a hoisted one yields one).
+    const nestedFile = files.find((f) => (asarRelative(f).match(/node_modules\//g) ?? []).length > 1)
+    expect(nestedFile, 'expected at least one nested package on the graph').toBeDefined()
+    expect(asarCandidates(nestedFile as string)).toHaveLength(2)
+    expect(asarCandidates(entry)).toHaveLength(1)
   })
 
-  it('every module the worker can require is covered by an asarUnpack glob (fails on the DEP-1 P4 gap)', () => {
+  it('every module the worker can require is covered by an asarUnpack glob at every destination (fails on the DEP-1 P4 gap)', () => {
     expect(globs.length).toBeGreaterThan(0)
-    const uncovered = files
-      .map(asarRelative)
-      .filter((rel) => !matchers.some((re) => re.test(rel)))
+    const uncovered = files.flatMap((f) => asarCandidates(f).filter((p) => !covered(p)))
     // Print the offenders by package so the fix is a glob per line, not a guess.
-    const offendingPackages = [
-      ...new Set(
-        uncovered.map((rel) => {
-          const m = rel.match(/^node_modules\/((?:@[^/]+\/)?[^/]+)/)
-          return m ? m[1] : rel
-        })
-      )
-    ].sort()
+    const offendingPackages = [...new Set(uncovered.map(packageOf))].sort()
     expect(offendingPackages, `uncovered by asarUnpack: ${uncovered.join(', ')}`).toEqual([])
   })
 
-  it('unresolved specifiers are only optional deps guarded by try/catch (nothing packed is missing)', () => {
+  it('unresolved specifiers are only the known optional try/catch deps (a new one fails the walk)', () => {
     // node-fetch 2.x: `require('encoding')` inside a try/catch (an optional peer that is not
-    // installed here). Anything else unresolved means the graph walk hit a real gap.
-    const allowed = new Set(['encoding'])
-    const unexpected = unresolved.filter((u) => !allowed.has(u.split(' -> ')[1]))
+    // installed here). Keyed on the exact `file -> spec`, so the same name from another file, or
+    // any other unresolvable specifier, is a real gap.
+    const allowed = new Set(['node_modules/node-fetch/lib/index.js -> encoding'])
+    const unexpected = unresolved.filter((u) => !allowed.has(u))
     expect(unexpected).toEqual([])
   })
 })

--- a/apps/desktop/tests/integration/packaging.test.ts
+++ b/apps/desktop/tests/integration/packaging.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { parse } from 'yaml'
+// The glob → RegExp translation is shared with asar-unpack-closure.test.ts (REL-6).
+import { globToRegExp } from '../helpers/globs'
 
 // L18 (audit-2026-06-13): @napi-rs/canvas is an OPTIONAL transitive dep of pdfjs-dist —
 // a platform-specific native `.node` (Skia) the app never imports. With
@@ -30,19 +32,6 @@ interface BuilderConfig {
 
 function loadBuilderConfig(): BuilderConfig {
   return parse(readFileSync(BUILDER_YML, 'utf8')) as BuilderConfig
-}
-
-/** Translate a minimatch-style files glob to a coarse RegExp (same rules as the L18 test below). */
-function globToRegExp(glob: string): RegExp {
-  return new RegExp(
-    '^' +
-      glob
-        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-        .replace(/\*\*\//g, '(?:.*/)?')
-        .replace(/\*\*/g, '.*')
-        .replace(/(?<!\.)\*/g, '[^/]*') +
-      '$'
-  )
 }
 
 interface LockPackage {

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2012,33 +2012,34 @@ _The **`audit §N.M`** citations in the skills/extraction residuals below refer 
   step total, and the persisted `ocr_json.pageCount` all report the **clamped** count (so
   they stay truthful), and a truncation is logged locally. A genuine ≤5 000-page scan is
   unaffected; beyond that, the tail of pages is not recognized.
-- **OCR does not yet work in a PACKAGED build — since audit 2026-09-02 Phase 1 it degrades
-  instead of crashing the app.** The defect (measured 2026-07-19 on a real packaged Windows
-  build; pre-existing and **version-independent**, it fails the same way on the previously
-  pinned Electron): `worker_threads` cannot load a script from inside `app.asar`, so
-  `electron-builder.yml` unpacks `tesseract.js` + `tesseract.js-core` and the engine rewrites the
-  resolved workerPath to `app.asar.unpacked` — but the worker's own **hoisted** dependencies
-  (`regenerator-runtime`, `is-url`, …) are not in that unpack list, stay packed inside
-  `app.asar`, and cannot be resolved from the unpacked directory. **Before Phase 1** the
+- **OCR in a PACKAGED build: the crash is fixed and the packaging gap is closed (audit
+  2026-09-02 Phase 1); the end-to-end recognition smoke on a packaged build is still to be
+  recorded per platform.** The defect (measured 2026-07-19 on a real packaged Windows build;
+  pre-existing and **version-independent**): `worker_threads` cannot load a script from inside
+  `app.asar`, so `electron-builder.yml` unpacks the tesseract packages and the engine rewrites
+  the resolved workerPath to `app.asar.unpacked` — but the worker's own **hoisted** dependencies
+  (`regenerator-runtime`, `is-url`, …) were not in that unpack list, stayed packed inside
+  `app.asar`, and could not be resolved from the unpacked directory. **Before Phase 1** the
   resulting worker load failure had no listener (tesseract.js sets the browser-only
   `worker.onerror`, inert on a Node Worker) and reached the process as an uncaught exception
-  that killed it, while `ocrAvailable` still reported `true` beforehand. **Since Phase 1 (REL-6,
-  PR 1-a)** the engine catches the worker's failure and turns it into a per-document error; a
-  packaged build proves the worker once at startup (execution probe, released again on success)
-  and reports OCR **unavailable** until that proof passes: photos import and are stored without
-  readable text, their row says *"Text recognition (OCR) could not run in this build …"*, "Make
-  searchable (OCR)" is not offered, and the Documents screen shows a banner saying the
-  OCR files are on the drive but the recognizer could not start. A re-index recognizes such a
-  photo once OCR runs. **Dev mode is unaffected** — the full raster → IPC → recognize pipeline
-  was proven end to end on Electron 39 outside packaging, and no other packaged feature is
-  touched. Unchanged by the Electron 43 bump (wave DEP-4): the defect is an `asarUnpack` gap,
-  not a runtime-version effect — and DEP-4 did NOT re-run the recognition leg at all, because
-  that build machine carries no `*.traineddata`. The closure itself (a test that resolves the
-  worker's `require` graph against the unpack globs, then the missing entries) is Phase 1's
-  second PR; registered as follow-up 2 in [`architecture.md`](architecture.md) "Dependency
-  remediation — design record (wave DEP-1, PR #77)" §5. Until the manual packaged smoke
-  (BUILD_STATE §5 item 18(c)) has passed on an asset-carrying drive, do not treat a packaged OCR
-  run as a release-acceptance step: the feature is degraded by design, not proven.
+  that killed it, while `ocrAvailable` still reported `true` beforehand. **Phase 1 PR 1-a
+  (REL-6)** made any such failure a per-document error: a packaged build proves the worker once
+  at startup (execution probe, released again on success) and reports OCR **unavailable** until
+  that proof passes — photos import and are stored without readable text, their row says *"Text
+  recognition (OCR) could not run in this build …"*, "Make searchable (OCR)" is not offered, and
+  the Documents screen shows a banner saying the OCR files are on the drive but the recognizer
+  could not start; a re-index recognizes such a photo once OCR runs. **Phase 1 PR 1-b** closed
+  the gap: `tests/integration/asar-unpack-closure.test.ts` derives the worker's `require` graph
+  and pins every module to an `asarUnpack` glob, and the missing packages are unpacked.
+  **Measured 2026-09-02 on a packaged Windows build** with the `deu`+`eng` language files: the
+  startup probe passes (`ok: true`, 277 ms) — worker script, hoisted deps, WASM core and language
+  init all load from `app.asar.unpacked`. What is NOT yet recorded is the interactive smoke on a
+  packaged build (import a photo, run "Make searchable (OCR)" on a scanned PDF; BUILD_STATE §5
+  item 18(c)) — the probe proves the load chain, that smoke proves recognition end to end; run it
+  per platform before certifying a kit for that platform. **Dev mode was never affected** — the
+  full raster → IPC → recognize pipeline was proven end to end on Electron 39 outside packaging.
+  Registered as follow-up 2 in [`architecture.md`](architecture.md) "Dependency remediation —
+  design record (wave DEP-1, PR #77)" §5.
 
 ## Image understanding ([`architecture.md`](architecture.md) "Image understanding — design record")
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -177,31 +177,37 @@ Key config points:
   emit it to `out/preview/` and `electron-vite build` clears only `out/main|preload|renderer`, so a
   local package run after a screenshot run would otherwise fold the harness (incl. staged demo
   chats) into the artifact; `tests/integration/packaging.test.ts` pins the negation.
-- **`tesseract.js` + `tesseract.js-core` are `asarUnpack`ed — and that list is NOT yet
-  sufficient**: the OCR engine spawns its Node worker via `worker_threads`, which loads the
-  worker script (and the WASM core it requires) through real filesystem reads that cannot see
-  inside the asar archive. The engine rewrites `app.asar` → `app.asar.unpacked` in the resolved
-  workerPath. The worker's own **hoisted** dependencies (`regenerator-runtime`, `is-url`, …) are
-  not in the `asarUnpack` list, so they stay packed inside `app.asar` and cannot be resolved from
-  `app.asar.unpacked` (measured 2026-07-19 on a real packaged Windows build; pre-existing and
-  version-independent). **Until audit 2026-09-02 Phase 1 (REL-6, PR 1-a) that load failure
-  killed the whole app** while `ocrAvailable` still reported `true`: tesseract.js sets the
-  browser-only `worker.onerror`, inert on a Node Worker, so the worker's `'error'` event had no
-  listener and Node rethrew it as `uncaughtException`. **Since PR 1-a it is contained**: the
-  engine captures the raw worker through Node's `process.on('worker')` hook, bounds the start,
-  and passes tesseract's `errorHandler`, so a load failure rejects the recognition per document
-  and latches the engine unavailable; a **packaged build runs an execution probe at startup**
-  (one bounded worker start, released on success) and reports OCR unavailable until it passes —
-  photos import without text and carry a per-document note, "Make searchable (OCR)" is not
-  offered, the Documents screen shows a banner. **Packaged OCR still does not WORK**
-  until the `asarUnpack` closure lands (PR 1-b: a test that resolves the worker's `require`
-  graph against the globs, then the missing entries); **do not treat a packaged OCR run as a
-  release-acceptance step before the manual packaged smoke** (BUILD_STATE §5 item 18(c)) passes.
-  Registered as follow-up 2 in [`architecture.md`](architecture.md) "Dependency remediation —
-  design record (wave DEP-1, PR #77)" §5. Dev-mode OCR is unaffected (the raster → IPC →
-  recognize pipeline was proven end to end on Electron 39), so this is a packaging defect, not an
-  OCR-engine one; the other runtime-only-failure smokes above (parsers, encrypted workspace)
-  still apply.
+- **The `asarUnpack` list is the tesseract.js worker's require-graph CLOSURE, derived by a
+  test**: the OCR engine spawns its Node worker via `worker_threads`, which loads the worker
+  script and everything it `require`s through real filesystem reads that cannot see inside the
+  asar archive; the engine rewrites `app.asar` → `app.asar.unpacked` in the resolved workerPath,
+  and every module on the worker's graph must be unpacked too.
+  `tests/integration/asar-unpack-closure.test.ts` resolves the worker entry, walks its literal
+  `require()` graph and asserts every resolved module path matches an `asarUnpack` glob — today
+  `tesseract.js`, `tesseract.js-core`, `regenerator-runtime`, `is-url`, `bmp-js`,
+  `wasm-feature-detect` and `node-fetch` (with its nested deps). History (audit 2026-09-02 Phase
+  1, REL-6): with only the two tesseract packages listed, the worker's **hoisted** deps stayed
+  inside `app.asar` (measured 2026-07-19 on a real packaged Windows build) and the load failure
+  **killed the whole app** while `ocrAvailable` still reported `true` — tesseract.js sets the
+  browser-only `worker.onerror`, inert on a Node Worker, so the `'error'` event had no listener
+  and Node rethrew it as `uncaughtException`. PR 1-a **contained** it: the engine captures the
+  raw worker through Node's `process.on('worker')` hook, bounds the start, passes tesseract's
+  `errorHandler`, so a load failure rejects the recognition per document and latches the engine
+  unavailable; a **packaged build runs an execution probe at startup** (one bounded worker start,
+  released on success) and reports OCR unavailable until it passes — photos import without text
+  and carry a per-document note, "Make searchable (OCR)" is not offered, the Documents screen
+  shows a banner. PR 1-b **closed** the gap with the test + globs above; **measured 2026-09-02 on
+  a packaged Windows build** (`HilbertRaum-0.1.59-portable`, `win-unpacked`, scratch drive root
+  with `deu`+`eng` language files): `OCR execution probe {ok: true, ms: 277}` — worker script,
+  hoisted deps, WASM core and both language files load from `app.asar.unpacked`. The
+  **interactive recognition smoke** (photo import + "Make searchable (OCR)" on a packaged build;
+  BUILD_STATE §5 item 18(c)) is still to be recorded per platform before a kit for that platform
+  is certified — the probe proves the load chain, the smoke proves recognition end to end. If the
+  probe ever fails again the app degrades as above instead of crashing. Registered as follow-up
+  2 in [`architecture.md`](architecture.md) "Dependency remediation — design record (wave DEP-1,
+  PR #77)" §5. Dev-mode OCR was never affected (the raster → IPC → recognize pipeline was proven
+  end to end on Electron 39); the other runtime-only-failure smokes above (parsers, encrypted
+  workspace) still apply.
 - **`model-manifests/` ship as `extraResources`** (beside `app.asar`). The packaged main process
   finds them via `resolveManifestsDir(app.getAppPath())`, which walks up to `resources/model-manifests`;
   `HILBERTRAUM_MANIFESTS_DIR` overrides. Weights + sidecar binaries + the `ocr/` language files are

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -185,7 +185,11 @@ Key config points:
   `tests/integration/asar-unpack-closure.test.ts` resolves the worker entry, walks its literal
   `require()` graph and asserts every resolved module path matches an `asarUnpack` glob — today
   `tesseract.js`, `tesseract.js-core`, `regenerator-runtime`, `is-url`, `bmp-js`,
-  `wasm-feature-detect` and `node-fetch` (with its nested deps). History (audit 2026-09-02 Phase
+  `wasm-feature-detect`, `node-fetch` and node-fetch's own deps `whatwg-url`, `tr46`,
+  `webidl-conversions` — nested under node-fetch in the source tree but FLATTENED to top level
+  inside the asar by electron-builder 26's collector, so the test checks every module at both
+  destinations (the PR 1-b review caught a source-path-only check passing while those three sat
+  packed at top level). History (audit 2026-09-02 Phase
   1, REL-6): with only the two tesseract packages listed, the worker's **hoisted** deps stayed
   inside `app.asar` (measured 2026-07-19 on a real packaged Windows build) and the load failure
   **killed the whole app** while `ocrAvailable` still reported `true` — tesseract.js sets the


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 1 (PR 1-b): packaged OCR — `asarUnpack` closure, derived not guessed
Closes #232 (REL-6; PR 1-a #268 landed the worker boundary + probe + interim degrade)
Tracker: #217

### What
- **New test** `apps/desktop/tests/integration/asar-unpack-closure.test.ts` (beside `packaging.test.ts`): resolves `tesseract.js/src/worker-script/node/index.js` from the app package, walks its literal `require()` graph with `createRequire(file).resolve`, and asserts every resolved module is covered at EVERY destination electron-builder may give it inside the asar — the source-nested path AND the flattened top-level path (reviewer finding 1: the collector flattens nested packages; a source-path-only check gave a false green for node-fetch's three deps). Worker entry taken from the engine's exported `TESSERACT_WORKER_ENTRY`; `globToRegExp` shared with `packaging.test.ts` via `tests/helpers/globs.ts`. Unresolvable specifiers are tolerated only from an allow-list of optional try/catch deps (`encoding`, node-fetch's) — a package that is not installed cannot be packed either. Red at `origin/master` (commit `8d5fbfd5`): `bmp-js`, `is-url`, `node-fetch` (+ nested `tr46`/`webidl-conversions`/`whatwg-url`), `regenerator-runtime`, `wasm-feature-detect` uncovered.
- **Closure fix** `apps/desktop/electron-builder.yml`: eight globs added under `asarUnpack` (`regenerator-runtime/**`, `is-url/**`, `bmp-js/**`, `wasm-feature-detect/**`, `node-fetch/**`, and — after the review — `whatwg-url/**`, `tr46/**`, `webidl-conversions/**`: electron-builder 26 FLATTENS node-fetch's nested deps to top level inside the asar); the KNOWN-BROKEN/KNOWN-INSUFFICIENT comment block is replaced by the closure record (what the test derives, the 2026-07-19 history, what PR 1-a contained, the smoke as the executable proof, the `node-fetch`-behind-`global.fetch` note).
- **Docs**: `docs/packaging.md` asar bullet, `docs/known-limitations.md` OCR bullet (crash fixed + gap closed; interactive smoke still to be recorded per platform), `CHANGELOG.md` `[Unreleased]` Fixed (one new bullet; the PR 1-a bullet's "still being repaired" parenthetical removed). BUILD_STATE: §5 16(b)/18(b)/18(c) close-out lines + item 19 line + the Phase 1 dated entry extended (one entry for both PRs, ≤ 12 lines).

### Why (finding IDs + the promise line each restores)
- **REL-6 (High, #232)** — "the `asarUnpack` closure is derived, not guessed"; with PR 1-a: "OCR failure is a per-document error, never a process exit; `ocrAvailable` is honest". Release-acceptance line 4 (packaged OCR) per OS: Windows — probe measured (below); macOS/Linux — before that platform's kit.

### Tests
- characterisation (red before, commit `8d5fbfd5`): the closure test — `uncovered by asarUnpack: node_modules/bmp-js/…, node_modules/is-url/…, node_modules/node-fetch/…, node_modules/regenerator-runtime/…, node_modules/wasm-feature-detect/…` (the walk-sanity and optional-deps tests green at HEAD).
- after the globs: 3/3 green; `packaging.test.ts` (L18 `@napi-rs/canvas` exclusion, DEP-4 parity) unchanged and green.
- **Manual packaged measurement (plan step 7, owner-gated) — RUN on this machine, 2026-09-02, Windows 11 host:** `npm run package:win` → `HilbertRaum-0.1.59-portable.exe` + `win-unpacked`. (a) The unpacked worker script loads under plain Node 24.19 and under Electron's own runtime (`ELECTRON_RUN_AS_NODE`, Node 24.18.1): `worker online after 18 ms`, no error. (b) The packaged app (`win-unpacked/HilbertRaum.exe`, `HILBERTRAUM_DRIVE_ROOT` = a SCRATCH root carrying only `ocr/deu.traineddata.gz` + `ocr/eng.traineddata.gz`, workspace uninitialized) logged `OCR backend selected {kind: tesseract, reason: language files present: deu, eng}` and **`OCR execution probe {ok: true, ms: 277, engine: tesseract.js-7.0.0}`** — worker script + hoisted deps + WASM core + both language inits from `app.asar.unpacked`, the exact chain the 2026-07-19 crash broke; 45 s watchdog, no orphaned process. (c) **NOT run: the interactive recognition leg** (import a photo, "Make searchable (OCR)" on a scanned PDF in the packaged GUI) — non-interactive session. BUILD_STATE 18(c) therefore stays open with a dated note; 16(b) closes (all three bundle items landed; the probe is the packaged proof of the load chain); 18(b) closes into 18(c). No real kit or live `workspace/` was touched; the language files were copied from a local smoke fixture into the scratch root.
- `npm test` count: **365 files passed, 23 skipped · 5,427 passed / 52 skipped** (after PR 1-a: 364 / 5,424 / 52 → +1 file, +3 tests); `npm run typecheck` + `npm run build` green; `npm run package:win` green (Windows host, real kit not used).

### Docs + BUILD_STATE
As above. `git grep 'tmp/hilbertraum-'` empty.

### Owner decisions relied on (issue #, answer or default)
- **Decision 2 (#219)** — still unanswered at PR 1-b → default stands. Note: with the closure landed the probe passes on a correct build, so the "interim" gate is now simply the honest availability check — it stays as the permanent design (a future packaging regression degrades instead of crashing). Removing it would need the owner to answer #219 the other way.
- **Q22 copy** — unchanged from PR 1-a's draft; owner review pending.

### Landed differently from the plan
- The plan expected the packaged smoke on "an asset-carrying machine" (the real kit). The kit mounted here carries no `ocr/` assets and its live `workspace/` is off limits; the language files came from a local smoke fixture folder into a scratch root instead. The measurement is the packaged app's own startup probe log line, not a GUI recognition — recorded as such (18(c) open).
- `jszip` appears under `app.asar.unpacked/node_modules` in the built artifact although no glob names it — electron-builder unpacks it on its own (not on the worker's graph; not investigated further, no effect on the closure).

### Reviewer pass
Opus tier (plan §1.1). 7 findings, none blocking: (1, should-fix, high) the source→asar path mapping did not match electron-builder's flattened layout — measured on this PR's own artifact: `whatwg-url`/`tr46`/`webidl-conversions` sat at TOP level, packed, while the test reported the closure complete (harmless today only because `global.fetch || require('node-fetch')` never takes the branch) → repaired: both-destinations check + 3 globs (`a1` commit "reviewer repairs"); (2) yml + packaging.md "nested deps covered by the recursive glob" claim corrected; (3) ESM/`.mjs` legs not walked → comment; (4) allow-list keyed on exact `file -> spec`; (5) worker-entry literal duplicated → `TESSERACT_WORKER_ENTRY` exported from the engine; (6) `globToRegExp` copy → `tests/helpers/globs.ts`; (7) pre-existing stale `includeSubNodeModules` comment → one clarifying sentence. Reviewer independently confirmed on the artifact: the added globs land in `app.asar.unpacked`, `tesseract.js-core` reads its `.wasm` via `fs` beside its `.js` (covered by the package-wide glob), tesseract.js 7.0.0 has no computed requires on the worker path, docs do not overclaim; `jszip` under `app.asar.unpacked` is electron-builder's own binary-file heuristic (`.jekyll-metadata`), cosmetic. Verdict: merge after repairs — repaired.

### Rollback
Revert the PR: the globs go, the test turns red again, the app degrades (PR 1-a) instead of crashing.
