### PR TITLE
fix(commercial-gate): one canonical sell gate — app + launcher per declared platform, hashed sidecars, fetch-runtime --commercial fails closed (audit 2026-09-02 Phase 2 — GAP-4, SEC-11)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-02 — **Audit 2026-09-02 Phase 2 — one commercial gate: both builder scripts now call
+`assertCommercialDrive`, which requires the app + launcher per declared platform and hashed
+sidecars; `fetch-runtime --commercial` fails closed (GAP-4 #233, SEC-11 #234; PR #271).**_
+`assertCommercialDrive(…, opts: { platforms, appVersion })` gained `platformMatrixDeclared` /
+`appArtifactsPresent` / `launchersPresent` / `runtimeHashed`; a thin Node entry
+(`src/main/tools/assert-commercial-drive.ts` → `out/tools/…mjs`, own `vite.tools.config.ts`, built by
+`npm run build`) is what `build-commercial-drive.{ps1,sh}` run for the verdict — SELLABLE only from
+it; `-DryRun` reaches the verdict, `-VerifyOnly` runs only the gate, a prior `HilbertRaum-*` artifact
+at the root is refused (never deleted). `fetch-runtime -Commercial`: placeholder hash refused before
+any download, hashless marker re-fetched, marker hash only after a verified archive. Verifier:
+`isCommercialPolicy` + `setBinaryVerificationPosture`; the spawn-time refusal of hashless markers on
+commercial drives is wired but OFF (constant; owner call on #234). Decision 12 (#229) on its default.
+
 _2026-09-02 — **Audit 2026-09-02 Phase 1 — packaged OCR: worker failures degrade per document,
 `ocrAvailable` reads execution state, the `asarUnpack` closure is derived by a test (REL-6; PRs
 #268 + #269).**_ tesseract.js sets the inert browser `worker.onerror` on its Node Worker and never
@@ -145,7 +158,10 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
    portable `.exe` + a **signed & notarized** macOS `.app`, run `build-commercial-drive`
    end-to-end onto a real drive (`-AppArtifact` the signed build), then do the spec §17 demo on
    a **fresh laptop with Wi-Fi off** + the **second-laptop continuity** check (same encrypted
-   workspace, different drive letter). **⚠️ 2026-08-19, wave 188 — this check has already
+   workspace, different drive letter). **Gate note (2026-09-02, PR #271):** the SELLABLE verdict now
+   comes from `assertCommercialDrive` alone (both builder scripts call it) and requires the app
+   artifact + launcher per declared platform; the demo stays a manual acceptance step, not a recorded
+   gate input — it becomes one only when the gate requires a per-batch smoke record (#233). **⚠️ 2026-08-19, wave 188 — this check has already
    FIRED once, from a real drive, before it was ever run deliberately:** issue #188 was exactly the
    failure it exists to catch (`documents.stored_path` absolute ⇒ every stored copy stale under a
    different mount point, and "Delete document" silently not deleting). **✅ ANSWERED 2026-08-20 —
@@ -596,6 +612,10 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     - **1-b** (2026-09-02, PR #269): `asarUnpack` closure derived by `asar-unpack-closure.test.ts`
       (+5 globs); packaged Windows probe passed (277 ms); interactive recognition leg still open
       (18(c)); #232 closed — Phase 1 complete.
+    - **2** (2026-09-02, PR #271): GAP-4 + SEC-11 — one gate (`assertCommercialDrive` via
+      `out/tools/assert-commercial-drive.mjs`) called by both builders: app + launcher per declared
+      platform, hashed sidecars, `fetch-runtime --commercial` fails closed; spawn-time refusal of
+      hashless markers built but OFF (owner call, #234); decision 12 on its default — dated entry above.
 
 **Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
 the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/
@@ -693,7 +713,10 @@ the offline/privacy guarantees:
   member fails the install, no marker written), closing the symlink residual; the
   `--no-same-owner --no-same-permissions -k` tar flags were deliberately dropped (GNU tar `-k`
   hard-errors on the legitimately-retained archive `cpu/` dir). The build-time
-  `scripts/fetch-runtime.*` half of L-7 remains as previously recorded.
+  `scripts/fetch-runtime.*` half of L-7 remains as previously recorded. (2026-09-02, PR #271:
+  `fetch-runtime --commercial` now refuses a placeholder hash before any download and records the
+  marker's binary hash only after a verified archive — the sell-gate side of #234; the
+  member-traversal half of L-7 is unchanged.)
   **Watch-item (full-audit 2026-07-12b SEC-2, owner-declined probe):** the sweep covers
   symlink/junction dirents but not tar HARDLINK members (a hardlink is not a symlink dirent) —
   labeled hypothesis, likely moot (libarchive/bsdtar checks linknames; hardlinks need an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ from its first public `1.0.0` release onward.
   otherwise download a spelling dictionary from a Google server on Windows and Linux the first
   time you type — against the promise that nothing leaves the space. Shipping dictionaries on the
   drive instead is under consideration.
+- **A kit is only called sellable when it really carries the app.** The check that clears a
+  prepared drive for sale now runs as one program for every builder and requires, for each system
+  the kit is sold for, exactly one app of the version being built plus its launcher, and an
+  engine binary whose recorded checksum still matches. A leftover older app build, an engine
+  downloaded without a verifiable checksum, or an engine with no recorded checksum now stops the
+  drive from being cleared (drive builders only; nothing changes for an app already in use).
 
 ## [0.1.59] — 2026-08-21
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -59,6 +59,9 @@ files:
   # after a screenshot run would fold the whole harness into app.asar. Nothing loads it at
   # runtime; keep it out. tests/integration/packaging.test.ts pins this negation.
   - '!out/preview/**'
+  # out/tools/ holds the drive builders' commercial-gate tool (vite.tools.config.ts, #233) —
+  # a build-machine tool run with plain node, not app code.
+  - '!out/tools/**'
   - package.json
   # L18 (audit-2026-06-13): `@napi-rs/canvas` is an OPTIONAL transitive dep of pdfjs-dist
   # — a platform-specific native `.node` (Skia) we never import (the PDF path uses the

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,8 @@
   ],
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build",
+    "build": "electron-vite build && vite build --config vite.tools.config.ts",
+    "build:tools": "vite build --config vite.tools.config.ts",
     "start": "electron-vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.node.json --composite false && tsc --noEmit -p tsconfig.web.json --composite false",
     "test": "vitest run",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,7 +13,7 @@ import {
 } from './window-security'
 import { getSettings, updateSettings } from './services/settings'
 import { effectiveContextWindow } from './services/chat'
-import { loadPolicy, buildPolicyStatus } from './services/policy'
+import { loadPolicy, buildPolicyStatus, isCommercialPolicy } from './services/policy'
 import { vaultPathsFrom, workspaceAdmitsWork, WorkspaceController } from './services/workspace-vault'
 import { assertOfflinePosture } from './services/offlineGuard'
 import { initLogging, log, usesPlaintextLog, detachVaultKey } from './services/logging'
@@ -62,7 +62,11 @@ import { findManifestById, launchContextTokens, resolveManifestsDir } from './se
 import { resolveAppSkillsDir, resolveUserSkillsDir } from './services/drive'
 import { createSkillRegistry } from './services/skills/registry'
 import { composeServices, composeTranslator, shouldReplaceTranslator } from './services/compose-services'
-import { initBinaryVerification } from './services/binary-verifier'
+import {
+  initBinaryVerification,
+  setBinaryVerificationPosture,
+  REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES
+} from './services/binary-verifier'
 import { createAppLifecycleHandlers, performShutdown } from './shutdown'
 import type { AppContext } from './services/context'
 
@@ -158,6 +162,12 @@ function initBackend(): void {
     // M-4: a packaged build fails CLOSED (STRICT_POLICY) on a missing/malformed policy.json.
     { isDev }
   )
+  // Drive posture for the pre-spawn binary verifier (#234): a commercial drive may refuse
+  // hashless install markers — behind the shipped-OFF constant until the owner rules.
+  setBinaryVerificationPosture({
+    commercial: isCommercialPolicy(policy),
+    refuseHashlessMarkers: REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES
+  })
   const workspace = new WorkspaceController(
     vaultPathsFrom({ configPath: paths.configPath, dbPath: paths.dbPath }),
     policy,

--- a/apps/desktop/src/main/services/binary-verifier.ts
+++ b/apps/desktop/src/main/services/binary-verifier.ts
@@ -19,7 +19,9 @@ import { sha256File } from './models'
 //     explicitly UNVERIFIED path — neither should be hash-gated.
 //   - PACKAGED → enforced. A binary WITH a recorded hash is verified (`ok`/`mismatch`); a
 //     binary with NO recorded hash (legacy drive, or one provisioned by an older
-//     fetch-runtime) is TOLERATED ⇒ `skip-legacy` (logged) so it still launches.
+//     fetch-runtime) is TOLERATED ⇒ `skip-legacy` (logged) so it still launches — on a
+//     COMMERCIAL drive that tolerance can be switched to a refusal (#234, see
+//     `REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES`).
 //
 // The result is SESSION-CACHED per resolved binary path: the GPU probe and the server
 // start race for the very same path (factory.ts kicks the probe concurrently with the
@@ -43,6 +45,19 @@ type RawVerifyResult = BinaryVerifyResult | 'unreadable'
 /** True only after `initBinaryVerification(false)` (a packaged build). */
 let enforced = false
 
+/**
+ * Whether a COMMERCIAL drive (policy.json in the sold posture) refuses to spawn a binary
+ * whose install marker records no hash (#234). The sell gate and `fetch-runtime
+ * --commercial` already refuse hashless markers at build time; refusing them at spawn
+ * would stop already-sold kits from launching until re-provisioned, which is the owner's
+ * call — shipped OFF until #234 is answered. Flip to true to enable.
+ */
+export const REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES = false
+
+/** Drive posture, set after policy.json is loaded (`setBinaryVerificationPosture`). */
+let commercialPosture = false
+let refuseHashlessMarkers = false
+
 /** Session cache: one verification (one hash) per resolved binary path. */
 const cache = new Map<string, Promise<BinaryVerifyResult>>()
 
@@ -56,9 +71,25 @@ export function initBinaryVerification(isDev: boolean): void {
   enforced = !isDev
 }
 
-/** Test-only: reset enforcement + drop the session cache between cases. */
+/**
+ * Record the drive posture once policy.json is known (`index.ts`, right after
+ * `loadPolicy`; `initBinaryVerification` runs earlier). On a commercial drive a hashless
+ * marker is refused only when `refuseHashlessMarkers` is set (#234); a DIY drive keeps
+ * the documented `skip-legacy` tolerance.
+ */
+export function setBinaryVerificationPosture(opts: {
+  commercial: boolean
+  refuseHashlessMarkers?: boolean
+}): void {
+  commercialPosture = opts.commercial
+  refuseHashlessMarkers = opts.refuseHashlessMarkers ?? false
+}
+
+/** Test-only: reset enforcement + posture and drop the session cache between cases. */
 export function _resetBinaryVerificationForTests(): void {
   enforced = false
+  commercialPosture = false
+  refuseHashlessMarkers = false
   cache.clear()
 }
 
@@ -169,6 +200,13 @@ export function verifyBinaryBeforeSpawn(
       // next spawn re-hashes. Identity-guard the delete so we never evict a newer entry.
       if (cache.get(binPath) === pending) cache.delete(binPath)
       return 'mismatch'
+    }
+    if (raw === 'skip-legacy' && commercialPosture) {
+      if (refuseHashlessMarkers) {
+        log.warn('Sidecar binary has no recorded hash on a commercial drive — refusing to spawn (re-run fetch-runtime --commercial)')
+        return 'mismatch'
+      }
+      log.warn('Sidecar binary has no recorded hash on a commercial drive — tolerated (spawn-time refusal not enabled)')
     }
     return raw
   })

--- a/apps/desktop/src/main/services/commercial-drive.ts
+++ b/apps/desktop/src/main/services/commercial-drive.ts
@@ -600,7 +600,7 @@ export async function assertCommercialDrive(
         )
       } else {
         // Version + backend match — now require the marker to carry the binary's SHA-256
-        // and to MATCH the on-disk binary (vuln-scan B; #234). A sold drive must ship this
+        // and to MATCH the on-disk binary (#234). A sold drive must ship this
         // hash so the app can re-verify it before spawn; a hashless marker (an older
         // fetch-runtime, or an unverified archive) fails the gate and must be re-fetched.
         const expected = marker.binaries?.[markerBinaryKey(extractTo, binaryPath)]

--- a/apps/desktop/src/main/services/commercial-drive.ts
+++ b/apps/desktop/src/main/services/commercial-drive.ts
@@ -1,8 +1,14 @@
-import { existsSync, readdirSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import type { ModelManifest } from '../../shared/manifest'
-import type { OcrSources, RuntimeSources } from '../../shared/runtime-sources'
-import { loadPolicy } from './policy'
+import {
+  isKitPlatform,
+  KIT_PLATFORMS,
+  type KitPlatform,
+  type OcrSources,
+  type RuntimeSources
+} from '../../shared/runtime-sources'
+import { isCommercialPolicy, loadPolicy } from './policy'
 import {
   markerBinaryKey,
   planOcrDownloads,
@@ -17,15 +23,18 @@ import { verifyDriveModels, listSkillFolders, type ModelVerifyResult } from './d
 // Commercial-drive pipeline + final posture assertion (spec §12.2).
 //
 // Mirrors services/drive.ts + services/assets.ts: this module is the CANONICAL,
-// unit-tested reference, and `scripts/build-commercial-drive.{ps1,sh}` re-implement the
-// SAME ordered plan natively (self-contained, no Node/npm). It does NOT re-implement
-// prepare-drive/fetch-*/verify-models — it ORCHESTRATES them. The final automated check
+// unit-tested reference. `scripts/build-commercial-drive.{ps1,sh}` run the SAME ordered
+// plan natively and, for the verdict, CALL this assertion through the built
+// `out/tools/assert-commercial-drive.mjs` (src/main/tools) — SELLABLE is printed only
+// from its result (#233, #234). It does NOT re-implement prepare-drive/fetch-*/
+// verify-models — it ORCHESTRATES them. The final automated check
 // (`assertCommercialDrive`) is the gate that decides "is this drive actually sellable?"
 // and reuses loadPolicy + verifyDriveModels rather than duplicating that logic.
 //
 // A sellable drive MUST ship the commercial posture (encryption required, plaintext off,
-// models must verify, NETWORK DENIED — spec §12.2) and contain NO user data. The assertion
-// FAILS LOUDLY if any of that is violated.
+// models must verify, NETWORK DENIED — spec §12.2), contain NO user data, and carry the
+// app artifact + launcher for every platform it is sold for. The assertion FAILS LOUDLY
+// if any of that is violated.
 
 /**
  * Distribution-level license/attribution artifacts every prepared drive carries at its
@@ -224,6 +233,110 @@ export function formatPlan(steps: CommercialStep[]): string {
 
 // ---- The final "is this drive sellable?" assertion ---------------------------------
 
+/** What a kit must carry at its root per platform it is sold for (#233). */
+export interface KitPlatformSpec {
+  /** The double-click launcher for that OS (`launchers/`). */
+  launcher: string
+  /** The release artifact name for a given app version. */
+  artifact: (version: string) => string
+  /** The version segment of a release artifact name of this platform, else null. */
+  artifactVersion: (name: string) => string | null
+}
+
+const versionOf =
+  (re: RegExp) =>
+  (name: string): string | null =>
+    re.exec(name)?.[1] ?? null
+
+/**
+ * Per-platform artifact + launcher names — the same names the launchers glob for on the
+ * drive root and the release workflow uploads. macOS additionally accepts an extracted
+ * `*.app` bundle (the launcher prefers one), whose version is read from its Info.plist.
+ */
+export const KIT_PLATFORM_SPECS: Record<KitPlatform, KitPlatformSpec> = {
+  'win-x64': {
+    launcher: 'Start HilbertRaum.cmd',
+    artifact: (v) => `HilbertRaum-${v}-portable.exe`,
+    artifactVersion: versionOf(/^HilbertRaum-(.+)-portable\.exe$/)
+  },
+  'mac-arm64': {
+    launcher: 'Start HilbertRaum.command',
+    artifact: (v) => `HilbertRaum-${v}-mac-arm64.app.zip`,
+    artifactVersion: versionOf(/^HilbertRaum-(.+)-mac-arm64\.app\.zip$/)
+  },
+  'linux-x64': {
+    launcher: 'start-hilbertraum.sh',
+    artifact: (v) => `HilbertRaum-${v}.AppImage`,
+    artifactVersion: versionOf(/^HilbertRaum-(.+)\.AppImage$/)
+  }
+}
+
+/** The platform matrix a kit is declared for + the app version being built (#233). */
+export interface CommercialGateOptions {
+  platforms: KitPlatform[]
+  appVersion: string
+}
+
+interface FoundAppArtifact {
+  name: string
+  platform: KitPlatform | null
+  version: string | null
+  size: number
+  isDir: boolean
+}
+
+/** `CFBundleShortVersionString` of an extracted bundle, or null when unreadable. */
+function readBundleVersion(appDir: string): string | null {
+  try {
+    const plist = readFileSync(join(appDir, 'Contents', 'Info.plist'), 'utf8')
+    return /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/.exec(plist)?.[1]?.trim() ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Every app artifact at the drive root: `HilbertRaum-*` files and `*.app` directories. */
+function scanAppArtifacts(rootPath: string): FoundAppArtifact[] {
+  const found: FoundAppArtifact[] = []
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = readdirSync(rootPath, { withFileTypes: true })
+  } catch {
+    return found
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && /\.app$/.test(entry.name)) {
+      found.push({
+        name: entry.name,
+        platform: 'mac-arm64',
+        version: readBundleVersion(join(rootPath, entry.name)),
+        size: 1,
+        isDir: true
+      })
+      continue
+    }
+    if (!entry.isFile() || !entry.name.startsWith('HilbertRaum-')) continue
+    let size = 0
+    try {
+      size = statSync(join(rootPath, entry.name)).size
+    } catch {
+      size = 0
+    }
+    let platform: KitPlatform | null = null
+    let version: string | null = null
+    for (const p of KIT_PLATFORMS) {
+      const v = KIT_PLATFORM_SPECS[p].artifactVersion(entry.name)
+      if (v !== null) {
+        platform = p
+        version = v
+        break
+      }
+    }
+    found.push({ name: entry.name, platform, version, size, isDir: false })
+  }
+  return found
+}
+
 export interface CommercialAssertion {
   ok: boolean
   /** Human-readable reasons the drive is NOT sellable (empty when ok). */
@@ -253,6 +366,12 @@ export interface CommercialAssertion {
      */
     runtimeCurrent: boolean
     /**
+     * Every pinned runtime build's marker records the binary's SHA-256 AND the on-disk
+     * bytes still match it (#234). Opt-in like `runtimeCurrent`. A hashless (legacy)
+     * marker fails here, not in `runtimeCurrent`.
+     */
+    runtimeHashed: boolean
+    /**
      * Every pinned OCR language file is present + sha256-verified (opt-in:
      * true when no `ocrSources` were passed).
      */
@@ -275,6 +394,20 @@ export interface CommercialAssertion {
      * in all copies, and the app's own GPL text + source statement ride the same files.
      */
     licenseArtifactsPresent: boolean
+    /**
+     * `opts.platforms` names at least one known platform (no duplicates) and
+     * `opts.appVersion` is set (#233). False when the gate is called without them — the
+     * app cannot be checked against an undeclared kit, so the drive is not sellable.
+     */
+    platformMatrixDeclared: boolean
+    /**
+     * Exactly one non-empty app artifact per declared platform, named for `appVersion`,
+     * none for an undeclared platform, none unrecognised (#233). One extra artifact —
+     * an older build left beside the new one — fails the drive.
+     */
+    appArtifactsPresent: boolean
+    /** The launcher file of every declared platform is present + non-empty at the root. */
+    launchersPresent: boolean
   }
   /** The per-weight verification detail (for surfacing which weight failed). */
   modelResults: ModelVerifyResult[]
@@ -314,16 +447,19 @@ function userDataArtifacts(rootPath: string): string[] {
  * Assert that a prepared drive is actually SELLABLE (spec §12.2). Reuses `loadPolicy`
  * (the commercial posture) + `verifyDriveModels` (all weights VERIFIED) and checks the
  * drive carries no user data. When `runtimeSources` (the yaml pin) is passed, each pinned
- * build's `.hilbertraum-runtime.json` install marker must also match (version + backend).
- * Returns a structured result; never throws. Fails loudly: any violated
- * invariant adds a `problems[]` entry and flips `ok` to false.
+ * build's `.hilbertraum-runtime.json` install marker must also match (version + backend)
+ * and record the binary's hash. `opts` declares the platforms the kit is sold for and the
+ * app version: one artifact + launcher per platform is required (#233); without `opts`
+ * the drive is not sellable. Returns a structured result; never throws. Fails loudly:
+ * any violated invariant adds a `problems[]` entry and flips `ok` to false.
  */
 export async function assertCommercialDrive(
   rootPath: string,
   manifests: ModelManifest[],
   runtimeSources?: RuntimeSources | null,
   whisperSources?: RuntimeSources | null,
-  ocrSources?: OcrSources | null
+  ocrSources?: OcrSources | null,
+  opts?: CommercialGateOptions
 ): Promise<CommercialAssertion> {
   const problems: string[] = []
 
@@ -333,10 +469,7 @@ export async function assertCommercialDrive(
   // missing file would resolve to an encrypted/verified posture and silently pass — here
   // we want a missing/loose policy.json to surface as a problem below.
   const { policy } = loadPolicy(join(rootPath, 'config'))
-  const policyCommercial =
-    policy.workspace.encryptionRequired &&
-    !policy.workspace.allowPlaintextDevMode &&
-    policy.models.requireSha256Match
+  const policyCommercial = isCommercialPolicy(policy)
   // "Network denied" for a sold drive means the app never PHONES HOME on its own: no update
   // checks, no telemetry. Model downloads are an explicit, user-initiated, per-download-confirmed
   // action (the drive ships with them permitted so a buyer can add models), so they do NOT count
@@ -424,6 +557,7 @@ export async function assertCommercialDrive(
   // after the default moved to vulkan) and must be re-provisioned. The same
   // check runs for the whisper family (binary `whisper-cli`) when its pin is passed.
   let runtimeCurrent = true
+  let runtimeHashed = true
   const checkFamily = async (sources: RuntimeSources, family: string, binaryBase: string): Promise<void> => {
     for (const build of sources.builds) {
       const label = `${family} build ${build.os}/${build.arch} ${build.backend}`
@@ -466,21 +600,21 @@ export async function assertCommercialDrive(
         )
       } else {
         // Version + backend match — now require the marker to carry the binary's SHA-256
-        // and to MATCH the on-disk binary (vuln-scan B). A sold drive must ship this hash
-        // so the app can re-verify it before spawn; a drive provisioned by a fetch-runtime
-        // predating that field fails the gate and must be re-run.
+        // and to MATCH the on-disk binary (vuln-scan B; #234). A sold drive must ship this
+        // hash so the app can re-verify it before spawn; a hashless marker (an older
+        // fetch-runtime, or an unverified archive) fails the gate and must be re-fetched.
         const expected = marker.binaries?.[markerBinaryKey(extractTo, binaryPath)]
         if (!expected) {
-          runtimeCurrent = false
+          runtimeHashed = false
           problems.push(
             `${label}: install marker records no SHA-256 for ${binaryBase} — re-run ` +
-              'fetch-runtime so the binary can be re-verified before spawn'
+              'fetch-runtime --commercial so the binary can be re-verified before spawn'
           )
         } else if ((await sha256File(binaryPath)).toLowerCase() !== expected.toLowerCase()) {
-          runtimeCurrent = false
+          runtimeHashed = false
           problems.push(
             `${label}: ${binaryBase} does not match the SHA-256 recorded in the install ` +
-              'marker — the binary was modified after install; re-run fetch-runtime'
+              'marker — the binary or the marker was modified after install; re-run fetch-runtime --commercial'
           )
         }
       }
@@ -531,6 +665,99 @@ export async function assertCommercialDrive(
     /* unreadable → treat as empty; the policy/weight/app-skill gates still apply */
   }
 
+  // --- App artifact + launcher per declared platform (#233) ---
+  // A kit is sold for a declared set of platforms; each needs exactly one release
+  // artifact of the version being built and its launcher at the drive root. An artifact
+  // of an undeclared platform, an unrecognised name, or a second artifact of one platform
+  // (an older build beside the new one) fails the drive.
+  let platformMatrixDeclared = true
+  const declared: KitPlatform[] = []
+  if (!opts || !Array.isArray(opts.platforms) || opts.platforms.length === 0) {
+    platformMatrixDeclared = false
+    problems.push(
+      `no platform matrix declared — name the platforms this kit is sold for (${KIT_PLATFORMS.join(', ')}); ` +
+        'the app artifacts and launchers cannot be checked without it'
+    )
+  } else {
+    for (const p of opts.platforms) {
+      if (!isKitPlatform(p)) {
+        platformMatrixDeclared = false
+        problems.push(`unknown platform "${String(p)}" (known: ${KIT_PLATFORMS.join(', ')})`)
+      } else if (declared.includes(p)) {
+        platformMatrixDeclared = false
+        problems.push(`platform "${p}" declared more than once`)
+      } else {
+        declared.push(p)
+      }
+    }
+    if (typeof opts.appVersion !== 'string' || opts.appVersion.trim() === '') {
+      platformMatrixDeclared = false
+      problems.push('no app version declared — the app artifacts cannot be checked without it')
+    }
+  }
+  let appArtifactsPresent = false
+  let launchersPresent = false
+  if (platformMatrixDeclared) {
+    appArtifactsPresent = true
+    launchersPresent = true
+    const version = opts!.appVersion.trim()
+    const found = scanAppArtifacts(rootPath)
+    for (const a of found) {
+      if (a.platform === null) {
+        appArtifactsPresent = false
+        problems.push(
+          `app artifact "${a.name}" is not a release artifact of any platform (expected ` +
+            `${KIT_PLATFORMS.map((p) => KIT_PLATFORM_SPECS[p].artifact('<version>')).join(', ')} ` +
+            'or an extracted HilbertRaum.app)'
+        )
+      } else if (!declared.includes(a.platform)) {
+        appArtifactsPresent = false
+        problems.push(
+          `app artifact "${a.name}" is for ${a.platform}, a platform this kit is not declared for ` +
+            `(declared: ${declared.join(', ')}) — remove it or declare the platform`
+        )
+      }
+    }
+    for (const p of declared) {
+      const spec = KIT_PLATFORM_SPECS[p]
+      const mine = found.filter((a) => a.platform === p)
+      if (mine.length === 0) {
+        appArtifactsPresent = false
+        problems.push(`${p}: no app artifact at the drive root (expected ${spec.artifact(version)})`)
+      } else if (mine.length > 1) {
+        appArtifactsPresent = false
+        problems.push(
+          `${p}: more than one app artifact at the drive root (${mine.map((a) => a.name).join(', ')}) — ` +
+            'a drive must carry exactly one; delete the others'
+        )
+      } else {
+        const a = mine[0]
+        if (!a.isDir && a.size === 0) {
+          appArtifactsPresent = false
+          problems.push(`${p}: app artifact "${a.name}" is zero bytes`)
+        }
+        if (a.version === null) {
+          appArtifactsPresent = false
+          problems.push(`${p}: cannot read the version of "${a.name}" (Contents/Info.plist CFBundleShortVersionString)`)
+        } else if (a.version !== version) {
+          appArtifactsPresent = false
+          problems.push(`${p}: app artifact "${a.name}" is version ${a.version}, the kit is being built as ${version}`)
+        }
+      }
+      let launcherOk = false
+      try {
+        const lp = join(rootPath, spec.launcher)
+        launcherOk = existsSync(lp) && statSync(lp).size > 0
+      } catch {
+        launcherOk = false
+      }
+      if (!launcherOk) {
+        launchersPresent = false
+        problems.push(`${p}: launcher "${spec.launcher}" missing or empty at the drive root — re-run build-commercial-drive`)
+      }
+    }
+  }
+
   return {
     ok: problems.length === 0,
     problems,
@@ -541,10 +768,14 @@ export async function assertCommercialDrive(
       licensesApproved,
       noUserData,
       runtimeCurrent,
+      runtimeHashed,
       ocrAssetsVerified,
       appSkillsPresent,
       userSkillsEmpty,
-      licenseArtifactsPresent
+      licenseArtifactsPresent,
+      platformMatrixDeclared,
+      appArtifactsPresent,
+      launchersPresent
     },
     modelResults
   }

--- a/apps/desktop/src/main/services/policy.ts
+++ b/apps/desktop/src/main/services/policy.ts
@@ -176,6 +176,19 @@ export function mergePolicyObject(base: PrivacyPolicy, raw: unknown): PrivacyPol
  * `DEFAULT_POLICY`). Malformed JSON → `base` + an `onWarn` note; never throws. A packaged
  * build passes `STRICT_POLICY` as the base so a malformed file fails CLOSED (M-4).
  */
+/**
+ * The commercial posture in one predicate: encryption required, plaintext off, models
+ * must verify. The sell gate (`assertCommercialDrive`) and the pre-spawn binary verifier
+ * key on the same three fields (#234).
+ */
+export function isCommercialPolicy(policy: PrivacyPolicy): boolean {
+  return (
+    policy.workspace.encryptionRequired &&
+    !policy.workspace.allowPlaintextDevMode &&
+    policy.models.requireSha256Match
+  )
+}
+
 export function parsePolicy(
   contents: string,
   onWarn?: (msg: string) => void,

--- a/apps/desktop/src/main/tools/assert-commercial-drive.ts
+++ b/apps/desktop/src/main/tools/assert-commercial-drive.ts
@@ -1,0 +1,154 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import { assertCommercialDrive, type CommercialAssertion } from '../services/commercial-drive'
+import { discoverManifests } from '../services/models'
+import {
+  KIT_PLATFORMS,
+  validateRuntimeSources,
+  type KitPlatform,
+  type OcrSources,
+  type RuntimeSources
+} from '../../shared/runtime-sources'
+
+// The one commercial gate, runnable from a shell (#233, #234). Built by
+// `vite.tools.config.ts` into `out/tools/assert-commercial-drive.mjs` and called by
+// `scripts/build-commercial-drive.{ps1,sh}` with plain `node`: the scripts print
+// SELLABLE only from this verdict. Reads only the drive (no network). Exit codes:
+// 0 sellable · 1 not sellable · 2 usage error.
+
+const USAGE =
+  'usage: node assert-commercial-drive.mjs --target <drive-root> ' +
+  '--platforms <win-x64,mac-arm64,linux-x64> --app-version <version> [--json]'
+
+interface Args {
+  target: string
+  platforms: string[]
+  appVersion: string
+  json: boolean
+}
+
+function parseArgs(argv: string[]): Args | string {
+  let target = ''
+  let platforms: string[] = []
+  let appVersion = ''
+  let json = false
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    const next = (): string => {
+      const v = argv[i + 1]
+      if (v === undefined) throw new Error(`${a} needs a value`)
+      i++
+      return v
+    }
+    try {
+      if (a === '--target') target = next()
+      else if (a === '--platforms')
+        platforms = next()
+          .split(',')
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0)
+      else if (a === '--app-version') appVersion = next()
+      else if (a === '--json') json = true
+      else if (a === '-h' || a === '--help') return USAGE
+      else return `unknown argument: ${a}\n${USAGE}`
+    } catch (err) {
+      return `${err instanceof Error ? err.message : String(err)}\n${USAGE}`
+    }
+  }
+  if (!target) return `--target is required\n${USAGE}`
+  if (platforms.length === 0) return `--platforms is required (${KIT_PLATFORMS.join(', ')})\n${USAGE}`
+  if (!appVersion) return `--app-version is required\n${USAGE}`
+  return { target: resolve(target), platforms, appVersion, json }
+}
+
+interface DriveInputs {
+  manifests: ReturnType<typeof discoverManifests>['manifests']
+  runtime: RuntimeSources | null
+  whisper: RuntimeSources | null
+  ocr: OcrSources | null
+  problems: string[]
+  summary: string[]
+}
+
+/** The drive's own manifests + runtime pin — what the app itself reads at launch. */
+function readDriveInputs(root: string): DriveInputs {
+  const problems: string[] = []
+  const summary: string[] = []
+  const manifestsDir = join(root, 'model-manifests')
+  let manifests: DriveInputs['manifests'] = []
+  if (!existsSync(manifestsDir)) {
+    problems.push('model-manifests/ missing on the drive — run prepare-drive')
+  } else {
+    const discovered = discoverManifests(manifestsDir)
+    manifests = discovered.manifests
+    for (const e of discovered.errors) problems.push(`model manifest invalid: ${e}`)
+    summary.push(`${manifests.length} model manifest(s)`)
+  }
+  let runtime: RuntimeSources | null = null
+  let whisper: RuntimeSources | null = null
+  let ocr: OcrSources | null = null
+  const pin = join(manifestsDir, 'runtime-sources.yaml')
+  if (!existsSync(pin)) {
+    problems.push('model-manifests/runtime-sources.yaml missing on the drive — run prepare-drive')
+  } else {
+    let raw: unknown
+    try {
+      raw = parseYaml(readFileSync(pin, 'utf8'))
+    } catch (err) {
+      problems.push(`runtime-sources.yaml: YAML parse error — ${String(err)}`)
+    }
+    if (raw !== undefined) {
+      const res = validateRuntimeSources(raw)
+      if (!res.ok || !res.sources) {
+        problems.push(`runtime-sources.yaml invalid: ${res.errors.join('; ')}`)
+      } else {
+        runtime = res.sources
+        whisper = res.whisper ?? null
+        ocr = res.ocr ?? null
+        summary.push(
+          `runtime pin llama_cpp ${runtime.version}` +
+            (whisper ? `, whisper_cpp ${whisper.version}` : ', no whisper_cpp block') +
+            (ocr ? `, ocr ${ocr.version}` : ', no ocr block')
+        )
+      }
+    }
+  }
+  return { manifests, runtime, whisper, ocr, problems, summary }
+}
+
+export async function main(argv: string[], out: (line: string) => void = console.log): Promise<number> {
+  const args = parseArgs(argv)
+  if (typeof args === 'string') {
+    console.error(args)
+    return 2
+  }
+  const inputs = readDriveInputs(args.target)
+  const result: CommercialAssertion = await assertCommercialDrive(
+    args.target,
+    inputs.manifests.map((m) => m.manifest),
+    inputs.runtime,
+    inputs.whisper,
+    inputs.ocr,
+    { platforms: args.platforms as KitPlatform[], appVersion: args.appVersion }
+  )
+  const problems = [...inputs.problems, ...result.problems]
+  const ok = problems.length === 0
+  if (args.json) {
+    out(JSON.stringify({ ok, problems, checks: result.checks }))
+    return ok ? 0 : 1
+  }
+  out(`assert-commercial-drive: ${args.target}`)
+  out(`  platforms: ${args.platforms.join(', ')} | app version: ${args.appVersion}`)
+  for (const s of inputs.summary) out(`  ${s}`)
+  for (const [name, value] of Object.entries(result.checks)) out(`  ${value ? 'ok  ' : 'FAIL'} ${name}`)
+  if (ok) {
+    out(`SELLABLE: every check passed (${Object.keys(result.checks).length} checks).`)
+    return 0
+  }
+  out('NOT SELLABLE:')
+  for (const p of problems) out(`  - ${p}`)
+  return 1
+}
+
+process.exitCode = await main(process.argv.slice(2))

--- a/apps/desktop/src/shared/runtime-sources.ts
+++ b/apps/desktop/src/shared/runtime-sources.ts
@@ -15,6 +15,19 @@ export type RuntimeOs = 'win' | 'mac' | 'linux'
 
 const OS_KEYS: RuntimeOs[] = ['win', 'mac', 'linux']
 
+/**
+ * The platforms a kit can be sold for — one release artifact + launcher each (#233).
+ * The sell gate takes the platforms a kit is DECLARED for and requires the app for each;
+ * the builder scripts re-spell this list (script-drift.test.ts keeps them in sync).
+ */
+export type KitPlatform = 'win-x64' | 'mac-arm64' | 'linux-x64'
+
+export const KIT_PLATFORMS: readonly KitPlatform[] = ['win-x64', 'mac-arm64', 'linux-x64']
+
+export function isKitPlatform(value: unknown): value is KitPlatform {
+  return typeof value === 'string' && (KIT_PLATFORMS as readonly string[]).includes(value)
+}
+
 /** One prebuilt `llama-server` build for a specific OS/arch/backend. */
 export interface RuntimeBuild {
   os: RuntimeOs

--- a/apps/desktop/tests/integration/commercial-drive.test.ts
+++ b/apps/desktop/tests/integration/commercial-drive.test.ts
@@ -11,10 +11,60 @@ import {
 import { buildPolicyJson } from '../../src/main/services/drive'
 import { writeRuntimeMarker } from '../../src/main/services/assets'
 import { validateManifest, type ModelManifest } from '../../src/shared/manifest'
-import { validateRuntimeSources, type RuntimeSources } from '../../src/shared/runtime-sources'
+import {
+  validateRuntimeSources,
+  type KitPlatform,
+  type RuntimeSources
+} from '../../src/shared/runtime-sources'
 
 function tempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
+}
+
+// The app artifact + launcher a kit must carry per platform it is sold for (#233). The
+// names are spelled here as literals (not the exported table) so the test stays an
+// independent check of what the launchers look for on the drive root.
+const APP_VERSION = '0.1.59'
+const ALL_PLATFORMS: KitPlatform[] = ['win-x64', 'mac-arm64', 'linux-x64']
+const LAUNCHER: Record<KitPlatform, string> = {
+  'win-x64': 'Start HilbertRaum.cmd',
+  'mac-arm64': 'Start HilbertRaum.command',
+  'linux-x64': 'start-hilbertraum.sh'
+}
+const ARTIFACT: Record<KitPlatform, string> = {
+  'win-x64': `HilbertRaum-${APP_VERSION}-portable.exe`,
+  'mac-arm64': `HilbertRaum-${APP_VERSION}-mac-arm64.app.zip`,
+  'linux-x64': `HilbertRaum-${APP_VERSION}.AppImage`
+}
+
+/** Place one app artifact + one launcher per platform at the drive root. */
+function provisionApp(root: string, platforms: KitPlatform[] = ALL_PLATFORMS): void {
+  for (const p of platforms) {
+    writeFileSync(join(root, ARTIFACT[p]), 'app-bytes')
+    writeFileSync(join(root, LAUNCHER[p]), 'launcher')
+  }
+}
+
+/** The declared platform matrix the gate is asked to check against. */
+function kit(platforms: KitPlatform[] = ALL_PLATFORMS): { platforms: KitPlatform[]; appVersion: string } {
+  return { platforms, appVersion: APP_VERSION }
+}
+
+/** An extracted macOS bundle (what the .command launcher prefers over the zip). */
+function provisionExtractedApp(root: string, version: string): void {
+  const contents = join(root, 'HilbertRaum.app', 'Contents')
+  mkdirSync(join(contents, 'MacOS'), { recursive: true })
+  writeFileSync(
+    join(contents, 'Info.plist'),
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<plist version="1.0"><dict>',
+      '  <key>CFBundleName</key><string>HilbertRaum</string>',
+      '  <key>CFBundleShortVersionString</key>',
+      `  <string>${version}</string>`,
+      '</dict></plist>'
+    ].join('\n')
+  )
 }
 
 function manifestObj(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -138,11 +188,13 @@ describe('assertCommercialDrive', () => {
     provisionLicenseArtifacts(root)
     const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
     const embed = writeVerifiedWeight(root, 'embed', 'models/embeddings/e5.gguf', 'embed-weights')
+    provisionApp(root)
 
-    const res = await assertCommercialDrive(root, [chat, embed])
+    const res = await assertCommercialDrive(root, [chat, embed], null, null, null, kit())
 
     expect(res.ok).toBe(true)
     expect(res.problems).toEqual([])
+    // Exact shape: a new check must be added here on purpose (#233, #234).
     expect(res.checks).toEqual({
       policyCommercial: true,
       networkDenied: true,
@@ -150,10 +202,14 @@ describe('assertCommercialDrive', () => {
       licensesApproved: true,
       noUserData: true,
       runtimeCurrent: true,
+      runtimeHashed: true,
       ocrAssetsVerified: true,
       appSkillsPresent: true,
       userSkillsEmpty: true,
-      licenseArtifactsPresent: true
+      licenseArtifactsPresent: true,
+      platformMatrixDeclared: true,
+      appArtifactsPresent: true,
+      launchersPresent: true
     })
   })
 
@@ -230,7 +286,8 @@ describe('assertCommercialDrive', () => {
     provisionLicenseArtifacts(root)
     const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
     mkdirSync(join(root, 'user-skills'), { recursive: true }) // empty
-    const res = await assertCommercialDrive(root, [chat])
+    provisionApp(root)
+    const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
     expect(res.ok).toBe(true)
     expect(res.checks.userSkillsEmpty).toBe(true)
   })
@@ -411,7 +468,8 @@ describe('assertCommercialDrive', () => {
     provisionLicenseArtifacts(root)
     const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
     mkdirSync(join(root, 'workspace', 'documents'), { recursive: true }) // empty
-    const res = await assertCommercialDrive(root, [chat])
+    provisionApp(root)
+    const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
     expect(res.ok).toBe(true)
     expect(res.checks.noUserData).toBe(true)
   })
@@ -474,9 +532,11 @@ describe('assertCommercialDrive', () => {
       provisionLicenseArtifacts(root)
       const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
       writeInstalls(root)
-      const res = await assertCommercialDrive(root, [chat], sources())
+      provisionApp(root)
+      const res = await assertCommercialDrive(root, [chat], sources(), null, null, kit())
       expect(res.ok).toBe(true)
       expect(res.checks.runtimeCurrent).toBe(true)
+      expect(res.checks.runtimeHashed).toBe(true)
     })
 
     it('fails when a pinned build has NO install marker', async () => {
@@ -537,7 +597,9 @@ describe('assertCommercialDrive', () => {
       })
       const res = await assertCommercialDrive(root, [chat], sources())
       expect(res.ok).toBe(false)
-      expect(res.checks.runtimeCurrent).toBe(false)
+      // Presence + version/backend are fine; the missing hash is its own verdict (#234).
+      expect(res.checks.runtimeCurrent).toBe(true)
+      expect(res.checks.runtimeHashed).toBe(false)
       expect(res.problems.some((p) => /records no SHA-256/.test(p))).toBe(true)
     })
 
@@ -551,7 +613,27 @@ describe('assertCommercialDrive', () => {
       writeFileSync(join(root, 'runtime', 'llama.cpp', 'win', 'llama-server.exe'), 'TAMPERED')
       const res = await assertCommercialDrive(root, [chat], sources())
       expect(res.ok).toBe(false)
-      expect(res.checks.runtimeCurrent).toBe(false)
+      expect(res.checks.runtimeCurrent).toBe(true)
+      expect(res.checks.runtimeHashed).toBe(false)
+      expect(res.problems.some((p) => /does not match the SHA-256 recorded/.test(p))).toBe(true)
+    })
+
+    it('fails when the marker HASH was tampered (binary untouched, recorded hash rewritten)', async () => {
+      const root = tempDir('hilbertraum-commercial-rt-marker-tamper-')
+      writePolicy(root, buildPolicyJson())
+      provisionAppSkill(root)
+      const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
+      writeInstalls(root)
+      writeRuntimeMarker(join(root, 'runtime', 'llama.cpp', 'win'), {
+        version: 'b9585',
+        backend: 'vulkan',
+        os: 'win',
+        arch: 'x64',
+        binaries: { 'llama-server.exe': 'e'.repeat(64) }
+      })
+      const res = await assertCommercialDrive(root, [chat], sources())
+      expect(res.ok).toBe(false)
+      expect(res.checks.runtimeHashed).toBe(false)
       expect(res.problems.some((p) => /does not match the SHA-256 recorded/.test(p))).toBe(true)
     })
 
@@ -561,9 +643,11 @@ describe('assertCommercialDrive', () => {
       provisionAppSkill(root)
       provisionLicenseArtifacts(root)
       const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
-      const res = await assertCommercialDrive(root, [chat])
+      provisionApp(root)
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
       expect(res.ok).toBe(true)
       expect(res.checks.runtimeCurrent).toBe(true)
+      expect(res.checks.runtimeHashed).toBe(true)
     })
 
     // ---- Phase 36: the whisper family rides the same gate (binary = whisper-cli) ----
@@ -622,9 +706,11 @@ describe('assertCommercialDrive', () => {
       const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
       writeInstalls(root)
       writeWhisperInstall(root)
-      const res = await assertCommercialDrive(root, [chat], sources(), whisperSources())
+      provisionApp(root)
+      const res = await assertCommercialDrive(root, [chat], sources(), whisperSources(), null, kit())
       expect(res.ok).toBe(true)
       expect(res.checks.runtimeCurrent).toBe(true)
+      expect(res.checks.runtimeHashed).toBe(true)
     })
 
     it('fails when the whisper-cli binary is missing under the whisper pin', async () => {
@@ -657,6 +743,179 @@ describe('assertCommercialDrive', () => {
       expect(res.problems.some((p) => /whisper build .*does not match the pinned v1\.8\.6/.test(p))).toBe(
         true
       )
+    })
+  })
+
+  // #233: the gate requires the app artifact + launcher for every platform the kit is
+  // declared for, exactly one artifact per platform, with the version the builder names.
+  describe('app artifacts + launchers per declared platform (#233)', () => {
+    /** Everything but the app: posture, skill, notices, one weight. */
+    function otherwiseValidDrive(prefix: string): { root: string; chat: ModelManifest } {
+      const root = tempDir(prefix)
+      writePolicy(root, buildPolicyJson())
+      provisionAppSkill(root)
+      provisionLicenseArtifacts(root)
+      const chat = writeVerifiedWeight(root, 'chat', 'models/chat/qwen.gguf', 'chat-weights')
+      return { root, chat }
+    }
+
+    it('fails with no app artifact at all (launchers present)', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-noapp-')
+      for (const p of ALL_PLATFORMS) writeFileSync(join(root, LAUNCHER[p]), 'launcher')
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.problems.length).toBeGreaterThan(0)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.checks.launchersPresent).toBe(true)
+      expect(res.checks.platformMatrixDeclared).toBe(true)
+      for (const p of ALL_PLATFORMS) {
+        expect(res.problems.some((m) => m.includes(p) && /no app artifact/i.test(m)), p).toBe(true)
+      }
+    })
+
+    it('fails on a zero-byte app artifact', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-zeroapp-')
+      provisionApp(root)
+      writeFileSync(join(root, ARTIFACT['win-x64']), Buffer.alloc(0))
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.problems.some((m) => m.includes(ARTIFACT['win-x64']) && /zero bytes/i.test(m))).toBe(true)
+    })
+
+    it('fails on a wrong-arch artifact name (not a release artifact of any declared platform)', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-wrongarch-')
+      provisionApp(root, ['win-x64', 'linux-x64'])
+      writeFileSync(join(root, LAUNCHER['mac-arm64']), 'launcher')
+      writeFileSync(join(root, `HilbertRaum-${APP_VERSION}-mac-x64.app.zip`), 'app-bytes')
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.problems.some((m) => m.includes('mac-x64'))).toBe(true)
+      expect(res.problems.some((m) => m.includes('mac-arm64') && /no app artifact/i.test(m))).toBe(true)
+    })
+
+    it('fails when a declared platform has its artifact but no launcher', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-nolauncher-')
+      provisionApp(root)
+      rmSync(join(root, LAUNCHER['linux-x64']))
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.launchersPresent).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(true)
+      expect(res.problems.some((m) => m.includes(LAUNCHER['linux-x64']))).toBe(true)
+    })
+
+    it('fails when the declared platform set is only partly provisioned', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-partial-')
+      provisionApp(root, ['win-x64'])
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.checks.launchersPresent).toBe(false)
+      expect(res.problems.some((m) => m.includes('mac-arm64'))).toBe(true)
+      expect(res.problems.some((m) => m.includes('linux-x64'))).toBe(true)
+    })
+
+    it('fails when two app artifacts of one platform sit at the root (an older build beside the new one)', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-twoapps-')
+      provisionApp(root)
+      writeFileSync(join(root, 'HilbertRaum-0.1.58-portable.exe'), 'old-app-bytes')
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      const dup = res.problems.find((m) => /more than one app artifact/i.test(m))
+      expect(dup).toBeDefined()
+      expect(dup).toContain('HilbertRaum-0.1.58-portable.exe')
+      expect(dup).toContain(ARTIFACT['win-x64'])
+    })
+
+    it('fails when the only artifact carries another version than the one being built', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-oldversion-')
+      provisionApp(root)
+      rmSync(join(root, ARTIFACT['win-x64']))
+      writeFileSync(join(root, 'HilbertRaum-0.1.58-portable.exe'), 'old-app-bytes')
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.problems.some((m) => m.includes('0.1.58') && m.includes(APP_VERSION))).toBe(true)
+    })
+
+    it('fails when the drive carries an artifact for a platform the kit is NOT declared for', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-undeclared-')
+      provisionApp(root)
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit(['win-x64']))
+      expect(res.ok).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.problems.some((m) => m.includes(ARTIFACT['mac-arm64']) && /not declared/i.test(m))).toBe(true)
+      expect(res.problems.some((m) => m.includes(ARTIFACT['linux-x64']) && /not declared/i.test(m))).toBe(true)
+    })
+
+    it('a single-platform kit passes with just that platform declared and provisioned', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-winonly-')
+      provisionApp(root, ['win-x64'])
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit(['win-x64']))
+      expect(res.ok).toBe(true)
+      expect(res.checks.platformMatrixDeclared).toBe(true)
+      expect(res.checks.appArtifactsPresent).toBe(true)
+      expect(res.checks.launchersPresent).toBe(true)
+    })
+
+    it('an extracted .app bundle counts as the mac artifact when its Info.plist carries the version', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-appdir-')
+      provisionApp(root)
+      rmSync(join(root, ARTIFACT['mac-arm64']))
+      provisionExtractedApp(root, APP_VERSION)
+      const res = await assertCommercialDrive(root, [chat], null, null, null, kit())
+      expect(res.ok).toBe(true)
+      expect(res.checks.appArtifactsPresent).toBe(true)
+    })
+
+    it('fails on an extracted .app of another version, and on a .app beside a .app.zip', async () => {
+      const stale = otherwiseValidDrive('hilbertraum-commercial-appdir-stale-')
+      provisionApp(stale.root)
+      rmSync(join(stale.root, ARTIFACT['mac-arm64']))
+      provisionExtractedApp(stale.root, '0.1.58')
+      const staleRes = await assertCommercialDrive(stale.root, [stale.chat], null, null, null, kit())
+      expect(staleRes.ok).toBe(false)
+      expect(staleRes.problems.some((m) => m.includes('HilbertRaum.app') && m.includes('0.1.58'))).toBe(true)
+
+      const both = otherwiseValidDrive('hilbertraum-commercial-appdir-both-')
+      provisionApp(both.root)
+      provisionExtractedApp(both.root, APP_VERSION)
+      const bothRes = await assertCommercialDrive(both.root, [both.chat], null, null, null, kit())
+      expect(bothRes.ok).toBe(false)
+      const dup = bothRes.problems.find((m) => /more than one app artifact/i.test(m))
+      expect(dup).toBeDefined()
+      expect(dup).toContain('HilbertRaum.app')
+      expect(dup).toContain(ARTIFACT['mac-arm64'])
+    })
+
+    it('fails closed when no platform matrix is declared (nothing to check the app against)', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-nomatrix-')
+      provisionApp(root)
+      const res = await assertCommercialDrive(root, [chat])
+      expect(res.ok).toBe(false)
+      expect(res.checks.platformMatrixDeclared).toBe(false)
+      expect(res.checks.appArtifactsPresent).toBe(false)
+      expect(res.checks.launchersPresent).toBe(false)
+      expect(res.problems.some((m) => /platform/i.test(m))).toBe(true)
+    })
+
+    it('rejects an empty, duplicated or unknown platform declaration and a missing version', async () => {
+      const { root, chat } = otherwiseValidDrive('hilbertraum-commercial-badmatrix-')
+      provisionApp(root)
+      const bad = [
+        { platforms: [] as KitPlatform[], appVersion: APP_VERSION },
+        { platforms: ['win-x64', 'win-x64'] as KitPlatform[], appVersion: APP_VERSION },
+        { platforms: ['win-arm64' as KitPlatform], appVersion: APP_VERSION },
+        { platforms: ALL_PLATFORMS, appVersion: '' }
+      ]
+      for (const opts of bad) {
+        const res = await assertCommercialDrive(root, [chat], null, null, null, opts)
+        expect(res.ok, JSON.stringify(opts)).toBe(false)
+        expect(res.checks.platformMatrixDeclared, JSON.stringify(opts)).toBe(false)
+      }
     })
   })
 })

