### PR TITLE
fix(launchers): refuse two app versions on one drive; --check control; set -euo pipefail (audit 2026-09-02 Phase 3 — REL-7, REL-3)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-02 — **Audit 2026-09-02 Phase 3 — update multiplicity: the three drive launchers refuse
+to start while more than one app artifact sits at the drive root, name what to delete and never
+delete; `--check` / `/check` resolves the app without starting it (REL-7 #235 with DOC-2/DOC-13
+folded, REL-3 #257; PR #272).**_
+`Start HilbertRaum.cmd` counts `HilbertRaum-*-portable.exe`, `start-hilbertraum.sh` the AppImages,
+`Start HilbertRaum.command` extracted `.app` bundles + `.app.zip`s (any `.app` beside any zip = two;
+refused before the `$HOME/Library/Caches` write); both shell launchers run under `set -euo pipefail`.
+New `tests/integration/launcher-execution.test.ts` executes all three in scratch roots (16 cases;
+`.cmd` on Windows, bash legs elsewhere or `HILBERTRAUM_SCRIPT_SH_LEG=1`). Docs: `drive-layout.md`
+update step ("delete the prior artifact first"), `troubleshooting.md` "Two app versions on the
+drive" + version floor, `security-model.md`, `known-limitations.md`, `packaging.md`, CHANGELOG.
+Decisions 3 (#220, interim) and 8 (#225, not ratified — no `user_version`, REL-4 #247 stays a residual) on their defaults.
+
 _2026-09-02 — **Audit 2026-09-02 Phase 2 — one commercial gate: both builder scripts now call
 `assertCommercialDrive`, which requires the app + launcher per declared platform and hashed
 sidecars; `fetch-runtime --commercial` fails closed (GAP-4 #233, SEC-11 #234; PR #271).**_
@@ -616,6 +629,9 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
       `out/tools/assert-commercial-drive.mjs`) called by both builders: app + launcher per declared
       platform, hashed sidecars, `fetch-runtime --commercial` fails closed; spawn-time refusal of
       hashless markers built but OFF (owner call, #234); decision 12 on its default — dated entry above.
+    - **3** (2026-09-02, PR #272): REL-7 (DOC-2, DOC-13 folded) + REL-3 — the launchers refuse two
+      app versions at the root and take `--check`/`/check`; `set -euo pipefail`; docs mandate deleting
+      the prior artifact; decisions 3/8 on defaults (no PR 3-b; REL-4 #247 residual) — dated entry above.
 
 **Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
 the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ from its first public `1.0.0` release onward.
   engine binary whose recorded checksum still matches. A leftover older app build, an engine
   downloaded without a verifiable checksum, or an engine with no recorded checksum now stops the
   drive from being cleared (drive builders only; nothing changes for an app already in use).
+- **Updating the app on a drive now means deleting the old one first.** The launchers refuse to
+  start while more than one app version sits on the drive (two portable `.exe` files, two
+  AppImages, or an extracted `HilbertRaum.app` beside a `.app.zip`) and list the files so you can
+  delete the older one — nothing is deleted for you. An older build running beside a newer one
+  could destroy the workspace (the 0.1.59 fix for issue #208 only protects when both copies are
+  0.1.59 or newer). Each launcher also accepts `--check` (`/check` on Windows) to show which app
+  it would start without starting it.
 
 ## [0.1.59] — 2026-08-21
 

--- a/apps/desktop/src/main/services/commercial-drive.ts
+++ b/apps/desktop/src/main/services/commercial-drive.ts
@@ -250,8 +250,9 @@ const versionOf =
 
 /**
  * Per-platform artifact + launcher names — the same names the launchers glob for on the
- * drive root and the release workflow uploads. macOS additionally accepts an extracted
- * `*.app` bundle (the launcher prefers one), whose version is read from its Info.plist.
+ * drive root and the release workflow uploads. macOS additionally accepts a lone extracted
+ * `*.app` bundle, whose version is read from its Info.plist; beside a zip the launcher
+ * refuses to start (#235), and so does this gate.
  */
 export const KIT_PLATFORM_SPECS: Record<KitPlatform, KitPlatformSpec> = {
   'win-x64': {

--- a/apps/desktop/tests/integration/commercial-drive.test.ts
+++ b/apps/desktop/tests/integration/commercial-drive.test.ts
@@ -50,7 +50,7 @@ function kit(platforms: KitPlatform[] = ALL_PLATFORMS): { platforms: KitPlatform
   return { platforms, appVersion: APP_VERSION }
 }
 
-/** An extracted macOS bundle (what the .command launcher prefers over the zip). */
+/** An extracted macOS bundle (accepted alone; beside a zip the .command launcher refuses, #235). */
 function provisionExtractedApp(root: string, version: string): void {
   const contents = join(root, 'HilbertRaum.app', 'Contents')
   mkdirSync(join(contents, 'MacOS'), { recursive: true })

--- a/apps/desktop/tests/integration/launcher-execution.test.ts
+++ b/apps/desktop/tests/integration/launcher-execution.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi } from 'vitest'
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Executes the drive-root launchers (#235, #257). Every launcher derives the drive root from
+// its own location, so each case copies the launcher into a scratch root beside 0-byte app
+// artifacts. Two app versions on one drive must be refused, naming both, before anything is
+// started or written; `--check` (`.sh` / `.command`) and `/check` (`.cmd`) resolve the app and
+// exit without starting it — the single-artifact control. The `.cmd` leg runs on Windows, the
+// two bash legs elsewhere (Git Bash on a Windows dev box: HILBERTRAUM_SCRIPT_SH_LEG=1).
+
+const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', '..', '..')
+const LAUNCHERS = join(REPO_ROOT, 'launchers')
+const CMD = 'Start HilbertRaum.cmd'
+const COMMAND = 'Start HilbertRaum.command'
+const SH = 'start-hilbertraum.sh'
+
+// A launcher that reaches its launch line on a 0-byte artifact hangs (Windows shows an error
+// dialog for a bad exe) — the child is killed well before vitest's own budget so the failure
+// carries the launcher's output.
+const CHILD_TIMEOUT_MS = 10_000
+vi.setConfig({ testTimeout: 60_000 })
+
+const REFUSAL = /More than one HilbertRaum app was found on this drive/
+const NOT_STARTED = /Nothing was started/
+
+const text = (r: SpawnSyncReturns<string>): string => `${r.stdout ?? ''}\n${r.stderr ?? ''}`
+
+function scratchRoot(launcher: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'hilbertraum-launcher-'))
+  copyFileSync(join(LAUNCHERS, launcher), join(root, launcher))
+  return root
+}
+
+/** 0-byte artifacts, the NEWER name created first so a creation-order pick cannot pass. */
+function twoArtifacts(root: string, names: [string, string]): void {
+  writeFileSync(join(root, names[1]), '')
+  writeFileSync(join(root, names[0]), '')
+}
+
+const runCmd = (root: string, args: string[]): SpawnSyncReturns<string> =>
+  spawnSync('cmd.exe', ['/d', '/c', `""${join(root, CMD)}"${args.map((a) => ` ${a}`).join('')}"`], {
+    encoding: 'utf8',
+    timeout: CHILD_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsVerbatimArguments: true,
+    windowsHide: true
+  })
+
+const runBash = (
+  root: string,
+  launcher: string,
+  args: string[],
+  env: Record<string, string> = {}
+): SpawnSyncReturns<string> =>
+  spawnSync('bash', [join(root, launcher), ...args], {
+    encoding: 'utf8',
+    timeout: CHILD_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...env }
+  })
+
+const bashSyntaxOk = (launcher: string): SpawnSyncReturns<string> =>
+  spawnSync('bash', ['-n', join(LAUNCHERS, launcher)], { encoding: 'utf8', timeout: CHILD_TIMEOUT_MS })
+
+describe.skipIf(process.platform !== 'win32')('Start HilbertRaum.cmd (Windows)', () => {
+  const two: [string, string] = ['HilbertRaum-0.1.57-portable.exe', 'HilbertRaum-0.1.59-portable.exe']
+
+  it('refuses two portable apps, naming both, and starts nothing', () => {
+    const root = scratchRoot(CMD)
+    twoArtifacts(root, two)
+    const r = runCmd(root, [])
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain(two[0])
+    expect(out).toContain(two[1])
+  })
+
+  it('/check refuses two portable apps the same way', () => {
+    const root = scratchRoot(CMD)
+    twoArtifacts(root, two)
+    const r = runCmd(root, ['/check'])
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain(two[0])
+    expect(out).toContain(two[1])
+  })
+
+  it('/check with one app names it and starts nothing (exit 0)', () => {
+    const root = scratchRoot(CMD)
+    writeFileSync(join(root, two[1]), '')
+    const r = runCmd(root, ['/check'])
+    const out = text(r)
+    expect(r.status, out).toBe(0)
+    expect(out).toContain(two[1])
+    expect(out).toMatch(NOT_STARTED)
+  })
+
+  it('/check with no app fails with the existing not-found message', () => {
+    const root = scratchRoot(CMD)
+    const r = runCmd(root, ['/check'])
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(out).toMatch(/Could not find the HilbertRaum app/)
+  })
+})
+
+// Git Bash exists on the Windows CI runner too — gate the bash legs so they run once.
+const bashSkip = process.platform === 'win32' && !process.env.HILBERTRAUM_SCRIPT_SH_LEG
+
+describe.skipIf(bashSkip)('start-hilbertraum.sh (Linux)', () => {
+  const two: [string, string] = ['HilbertRaum-0.1.57.AppImage', 'HilbertRaum-0.1.59.AppImage']
+
+  /** An exec-able stand-in for the AppImage: records the drive root it was started with. */
+  function stubAppImage(root: string, name: string): void {
+    const p = join(root, name)
+    writeFileSync(p, '#!/usr/bin/env bash\nprintf %s "$HILBERTRAUM_DRIVE_ROOT" > "$(dirname "$0")/launched-$(basename "$0").txt"\n')
+    chmodSync(p, 0o755)
+  }
+  const launched = (root: string, name: string): boolean => existsSync(join(root, `launched-${name}.txt`))
+
+  it('parses under bash -n and runs under set -euo pipefail (#257)', () => {
+    expect(bashSyntaxOk(SH).status).toBe(0)
+    expect(readFileSync(join(LAUNCHERS, SH), 'utf8')).toMatch(/^set -euo pipefail$/m)
+  })
+
+  it('refuses two AppImages, naming both, and starts neither', () => {
+    const root = scratchRoot(SH)
+    stubAppImage(root, two[1])
+    stubAppImage(root, two[0])
+    const r = runBash(root, SH, [])
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain(two[0])
+    expect(out).toContain(two[1])
+    expect(launched(root, two[0])).toBe(false)
+    expect(launched(root, two[1])).toBe(false)
+  })
+
+  it('--check refuses two AppImages the same way', () => {
+    const root = scratchRoot(SH)
+    twoArtifacts(root, two)
+    const r = runBash(root, SH, ['--check'])
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain(two[0])
+    expect(out).toContain(two[1])
+  })
+
+  it('--check with one AppImage names it and starts nothing (exit 0)', () => {
+    const root = scratchRoot(SH)
+    stubAppImage(root, two[1])
+    const r = runBash(root, SH, ['--check'])
+    const out = text(r)
+    expect(r.status, out).toBe(0)
+    expect(out).toContain(two[1])
+    expect(out).toMatch(NOT_STARTED)
+    expect(launched(root, two[1])).toBe(false)
+  })
+
+  it('with one AppImage and no argument it starts it (no unbound-variable abort)', () => {
+    const root = scratchRoot(SH)
+    stubAppImage(root, two[1])
+    const r = runBash(root, SH, [])
+    const out = text(r)
+    expect(r.status, out).toBe(0)
+    expect(out).not.toMatch(/unbound variable/)
+    expect(launched(root, two[1])).toBe(true)
+    // The stub saw the drive root the launcher derived from its own location.
+    expect(readFileSync(join(root, `launched-${two[1]}.txt`), 'utf8')).toContain('hilbertraum-launcher-')
+  })
+})
+
+describe.skipIf(bashSkip)('Start HilbertRaum.command (macOS)', () => {
+  const zips: [string, string] = ['HilbertRaum-0.1.57-mac-arm64.app.zip', 'HilbertRaum-0.1.59-mac-arm64.app.zip']
+
+  function extractedApp(root: string, name: string): void {
+    mkdirSync(join(root, name, 'Contents', 'MacOS'), { recursive: true })
+  }
+
+  /** A scratch HOME: the refusal must land before the launcher writes its unpack cache. */
+  function scratchHome(): string {
+    return mkdtempSync(join(tmpdir(), 'hilbertraum-launcher-home-'))
+  }
+  const cacheTouched = (home: string): boolean => existsSync(join(home, 'Library'))
+
+  it('parses under bash -n and runs under set -euo pipefail', () => {
+    expect(bashSyntaxOk(COMMAND).status).toBe(0)
+    expect(readFileSync(join(LAUNCHERS, COMMAND), 'utf8')).toMatch(/^set -euo pipefail$/m)
+  })
+
+  it('refuses two extracted .app bundles, naming both', () => {
+    const root = scratchRoot(COMMAND)
+    const home = scratchHome()
+    extractedApp(root, 'HilbertRaum.app')
+    extractedApp(root, 'HilbertRaum 2.app')
+    const r = runBash(root, COMMAND, [], { HOME: home })
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain('HilbertRaum.app')
+    expect(out).toContain('HilbertRaum 2.app')
+    expect(cacheTouched(home)).toBe(false)
+  })
+
+  it('refuses two .app.zip archives, naming both, before touching the unpack cache', () => {
+    const root = scratchRoot(COMMAND)
+    const home = scratchHome()
+    twoArtifacts(root, zips)
+    const r = runBash(root, COMMAND, [], { HOME: home })
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain(zips[0])
+    expect(out).toContain(zips[1])
+    expect(cacheTouched(home)).toBe(false)
+  })
+
+  it('refuses an extracted .app beside a newer .app.zip (the .app used to win silently)', () => {
+    const root = scratchRoot(COMMAND)
+    const home = scratchHome()
+    extractedApp(root, 'HilbertRaum.app')
+    writeFileSync(join(root, zips[1]), '')
+    const r = runBash(root, COMMAND, [], { HOME: home })
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(r.status, out).not.toBeNull()
+    expect(out).toMatch(REFUSAL)
+    expect(out).toContain('HilbertRaum.app')
+    expect(out).toContain(zips[1])
+    expect(cacheTouched(home)).toBe(false)
+  })
+
+  it('--check with one zip names it, writes nothing under $HOME and starts nothing', () => {
+    const root = scratchRoot(COMMAND)
+    const home = scratchHome()
+    writeFileSync(join(root, zips[1]), '')
+    const r = runBash(root, COMMAND, ['--check'], { HOME: home })
+    const out = text(r)
+    expect(r.status, out).toBe(0)
+    expect(out).toContain(zips[1])
+    expect(out).toMatch(NOT_STARTED)
+    expect(cacheTouched(home)).toBe(false)
+  })
+
+  it('--check with one extracted .app names it and starts nothing', () => {
+    const root = scratchRoot(COMMAND)
+    extractedApp(root, 'HilbertRaum.app')
+    const r = runBash(root, COMMAND, ['--check'], { HOME: scratchHome() })
+    const out = text(r)
+    expect(r.status, out).toBe(0)
+    expect(out).toContain('HilbertRaum.app')
+    expect(out).toMatch(NOT_STARTED)
+  })
+
+  it('--check with no app fails with the existing not-found message', () => {
+    const root = scratchRoot(COMMAND)
+    const r = runBash(root, COMMAND, ['--check'], { HOME: scratchHome() })
+    const out = text(r)
+    expect(r.status, out).not.toBe(0)
+    expect(out).toMatch(/Could not find the HilbertRaum app/)
+  })
+})

--- a/apps/desktop/tests/integration/launcher-execution.test.ts
+++ b/apps/desktop/tests/integration/launcher-execution.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterAll, describe, it, expect, vi } from 'vitest'
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -29,8 +29,14 @@ const NOT_STARTED = /Nothing was started/
 
 const text = (r: SpawnSyncReturns<string>): string => `${r.stdout ?? ''}\n${r.stderr ?? ''}`
 
+const scratchDirs: string[] = []
+afterAll(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true })
+})
+
 function scratchRoot(launcher: string): string {
   const root = mkdtempSync(join(tmpdir(), 'hilbertraum-launcher-'))
+  scratchDirs.push(root)
   copyFileSync(join(LAUNCHERS, launcher), join(root, launcher))
   return root
 }
@@ -190,7 +196,9 @@ describe.skipIf(bashSkip)('Start HilbertRaum.command (macOS)', () => {
 
   /** A scratch HOME: the refusal must land before the launcher writes its unpack cache. */
   function scratchHome(): string {
-    return mkdtempSync(join(tmpdir(), 'hilbertraum-launcher-home-'))
+    const home = mkdtempSync(join(tmpdir(), 'hilbertraum-launcher-home-'))
+    scratchDirs.push(home)
+    return home
   }
   const cacheTouched = (home: string): boolean => existsSync(join(home, 'Library'))
 

--- a/docs/drive-layout.md
+++ b/docs/drive-layout.md
@@ -146,7 +146,12 @@ drive is the same flow as building it, run again from a machine with the repo:
 1. `prepare-drive --target <drive> --force` refreshes `model-manifests/` + the bundled docs +
    `config/{drive,policy}.json` (the workspace and weights are untouched).
 2. `fetch-models` / `fetch-runtime` download anything new (present + verified files are skipped).
-3. Replace the portable app/launchers at the drive root with the new build.
+3. **Delete every prior app artifact** at the drive root — `HilbertRaum-<old>-portable.exe`,
+   `HilbertRaum-<old>.AppImage`, `HilbertRaum-<old>-mac-arm64.app.zip` — and any extracted
+   `HilbertRaum.app`, and only then copy the new build (and launchers) in. Two app versions on
+   one drive must never run: an older build beside a newer one can destroy the workspace, so the
+   launchers refuse to start while more than one is present and name what to delete (#235).
+   Start the app and verify the version shown under Settings → Diagnostics ("App version").
 4. `verify-models --target <drive> --strict` confirms every weight still verifies.
 
 The user's `workspace/` (and its encrypted data) is never modified by an update.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -43,7 +43,10 @@ password recovery — are documented in
   re-encrypt the garbage, so the at-rest `.enc` — the vault itself — survives and the next
   unlock recovers the last locked snapshot. A workspace-level cross-process lock file would
   close the corner fully; not built (stale-lock handling on hard-killed processes needs its
-  own design).
+  own design). A pre-0.1.59 build takes no lock at all: the drive launchers refuse to start
+  while two app versions sit at the drive root (#235), but starting an artifact directly
+  bypasses the launcher, and a signed current-release manifest at the root is an open owner
+  decision (#220).
 - **A pre-envelope build cannot open a v2 (envelope) vault.** New vaults — and any vault after
   its first password change — use the descriptor-v2 envelope (`security-model.md`). An older
   app version derives the correct KEK and even passes the verifier, but then tries to decrypt

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -397,6 +397,12 @@ The drive root ships an obvious, double-clickable launcher (spec §6 names). Sou
 | Linux | `start-hilbertraum.sh` | same, next to the AppImage. |
 | all | `READ ME FIRST.txt` | friendly first-run + SmartScreen/Gatekeeper instructions. |
 
+All three launchers refuse to start while more than one app artifact of their kind sits at the
+drive root (two portable `.exe`s, two AppImages, two `.app.zip`s, or an extracted `.app` beside a
+zip), naming the files to delete and never deleting anything themselves (#235); `--check`
+(`/check` on Windows) resolves the app and exits without starting it. `tests/integration/
+launcher-execution.test.ts` executes all three in scratch roots.
+
 > ⚠️ **No hardcoded paths — drive letters change per machine.** The launcher derives the root from
 > **its own location every launch** (`%~dp0` / `dirname "$0"`), so the same drive works on a second
 > laptop with a different letter/mount and continues the **same encrypted workspace** (success

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -400,8 +400,8 @@ The drive root ships an obvious, double-clickable launcher (spec §6 names). Sou
 All three launchers refuse to start while more than one app artifact of their kind sits at the
 drive root (two portable `.exe`s, two AppImages, two `.app.zip`s, or an extracted `.app` beside a
 zip), naming the files to delete and never deleting anything themselves (#235); `--check`
-(`/check` on Windows) resolves the app and exits without starting it. `tests/integration/
-launcher-execution.test.ts` executes all three in scratch roots.
+(`/check` on Windows) resolves the app and exits without starting it.
+`tests/integration/launcher-execution.test.ts` executes all three in scratch roots.
 
 > ⚠️ **No hardcoded paths — drive letters change per machine.** The launcher derives the root from
 > **its own location every launch** (`%~dp0` / `dirname "$0"`), so the same drive works on a second

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -734,7 +734,11 @@ password. Four guards close this:
 - **Single instance (Electron).** `app.requestSingleInstanceLock()` before any workspace
   path is touched; a second instance exits immediately and the primary's window is
   focused. The lock is scoped to `userData`, which every portable release build shares —
-  so old-exe + new-exe overlap (the incident) is refused at the door. Dev builds get their
+  so old-exe + new-exe overlap (the incident) is refused at the door — when both copies are
+  0.1.59 or newer. A pre-0.1.59 build takes no lock at all, so the drive launchers refuse to
+  start while more than one app artifact sits at the drive root (naming what to delete, never
+  deleting) and the update procedure deletes the prior artifact first (`drive-layout.md`
+  "Updating a drive", #235). Dev builds get their
   own `userData` suffix (`-dev`), so `npm run dev` no longer operates on the production
   vault at all (mixed dev/release access to one vault is what widened the incident
   window). Residual: two processes with *different* `userData` pointed at one drive

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -181,9 +181,11 @@ What to do:
   proves what happened, and your imported documents' encrypted copies under
   `workspace/documents/` may be individually recoverable.
 
-Never run two copies of the app at the same time against the same drive. Current versions
-refuse a second instance on their own; when upgrading, quit the old version **before**
-starting the new one.
+Never run two copies of the app at the same time against the same drive. Versions 0.1.59 and
+newer refuse a second instance on their own — but an older copy takes no such lock, so that
+protection only holds when **both** copies are 0.1.59 or newer. When upgrading, quit the old
+version, delete its app file from the drive, and only then start the new one (see "Two app
+versions on the drive" below).
 
 ---
 
@@ -306,6 +308,26 @@ pages (png, jpg, jpeg — needs the OCR files). Other files in the same import s
 - Check that the drive has free space and is writable. The app shows a friendly note on the Home
   screen if the drive is read-only, low on space, or slow (none of these block you).
 - If the drive was just prepared, confirm `config/drive.json` exists at the drive root.
+
+---
+
+## Two app versions on the drive
+
+The launcher stopped with **"More than one HilbertRaum app was found on this drive"** and a
+list of files. An update left the previous app beside the new one — two
+`HilbertRaum-<version>-portable.exe` files, two `.AppImage` files, or an extracted
+`HilbertRaum.app` next to a `.app.zip`. The launcher refuses to start **either**: an older
+build running beside a newer one can destroy the workspace (see "Your password is correct, but
+the workspace data on the drive is damaged" above). It never deletes anything for you.
+
+What to do: keep only the newest version and delete every other HilbertRaum app file at the
+drive root — on macOS also the extracted `HilbertRaum.app` when a `.app.zip` is present (the
+launcher unpacks the zip again on the next start) — then double-click the launcher again.
+
+To see which app the launcher would start **without** starting it, run it with `/check` on
+Windows (`"Start HilbertRaum.cmd" /check` in a Command Prompt opened at the drive root) or
+`--check` on macOS/Linux (`./"Start HilbertRaum.command" --check`, `./start-hilbertraum.sh
+--check`). It prints the drive root and the app it resolved, then "Nothing was started".
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -322,7 +322,8 @@ the workspace data on the drive is damaged" above). It never deletes anything fo
 
 What to do: keep only the newest version and delete every other HilbertRaum app file at the
 drive root — on macOS also the extracted `HilbertRaum.app` when a `.app.zip` is present (the
-launcher unpacks the zip again on the next start) — then double-click the launcher again.
+launcher runs the zip's copy from its local cache, unpacking it first if needed) — then
+double-click the launcher again.
 
 To see which app the launcher would start **without** starting it, run it with `/check` on
 Windows (`"Start HilbertRaum.cmd" /check` in a Command Prompt opened at the drive root) or

--- a/launchers/Start HilbertRaum.cmd
+++ b/launchers/Start HilbertRaum.cmd
@@ -7,20 +7,28 @@ rem  It derives the drive root from its OWN location (%~dp0) every launch, so th
 rem  same drive works on any laptop no matter which drive letter it is given
 rem  (E:\ on one machine, F:\ on the next). NO path is hardcoded.
 rem
+rem  "Start HilbertRaum.cmd" /check  names the app it would start and starts
+rem  nothing (a support tool -- see docs\troubleshooting.md).
+rem
 rem  Mirrors apps/desktop/src/main/services/launcher.ts resolveDriveRootFromLauncher.
 rem ============================================================================
 setlocal enableextensions
+
+set "CHECK="
+if /i "%~1"=="/check" set "CHECK=1"
 
 rem %~dp0 = this script's directory, with a trailing backslash = the drive root.
 set "HILBERTRAUM_DRIVE_ROOT=%~dp0"
 rem One source of truth: the app reads the SAME manifests the drive scripts verified.
 set "HILBERTRAUM_MANIFESTS_DIR=%~dp0model-manifests"
 
-rem Find the portable app (the version is part of its name). Take the FIRST match, to
-rem match the first-match behaviour of the macOS/Linux launchers (consistent selection
-rem if more than one version is ever left on the drive).
+rem Find the portable app (the version is part of its name) and count the matches.
 set "APP="
-for %%f in ("%~dp0HilbertRaum-*-portable.exe") do if not defined APP set "APP=%%f"
+set "APP_COUNT=0"
+for %%f in ("%~dp0HilbertRaum-*-portable.exe") do (
+  set /a APP_COUNT+=1
+  if not defined APP set "APP=%%f"
+)
 
 if not defined APP (
   echo.
@@ -28,9 +36,35 @@ if not defined APP (
   echo   Make sure HilbertRaum-...-portable.exe is in this folder.
   echo   See docs\troubleshooting.md for help.
   echo.
-  pause
+  if not defined CHECK pause
   exit /b 1
 )
+
+rem Two app versions on one drive must never run: an older build beside a newer
+rem one can destroy the workspace (#235). Refuse, say what to delete, never delete.
+if %APP_COUNT% GTR 1 (
+  echo.
+  echo   More than one HilbertRaum app was found on this drive:
+  for %%f in ("%~dp0HilbertRaum-*-portable.exe") do echo     %%~nxf
+  echo.
+  echo   Two versions must never run from one drive. Keep only the newest
+  echo   HilbertRaum-...-portable.exe, delete the older one, then start again.
+  echo   See docs\troubleshooting.md, "Two app versions on the drive".
+  echo.
+  if not defined CHECK pause
+  exit /b 1
+)
+
+rem /check: report and stop. Delayed expansion keeps a drive path with special
+rem characters from being re-parsed; it is enabled only for these lines.
+if defined CHECK setlocal enabledelayedexpansion
+if defined CHECK echo.
+if defined CHECK echo   HilbertRaum launcher check
+if defined CHECK echo   Drive root : !HILBERTRAUM_DRIVE_ROOT!
+if defined CHECK echo   App        : !APP!
+if defined CHECK echo   Nothing was started.
+if defined CHECK echo.
+if defined CHECK exit /b 0
 
 rem If Windows SmartScreen says "Windows protected your PC", click "More info"
 rem then "Run anyway" (see READ ME FIRST.txt / docs\troubleshooting.md).

--- a/launchers/Start HilbertRaum.command
+++ b/launchers/Start HilbertRaum.command
@@ -14,9 +14,15 @@
 #  on the drive -- only the app binary is unpacked locally.
 #  See docs/packaging.md "The release workflow".
 #
+#  "Start HilbertRaum.command" --check  names the app it would start and starts
+#  nothing (a support tool -- see docs/troubleshooting.md).
+#
 #  Mirrors apps/desktop/src/main/services/launcher.ts resolveDriveRootFromLauncher.
 # ============================================================================
-set -e
+set -euo pipefail
+
+CHECK=0
+if [ "${1:-}" = "--check" ]; then CHECK=1; fi
 
 # The directory this script sits in = the drive root.
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,24 +30,73 @@ export HILBERTRAUM_DRIVE_ROOT="$DIR"
 # One source of truth: the app reads the SAME manifests the drive scripts verified.
 export HILBERTRAUM_MANIFESTS_DIR="$DIR/model-manifests"
 
-# --- 1. An already-extracted bundle on the drive wins (non-exFAT drives can hold one).
+# --- 1. Take stock: extracted bundles (non-exFAT drives can hold one) and ditto-zips.
 APP=""
+APP_COUNT=0
 for candidate in "$DIR"/*.app; do
-  if [ -d "$candidate" ]; then APP="$candidate"; break; fi
+  if [ -d "$candidate" ]; then
+    APP_COUNT=$((APP_COUNT + 1))
+    if [ -z "$APP" ]; then APP="$candidate"; fi
+  fi
+done
+ZIP=""
+ZIP_COUNT=0
+for candidate in "$DIR"/HilbertRaum-*-mac-arm64.app.zip; do
+  if [ -f "$candidate" ]; then
+    ZIP_COUNT=$((ZIP_COUNT + 1))
+    if [ -z "$ZIP" ]; then ZIP="$candidate"; fi
+  fi
 done
 
-# --- 2. Otherwise extract the ditto-zip into a local cache, keyed by zip name so a
-#        new version on the drive re-extracts instead of running the stale one.
-if [ -z "$APP" ]; then
-  ZIP=""
-  for candidate in "$DIR"/HilbertRaum-*-mac-arm64.app.zip; do
-    if [ -f "$candidate" ]; then ZIP="$candidate"; break; fi
-  done
+if [ "$APP_COUNT" -eq 0 ] && [ "$ZIP_COUNT" -eq 0 ]; then
+  echo
+  echo "  Could not find the HilbertRaum app on this drive."
+  echo "  Expected 'HilbertRaum.app' or 'HilbertRaum-<version>-mac-arm64.app.zip' in this folder."
+  echo "  See docs/troubleshooting.md for help."
+  echo
+  exit 1
+fi
 
-  if [ -z "$ZIP" ]; then
+# Two app versions on one drive must never run: an older build beside a newer
+# one can destroy the workspace (#235). An extracted bundle carries no version in
+# its name, so ANY .app beside ANY zip counts as two. Refuse before the cache
+# below is touched, say what to delete, never delete.
+if [ $((APP_COUNT + ZIP_COUNT)) -gt 1 ]; then
+  echo
+  echo "  More than one HilbertRaum app was found on this drive:"
+  for candidate in "$DIR"/*.app "$DIR"/HilbertRaum-*-mac-arm64.app.zip; do
+    if [ -e "$candidate" ]; then echo "    $(basename "$candidate")"; fi
+  done
+  echo
+  echo "  Two versions must never run from one drive. Keep only the newest"
+  echo "  HilbertRaum-<version>-mac-arm64.app.zip, delete the older ones and any"
+  echo "  extracted HilbertRaum.app next to it, then start again."
+  echo "  See docs/troubleshooting.md, \"Two app versions on the drive\"."
+  echo
+  exit 1
+fi
+
+if [ "$CHECK" = 1 ]; then
+  echo
+  echo "  HilbertRaum launcher check"
+  echo "  Drive root : $DIR"
+  if [ -n "$APP" ]; then
+    echo "  App        : $APP"
+  else
+    echo "  App        : $ZIP (unpacked into a local cache on start)"
+  fi
+  echo "  Nothing was started."
+  echo
+  exit 0
+fi
+
+# --- 2. No extracted bundle: extract the ditto-zip into a local cache, keyed by
+#        zip name so a new version on the drive re-extracts instead of running the
+#        stale one.
+if [ -z "$APP" ]; then
+  if [ -z "${HOME:-}" ]; then
     echo
-    echo "  Could not find the HilbertRaum app on this drive."
-    echo "  Expected 'HilbertRaum.app' or 'HilbertRaum-<version>-mac-arm64.app.zip' in this folder."
+    echo "  HOME is not set, so there is nowhere to unpack the app."
     echo "  See docs/troubleshooting.md for help."
     echo
     exit 1

--- a/launchers/start-hilbertraum.sh
+++ b/launchers/start-hilbertraum.sh
@@ -6,19 +6,29 @@
 #  root from its OWN location every launch, so the same drive works wherever it
 #  mounts (/media/<user>/HILBERTRAUM, /mnt/usb, ...). NO path is hardcoded.
 #
+#  ./start-hilbertraum.sh --check  names the app it would start and starts
+#  nothing (a support tool -- see docs/troubleshooting.md).
+#
 #  Mirrors apps/desktop/src/main/services/launcher.ts resolveDriveRootFromLauncher.
 # ============================================================================
-set -e
+set -euo pipefail
+
+CHECK=0
+if [ "${1:-}" = "--check" ]; then CHECK=1; fi
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 export HILBERTRAUM_DRIVE_ROOT="$DIR"
 # One source of truth: the app reads the SAME manifests the drive scripts verified.
 export HILBERTRAUM_MANIFESTS_DIR="$DIR/model-manifests"
 
-# Find the AppImage on the drive.
+# Find the AppImage on the drive and count the matches.
 APP=""
+APP_COUNT=0
 for candidate in "$DIR"/*.AppImage; do
-  if [ -f "$candidate" ]; then APP="$candidate"; break; fi
+  if [ -f "$candidate" ]; then
+    APP_COUNT=$((APP_COUNT + 1))
+    if [ -z "$APP" ]; then APP="$candidate"; fi
+  fi
 done
 
 if [ -z "$APP" ]; then
@@ -27,6 +37,32 @@ if [ -z "$APP" ]; then
   echo "  See docs/troubleshooting.md for help."
   echo
   exit 1
+fi
+
+# Two app versions on one drive must never run: an older build beside a newer
+# one can destroy the workspace (#235). Refuse, say what to delete, never delete.
+if [ "$APP_COUNT" -gt 1 ]; then
+  echo
+  echo "  More than one HilbertRaum app was found on this drive:"
+  for candidate in "$DIR"/*.AppImage; do
+    if [ -f "$candidate" ]; then echo "    $(basename "$candidate")"; fi
+  done
+  echo
+  echo "  Two versions must never run from one drive. Keep only the newest"
+  echo "  .AppImage, delete the older one, then start again."
+  echo "  See docs/troubleshooting.md, \"Two app versions on the drive\"."
+  echo
+  exit 1
+fi
+
+if [ "$CHECK" = 1 ]; then
+  echo
+  echo "  HilbertRaum launcher check"
+  echo "  Drive root : $DIR"
+  echo "  App        : $APP"
+  echo "  Nothing was started."
+  echo
+  exit 0
 fi
 
 chmod +x "$APP" 2>/dev/null || true

--- a/launchers/start-hilbertraum.sh
+++ b/launchers/start-hilbertraum.sh
@@ -24,7 +24,7 @@ export HILBERTRAUM_MANIFESTS_DIR="$DIR/model-manifests"
 # Find the AppImage on the drive and count the matches.
 APP=""
 APP_COUNT=0
-for candidate in "$DIR"/*.AppImage; do
+for candidate in "$DIR"/HilbertRaum-*.AppImage; do
   if [ -f "$candidate" ]; then
     APP_COUNT=$((APP_COUNT + 1))
     if [ -z "$APP" ]; then APP="$candidate"; fi
@@ -44,7 +44,7 @@ fi
 if [ "$APP_COUNT" -gt 1 ]; then
   echo
   echo "  More than one HilbertRaum app was found on this drive:"
-  for candidate in "$DIR"/*.AppImage; do
+  for candidate in "$DIR"/HilbertRaum-*.AppImage; do
     if [ -f "$candidate" ]; then echo "    $(basename "$candidate")"; fi
   done
   echo


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 3: update multiplicity — launchers refuse two app versions
Closes #235 (REL-7; DOC-2 and DOC-13 are folded into it and land here)
Closes #257 (REL-3)
Refs #220 (decision 3 used on its default: interim), #225 / #247 (decision 8 unanswered → default not ratified: no PR 3-b, REL-4 stays a recorded residual)
Tracker: #217

### What
- **All three drive launchers count their app artifacts and refuse to start when more than one is present**, printing the files and telling the user to keep the newest and delete the rest — the launcher never deletes anything (Q25 default: message only; the launchers are EN-only, no i18n exists for them).
  - `Start HilbertRaum.cmd`: counts `HilbertRaum-*-portable.exe`.
  - `start-hilbertraum.sh`: counts `*.AppImage`.
  - `Start HilbertRaum.command`: counts extracted `*.app` bundles and `HilbertRaum-*-mac-arm64.app.zip` archives; any `.app` beside any zip counts as two (presence-based — the extracted bundle's name carries no version). The refusal sits before the `$HOME/Library/Caches` write and before `ditto`.
- **Control argument** `--check` (`.sh`, `.command`) / `/check` (`.cmd`): resolves the app exactly as a launch would (including the refusal) and exits 0 with `HilbertRaum launcher check` / `Drive root : …` / `App        : …` / `Nothing was started.` — a support tool, documented in troubleshooting. No launcher reads an ambient environment variable (review rec 14 default: argument, not env flag).
- **`set -euo pipefail`** in `start-hilbertraum.sh` (#257) and — Q16 default, yes — in `Start HilbertRaum.command`; optional inputs are read as `${1:-}` / `${HOME:-}` (the `.command` now fails with a message when `HOME` is unset instead of unpacking under `/Library`).
- The `.cmd` `/check` report enables delayed expansion only for its own echo lines so a drive path with `&`, `(`, `)` or `!` is printed, not re-parsed (probed on such roots).

### Why (finding IDs + the promise line each restores)
- REL-7 (#235): every launcher took the first name-sorted match, so an update that left the old artifact beside the new one launched the OLD build deterministically on Windows/Linux, and a pre-0.1.59 build running beside a newer one replays the #208 vault corruption (the single-instance lock exists only from 0.1.59). Now two versions on one drive cannot be launched through the launchers at all, and the docs say to delete the prior artifact first.
- DOC-2 / DOC-13 (folded): `drive-layout.md` said "Replace"; `troubleshooting.md` claimed "current versions refuse a second instance" with no version floor — both corrected.
- REL-3 (#257): the Linux launcher ran with `set -e` only, unlike every other shipped shell script.

### Tests
- characterisation (red before, commit 1): new `tests/integration/launcher-execution.test.ts` — the first test that executes the launchers. Each case copies a launcher into a scratch root beside 0-byte artifacts (newer name created first). Red at HEAD: 13 of 16 (the launchers picked the older name; the `.cmd` cases failed by child timeout because `start` on a 0-byte exe blocks).
- regression / inverted B9: two `.exe`s / two AppImages / two `.app`s / two zips / `.app` + newer zip → exit ≠ 0, message names both, nothing launched (AppImage stubs record whether they ran; the `.command` cases run with `HOME` = a scratch dir and assert `$HOME/Library` was never created); `--check`/`/check` with one artifact → exit 0 + the artifact + "Nothing was started"; no artifact → the existing not-found message; one AppImage with no argument → the exec-able stub really runs and sees the derived drive root (no unbound-variable abort under `set -u`); `bash -n` + the `set -euo pipefail` pin on both shell launchers.
- Legs: `.cmd` on Windows (`cmd.exe /d /c`, stdin ignored so `pause` returns, 10 s child timeout); bash legs on non-Windows, or on a Windows dev box with `HILBERTRAUM_SCRIPT_SH_LEG=1` (all 16 ran green here under Git Bash + cmd.exe).
- `npm test` count: **367 files passed / 23 skipped; 5,470 passed / 74 skipped** (Phase 2 baseline 366 / 5,466 / 62: +1 file, +4 tests = the `.cmd` leg, +12 skipped = the bash legs on a Windows host; all 16 green locally under Git Bash with `HILBERTRAUM_SCRIPT_SH_LEG=1`). `npm run typecheck`, `npm run build` green; `npm run dev` launch gate green (workspace resolved, offline posture logged, no orphaned Electron).

### Docs + BUILD_STATE
`docs/drive-layout.md` update step rewritten ("delete every prior app artifact … then copy the new build … verify the version under Settings → Diagnostics"); `docs/troubleshooting.md` new entry "Two app versions on the drive" (+ the `--check` support tool) and the version floor in the #208 entry; `docs/security-model.md` single-instance bullet gains the 0.1.59 floor + the launcher refusal; `docs/known-limitations.md` single-instance bullet records the residual (direct artifact launch bypasses the launcher; signed manifest = #220); `docs/packaging.md` launcher table note; `CHANGELOG.md` `[Unreleased]` Changed; BUILD_STATE dated entry + §5 item 19 line.

### Owner decisions relied on (issue #, answer or default)
- Decision 3 (#220): unanswered → **default: interim** (launchers refuse >1, builders refuse to proceed — landed in PR #271 —, docs mandate deletion). The signed current-release manifest stays open on #220.
- Decision 8 (#225): unanswered → **default: not ratified** — no `PRAGMA user_version`, no PR 3-b; REL-4 (#247) stays open as a residual tied to #235.
- Q16 (`.command` gets `set -u`/`pipefail` too): default yes. Q25 (message only, never delete): default. Review rec 14 (argument, not env flag): default. Review rec 17 (walk steps written before running): default.

### Manual adjacent-version walk
- Windows: **run** on a scratch root with the real 0.1.57 and 0.1.59 portable artifacts beside the branch launcher — `/check` and the plain double-click path both refuse, naming both files (the plain path also pauses), nothing starts; after deleting 0.1.57, `/check` names 0.1.59 and the plain launch starts it (process observed within 2 s, watchdog-killed, no orphan). The Settings → Diagnostics version check is a GUI step and was not run in this non-interactive session; release-acceptance stays open for that leg.
- macOS / Linux: deferred — no machine; to be run before a kit for that platform ships (release-acceptance line 6 stays open for those platforms).

### Reviewer pass: Fable tier, read-only — verdict "merge", 5 nits + 1 accepted, all nits repaired
- (1, nit) two comments outside the diff still said the `.command` "prefers" an extracted `.app` over the zip (`commercial-drive.ts` `KIT_PLATFORM_SPECS` header, `commercial-drive.test.ts` `provisionExtractedApp`) → reworded: a lone `.app` is accepted, beside a zip the launcher and the gate refuse.
- (2, nit) `start-hilbertraum.sh` counted ANY `*.AppImage`, so a stray unrelated AppImage would have produced a "More than one HilbertRaum app" refusal naming it → the glob is now `HilbertRaum-*.AppImage` in both loops (the name the gate recognises).
- (3, nit) troubleshooting said the launcher "unpacks the zip again on the next start" — it re-uses its name-keyed cache → reworded.
- (4, nit) a code span in `packaging.md` was split across a line → joined.
- (5, nit) the test left its scratch roots in the temp dir (house style, cf. `script-execution.test.ts`) → `afterAll` removes them.
- (6, accepted) audit IDs appear in BUILD_STATE and commit subjects — the established convention for those two places; every launcher, test and docs line cites issue numbers only.
- Independently verified by the reviewer: the `.cmd` on hostile roots (spaces, `( ) & ! ^ %`), `/CHECK` case-insensitive, exit codes through `cmd /c`, the CRLF attribute, `bash -n`, every `set -u` expansion guarded, bash 3.2 syntax only, refusal and `--check` both before the first `$HOME` read and before `ditto`, leg gating runs each leg once per CI runner, the 0.1.59 single-instance floor against `index.ts`/CHANGELOG, the Settings → Diagnostics "App version" label.

### Rollback
Revert the PR: the launchers return to first-match selection and the docs to the previous wording. Nothing on disk changes format; no app code is touched.