--- a/apps/desktop/tests/integration/policy.test.ts
+++ b/apps/desktop/tests/integration/policy.test.ts
@@ -14,6 +14,7 @@ import {
   loadPolicy,
   resolveNetwork,
   buildPolicyStatus,
+  isCommercialPolicy,
   __policyMaterializations,
   __resetPolicyCache
 } from '../../src/main/services/policy'
@@ -526,5 +527,26 @@ describe('local API policy ceiling (local-api P2)', () => {
     // Unprovisioned app-data root => STANDALONE => permitted (setting still default-off).
     const standalone = mkdtempSync(join(tmpdir(), 'hilbertraum-policy-lapi4-'))
     expect(loadPolicy(standalone, undefined, { isDev: false }).policy.network.allowLocalApi).toBe(true)
+  })
+})
+
+// The one commercial-posture predicate the sell gate and the spawn verifier share (#234).
+describe('isCommercialPolicy', () => {
+  it('is true for the strict/commercial posture and false for the dev default', () => {
+    expect(isCommercialPolicy(STRICT_POLICY)).toBe(true)
+    expect(isCommercialPolicy(DEFAULT_POLICY)).toBe(false)
+  })
+
+  it('needs all three: encryption required, plaintext off, sha256 match required', () => {
+    const base = STRICT_POLICY
+    expect(
+      isCommercialPolicy({ ...base, workspace: { ...base.workspace, encryptionRequired: false } })
+    ).toBe(false)
+    expect(
+      isCommercialPolicy({ ...base, workspace: { ...base.workspace, allowPlaintextDevMode: true } })
+    ).toBe(false)
+    expect(isCommercialPolicy({ ...base, models: { ...base.models, requireSha256Match: false } })).toBe(
+      false
+    )
   })
 })

--- a/apps/desktop/tests/integration/script-drift.test.ts
+++ b/apps/desktop/tests/integration/script-drift.test.ts
@@ -616,10 +616,11 @@ describe('one commercial gate — builder + fetch-runtime literals (#233, #234)'
     ['scripts/fetch-runtime.sh', 'ARCHIVE_VERIFIED']
   ])('%s writes the marker binary hash only behind the archive-verified flag', (rel, flag) => {
     const src = read(rel)
-    const markerWrite = src.indexOf('"binaries"')
+    // The LAST `"binaries"` literal is the marker write (earlier ones read a marker).
+    const markerWrite = src.lastIndexOf('"binaries"')
     expect(markerWrite, 'marker write not found').toBeGreaterThan(0)
     // The flag is tested within the 25 lines that precede the marker write.
-    const window = src.slice(src.lastIndexOf('\n', markerWrite) - 2000, markerWrite)
+    const window = src.slice(Math.max(0, markerWrite - 2000), markerWrite)
     expect(window.split('\n').slice(-25).join('\n')).toContain(flag)
   })
 })

--- a/apps/desktop/tests/integration/script-drift.test.ts
+++ b/apps/desktop/tests/integration/script-drift.test.ts
@@ -11,7 +11,7 @@ import {
   SUPPORTED_RUNTIME_FORMATS
 } from '../../src/main/services/drive'
 import { isRealSha256 } from '../../src/shared/manifest'
-import { validateRuntimeSources } from '../../src/shared/runtime-sources'
+import { KIT_PLATFORMS, validateRuntimeSources } from '../../src/shared/runtime-sources'
 import { DRIVE_LICENSE_ARTIFACTS } from '../../src/main/services/commercial-drive'
 
 // Drift guard (audit H5 / M-A1). The drive layout, the format version, and the runtime
@@ -566,5 +566,60 @@ describe('fetch-runtime — the OCR re-fetch delete is deliberately UNCONDITIONA
       `${rel}: the OCR delete gained a condition. It is unconditional on purpose — see the ` +
         'comment above it; do not harmonize it with the size-guarded fetch-models delete.'
     ).toEqual([])
+  })
+})
+
+// The commercial gate is ONE function (#233, #234): both builders call the built
+// assert-commercial-drive tool, spell the same platform labels, pass --commercial to
+// every fetch-runtime run, and the fetch scripts record a binary hash only after the
+// archive verified. Text pins; the execution cases live in script-execution.test.ts.
+describe('one commercial gate — builder + fetch-runtime literals (#233, #234)', () => {
+  const GATE_TOOL = 'apps/desktop/out/tools/assert-commercial-drive.mjs'
+
+  it.each([
+    ['scripts/build-commercial-drive.ps1', '$KitPlatforms = @(', ')'],
+    ['scripts/build-commercial-drive.sh', 'KIT_PLATFORMS=(', ')']
+  ])('%s spells exactly the canonical KitPlatform list', (rel, header, close) => {
+    expect(extractArray(read(rel), header, close)).toEqual([...KIT_PLATFORMS])
+  })
+
+  it.each(['scripts/build-commercial-drive.ps1', 'scripts/build-commercial-drive.sh'])(
+    '%s invokes the built canonical gate and prints SELLABLE only from its result',
+    (rel) => {
+      const code = codeLines(rel).map((l) => l.text)
+      expect(code.some((l) => l.includes(GATE_TOOL))).toBe(true)
+      // The word SELLABLE (as a verdict) appears on exactly two code lines: the NOT SELLABLE
+      // branch and the SELLABLE branch — no third place can print a verdict.
+      const verdicts = code.filter((l) => /SELLABLE:/.test(l) && !/NOT SELLABLE/.test(l))
+      expect(verdicts).toHaveLength(1)
+    }
+  )
+
+  it('build-commercial-drive.ps1 passes -Commercial to every fetch-runtime run', () => {
+    const code = codeLines('scripts/build-commercial-drive.ps1').map((l) => l.text)
+    const runs = code.filter((l) => l.includes("Run 'fetch-runtime.ps1'")).length
+    const flagged = code.filter((l) => /Commercial\s*=\s*\$true/.test(l)).length
+    expect(runs).toBeGreaterThan(0)
+    expect(flagged).toBeGreaterThanOrEqual(runs)
+  })
+
+  it('build-commercial-drive.sh passes --commercial to every fetch-runtime run', () => {
+    const code = codeLines('scripts/build-commercial-drive.sh').map((l) => l.text)
+    const runs = code.filter((l) => l.includes('fetch-runtime.sh')).length
+    const flagged = code.filter((l) => l.includes('--commercial')).length
+    expect(runs).toBeGreaterThan(0)
+    expect(flagged).toBeGreaterThanOrEqual(runs)
+  })
+
+  it.each([
+    ['scripts/fetch-runtime.ps1', '$archiveVerified'],
+    ['scripts/fetch-runtime.sh', 'ARCHIVE_VERIFIED']
+  ])('%s writes the marker binary hash only behind the archive-verified flag', (rel, flag) => {
+    const src = read(rel)
+    const markerWrite = src.indexOf('"binaries"')
+    expect(markerWrite, 'marker write not found').toBeGreaterThan(0)
+    // The flag is tested within the 25 lines that precede the marker write.
+    const window = src.slice(src.lastIndexOf('\n', markerWrite) - 2000, markerWrite)
+    expect(window.split('\n').slice(-25).join('\n')).toContain(flag)
   })
 })

--- a/apps/desktop/tests/integration/script-execution.test.ts
+++ b/apps/desktop/tests/integration/script-execution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -91,7 +91,8 @@ const LEGS: Leg[] = [
   },
   {
     name: 'bash scripts (.sh)',
-    skip: process.platform === 'win32',
+    // Git Bash on a Windows dev box can run this leg too: HILBERTRAUM_SCRIPT_SH_LEG=1.
+    skip: process.platform === 'win32' && !process.env.HILBERTRAUM_SCRIPT_SH_LEG,
     ext: 'sh',
     flag: (n) => `--${n.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`,
     run: (script, args) =>
@@ -100,6 +101,11 @@ const LEGS: Leg[] = [
 ]
 
 const text = (r: SpawnSyncReturns<string>): string => `${r.stdout ?? ''}\n${r.stderr ?? ''}`
+
+// A shell + a node child per case: well under a second on Linux, several seconds under
+// PowerShell or Git Bash on a loaded Windows runner — give every case in this file real headroom.
+const CASE_TIMEOUT_MS = 90_000
+vi.setConfig({ testTimeout: CASE_TIMEOUT_MS })
 
 for (const leg of LEGS) {
   describe.skipIf(leg.skip)(`script execution — ${leg.name}`, () => {

--- a/apps/desktop/tests/integration/script-execution.test.ts
+++ b/apps/desktop/tests/integration/script-execution.test.ts
@@ -19,6 +19,10 @@ if (!toolBuilt) {
   console.warn(`script-execution: ${GATE_TOOL} is not built (run \`npm run build\`) — the gate cases are skipped`)
 }
 
+// The child is killed before vitest's own budget (below) expires, so a hung script fails
+// with its output attached instead of as a bare test timeout.
+const CHILD_TIMEOUT_MS = 60_000
+
 const PLACEHOLDER = 'REPLACE_WITH_REAL_HASH'
 const REAL_SHA = 'a'.repeat(64)
 
@@ -86,7 +90,7 @@ const LEGS: Leg[] = [
       spawnSync(
         'powershell.exe',
         ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', join(SCRIPTS, script), ...args],
-        { encoding: 'utf8', timeout: 120_000, windowsHide: true }
+        { encoding: 'utf8', timeout: CHILD_TIMEOUT_MS, windowsHide: true }
       )
   },
   {
@@ -96,7 +100,7 @@ const LEGS: Leg[] = [
     ext: 'sh',
     flag: (n) => `--${n.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`,
     run: (script, args) =>
-      spawnSync('bash', [join(SCRIPTS, script), ...args], { encoding: 'utf8', timeout: 120_000 })
+      spawnSync('bash', [join(SCRIPTS, script), ...args], { encoding: 'utf8', timeout: CHILD_TIMEOUT_MS })
   }
 ]
 

--- a/apps/desktop/tests/integration/script-execution.test.ts
+++ b/apps/desktop/tests/integration/script-execution.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Executes the drive-builder scripts (#233, #234) — unlike script-drift.test.ts, which is
+// text-only by charter. Every case is OFFLINE and deterministic: the fetch-runtime cases
+// stop before any download (placeholder hash refused, or the install skipped), and the
+// builder cases run only its verify-only gate or its up-front refusal. The .ps1 leg runs
+// on Windows, the .sh leg elsewhere (CI runs `npm test` on both).
+
+const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', '..', '..')
+const SCRIPTS = join(REPO_ROOT, 'scripts')
+const GATE_TOOL = join(REPO_ROOT, 'apps', 'desktop', 'out', 'tools', 'assert-commercial-drive.mjs')
+const toolBuilt = existsSync(GATE_TOOL)
+if (!toolBuilt) {
+  console.warn(`script-execution: ${GATE_TOOL} is not built (run \`npm run build\`) — the gate cases are skipped`)
+}
+
+const PLACEHOLDER = 'REPLACE_WITH_REAL_HASH'
+const REAL_SHA = 'a'.repeat(64)
+
+/** A runtime-sources.yaml whose sha256 fields are all `sha`; URLs on a reserved TLD. */
+function runtimeSourcesYaml(sha: string): string {
+  return [
+    'llama_cpp:',
+    '  version: b9585',
+    '  builds:',
+    '    - os: win',
+    '      arch: x64',
+    '      backend: vulkan',
+    '      url: https://example.invalid/llama-b9585-bin-win-vulkan-x64.zip',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/llama.cpp/win',
+    '    - os: linux',
+    '      arch: x64',
+    '      backend: vulkan',
+    '      url: https://example.invalid/llama-b9585-bin-ubuntu-vulkan-x64.tar.gz',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/llama.cpp/linux',
+    'ocr:',
+    '  version: 4.0.0_best_int',
+    '  files:',
+    '    - lang: deu',
+    '      url: https://example.invalid/deu.traineddata.gz',
+    `      sha256: ${sha}`,
+    '      dest: ocr/deu.traineddata.gz',
+    ''
+  ].join('\n')
+}
+
+function scratchTarget(sha: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'hilbertraum-script-exec-'))
+  mkdirSync(join(root, 'model-manifests'), { recursive: true })
+  writeFileSync(join(root, 'model-manifests', 'runtime-sources.yaml'), runtimeSourcesYaml(sha))
+  return root
+}
+
+/** A win vulkan install: binary + marker (hashless unless `withHash`). */
+function installWinBuild(root: string, withHash: boolean): void {
+  const dir = join(root, 'runtime', 'llama.cpp', 'win')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'llama-server.exe'), 'fake-binary')
+  const marker: Record<string, unknown> = { version: 'b9585', backend: 'vulkan', os: 'win', arch: 'x64' }
+  if (withHash) marker.binaries = { 'llama-server.exe': REAL_SHA }
+  writeFileSync(join(dir, '.hilbertraum-runtime.json'), JSON.stringify(marker))
+}
+
+interface Leg {
+  name: string
+  skip: boolean
+  run: (script: string, args: string[]) => SpawnSyncReturns<string>
+  ext: 'ps1' | 'sh'
+  flag: (name: string) => string
+}
+
+const LEGS: Leg[] = [
+  {
+    name: 'PowerShell scripts (.ps1)',
+    skip: process.platform !== 'win32',
+    ext: 'ps1',
+    flag: (n) => `-${n}`,
+    run: (script, args) =>
+      spawnSync(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', join(SCRIPTS, script), ...args],
+        { encoding: 'utf8', timeout: 120_000, windowsHide: true }
+      )
+  },
+  {
+    name: 'bash scripts (.sh)',
+    skip: process.platform === 'win32',
+    ext: 'sh',
+    flag: (n) => `--${n.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`,
+    run: (script, args) =>
+      spawnSync('bash', [join(SCRIPTS, script), ...args], { encoding: 'utf8', timeout: 120_000 })
+  }
+]
+
+const text = (r: SpawnSyncReturns<string>): string => `${r.stdout ?? ''}\n${r.stderr ?? ''}`
+
+for (const leg of LEGS) {
+  describe.skipIf(leg.skip)(`script execution — ${leg.name}`, () => {
+    const builder = `build-commercial-drive.${leg.ext}`
+    const fetcher = `fetch-runtime.${leg.ext}`
+    const f = leg.flag
+
+    describe('build-commercial-drive verify-only gate (#233)', () => {
+      it.skipIf(!toolBuilt)('runs the canonical gate offline and prints NOT SELLABLE for an empty target', () => {
+        const root = mkdtempSync(join(tmpdir(), 'hilbertraum-script-gate-'))
+        const r = leg.run(builder, [f('Target'), root, f('VerifyOnly')])
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toContain('NOT SELLABLE')
+        expect(out).toContain('assert-commercial-drive')
+        // The verdict is the canonical gate's: it names the missing platform artifacts.
+        expect(out).toMatch(/no app artifact/i)
+        expect(out).not.toMatch(/^\s*SELLABLE:/m)
+        expect(out).not.toContain('Done. Test the drive')
+      })
+
+      it('rejects an unknown platform label before doing anything (exit 2)', () => {
+        const root = mkdtempSync(join(tmpdir(), 'hilbertraum-script-plat-'))
+        const r = leg.run(builder, [f('Target'), root, f('VerifyOnly'), f('Platforms'), 'win-arm64'])
+        expect(r.status, text(r)).toBe(2)
+        expect(text(r)).toContain('win-arm64')
+      })
+
+      it('refuses to proceed when a differently named app artifact already sits at the root', () => {
+        const root = mkdtempSync(join(tmpdir(), 'hilbertraum-script-prior-'))
+        writeFileSync(join(root, 'HilbertRaum-0.1.58-portable.exe'), 'old')
+        const src = mkdtempSync(join(tmpdir(), 'hilbertraum-script-artifact-'))
+        const artifact = join(src, 'HilbertRaum-0.1.59-portable.exe')
+        writeFileSync(artifact, 'new')
+        const r = leg.run(builder, [f('Target'), root, f('AppArtifact'), artifact, f('DryRun')])
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toContain('HilbertRaum-0.1.58-portable.exe')
+        expect(out).not.toContain('[1]') // refused before step 1 ran
+        expect(existsSync(join(root, 'HilbertRaum-0.1.59-portable.exe'))).toBe(false)
+      })
+    })
+
+    describe('fetch-runtime commercial mode (#234)', () => {
+      const commercialArgs = (root: string, extra: string[] = []): string[] => [
+        f('Target'),
+        root,
+        f('Os'),
+        'win',
+        f('Commercial'),
+        ...extra
+      ]
+
+      it('refuses a placeholder archive hash BEFORE any download: nothing extracted, no marker', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        const r = leg.run(fetcher, commercialArgs(root))
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toMatch(/placeholder/i)
+        expect(existsSync(join(root, 'runtime'))).toBe(false)
+      })
+
+      it('does not SKIP a hashless (legacy) install: the placeholder is refused instead', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        installWinBuild(root, false)
+        const r = leg.run(fetcher, commercialArgs(root))
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toMatch(/placeholder/i)
+        expect(out).not.toMatch(/skip \(/)
+      })
+
+      it('without the flag a hashless install is still skipped (DIY tolerance unchanged)', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        installWinBuild(root, false)
+        const r = leg.run(fetcher, [f('Target'), root, f('Os'), 'win'])
+        const out = text(r)
+        expect(r.status, out).toBe(0)
+        expect(out).toMatch(/skip \(/)
+      })
+
+      it('a hashed, matching install is skipped in commercial mode too (nothing to re-fetch)', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        installWinBuild(root, true)
+        const r = leg.run(fetcher, commercialArgs(root))
+        const out = text(r)
+        expect(r.status, out).toBe(0)
+        expect(out).toMatch(/skip \(/)
+      })
+
+      it('a dry run in commercial mode reports the placeholder as a failure (exit 1)', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        const r = leg.run(fetcher, commercialArgs(root, [f('DryRun')]))
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toMatch(/placeholder/i)
+      })
+
+      it('the OCR family refuses a placeholder before any download too', () => {
+        const root = scratchTarget(PLACEHOLDER)
+        const r = leg.run(fetcher, [f('Target'), root, f('Family'), 'ocr', f('Commercial')])
+        const out = text(r)
+        expect(r.status, out).toBe(1)
+        expect(out).toMatch(/placeholder/i)
+        expect(existsSync(join(root, 'ocr')) ? readdirSync(join(root, 'ocr')) : []).toEqual([])
+      })
+    })
+
+    // The whole dry pipeline (six child fetch runs, all dry) takes ~30 s per leg and needs
+    // -AcceptLicense to get past the license-blocked model in step 2 — opt in locally.
+    describe.skipIf(!process.env.HILBERTRAUM_SCRIPT_DRY_RUN)('full -DryRun pipeline (opt-in)', () => {
+      it.skipIf(!toolBuilt)(
+        'a dry run reaches the canonical verdict: NOT SELLABLE on an empty target',
+        () => {
+          const root = mkdtempSync(join(tmpdir(), 'hilbertraum-script-dry-'))
+          const r = leg.run(builder, [f('Target'), root, f('AcceptLicense'), f('DryRun')])
+          const out = text(r)
+          expect(r.status, out).toBe(1)
+          expect(out).toContain('NOT SELLABLE')
+          expect(out).toContain('[7]')
+          expect(out).not.toContain('Done. Test the drive')
+        },
+        300_000
+      )
+    })
+  })
+}

--- a/apps/desktop/tests/unit/binary-verifier.test.ts
+++ b/apps/desktop/tests/unit/binary-verifier.test.ts
@@ -6,6 +6,8 @@ import {
   computeBinaryVerification,
   verifyBinaryBeforeSpawn,
   initBinaryVerification,
+  setBinaryVerificationPosture,
+  REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES,
   _resetBinaryVerificationForTests
 } from '../../src/main/services/binary-verifier'
 import {
@@ -208,5 +210,69 @@ describe('verifyBinaryBeforeSpawn (enforcement gate + session cache)', () => {
     // Even after the file is tampered, the cached decision stands for the rest of the session.
     writeFileSync(bin, 'now-tampered-but-already-verified')
     expect(await verifyBinaryBeforeSpawn(bin)).toBe('ok')
+  })
+})
+
+// #234: a hashless marker on a COMMERCIAL drive can be refused at spawn. The refusal is
+// wired but shipped OFF (the constant) until the owner rules on already-sold kits; DIY
+// drives keep the documented tolerance either way.
+describe('commercial posture: hashless markers (#234)', () => {
+  function hashlessInstall(): string {
+    const dir = tmp()
+    const bin = join(dir, 'llama-server.exe')
+    writeFileSync(bin, 'legacy-binary')
+    writeRuntimeMarker(dir, { version: 'b9585', backend: 'vulkan', os: 'win', arch: 'x64' })
+    return bin
+  }
+
+  it('ships with the spawn-time refusal OFF', () => {
+    expect(REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES).toBe(false)
+  })
+
+  it('DIY posture: a hashless marker stays skip-legacy even with the refusal enabled', async () => {
+    initBinaryVerification(false)
+    setBinaryVerificationPosture({ commercial: false, refuseHashlessMarkers: true })
+    expect(await verifyBinaryBeforeSpawn(hashlessInstall())).toBe('skip-legacy')
+  })
+
+  it('commercial posture + refusal enabled: a hashless marker is REFUSED (mismatch)', async () => {
+    initBinaryVerification(false)
+    setBinaryVerificationPosture({ commercial: true, refuseHashlessMarkers: true })
+    expect(await verifyBinaryBeforeSpawn(hashlessInstall())).toBe('mismatch')
+  })
+
+  it('commercial posture with the shipped default (refusal off): tolerated as skip-legacy', async () => {
+    initBinaryVerification(false)
+    setBinaryVerificationPosture({ commercial: true })
+    expect(await verifyBinaryBeforeSpawn(hashlessInstall())).toBe('skip-legacy')
+  })
+
+  it('the refusal never touches a binary whose recorded hash matches (ok) or a dev build (skip-dev)', async () => {
+    initBinaryVerification(false)
+    setBinaryVerificationPosture({ commercial: true, refuseHashlessMarkers: true })
+    const dir = tmp()
+    const bin = join(dir, 'llama-server.exe')
+    writeFileSync(bin, 'hashed-binary')
+    writeRuntimeMarker(dir, {
+      version: 'b9585',
+      backend: 'vulkan',
+      os: 'win',
+      arch: 'x64',
+      binaries: { [markerBinaryKey(dir, bin)]: await sha256File(bin) }
+    })
+    expect(await verifyBinaryBeforeSpawn(bin)).toBe('ok')
+
+    _resetBinaryVerificationForTests()
+    initBinaryVerification(true)
+    setBinaryVerificationPosture({ commercial: true, refuseHashlessMarkers: true })
+    expect(await verifyBinaryBeforeSpawn(hashlessInstall())).toBe('skip-dev')
+  })
+
+  it('the test reset clears the posture (a later case is not silently commercial)', async () => {
+    initBinaryVerification(false)
+    setBinaryVerificationPosture({ commercial: true, refuseHashlessMarkers: true })
+    _resetBinaryVerificationForTests()
+    initBinaryVerification(false)
+    expect(await verifyBinaryBeforeSpawn(hashlessInstall())).toBe('skip-legacy')
   })
 })

--- a/apps/desktop/tsconfig.node.json
+++ b/apps/desktop/tsconfig.node.json
@@ -6,5 +6,5 @@
     "composite": true,
     "lib": ["ES2022"]
   },
-  "include": ["src/main", "src/preload", "electron.vite.config.ts", "vitest.config.ts"]
+  "include": ["src/main", "src/preload", "electron.vite.config.ts", "vite.tools.config.ts", "vitest.config.ts"]
 }

--- a/apps/desktop/vite.tools.config.ts
+++ b/apps/desktop/vite.tools.config.ts
@@ -1,0 +1,27 @@
+import { builtinModules } from 'node:module'
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+// Standalone Node build of the commercial gate tool (src/main/tools/assert-commercial-drive.ts)
+// into out/tools/, called by scripts/build-commercial-drive.{ps1,sh} with plain `node` (#233).
+// A separate build, not a second electron-vite main entry: the main bundle runs
+// `app.requestSingleInstanceLock()` on import and must stay one file. Dependencies (yaml)
+// are bundled in so the tool needs nothing but Node; electron-builder excludes out/tools/.
+export default defineConfig({
+  build: {
+    outDir: resolve(__dirname, 'out/tools'),
+    emptyOutDir: true,
+    target: 'node22',
+    ssr: resolve(__dirname, 'src/main/tools/assert-commercial-drive.ts'),
+    minify: false,
+    sourcemap: false,
+    rollupOptions: {
+      external: [/^node:/, ...builtinModules, 'electron'],
+      output: { format: 'es', entryFileNames: 'assert-commercial-drive.mjs' }
+    }
+  },
+  ssr: { noExternal: true, target: 'node' },
+  resolve: {
+    alias: { '@shared': resolve(__dirname, 'src/shared') }
+  }
+})

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -88,8 +88,12 @@ password recovery — are documented in
   sidecar binaries before spawn") re-verifies `llama-server` / `whisper-cli` against a SHA-256 the
   install marker now records. A drive provisioned by a `fetch-runtime.{ps1,sh}` predating that change
   has no recorded hash, so the verifier **tolerates** the binary (`skip-legacy`) rather than refusing to
-  start — it stays unprotected until the runtime is re-fetched (the commercial sell-gate forces this for
-  sold drives, but a self-built DIY drive does not). Trust there still rests on drive provisioning +
+  start — it stays unprotected until the runtime is re-fetched. Since PR #271 (#234) the sell gate
+  (`assertCommercialDrive`, which both builder scripts now call) refuses a hashless marker and
+  `fetch-runtime --commercial` re-fetches it, so a newly built sold drive cannot carry one; a
+  self-built DIY drive keeps the tolerance. A spawn-time refusal on commercial drives is wired but
+  switched **off** (`REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES` in `binary-verifier.ts`) until the
+  owner rules on kits sold before this change (#234). Trust there still rests on drive provisioning +
   filesystem integrity, the same residual already accepted for on-drive sidecars and app skills.
 - **App-skill integrity is by location, not signature (Skills §22-M2 — accept + document).** A
   shipped skill's `trusted_level: app` is assigned because it sits in `app-skills/`, copied there at

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -444,28 +444,46 @@ fetch-runtime                     # verified llama.cpp sidecar builds: per OS th
 package + sign + notarize         # MANUAL — secrets never in the repo (pass --app-artifact / --skip-package)
 copy launcher + portable app + user docs -> drive root
 verify-models  --generate         # capture real hashes -> config/checksums.json
-final check: commercial posture (encrypted, no phone-home — downloads OK, update-checks + telemetry denied) + all weights VERIFIED
-             + runtime install markers match the pin + no user data
+final check: THE canonical gate — node apps/desktop/out/tools/assert-commercial-drive.mjs (built by npm run build)
+             commercial posture (encrypted, no phone-home — downloads OK, update-checks + telemetry denied) + all weights VERIFIED
+             + runtime install markers match the pin AND record a matching binary hash (#234)
+             + exactly one app artifact + the launcher per declared platform (--platforms; #233)
+             + no user data
              + app skills provisioned (app-skills/) + user-skills/ empty (Skills S9)
              + root license/attribution artifacts present + non-empty (LIC-1)
 ```
 
 ```powershell
-# Windows (supply a pre-built, signed .exe; or --skip-package to assemble + sign yourself)
-.\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -AppArtifact .\apps\desktop\release\HilbertRaum-0.1.0-portable.exe
-.\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -DryRun        # print the plan
+# Windows (supply the pre-built, signed artifact(s); or -SkipPackage to assemble + sign yourself — NOT SELLABLE until the apps are on the drive)
+.\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -Platforms win-x64 -AppArtifact .\apps\desktop\release\HilbertRaum-0.1.0-portable.exe
+.\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -DryRun        # print the plan; the gate still runs and prints its verdict
+.\scripts\build-commercial-drive.ps1 -Target E:\ -VerifyOnly                    # only the gate, against the drive as it is
 ```
 ```bash
-# macOS / Linux
-scripts/build-commercial-drive.sh --target /Volumes/HILBERTRAUM --accept-license --app-artifact ./apps/desktop/release/HilbertRaum.app
+# macOS / Linux (--app-artifact repeats, one per platform in --platforms)
+scripts/build-commercial-drive.sh --target /Volumes/HILBERTRAUM --accept-license --platforms mac-arm64,linux-x64 \
+    --app-artifact ./apps/desktop/release/HilbertRaum-0.1.0-mac-arm64.app.zip --app-artifact ./apps/desktop/release/HilbertRaum-0.1.0.AppImage
 ```
+
+The builders **refuse to proceed** when a differently named `HilbertRaum-*` artifact (or an extracted
+`.app`) already sits at the drive root — delete the old build first (#233; the launchers must never
+find two). `--platforms` declares the platforms the kit is sold for (default all three: `win-x64`,
+`mac-arm64`, `linux-x64` — decision #229 on its default); the kit's label names them and the gate
+requires the artifact + launcher for each and none for any other. Every `fetch-runtime` run gets
+`--commercial` (#234): a placeholder hash is refused **before** any download, a hashless install marker
+is re-fetched instead of skipped, and the marker records the binary hash only after a verified archive.
 
 The final automated check asserts the **commercial posture** (`policy.json`: encryption required,
 plaintext off, models must verify, **no phone-home** — model downloads are a permitted user action,
 but update-checks + telemetry are denied) **and** that **every weight is VERIFIED** **and**
 that **no user data is present** (spec §12.2) **and** that **at least one trusted product skill is
-provisioned under `app-skills/` while `user-skills/` ships empty** (Skills S9) — the canonical gate is
-`assertCommercialDrive(...)`; the scripts add a native cross-check of the same invariants. **"Every
+provisioned under `app-skills/` while `user-skills/` ships empty** (Skills S9) **and** that **every
+declared platform has exactly one app artifact of the version being built plus its launcher** (#233)
+**and** that **every sidecar binary matches the SHA-256 its install marker records** (#234) — the
+canonical gate is `assertCommercialDrive(...)`, and since PR #271 both scripts **call it** (through the
+built `apps/desktop/out/tools/assert-commercial-drive.mjs`; `npm run build` produces it, `node` runs it):
+`SELLABLE` is printed only from its verdict, the scripts' own native checks are a pre-flight, not a
+second gate. **"Every
 weight VERIFIED" spans every shipped runtime family (2026-07-01):** the verifier + `verify-models.{ps1,sh}`
 gate on the canonical `(runtime → format)` support table (`models.ts` `SUPPORTED_RUNTIME_FORMATS`), so the
 bundled **ggml / whisper_cpp** transcriber verifies by SHA-256 like any GGUF — previously it was reported
@@ -476,8 +494,9 @@ packages), and `DRIVE-NOTICES.md` (GENERATED — runtime-binary + model-weight a
 from `model-manifests/**` and the pinned texts under `licenses/`, plus the GPLv3 source-availability
 statement; regenerate with `node scripts/generate-drive-notices.mjs`). `prepare-drive` copies them
 to the drive root in step 1; a missing or empty artifact fails the SELLABLE verdict
-(`assertCommercialDrive` + both scripts' native cross-check; freshness/coverage enforced by
-`tests/integration/drive-notices.test.ts`, list parity by `script-drift.test.ts`).
+(`assertCommercialDrive`, which both scripts call; freshness/coverage enforced by
+`tests/integration/drive-notices.test.ts`, list parity by `script-drift.test.ts`, the scripts' behaviour
+by `script-execution.test.ts`).
 **Remaining manual acceptance (R5/R7):** a
 real signed build + notarization + a USB-drive §17 demo on a fresh laptop with Wi-Fi off, and the
 second-laptop continuity check.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1802,6 +1802,15 @@ closed. (The long-tracked audit-2026-06-14 "engine-binary not re-hashed before s
    (`skip-legacy`, logged) so it still launches. Before init the verifier is inert, which keeps the
    headless unit suite — which constructs sidecars with fake paths and no marker — unaffected.
 
+4. **Commercial drives (#234, PR #271).** The drive posture is recorded once `policy.json` is loaded
+   (`setBinaryVerificationPosture({ commercial: isCommercialPolicy(policy), refuseHashlessMarkers })`
+   in `index.ts`, right after `loadPolicy`). At build time the sell gate (`assertCommercialDrive`,
+   which both builder scripts now call) refuses a hashless marker and `fetch-runtime --commercial`
+   re-fetches it, so a newly built sold drive never carries one. At spawn time a commercial drive
+   **can** refuse a hashless marker (`mismatch`) — that branch is wired and tested but shipped **off**
+   (`REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES`) until the owner rules on kits sold before this
+   change; a DIY drive keeps the `skip-legacy` tolerance either way (`known-limitations.md`).
+
 **Behaviour at each spawn seam (a `mismatch` only ever fires in a packaged build):**
 - **`LlamaServer.start()` (`sidecar.ts`)** — throws before allocating a port/child, so the start **ladder
   falls to the next rung / MockRuntime** with a content-free tamper warning to the local log. This one

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,9 @@ a portable drive. Your prompts, documents, embeddings, and chat history stay loc
 
 - **The HilbertRaum** — a USB/SSD drive that already has the app **and** the AI models on it.
   Everything is preloaded; you don't download or install anything.
-- **A laptop** running Windows (macOS and Linux also work). No admin rights needed.
+- **A laptop** running a system your kit is made for. The kit's label names them — Windows,
+  macOS (Apple silicon) or Linux; a kit can cover one or several, and it carries the app and the
+  launcher for each one it names. No admin rights needed.
 - **Enough memory (RAM):** about **8 GB** runs the standard model well; **16 GB or more** lets you
   use the larger, more capable model. The app checks your laptop and picks the best fit for you.
 - **A free USB port** — ideally **USB-3** (the blue port) for the best speed.
@@ -27,7 +29,8 @@ type or import ever leaves the drive.
 
 ### From a prepared drive
 1. Plug the drive into your laptop.
-2. Open the drive and **double-click the launcher** at the top level:
+2. Open the drive and **double-click the launcher** at the top level (you will find the one for
+   each system your kit is made for):
    - **Windows:** `Start HilbertRaum`
    - **macOS:** `Start HilbertRaum.command`
    - **Linux:** `start-hilbertraum.sh`

--- a/scripts/build-commercial-drive.ps1
+++ b/scripts/build-commercial-drive.ps1
@@ -12,15 +12,18 @@
     4. package + sign + notarize      # MANUAL (secrets never in the repo) -- see below
     5. copy launcher + portable app + user docs onto the drive root
     6. verify-models  -Generate       # capture real hashes -> config/checksums.json
-    7. final check: commercial posture + license reviews APPROVED (spec 13; not
-       overridable by -AcceptLicense) + verify-models -Strict (all weights VERIFIED)
-       + no user data -- exits 1 unless the drive is actually sellable
+    7. final check: the CANONICAL gate (assertCommercialDrive, run through the built
+       apps/desktop/out/tools/assert-commercial-drive.mjs -- needs `npm run build` and
+       node on PATH) after a native pre-flight -- exits 1 unless the drive is sellable.
+       SELLABLE is printed only from the canonical verdict (#233, #234). The gate also
+       requires the app artifact + launcher for every platform in -Platforms and a
+       recorded, matching hash for every sidecar binary.
 
   Mirrors apps/desktop/src/main/services/commercial-drive.ts (planCommercialDrive +
   assertCommercialDrive) -- that TS module is the CANONICAL, unit-tested reference. This
   script orchestrates the existing scripts; it does NOT re-implement them.
 
-  SIGNING IS MANUAL. The green gate does not sign. Supply a pre-built, signed portable app
+  SIGNING IS MANUAL. The green gate does not sign. Supply the pre-built, signed app(s)
   via -AppArtifact, or run with -SkipPackage to assemble everything else and sign/copy the
   app yourself. See docs/packaging.md for how a build machine supplies the certs/creds.
 
@@ -32,24 +35,38 @@
   drive needs a redistribution-permitting license whose review status is approved (spec 13).
 
 .PARAMETER AppArtifact
-  Path to a pre-built, SIGNED portable app to copy onto the drive (e.g. the
-  HilbertRaum-<version>-portable.exe produced + signed on the build machine).
+  Path(s) to the pre-built, SIGNED app artifact(s) to copy onto the drive -- one per
+  platform in -Platforms (e.g. HilbertRaum-<version>-portable.exe, the
+  HilbertRaum-<version>-mac-arm64.app.zip, HilbertRaum-<version>.AppImage). Comma-separated.
+  The script REFUSES to proceed when a differently named HilbertRaum-* artifact (or an
+  extracted .app) already sits at the drive root -- delete the old build first (#233).
+
+.PARAMETER Platforms
+  The platforms this kit is sold for (win-x64, mac-arm64, linux-x64; default all three).
+  The gate requires an app artifact + launcher for each -- and none for any other.
 
 .PARAMETER SkipPackage
   Skip the packaging/signing step entirely (assemble layout + assets + launchers + verify).
+  The drive is NOT SELLABLE until the app artifacts are on it.
+
+.PARAMETER VerifyOnly
+  Skip steps 1-6 and run only the final gate against the drive as it is.
 
 .PARAMETER DryRun
-  Print the plan and change nothing.
+  Print the plan, download and change nothing -- the final gate still runs and prints
+  its verdict for the target as it is.
 
 .EXAMPLE
-  .\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -AppArtifact .\release\HilbertRaum-0.1.0-portable.exe
+  .\scripts\build-commercial-drive.ps1 -Target E:\ -AcceptLicense -AppArtifact .\release\HilbertRaum-0.1.0-portable.exe -Platforms win-x64
 #>
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)] [string] $Target,
   [switch] $AcceptLicense,
-  [string] $AppArtifact,
+  [string[]] $AppArtifact,
+  [string[]] $Platforms = @('win-x64', 'mac-arm64', 'linux-x64'),
   [switch] $SkipPackage,
+  [switch] $VerifyOnly,
   [switch] $DryRun
 )
 
@@ -59,6 +76,38 @@ $RepoRoot = Split-Path -Parent $PSScriptRoot
 # Normalize -Target to a full path before passing it to the child scripts (audit M22).
 if (-not [System.IO.Path]::IsPathRooted($Target)) { $Target = Join-Path (Get-Location).Path $Target }
 $Target = [System.IO.Path]::GetFullPath($Target)
+
+# The platforms a kit can be sold for -- keep in sync with KIT_PLATFORMS in
+# apps/desktop/src/shared/runtime-sources.ts (script-drift test).
+$KitPlatforms = @(
+  'win-x64',
+  'mac-arm64',
+  'linux-x64'
+)
+foreach ($p in $Platforms) {
+  if ($KitPlatforms -notcontains $p) {
+    Write-Host "Unknown platform '$p' -- known: $($KitPlatforms -join ', ')" -ForegroundColor Red
+    exit 2
+  }
+}
+# The version the artifacts must carry = the repo's own (the release workflow names
+# HilbertRaum-<version>-... from it).
+$AppVersion = (Get-Content (Join-Path $RepoRoot 'package.json') -Raw | ConvertFrom-Json).version
+
+# Refuse to proceed when another app artifact already sits at the drive root (#233): the
+# copy in step 4 overwrites only the same basename, so an older build would stay beside
+# the new one and the launchers would find two. Delete it first, on purpose.
+if ($AppArtifact -and -not $VerifyOnly) {
+  $incoming = @($AppArtifact | ForEach-Object { Split-Path -Leaf $_ })
+  $prior = @(Get-ChildItem -Path $Target -Force -ErrorAction SilentlyContinue |
+    Where-Object { ($_.Name -like 'HilbertRaum-*' -or ($_.PSIsContainer -and $_.Name -like '*.app')) -and ($incoming -notcontains $_.Name) })
+  if ($prior.Count -gt 0) {
+    Write-Host 'Refusing to proceed: another app artifact already sits at the drive root:' -ForegroundColor Red
+    foreach ($p in $prior) { Write-Host "  - $($p.Name)" -ForegroundColor Red }
+    Write-Host '  Delete it first (a drive must carry exactly one app build), then re-run.' -ForegroundColor Red
+    exit 1
+  }
+}
 
 function Step([int]$n, [string]$msg) { Write-Host "`n[$n] $msg" -ForegroundColor Cyan }
 # Invoke a sibling script with NAMED parameters. Hashtable splatting (not array splatting)
@@ -73,8 +122,11 @@ function Run([string]$script, [hashtable]$params) {
 }
 
 Write-Host "Build a COMMERCIAL (sellable) drive at: $Target" -ForegroundColor Green
-if ($DryRun) { Write-Host '(dry run -- nothing will be changed)' -ForegroundColor Yellow }
+Write-Host "  platforms: $($Platforms -join ', ') | app version: $AppVersion"
+if ($DryRun) { Write-Host '(dry run -- nothing will be changed; the final gate still runs)' -ForegroundColor Yellow }
+if ($VerifyOnly) { Write-Host '(verify only -- steps 1-6 skipped)' -ForegroundColor Yellow }
 
+if (-not $VerifyOnly) {
 # --- 1. Lay out the drive with the COMMERCIAL policy --------------------------------
 Step 1 'Lay out the drive (commercial policy: encryption required, no phone-home)'
 $prep = @{ Target = $Target; Force = $true }
@@ -95,12 +147,15 @@ Run 'fetch-models.ps1' $models
 # on GPU-less machines) into runtime/llama.cpp/<os>/ plus the pure-CPU safety net into
 # runtime/llama.cpp/<os>/cpu/ (the app's fallback ladder rung 3). mac ships Metal only.
 Step 3 'Download + verify the llama.cpp sidecar builds (every shipped OS)'
+# -Commercial (#234): a placeholder archive hash is refused before any download, a
+# hashless (legacy) install marker is re-fetched instead of skipped, and the marker
+# records the binary hash only after a verified archive.
 foreach ($osName in @('win', 'mac', 'linux')) {
-  $runtime = @{ Target = $Target; Os = $osName }
+  $runtime = @{ Target = $Target; Os = $osName; Commercial = $true }
   if ($DryRun) { $runtime.DryRun = $true }
   Run 'fetch-runtime.ps1' $runtime
   if ($osName -ne 'mac') {
-    $cpuNet = @{ Target = $Target; Os = $osName; Backend = 'cpu' }
+    $cpuNet = @{ Target = $Target; Os = $osName; Backend = 'cpu'; Commercial = $true }
     if ($DryRun) { $cpuNet.DryRun = $true }
     Run 'fetch-runtime.ps1' $cpuNet
   }
@@ -109,27 +164,29 @@ foreach ($osName in @('win', 'mac', 'linux')) {
 # prebuilt WINDOWS build only (R-W1); mac/linux whisper builds are a documented manual
 # source-build step (docs/packaging.md) -- audio import degrades to a friendly per-file
 # failure on a drive without one.
-$whisper = @{ Target = $Target; Os = 'win'; Family = 'whisper_cpp' }
+$whisper = @{ Target = $Target; Os = 'win'; Family = 'whisper_cpp'; Commercial = $true }
 if ($DryRun) { $whisper.DryRun = $true }
 Run 'fetch-runtime.ps1' $whisper
 # OCR language files (Phase 38, D32): the ocr/ asset class -- plain sha256-verified
 # traineddata files, OS-independent (one run covers every shipped OS).
-$ocrAssets = @{ Target = $Target; Family = 'ocr' }
+$ocrAssets = @{ Target = $Target; Family = 'ocr'; Commercial = $true }
 if ($DryRun) { $ocrAssets.DryRun = $true }
 Run 'fetch-runtime.ps1' $ocrAssets
 
 # --- 4. Package + sign + notarize (MANUAL) -----------------------------------------
 Step 4 'Package + sign the portable app (MANUAL -- secrets never in the repo)'
 if ($SkipPackage) {
-  Write-Host '  -SkipPackage set: skipping packaging. Sign + copy the app yourself.' -ForegroundColor Yellow
+  Write-Host '  -SkipPackage set: skipping packaging. Sign + copy the app yourself (NOT SELLABLE until then).' -ForegroundColor Yellow
 } elseif ($AppArtifact) {
-  if (-not (Test-Path $AppArtifact)) { Write-Error "AppArtifact not found: $AppArtifact"; exit 1 }
-  $dst = Join-Path $Target (Split-Path -Leaf $AppArtifact)
-  if ($DryRun) { Write-Host "  copy $AppArtifact -> $dst" }
-  else { Copy-Item -Path $AppArtifact -Destination $dst -Force; Write-Host "  copied signed app -> $dst" }
+  foreach ($artifact in $AppArtifact) {
+    if (-not (Test-Path $artifact)) { Write-Host "AppArtifact not found: $artifact" -ForegroundColor Red; exit 1 }
+    $dst = Join-Path $Target (Split-Path -Leaf $artifact)
+    if ($DryRun) { Write-Host "  copy $artifact -> $dst" }
+    else { Copy-Item -Path $artifact -Destination $dst -Recurse -Force; Write-Host "  copied signed app -> $dst" }
+  }
 } else {
-  Write-Host '  No -AppArtifact supplied. Build + sign the portable .exe, then re-run with' -ForegroundColor Yellow
-  Write-Host '  -AppArtifact <path>, or copy it onto the drive manually. See docs/packaging.md.' -ForegroundColor Yellow
+  Write-Host '  No -AppArtifact supplied. Build + sign the app for every platform in -Platforms, then' -ForegroundColor Yellow
+  Write-Host '  re-run with -AppArtifact <paths>, or copy them onto the drive manually. See docs/packaging.md.' -ForegroundColor Yellow
 }
 
 # --- 5. Copy the launcher + user docs onto the drive root --------------------------
@@ -154,11 +211,11 @@ if ($DryRun) {
 } else {
   Run 'verify-models.ps1' @{ Target = $Target; Generate = $true }
 }
+} # end of steps 1-6 (skipped by -VerifyOnly)
 
 # --- 7. Final check: is this drive sellable? ---------------------------------------
-Step 7 'Final check: commercial posture + weights VERIFIED + no user data'
-Write-Host '  The CANONICAL gate is assertCommercialDrive() in commercial-drive.ts (unit-tested).'
-Write-Host '  Native cross-check of the key invariants:'
+Step 7 'Final check: native pre-flight, then the canonical gate (assertCommercialDrive)'
+Write-Host '  Native pre-flight of the key invariants (the verdict below comes from the canonical gate):'
 $policyPath = Join-Path $Target 'config/policy.json'
 $problems = @()
 if (Test-Path $policyPath) {
@@ -330,14 +387,27 @@ if (-not $DryRun) {
   & (Join-Path $PSScriptRoot 'verify-models.ps1') -Target $Target -Strict
   if ($LASTEXITCODE -ne 0) { $problems += 'weights: not every weight is VERIFIED (strict verify failed)' }
 }
-if ($DryRun) {
-  Write-Host '  (dry run: posture + weight checks skipped)'
-} elseif ($problems.Count -gt 0) {
+if ($DryRun) { Write-Host '  (dry run: weight verification skipped; the canonical gate still runs)' }
+# Canonical gate (#233, #234): the verdict is assertCommercialDrive()'s, run through the
+# built tool -- SELLABLE is printed only when it passes AND the pre-flight found nothing.
+# Reads only the drive (no network). Needs `npm run build` and node on PATH.
+$gateTool = Join-Path $RepoRoot 'apps/desktop/out/tools/assert-commercial-drive.mjs'
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+if (-not (Test-Path $gateTool)) {
+  $problems += "canonical gate not built: $gateTool missing (run npm run build)"
+} elseif (-not $nodeCmd) {
+  $problems += 'canonical gate needs node on PATH'
+} else {
+  Write-Host '  Canonical gate:'
+  $global:LASTEXITCODE = 0
+  & $nodeCmd.Source $gateTool --target $Target --platforms ($Platforms -join ',') --app-version $AppVersion
+  if ($LASTEXITCODE -ne 0) { $problems += "canonical gate: not sellable (exit $LASTEXITCODE, see above)" }
+}
+if ($problems.Count -gt 0) {
   Write-Host '  NOT SELLABLE:' -ForegroundColor Red
   foreach ($p in $problems) { Write-Host "    - $p" -ForegroundColor Red }
   exit 1
-} else {
-  Write-Host '  SELLABLE: posture OK (encrypted, no phone-home, no user data) + all weights VERIFIED.' -ForegroundColor Green
 }
+Write-Host "  SELLABLE: canonical gate passed for $($Platforms -join ', ') at $AppVersion." -ForegroundColor Green
 
 Write-Host "`nDone. Test the drive on a clean laptop with Wi-Fi OFF (spec section 17 demo)." -ForegroundColor Green

--- a/scripts/build-commercial-drive.ps1
+++ b/scripts/build-commercial-drive.ps1
@@ -84,22 +84,25 @@ $KitPlatforms = @(
   'mac-arm64',
   'linux-x64'
 )
+# Accept both `-Platforms win-x64,mac-arm64` (array binding) and a quoted comma list.
+$Platforms = @($Platforms | ForEach-Object { $_ -split ',' } | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+if ($Platforms.Count -eq 0) { Write-Host '-Platforms must name at least one platform' -ForegroundColor Red; exit 2 }
 foreach ($p in $Platforms) {
   if ($KitPlatforms -notcontains $p) {
     Write-Host "Unknown platform '$p' -- known: $($KitPlatforms -join ', ')" -ForegroundColor Red
     exit 2
   }
 }
-# The version the artifacts must carry = the repo's own (the release workflow names
-# HilbertRaum-<version>-... from it).
-$AppVersion = (Get-Content (Join-Path $RepoRoot 'package.json') -Raw | ConvertFrom-Json).version
+# The version the artifacts must carry = the desktop package's (electron-builder and the
+# release workflow name HilbertRaum-<version>-... from apps/desktop/package.json).
+$AppVersion = (Get-Content (Join-Path $RepoRoot 'apps/desktop/package.json') -Raw | ConvertFrom-Json).version
 
 # Refuse to proceed when another app artifact already sits at the drive root (#233): the
 # copy in step 4 overwrites only the same basename, so an older build would stay beside
 # the new one and the launchers would find two. Delete it first, on purpose.
 if ($AppArtifact -and -not $VerifyOnly) {
   $incoming = @($AppArtifact | ForEach-Object { Split-Path -Leaf $_ })
-  $prior = @(Get-ChildItem -Path $Target -Force -ErrorAction SilentlyContinue |
+  $prior = @(Get-ChildItem -LiteralPath $Target -Force -ErrorAction SilentlyContinue |
     Where-Object { ($_.Name -like 'HilbertRaum-*' -or ($_.PSIsContainer -and $_.Name -like '*.app')) -and ($incoming -notcontains $_.Name) })
   if ($prior.Count -gt 0) {
     Write-Host 'Refusing to proceed: another app artifact already sits at the drive root:' -ForegroundColor Red
@@ -400,7 +403,12 @@ if (-not (Test-Path $gateTool)) {
 } else {
   Write-Host '  Canonical gate:'
   $global:LASTEXITCODE = 0
-  & $nodeCmd.Source $gateTool --target $Target --platforms ($Platforms -join ',') --app-version $AppVersion
+  # Native-arg quoting (PS 5.1): a trailing backslash before the closing quote of a
+  # space-containing path escapes the quote -- hand node the path without it (a bare
+  # drive root like E:\ keeps its backslash).
+  $gateTarget = $Target.TrimEnd('\')
+  if ($gateTarget -match '^[A-Za-z]:$') { $gateTarget += '\' }
+  & $nodeCmd.Source $gateTool --target $gateTarget --platforms ($Platforms -join ',') --app-version $AppVersion
   if ($LASTEXITCODE -ne 0) { $problems += "canonical gate: not sellable (exit $LASTEXITCODE, see above)" }
 }
 if ($problems.Count -gt 0) {

--- a/scripts/build-commercial-drive.sh
+++ b/scripts/build-commercial-drive.sh
@@ -74,6 +74,7 @@ KIT_PLATFORMS=(
   mac-arm64
   linux-x64
 )
+[[ -n "$PLATFORMS" ]] || { echo "--platforms must name at least one platform" >&2; exit 2; }
 IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
 for p in "${PLATFORM_LIST[@]}"; do
   known=0
@@ -83,9 +84,9 @@ for p in "${PLATFORM_LIST[@]}"; do
     exit 2
   fi
 done
-# The version the artifacts must carry = the repo's own (the release workflow names
-# HilbertRaum-<version>-... from it).
-APP_VERSION="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO_ROOT/package.json" | head -n1)"
+# The version the artifacts must carry = the desktop package's (electron-builder and the
+# release workflow name HilbertRaum-<version>-... from apps/desktop/package.json).
+APP_VERSION="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO_ROOT/apps/desktop/package.json" | head -n1)"
 
 # Refuse to proceed when another app artifact already sits at the drive root (#233): the
 # copy in step 4 overwrites only the same basename, so an older build would stay beside

--- a/scripts/build-commercial-drive.sh
+++ b/scripts/build-commercial-drive.sh
@@ -8,26 +8,38 @@
 #   4. package + sign + notarize         # MANUAL (secrets never in the repo)
 #   5. copy launcher + portable app + user docs onto the drive root
 #   6. verify-models  --generate         # capture real hashes -> config/checksums.json
-#   7. final check: commercial posture + license reviews APPROVED (spec 13; not
-#      overridable by --accept-license) + verify-models --strict (all weights VERIFIED)
-#      + no user data -- exits 1 unless the drive is actually sellable
+#   7. final check: the CANONICAL gate (assertCommercialDrive, run through the built
+#      apps/desktop/out/tools/assert-commercial-drive.mjs -- needs `npm run build` and
+#      node on PATH) after a native pre-flight -- exits 1 unless the drive is sellable.
+#      SELLABLE is printed only from the canonical verdict (#233, #234). The gate also
+#      requires the app artifact + launcher for every platform in --platforms and a
+#      recorded, matching hash for every sidecar binary.
 #
 # Mirrors apps/desktop/src/main/services/commercial-drive.ts (planCommercialDrive +
 # assertCommercialDrive) -- that TS module is the CANONICAL, unit-tested reference. This
 # script ORCHESTRATES the existing scripts; it does not re-implement them.
 #
-# SIGNING IS MANUAL. The green gate does not sign. Supply a pre-built, signed app via
-# --app-artifact, or use --skip-package. See docs/packaging.md.
+# SIGNING IS MANUAL. The green gate does not sign. Supply the pre-built, signed app(s)
+# via --app-artifact (repeatable, one per platform), or use --skip-package (the drive is
+# NOT SELLABLE until the apps are on it). The script REFUSES to proceed when a differently
+# named HilbertRaum-* artifact (or an extracted .app) already sits at the drive root --
+# delete the old build first (#233). See docs/packaging.md.
 #
 # Usage:
 #   scripts/build-commercial-drive.sh --target /Volumes/HILBERTRAUM --accept-license \
-#       [--app-artifact ./release/HilbertRaum-0.1.0.AppImage] [--skip-package] [--dry-run]
+#       [--app-artifact ./release/HilbertRaum-0.1.0.AppImage]... [--platforms win-x64,mac-arm64,linux-x64] \
+#       [--skip-package] [--verify-only] [--dry-run]
+#   --platforms   the platforms this kit is sold for (default all three)
+#   --verify-only skip steps 1-6, run only the final gate against the drive as it is
+#   --dry-run     download and change nothing; the final gate still runs and prints its verdict
 set -euo pipefail
 
 TARGET=""
 ACCEPT_LICENSE=0
-APP_ARTIFACT=""
+APP_ARTIFACTS=()
+PLATFORMS="win-x64,mac-arm64,linux-x64"
 SKIP_PACKAGE=0
+VERIFY_ONLY=0
 DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
@@ -35,9 +47,12 @@ while [[ $# -gt 0 ]]; do
     --target) TARGET="${2:-}"; shift 2 ;;
     --target=*) TARGET="${1#*=}"; shift ;;
     --accept-license) ACCEPT_LICENSE=1; shift ;;
-    --app-artifact) APP_ARTIFACT="${2:-}"; shift 2 ;;
-    --app-artifact=*) APP_ARTIFACT="${1#*=}"; shift ;;
+    --app-artifact) APP_ARTIFACTS+=("${2:-}"); shift 2 ;;
+    --app-artifact=*) APP_ARTIFACTS+=("${1#*=}"); shift ;;
+    --platforms) PLATFORMS="${2:-}"; shift 2 ;;
+    --platforms=*) PLATFORMS="${1#*=}"; shift ;;
     --skip-package) SKIP_PACKAGE=1; shift ;;
+    --verify-only) VERIFY_ONLY=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -52,11 +67,55 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# The platforms a kit can be sold for -- keep in sync with KIT_PLATFORMS in
+# apps/desktop/src/shared/runtime-sources.ts (script-drift test).
+KIT_PLATFORMS=(
+  win-x64
+  mac-arm64
+  linux-x64
+)
+IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+for p in "${PLATFORM_LIST[@]}"; do
+  known=0
+  for k in "${KIT_PLATFORMS[@]}"; do [[ "$p" == "$k" ]] && known=1; done
+  if [[ $known -eq 0 ]]; then
+    echo "Unknown platform '$p' -- known: ${KIT_PLATFORMS[*]}" >&2
+    exit 2
+  fi
+done
+# The version the artifacts must carry = the repo's own (the release workflow names
+# HilbertRaum-<version>-... from it).
+APP_VERSION="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO_ROOT/package.json" | head -n1)"
+
+# Refuse to proceed when another app artifact already sits at the drive root (#233): the
+# copy in step 4 overwrites only the same basename, so an older build would stay beside
+# the new one and the launchers would find two. Delete it first, on purpose.
+if [[ ${#APP_ARTIFACTS[@]} -gt 0 && $VERIFY_ONLY -eq 0 ]]; then
+  PRIOR=()
+  shopt -s nullglob
+  for existing in "$TARGET"/HilbertRaum-* "$TARGET"/*.app; do
+    name="$(basename "$existing")"
+    incoming=0
+    for a in "${APP_ARTIFACTS[@]}"; do [[ "$(basename "$a")" == "$name" ]] && incoming=1; done
+    [[ $incoming -eq 0 ]] && PRIOR+=("$name")
+  done
+  shopt -u nullglob
+  if [[ ${#PRIOR[@]} -gt 0 ]]; then
+    echo "Refusing to proceed: another app artifact already sits at the drive root:" >&2
+    for p in "${PRIOR[@]}"; do echo "  - $p" >&2; done
+    echo "  Delete it first (a drive must carry exactly one app build), then re-run." >&2
+    exit 1
+  fi
+fi
+
 step() { echo; echo "[$1] $2"; }
 
 echo "Build a COMMERCIAL (sellable) drive at: $TARGET"
-[[ $DRY_RUN -eq 1 ]] && echo "(dry run -- nothing will be changed)"
+echo "  platforms: $PLATFORMS | app version: $APP_VERSION"
+[[ $DRY_RUN -eq 1 ]] && echo "(dry run -- nothing will be changed; the final gate still runs)"
+[[ $VERIFY_ONLY -eq 1 ]] && echo "(verify only -- steps 1-6 skipped)"
 
+if [[ $VERIFY_ONLY -eq 0 ]]; then
 # --- 1. Lay out the drive with the COMMERCIAL policy --------------------------------
 step 1 "Lay out the drive (commercial policy: encryption required, no phone-home)"
 PREP=(--target "$TARGET" --force)
@@ -77,12 +136,15 @@ bash "$SCRIPT_DIR/fetch-models.sh" "${MODELS[@]}"
 # on GPU-less machines) into runtime/llama.cpp/<os>/ plus the pure-CPU safety net into
 # runtime/llama.cpp/<os>/cpu/ (the app's fallback ladder rung 3). mac ships Metal only.
 step 3 "Download + verify the llama.cpp sidecar builds (every shipped OS)"
+# --commercial (#234): a placeholder archive hash is refused before any download, a
+# hashless (legacy) install marker is re-fetched instead of skipped, and the marker
+# records the binary hash only after a verified archive.
 for os_name in win mac linux; do
-  RUNTIME=(--target "$TARGET" --os "$os_name")
+  RUNTIME=(--target "$TARGET" --os "$os_name" --commercial)
   [[ $DRY_RUN -eq 1 ]] && RUNTIME+=(--dry-run)
   bash "$SCRIPT_DIR/fetch-runtime.sh" "${RUNTIME[@]}"
   if [[ "$os_name" != "mac" ]]; then
-    CPU_NET=(--target "$TARGET" --os "$os_name" --backend cpu)
+    CPU_NET=(--target "$TARGET" --os "$os_name" --backend cpu --commercial)
     [[ $DRY_RUN -eq 1 ]] && CPU_NET+=(--dry-run)
     bash "$SCRIPT_DIR/fetch-runtime.sh" "${CPU_NET[@]}"
   fi
@@ -91,27 +153,29 @@ done
 # prebuilt WINDOWS build only (R-W1); mac/linux whisper builds are a documented manual
 # source-build step (docs/packaging.md) — audio import degrades to a friendly per-file
 # failure on a drive without one.
-WHISPER=(--target "$TARGET" --os win --family whisper_cpp)
+WHISPER=(--target "$TARGET" --os win --family whisper_cpp --commercial)
 [[ $DRY_RUN -eq 1 ]] && WHISPER+=(--dry-run)
 bash "$SCRIPT_DIR/fetch-runtime.sh" "${WHISPER[@]}"
 # OCR language files (Phase 38, D32): the ocr/ asset class — plain sha256-verified
 # traineddata files, OS-independent (one run covers every shipped OS).
-OCR_ASSETS=(--target "$TARGET" --family ocr)
+OCR_ASSETS=(--target "$TARGET" --family ocr --commercial)
 [[ $DRY_RUN -eq 1 ]] && OCR_ASSETS+=(--dry-run)
 bash "$SCRIPT_DIR/fetch-runtime.sh" "${OCR_ASSETS[@]}"
 
 # --- 4. Package + sign + notarize (MANUAL) -----------------------------------------
 step 4 "Package + sign the app (MANUAL -- secrets never in the repo)"
 if [[ $SKIP_PACKAGE -eq 1 ]]; then
-  echo "  --skip-package set: skipping packaging. Sign + copy the app yourself."
-elif [[ -n "$APP_ARTIFACT" ]]; then
-  if [[ ! -e "$APP_ARTIFACT" ]]; then echo "AppArtifact not found: $APP_ARTIFACT" >&2; exit 1; fi
-  DST="$TARGET/$(basename "$APP_ARTIFACT")"
-  if [[ $DRY_RUN -eq 1 ]]; then echo "  copy $APP_ARTIFACT -> $DST"
-  else cp -R "$APP_ARTIFACT" "$DST"; echo "  copied signed app -> $DST"; fi
+  echo "  --skip-package set: skipping packaging. Sign + copy the app yourself (NOT SELLABLE until then)."
+elif [[ ${#APP_ARTIFACTS[@]} -gt 0 ]]; then
+  for artifact in "${APP_ARTIFACTS[@]}"; do
+    if [[ ! -e "$artifact" ]]; then echo "AppArtifact not found: $artifact" >&2; exit 1; fi
+    DST="$TARGET/$(basename "$artifact")"
+    if [[ $DRY_RUN -eq 1 ]]; then echo "  copy $artifact -> $DST"
+    else cp -R "$artifact" "$DST"; echo "  copied signed app -> $DST"; fi
+  done
 else
-  echo "  No --app-artifact supplied. Build + sign the app, then re-run with"
-  echo "  --app-artifact <path>, or copy it onto the drive manually. See docs/packaging.md."
+  echo "  No --app-artifact supplied. Build + sign the app for every platform in --platforms, then"
+  echo "  re-run with --app-artifact <path>..., or copy them onto the drive manually. See docs/packaging.md."
 fi
 
 # --- 5. Copy the launcher + user docs onto the drive root --------------------------
@@ -136,11 +200,11 @@ if [[ $DRY_RUN -eq 1 ]]; then
 else
   bash "$SCRIPT_DIR/verify-models.sh" --target "$TARGET" --generate
 fi
+fi # end of steps 1-6 (skipped by --verify-only)
 
 # --- 7. Final check: is this drive sellable? ---------------------------------------
-step 7 "Final check: commercial posture + weights VERIFIED + no user data"
-echo "  The CANONICAL gate is assertCommercialDrive() in commercial-drive.ts (unit-tested)."
-echo "  Native cross-check of the key invariants:"
+step 7 "Final check: native pre-flight, then the canonical gate (assertCommercialDrive)"
+echo "  Native pre-flight of the key invariants (the verdict below comes from the canonical gate):"
 # NOTE: policy.json is MACHINE-GENERATED by prepare-drive (the greps below tolerate
 # arbitrary whitespace after the colon, but not minified/hand-edited JSON — M24).
 PROBLEMS=()
@@ -313,15 +377,27 @@ if [[ $DRY_RUN -eq 0 ]]; then
     PROBLEMS+=("weights: not every weight is VERIFIED (strict verify failed)")
   fi
 fi
-if [[ $DRY_RUN -eq 1 ]]; then
-  echo "  (dry run: posture + weight checks skipped)"
-elif [[ ${#PROBLEMS[@]} -gt 0 ]]; then
+[[ $DRY_RUN -eq 1 ]] && echo "  (dry run: weight verification skipped; the canonical gate still runs)"
+# Canonical gate (#233, #234): the verdict is assertCommercialDrive()'s, run through the
+# built tool — SELLABLE is printed only when it passes AND the pre-flight found nothing.
+# Reads only the drive (no network). Needs `npm run build` and node on PATH.
+GATE_TOOL="$REPO_ROOT/apps/desktop/out/tools/assert-commercial-drive.mjs"
+if [[ ! -f "$GATE_TOOL" ]]; then
+  PROBLEMS+=("canonical gate not built: $GATE_TOOL missing (run npm run build)")
+elif ! command -v node >/dev/null 2>&1; then
+  PROBLEMS+=("canonical gate needs node on PATH")
+else
+  echo "  Canonical gate:"
+  GATE_EXIT=0
+  node "$GATE_TOOL" --target "$TARGET" --platforms "$PLATFORMS" --app-version "$APP_VERSION" || GATE_EXIT=$?
+  [[ $GATE_EXIT -ne 0 ]] && PROBLEMS+=("canonical gate: not sellable (exit $GATE_EXIT, see above)")
+fi
+if [[ ${#PROBLEMS[@]} -gt 0 ]]; then
   echo "  NOT SELLABLE:"
   for p in "${PROBLEMS[@]}"; do echo "    - $p"; done
   exit 1
-else
-  echo "  SELLABLE: posture OK (encrypted, no phone-home, no user data) + all weights VERIFIED."
 fi
+echo "  SELLABLE: canonical gate passed for $PLATFORMS at $APP_VERSION."
 
 echo
 echo "Done. Test the drive on a clean laptop with Wi-Fi OFF (spec section 17 demo)."

--- a/scripts/fetch-runtime.ps1
+++ b/scripts/fetch-runtime.ps1
@@ -19,10 +19,15 @@
   pure-CPU safety net into <os>/cpu/.
 
   Verify-before-trust: a real-hash MISMATCH deletes the zip and exits non-zero. A
-  placeholder zip hash extracts but reports UNVERIFIED. Idempotent via the MARKER, not
+  placeholder zip hash extracts but reports UNVERIFIED and the marker then records NO
+  binary hash (the sell gate refuses such an install). Idempotent via the MARKER, not
   mere binary presence: a present llama-server[.exe] whose .hilbertraum-runtime.json matches the
   selected version + backend is skipped; a missing/stale marker re-fetches (so upgrading
   a CPU-era drive to the Vulkan default actually replaces the build).
+
+  -Commercial (drive builders, #234): a placeholder hash is REFUSED before any download
+  (exit 1, nothing extracted, no marker) and a hashless (legacy) marker is re-fetched
+  instead of skipped, so a sold drive never carries an unverifiable sidecar.
 
 .PARAMETER Target
   The prepared drive root (e.g. E:\). Required.
@@ -45,14 +50,18 @@
   sha256-verified downloads into ocr/ -- no extraction, no marker; idempotency IS the
   hash).
 
+.PARAMETER Commercial
+  Drive-builder mode: refuse a placeholder hash before any download, re-fetch a hashless
+  (legacy) install marker. build-commercial-drive passes this on every run.
+
 .PARAMETER DryRun
-  Print the plan and download nothing.
+  Print the plan and download nothing (a -Commercial placeholder refusal still applies).
 
 .EXAMPLE
   .\scripts\fetch-runtime.ps1 -Target E:\
   .\scripts\fetch-runtime.ps1 -Target E:\ -Os linux -Arch x64 -DryRun
   .\scripts\fetch-runtime.ps1 -Target E:\ -Family whisper_cpp
-  .\scripts\fetch-runtime.ps1 -Target E:\ -Family ocr
+  .\scripts\fetch-runtime.ps1 -Target E:\ -Family ocr -Commercial
 #>
 [CmdletBinding()]
 param(
@@ -61,6 +70,7 @@ param(
   [string] $Arch,
   [string] $Backend,
   [ValidateSet('llama_cpp', 'whisper_cpp', 'ocr')] [string] $Family = 'llama_cpp',
+  [switch] $Commercial,
   [switch] $DryRun
 )
 
@@ -173,6 +183,14 @@ if ($Family -eq 'ocr') {
   }
   Write-Host "Fetch OCR language files -> $Target (data $ocrVersion)" -ForegroundColor Cyan
   $IsRealShaOcr = { param($h) $h -match '^[a-f0-9]{64}$' }
+  # -Commercial: every file must be verifiable BEFORE the first download (#234).
+  if ($Commercial) {
+    $placeholders = @($files | Where-Object { $_.sha256 -and -not (& $IsRealShaOcr ([string]$_.sha256).ToLower()) } | ForEach-Object { $_.lang })
+    if ($placeholders.Count -gt 0) {
+      Write-Host ("  commercial: placeholder sha256 for ocr file(s) {0} -- refusing to fetch (nothing downloaded)" -f ($placeholders -join ', ')) -ForegroundColor Red
+      exit 1
+    }
+  }
   $failed = 0
   foreach ($f in $files) {
     foreach ($required in @('url', 'sha256', 'dest')) {
@@ -322,25 +340,45 @@ Write-Host "Fetch runtime -> $Target" -ForegroundColor Cyan
 Write-Host ("  build: {0}/{1} {2} @ {3}" -f $build.os, $build.arch, $build.backend, $version)
 Write-Host ("  url:   {0}" -f $build.url)
 Write-Host ("  into:  {0}" -f $extractTo)
-if ($DryRun) { Write-Host '(dry run -- nothing will be downloaded)' -ForegroundColor Yellow; exit 0 }
 
 # Idempotent skip is MARKER-based (Phase 14, mirrors assets.ts runtimeInstallCurrent):
 # "binary exists" alone would silently keep a CPU-era build in place after the default
-# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend.
+# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend
+# -- and, under -Commercial, records the binary's hash (a hashless legacy marker is
+# re-fetched, #234).
 if (Test-Path $binaryPath) {
   $skip = $false
+  $why = 'install marker is missing or differs'
   if (Test-Path $markerPath) {
     try {
       $marker = Get-Content -Path $markerPath -Raw | ConvertFrom-Json
-      if ($marker.version -eq $version -and $marker.backend -eq $build.backend) { $skip = $true }
+      if ($marker.version -eq $version -and $marker.backend -eq $build.backend) {
+        $skip = $true
+        if ($Commercial) {
+          $recorded = $null
+          if ($marker.binaries) { $recorded = $marker.binaries.PSObject.Properties[$binaryName].Value }
+          if (-not $recorded -or -not (& $IsRealSha ([string]$recorded).ToLower())) {
+            $skip = $false
+            $why = 'install marker records no binary hash (legacy) -- commercial mode'
+          }
+        }
+      }
     } catch { $skip = $false }
   }
   if ($skip) {
     Write-Host "  skip ($binaryName already installed: $version/$($build.backend) per .hilbertraum-runtime.json)" -ForegroundColor Green
     exit 0
   }
-  Write-Host "  $binaryName present but install marker is missing or differs -- re-fetching $version/$($build.backend)" -ForegroundColor Yellow
+  Write-Host "  $binaryName present but $why -- re-fetching $version/$($build.backend)" -ForegroundColor Yellow
 }
+
+# -Commercial: refuse a placeholder hash BEFORE any download (#234) -- an unverifiable
+# archive must never be extracted onto a sold drive, dry run or not.
+if ($Commercial -and -not (& $IsRealSha $sha)) {
+  Write-Host ("  commercial: placeholder sha256 for {0}/{1} {2} @ {3} -- refusing to fetch (nothing downloaded, no marker written)" -f $build.os, $build.arch, $build.backend, $version) -ForegroundColor Red
+  exit 1
+}
+if ($DryRun) { Write-Host '(dry run -- nothing will be downloaded)' -ForegroundColor Yellow; exit 0 }
 
 New-Item -ItemType Directory -Force -Path $extractTo | Out-Null
 # Archive name from the URL basename so a .tar.gz (the macOS/Linux release format) is
@@ -361,6 +399,7 @@ if ($Curl) {
   Invoke-WebRequest -Uri $build.url -OutFile $archive -UseBasicParsing
 }
 
+$archiveVerified = $false
 if (& $IsRealSha $sha) {
   $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLower()
   if ($actual -ne $sha) {
@@ -369,6 +408,7 @@ if (& $IsRealSha $sha) {
     exit 1
   }
   Write-Host "  archive VERIFIED" -ForegroundColor Green
+  $archiveVerified = $true
 } else {
   Write-Host "  archive UNVERIFIED (placeholder hash) -- verify after a real release bump" -ForegroundColor Yellow
 }
@@ -456,9 +496,17 @@ if (Test-Path $binaryPath) {
   # `binaries` records the extracted binary's own SHA-256 so the app can re-hash it
   # immediately before spawn (vuln-scan B / binary-verifier.ts). The key is the binary's
   # name relative to the extract dir (here it sits at the root after the flatten above).
+  # Only a VERIFIED archive earns that hash (#234): an unverified install must not mint
+  # a marker the sell gate and the spawn verifier would trust.
   $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-  $binSha = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash.ToLower()
-  $markerJson = '{"version":"' + $version + '","backend":"' + $build.backend + '","os":"' + $build.os + '","arch":"' + $build.arch + '","binaries":{"' + $binaryName + '":"' + $binSha + '"}}'
+  $markerHead = '{"version":"' + $version + '","backend":"' + $build.backend + '","os":"' + $build.os + '","arch":"' + $build.arch + '"'
+  if ($archiveVerified) {
+    $binSha = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash.ToLower()
+    $markerJson = $markerHead + ',"binaries":{"' + $binaryName + '":"' + $binSha + '"}}'
+  } else {
+    $markerJson = $markerHead + '}'
+    Write-Host "  marker written WITHOUT a binary hash (archive unverified) -- the sell gate refuses this install" -ForegroundColor Yellow
+  }
   [System.IO.File]::WriteAllText($markerPath, $markerJson, $utf8NoBom)
   Write-Host "  extracted $binaryName (+ .hilbertraum-runtime.json install marker)" -ForegroundColor Green
   if ($build.os -ne 'win') {

--- a/scripts/fetch-runtime.ps1
+++ b/scripts/fetch-runtime.ps1
@@ -494,7 +494,7 @@ if (Test-Path $binaryPath) {
   # Record exactly which build is installed (UTF-8 without BOM -- PS 5.1 Set-Content
   # would prepend one and break Node's JSON.parse). Mirrors assets.ts writeRuntimeMarker.
   # `binaries` records the extracted binary's own SHA-256 so the app can re-hash it
-  # immediately before spawn (vuln-scan B / binary-verifier.ts). The key is the binary's
+  # immediately before spawn (binary-verifier.ts, #234). The key is the binary's
   # name relative to the extract dir (here it sits at the root after the flatten above).
   # Only a VERIFIED archive earns that hash (#234): an unverified install must not mint
   # a marker the sell gate and the spawn verifier would trust.

--- a/scripts/fetch-runtime.sh
+++ b/scripts/fetch-runtime.sh
@@ -347,7 +347,7 @@ if [[ -f "$BIN_PATH" ]]; then
     if [[ "$m_version" == "$VERSION" && "$m_backend" == "${B_BACKEND[$SEL]}" ]]; then
       SKIP=1
       if [[ $COMMERCIAL -eq 1 ]]; then
-        m_hash="$(sed -n 's/.*"binaries":{[^}]*"'"$BIN_NAME"'":"\([a-f0-9]\{64\}\)".*/\1/p' "$MARKER_PATH")"
+        m_hash="$(sed -n 's/.*"binaries":{[^}]*"'"$BIN_NAME"'":"\([a-fA-F0-9]\{64\}\)".*/\1/p' "$MARKER_PATH" | tr '[:upper:]' '[:lower:]')"
         if ! is_real_sha "$m_hash"; then
           SKIP=0
           WHY="install marker records no binary hash (legacy) — commercial mode"
@@ -484,7 +484,7 @@ if [[ -f "$BIN_PATH" ]]; then
   # Record exactly which build is installed (mirrors assets.ts writeRuntimeMarker). The
   # `binaries` map records the extracted binary's own SHA-256 (keyed by its name relative
   # to the extract dir — it sits at the root after the flatten above) so the app can
-  # re-hash it immediately before spawn (vuln-scan B / binary-verifier.ts). Only a
+  # re-hash it immediately before spawn (binary-verifier.ts, #234). Only a
   # VERIFIED archive earns that hash (#234): an unverified install must not mint a
   # marker the sell gate and the spawn verifier would trust.
   if [[ $ARCHIVE_VERIFIED -eq 1 ]]; then

--- a/scripts/fetch-runtime.sh
+++ b/scripts/fetch-runtime.sh
@@ -16,10 +16,15 @@
 # pure-CPU safety net into <os>/cpu/.
 #
 # Verify-before-trust: a real-hash MISMATCH deletes the zip and exits non-zero. A
-# placeholder zip hash extracts but reports UNVERIFIED. Idempotent via the MARKER, not
+# placeholder zip hash extracts but reports UNVERIFIED and the marker then records NO
+# binary hash (the sell gate refuses such an install). Idempotent via the MARKER, not
 # mere binary presence: a present llama-server whose .hilbertraum-runtime.json matches the
 # selected version + backend is skipped; a missing/stale marker re-fetches (so upgrading
 # a CPU-era drive to the Vulkan default actually replaces the build).
+#
+# --commercial (drive builders, #234): a placeholder hash is REFUSED before any download
+# (exit 1, nothing extracted, no marker) and a hashless (legacy) marker is re-fetched
+# instead of skipped, so a sold drive never carries an unverifiable sidecar.
 #
 # --family selects the asset family: llama_cpp (default, llama-server), whisper_cpp
 # (the whisper-cli transcriber, runtime/whisper.cpp/<os>/ — same verify + marker
@@ -28,10 +33,10 @@
 #
 # Usage:
 #   scripts/fetch-runtime.sh --target /Volumes/HILBERTRAUM \
-#       [--os linux] [--arch x64] [--backend cpu] [--family whisper_cpp|ocr] [--dry-run]
+#       [--os linux] [--arch x64] [--backend cpu] [--family whisper_cpp|ocr] [--commercial] [--dry-run]
 set -euo pipefail
 
-TARGET=""; OS=""; ARCH=""; BACKEND=""; FAMILY="llama_cpp"; DRY_RUN=0
+TARGET=""; OS=""; ARCH=""; BACKEND=""; FAMILY="llama_cpp"; COMMERCIAL=0; DRY_RUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target) TARGET="${2:-}"; shift 2 ;;
@@ -44,6 +49,7 @@ while [[ $# -gt 0 ]]; do
     --backend=*) BACKEND="${1#*=}"; shift ;;
     --family) FAMILY="${2:-}"; shift 2 ;;
     --family=*) FAMILY="${1#*=}"; shift ;;
+    --commercial) COMMERCIAL=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -156,6 +162,18 @@ if [[ "$FAMILY" == "ocr" ]]; then
     echo "runtime-sources.yaml: no ocr block (version + files) found." >&2; exit 2
   fi
   echo "Fetch OCR language files -> $TARGET (data $OCR_VERSION)"
+  # --commercial: every file must be verifiable BEFORE the first download (#234).
+  if [[ $COMMERCIAL -eq 1 ]]; then
+    PLACEHOLDERS=""
+    for i in $(seq 0 $fidx); do
+      sha_i="${F_SHA[$i]:-}"
+      if [[ -n "$sha_i" ]] && ! is_real_sha "$sha_i"; then PLACEHOLDERS="${PLACEHOLDERS:+$PLACEHOLDERS, }${F_LANG[$i]}"; fi
+    done
+    if [[ -n "$PLACEHOLDERS" ]]; then
+      echo "  commercial: placeholder sha256 for ocr file(s) $PLACEHOLDERS — refusing to fetch (nothing downloaded)" >&2
+      exit 1
+    fi
+  fi
   FAILED=0
   for i in $(seq 0 $fidx); do
     for required in url sha256 dest; do
@@ -313,24 +331,43 @@ echo "Fetch runtime -> $TARGET"
 echo "  build: ${B_OS[$SEL]}/${B_ARCH[$SEL]} ${B_BACKEND[$SEL]} @ $VERSION"
 echo "  url:   $URL"
 echo "  into:  $EXTRACT_TO"
-[[ $DRY_RUN -eq 1 ]] && { echo "(dry run — nothing will be downloaded)"; exit 0; }
 
 # Idempotent skip is MARKER-based (Phase 14, mirrors assets.ts runtimeInstallCurrent):
 # "binary exists" alone would silently keep a CPU-era build in place after the default
-# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend.
+# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend
+# — and, under --commercial, records the binary's hash (a hashless legacy marker is
+# re-fetched, #234).
 if [[ -f "$BIN_PATH" ]]; then
   SKIP=0
+  WHY="install marker is missing or differs"
   if [[ -f "$MARKER_PATH" ]]; then
     # The marker is written by us as flat single-line JSON — parse with sed (no jq dep).
     m_version="$(sed -n 's/.*"version":"\([^"]*\)".*/\1/p' "$MARKER_PATH")"
     m_backend="$(sed -n 's/.*"backend":"\([^"]*\)".*/\1/p' "$MARKER_PATH")"
-    [[ "$m_version" == "$VERSION" && "$m_backend" == "${B_BACKEND[$SEL]}" ]] && SKIP=1
+    if [[ "$m_version" == "$VERSION" && "$m_backend" == "${B_BACKEND[$SEL]}" ]]; then
+      SKIP=1
+      if [[ $COMMERCIAL -eq 1 ]]; then
+        m_hash="$(sed -n 's/.*"binaries":{[^}]*"'"$BIN_NAME"'":"\([a-f0-9]\{64\}\)".*/\1/p' "$MARKER_PATH")"
+        if ! is_real_sha "$m_hash"; then
+          SKIP=0
+          WHY="install marker records no binary hash (legacy) — commercial mode"
+        fi
+      fi
+    fi
   fi
   if [[ $SKIP -eq 1 ]]; then
     echo "  skip ($BIN_NAME already installed: $VERSION/${B_BACKEND[$SEL]} per .hilbertraum-runtime.json)"; exit 0
   fi
-  echo "  $BIN_NAME present but install marker is missing or differs — re-fetching $VERSION/${B_BACKEND[$SEL]}"
+  echo "  $BIN_NAME present but $WHY — re-fetching $VERSION/${B_BACKEND[$SEL]}"
 fi
+
+# --commercial: refuse a placeholder hash BEFORE any download (#234) — an unverifiable
+# archive must never be extracted onto a sold drive, dry run or not.
+if [[ $COMMERCIAL -eq 1 ]] && ! is_real_sha "$SHA"; then
+  echo "  commercial: placeholder sha256 for ${B_OS[$SEL]}/${B_ARCH[$SEL]} ${B_BACKEND[$SEL]} @ $VERSION — refusing to fetch (nothing downloaded, no marker written)" >&2
+  exit 1
+fi
+[[ $DRY_RUN -eq 1 ]] && { echo "(dry run — nothing will be downloaded)"; exit 0; }
 
 mkdir -p "$EXTRACT_TO"
 # Archive name from the URL basename so a .tar.gz (the macOS/Linux release format) is
@@ -360,6 +397,7 @@ else
   echo "No downloader found (need curl or wget)." >&2; exit 3
 fi
 
+ARCHIVE_VERIFIED=0
 if is_real_sha "$SHA"; then
   ACTUAL="$(sha256_of "$ARCHIVE")"
   if [[ "$ACTUAL" != "$SHA" ]]; then
@@ -367,6 +405,7 @@ if is_real_sha "$SHA"; then
     rm -f "$ARCHIVE"; exit 1
   fi
   echo "  archive VERIFIED"
+  ARCHIVE_VERIFIED=1
 else
   echo "  archive UNVERIFIED (placeholder hash) — verify after a real release bump"
 fi
@@ -445,10 +484,18 @@ if [[ -f "$BIN_PATH" ]]; then
   # Record exactly which build is installed (mirrors assets.ts writeRuntimeMarker). The
   # `binaries` map records the extracted binary's own SHA-256 (keyed by its name relative
   # to the extract dir — it sits at the root after the flatten above) so the app can
-  # re-hash it immediately before spawn (vuln-scan B / binary-verifier.ts).
-  BIN_SHA="$(sha256_of "$BIN_PATH")"
-  printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s","binaries":{"%s":"%s"}}' \
-    "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" "$BIN_NAME" "$BIN_SHA" > "$MARKER_PATH"
+  # re-hash it immediately before spawn (vuln-scan B / binary-verifier.ts). Only a
+  # VERIFIED archive earns that hash (#234): an unverified install must not mint a
+  # marker the sell gate and the spawn verifier would trust.
+  if [[ $ARCHIVE_VERIFIED -eq 1 ]]; then
+    BIN_SHA="$(sha256_of "$BIN_PATH")"
+    printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s","binaries":{"%s":"%s"}}' \
+      "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" "$BIN_NAME" "$BIN_SHA" > "$MARKER_PATH"
+  else
+    printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s"}' \
+      "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" > "$MARKER_PATH"
+    echo "  marker written WITHOUT a binary hash (archive unverified) — the sell gate refuses this install"
+  fi
   echo "  extracted + chmod +x $BIN_NAME (+ .hilbertraum-runtime.json install marker)"
   exit 0
 fi


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 2: one commercial gate
Closes #233 (GAP-4; DOC-7 folded), Closes #234 (SEC-11; NEW-4 and DOC-1 folded)
Refs #217 (tracker), #229 (decision 12 — used on its default)

### What
- **`assertCommercialDrive(root, manifests, runtime?, whisper?, ocr?, opts?)`** (`commercial-drive.ts`): new `opts: { platforms: KitPlatform[]; appVersion }` and four new checks — `platformMatrixDeclared` (no opts → not sellable), `appArtifactsPresent` (exactly ONE release artifact of the built version per declared platform: `HilbertRaum-<v>-portable.exe` / `HilbertRaum-<v>-mac-arm64.app.zip` or an extracted `*.app` whose `Info.plist` carries the version / `HilbertRaum-<v>.AppImage`; an artifact of an undeclared platform, an unrecognised `HilbertRaum-*` name, a zero-byte file, another version, or a second artifact of one platform — an older build beside the new one — all fail), `launchersPresent` (the platform's launcher, non-empty, at the root), and `runtimeHashed` (split out of `runtimeCurrent`: a hashless marker or a hash that no longer matches the bytes fails here). `KitPlatform` / `KIT_PLATFORMS` / `isKitPlatform` live beside `RuntimeOs` in `shared/runtime-sources.ts`; the per-platform names are one exported table (`KIT_PLATFORM_SPECS`). The commercial posture predicate is now `isCommercialPolicy(policy)` in `policy.ts`, shared with the verifier.
- **A script-callable entry** `src/main/tools/assert-commercial-drive.ts` → `apps/desktop/out/tools/assert-commercial-drive.mjs`, built by a separate `vite.tools.config.ts` (`npm run build` now runs it; `build:tools` alone too). Plain-Node ESM bundle (yaml bundled in; only `node:` imports; ~300 KB), excluded from the asar (`!out/tools/**`). It reads the drive's own `model-manifests/` (`discoverManifests`) and `runtime-sources.yaml`, calls the gate, prints one line per check and the problems, exits 0 / 1 / 2 (sellable / not / usage).
- **Both builder scripts** (`build-commercial-drive.{ps1,sh}`): `-Platforms`/`--platforms` (default all three), `-AppArtifact` as a list (`[string[]]` / repeatable `--app-artifact`), `-VerifyOnly`/`--verify-only` (only step 7), a differently named prior `HilbertRaum-*` artifact or `*.app` at the root **refuses the run before step 1** (never deleted), every `fetch-runtime` run gets `-Commercial`, and step 7 keeps its native checks as a pre-flight but the verdict is the tool's: **SELLABLE is printed only when the canonical gate passed and the pre-flight found nothing**; a missing tool or `node` is itself a NOT SELLABLE reason. `-DryRun` still runs the gate and prints the verdict (it used to skip it and exit 0).
- **`fetch-runtime.{ps1,sh} -Commercial/--commercial`**: a placeholder `sha256` is refused before any download (exit 1, nothing extracted, no marker — also under `-DryRun`; all three families incl. `ocr`), a marker that matches version+backend but records no real binary hash is re-fetched instead of skipped, and the marker's `binaries` hash is written only after a verified archive (an unverified DIY install now gets a hashless marker the gate refuses, instead of an authoritative-looking one).
- **`binary-verifier.ts`**: `setBinaryVerificationPosture({ commercial, refuseHashlessMarkers })`, called in `index.ts` right after `loadPolicy` (`initBinaryVerification` stays early). On a commercial drive a hashless marker becomes `mismatch` only when `refuseHashlessMarkers` is set; the shipped constant `REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES = false` keeps it a logged tolerance. DIY drives keep `skip-legacy` regardless.

### Why (finding IDs + the promise line each restores)
- **GAP-4 (High, #233)** — "the SELLABLE verdict is the final quality gate for a sold kit" (`docs/packaging.md`): the canonical gate now requires the app artifacts + launchers the kit promises, and the operator scripts can no longer print SELLABLE from their own subset. DOC-7: the user guide states per-kit platform coverage.
- **SEC-11 (High, #234)** — "Re-hash sidecar binaries before spawn" / "the scripts add a native cross-check of the same invariants": the scripts now run the hashing gate itself; a placeholder-hash archive or a hashless marker cannot reach SELLABLE, and an unverified install can no longer mint a marker with a hash (NEW-4). DOC-1: the parity claim in `packaging.md` is restated as what is now true.

### Tests
- characterisation (red before, commit `8406c9e8` on `origin/master` 2a3c1a9e): B5 inverted in `commercial-drive.test.ts` — no app / zero-byte / wrong-arch name / missing launcher / partial platform set / two artifacts / another version / undeclared platform / extracted `.app` (accepted with the right version, refused with another or beside the zip) / no matrix / bad matrix, the positive case now WITH artifacts + launchers, the exact-shape `checks` `toEqual` extended to 14 keys; tampered marker hash; `runtimeHashed` split; `binary-verifier.test.ts` posture matrix (DIY tolerated, commercial + flag → refused, commercial default → tolerated, hashed binary → ok, dev → skip-dev, reset clears the posture; the constant pinned `false`); `policy.test.ts` `isCommercialPolicy`; `script-drift.test.ts` pins (`KitPlatform` list parity in both builders, the tool call + a single SELLABLE verdict line, `--commercial` on every fetch-runtime run, marker hash behind the verified flag).
- **`script-execution.test.ts` (new; executes the scripts, offline)** — `.ps1` leg on win32, `.sh` leg elsewhere (`HILBERTRAUM_SCRIPT_SH_LEG=1` runs it under Git Bash on a Windows box): verify-only gate on an empty target → exit 1 + `NOT SELLABLE` from the tool (skips with a warning when `out/tools` is not built; CI builds first); unknown platform → exit 2; prior artifact → refused before step 1, nothing copied; `fetch-runtime --commercial`: placeholder refused before any download (no `runtime/`), a hashless install is NOT skipped, without the flag it still is, a hashed install is skipped, dry run + placeholder → exit 1, OCR family refused. Opt-in (`HILBERTRAUM_SCRIPT_DRY_RUN=1`): the full `-AcceptLicense -DryRun` pipeline reaches the canonical verdict (NOT SELLABLE, no `Done.`) — run on this machine for both legs, 2026-09-02.
- `npm test` count: **366 files passed, 23 skipped · 5,466 passed / 62 skipped** (baseline 365 / 5,427 / 52: +1 file, +39 tests, +10 skipped = the bash leg + the opt-in dry run on Windows); `npm run typecheck` + `npm run build` green; dev launch under the 75 s watchdog green.

### Docs + BUILD_STATE
`docs/packaging.md` (pipeline block, flags, refuse-to-proceed, the parity sentence restated), `docs/user-guide.md` §1/§2 (per-kit platform coverage), `docs/known-limitations.md` (the hashless-marker bullet: build-time gate now real, spawn-time refusal wired but off), `docs/security-model.md` "Re-hash sidecar binaries before spawn" (new fact 4), `CHANGELOG.md` `[Unreleased]` Changed. BUILD_STATE: one dated entry (12 lines), §5 item 19 line, §5 item 1 gate note, §8 L-7 cross-ref; section counter preamble 84/200 · §5 486/500 · §8 60/80 (item 19 at 28 of the 45-line cap).

### Owner decisions relied on (issue #, answer or default)
- **Decision 12 (#229)** — no `**DECISION:**` comment at kickoff → **default stands: declared platform matrix** (`-Platforms`, default all three; the kit label names them). The review's alternative (hard-code all three, defer the flag) is recorded; the default was NOT upgraded to a ruling.
- **Fail-closed key (SEC-11)** — default: the commercial policy posture (`isCommercialPolicy`), DIY tolerance kept.
- **Prior artifact at the root** — default: refuse to proceed, never delete.
- **Already-sold kits refused at spawn** — owner line blank. The plan text calls the refusal "intended", the review recommends landing it OFF behind a flag; the plan's own SEC-11 block says it is "an owner question, not an executor call". Landed **OFF** (`REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES = false`): the build-time closure is complete either way, and switching the constant on later is one line, while a live refusal on hardware in customers' hands is not reversible. No spawn-time refusal is live in this PR.
- OCR copy (Phase 1) and the Phase 0/1 manual smokes: unchanged / still not run — owner lines blank.

### Landed differently from the plan
- The offline script tests drive a new **`-VerifyOnly`/`--verify-only`** mode rather than `-DryRun`: at HEAD a plain `-DryRun` exits 1 at step 2 (the license-blocked model) before ever reaching step 7, and with `-AcceptLicense` the six dry child runs take ~30 s per leg — too slow and too wide for a per-run test. `-DryRun` does now reach the verdict as planned; that path is the opt-in test (run here, both legs).
- The script entry is a **separate `vite build`** (`vite.tools.config.ts`), not a second rollup input of the electron-vite main config: the main bundle must stay one file, and a shared-chunk split would have changed the packaged layout for a build-machine tool.
- `runtimeHashed` is a separate check (the plan listed it; two existing tests moved from `runtimeCurrent` to it).
- An extracted `.app` is accepted as the mac artifact when its `Info.plist` version matches (the sh builder documents `cp -R` of a `.app`), refused beside a `.app.zip` or with another version.
- `-DryRun` now exits 1 on an unsellable target (it used to exit 0 and print `Done.`); a `-Commercial` placeholder refusal also fires under `-DryRun`.

### Reviewer pass
Fable tier (plan §1.1). Verdict: **merge after repairs** — no blocking findings; every probed defect (no app, zero-byte, wrong-arch name, missing launcher, partial set, two artifacts, other version, undeclared platform, hashless / tampered marker, tampered binary) fails closed; the tool bundle is electron-free; no mocks; docs claim only what the code does. Should-fix, all repaired in the "reviewer repairs" commit: (1) PowerShell 5.1 native-arg quoting — a `-Target` with a space AND a trailing backslash reached `node` as one mangled argument (`--platforms is required`, a false NOT SELLABLE) → the gate is handed a trimmed path (a bare drive root keeps its backslash); (2) the app version was read from the root `package.json` while electron-builder / the release workflow stamp artifacts from `apps/desktop/package.json` → both builders now read the desktop one; (3) two reflowed comment lines still said "vuln-scan B" → `#234` only (the untouched ps1 twin swept too); (4) `-Platforms 'win-x64,mac-arm64'` (quoted) bound as one element → normalised by splitting on commas. Nits repaired: (5) the `spawnSync` child timeout (120 s) exceeded the vitest budget (90 s) → 60 s; (6) `--platforms ""` on bash 3.2 would die on an unbound variable → explicit guard; (7) the sh marker-hash `sed` accepted lowercase hex only → both cases, lowercased; (9) `-LiteralPath` for the root scan. Accepted, not changed: (8) a symlinked or lowercase-named artifact reads as "no app artifact" (safe direction; the drive is built by these scripts with canonical names).

### Rollback
Revert the PR: the scripts fall back to their own gates and print SELLABLE without an app again; no on-disk format changed (markers written by the new fetch-runtime are readable by every app version — a hashless marker is the historical shape).
