### PR TITLE
fix(lock-quit): plaintext-operation registry — lock/quit abort, settle and sweep in-flight preview/re-index/import/dictation/export transients (audit 2026-09-02 Phase 4 — SEC-10, TQ-1)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-02 — **Audit 2026-09-02 Phase 4 — lock/quit quiescence: a plaintext-operation registry
+(`services/ingestion/plaintext-ops.ts`, `ctx.plaintextOps`) that preview, re-index, import
+prepare, dictation and the two export readers join before writing a `.parse*` transient; "Lock
+now" and quit abort it, await its settle (5 s, the doc-task bound) and shred whatever is still
+registered before the vault re-encrypts (SEC-10 #237 with DOC-4 folded, TQ-1 #258; PR #273).**_
+Photo OCR and audio honour the abort; pdfjs/mammoth/txt cannot and are sweep-bounded. The parse
+wall-clock timeout now aborts the same signal; the preview IPC re-checks admission after its
+awaits. Quit's raced middle is 25.5 s worst case under the 30 s constant (rider 13 default kept).
+B2 inverted in `lock-admission-race.test.ts` (parked photo preview across a real lock and a real
+`performShutdown`, a `readdirSync` name sweep at the "locked" instant, stored copies survive;
+`waitUntil` ticks on `setTimeout`). Docs: `security-model.md` lifecycle bullet + quit bullet, §7
+conventions entry, CHANGELOG. Manual GUI smoke (lock mid-preview) not run — non-interactive session.
+
 _2026-09-02 — **Audit 2026-09-02 Phase 3 — update multiplicity: the three drive launchers refuse
 to start while more than one app artifact sits at the drive root, name what to delete and never
 delete; `--check` / `/check` resolves the app without starting it (REL-7 #235 with DOC-2/DOC-13
@@ -632,6 +645,9 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     - **3** (2026-09-02, PR #272): REL-7 (DOC-2, DOC-13 folded) + REL-3 — the launchers refuse two
       app versions at the root and take `--check`/`/check`; `set -euo pipefail`; docs mandate deleting
       the prior artifact; decisions 3/8 on defaults (no PR 3-b; REL-4 #247 residual) — dated entry above.
+    - **4** (2026-09-02, PR #273): SEC-10 (DOC-4 folded) + TQ-1 — plaintext-operation registry;
+      lock/quit abort → settle (5 s) → sweep before re-encrypting; parse timeout aborts; rec 8 / rec 2
+      on defaults (one PR, 30 s constant, 25.5 s worst case) — dated entry above.
 
 **Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
 the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/
@@ -681,6 +697,12 @@ per-phase test inventories) lives in git history.
 - Tests: under fake timers, never wait for real I/O by counting event-loop turns — a turn is not
   a unit of time (1000 `advanceTimersByTimeAsync(0)` ≈ 4 ms). Poll a real deadline with a real
   timer captured before `useFakeTimers()` (2026-08-22 entry).
+- Tests (audit 2026-09-02, #258 / #242): a helper that waits on real file I/O ticks with a real
+  macrotask — `setTimeout(r, 1)`, never a `setImmediate` loop, which starves the libuv poll phase
+  where fs callbacks land (a real async decrypt never left its `.tmp` stage under it). And for
+  filesystem fault injection use the pass-through `vi.mock('node:fs', async (importOriginal) => …)`
+  wrapper (`workspace-vault-durability.test.ts`), never `vi.spyOn(fs, …)` — it records nothing
+  for an ESM-namespace binder, so the injection is silently never reached.
 
 ---
 ## 8. Post-MVP audits & hardening (2026-06-09 → 2026-06-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **Locking or quitting during a document preview, re-index, import, dictation or export no
+  longer leaves a decrypted copy on the drive.** Those operations decrypt the document to a
+  temporary file while they read it. Lock now and Quit used to finish while such a read was still
+  running, so the temporary file stayed on the drive (until the next start cleaned it up) and a
+  preview started before the lock could still show its text afterwards. Both now stop these
+  operations, wait a few seconds for them to finish, and remove any temporary file that is still
+  there before the workspace is re-encrypted; a preview that was cut off reports the workspace as
+  locked instead of showing text.
 - **Quitting can no longer leave your workspace unencrypted.** Pressing Quit a second time while
   the app was still shutting down (for example while it waited on a slow AI-engine start) used to
   let the app exit before the workspace was re-encrypted, and the next start then discarded every

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -30,6 +30,7 @@ import { registerBuiltinSkillAnalysisHandlers } from './services/skills/analysis
 import { registerDocTasksIpc } from './ipc/registerDocTasksIpc'
 import { DocTaskManager } from './services/doctasks'
 import { documentsDir } from './services/ingestion'
+import { createPlaintextOps } from './services/ingestion/plaintext-ops'
 import { inFlightStreams } from './ipc/inflight'
 import { registerDictationIpc } from './ipc/registerDictationIpc'
 import { registerImagesIpc } from './ipc/registerImagesIpc'
@@ -398,6 +399,9 @@ function initBackend(): void {
   // vault lease serve the translation materialize step: the new document goes
   // through the normal import path (embedded + `.enc`-encrypted) while holding
   // `beginDocumentWork()` for exactly that step.
+  // #237: the registry of plaintext-materialising operations; the lock/quit teardowns abort,
+  // settle and sweep it (see `shutdown.ts` / `registerWorkspaceIpc.ts`).
+  const plaintextOps = createPlaintextOps()
   const docTasks = new DocTaskManager({
     getDb: () => workspace.requireDb(),
     getRuntime: () => runtime.active(),
@@ -425,7 +429,7 @@ function initBackend(): void {
       return launchContextTokens(s, findManifestById(manifestsDir, s.activeModelId))
     },
     getStoreDir: () => documentsDir(paths.workspacePath),
-    getIngestionDeps: () => ({ embedder, cipher: workspace.documentCipher(), ocrEngine }),
+    getIngestionDeps: () => ({ embedder, cipher: workspace.documentCipher(), ocrEngine, plaintextOps }),
     beginDocumentWork: () => workspace.beginDocumentWork(),
     // The OCR task's engine + the hidden-window PDF rasterizer.
     getOcrEngine: () => ocrEngine,
@@ -491,6 +495,7 @@ function initBackend(): void {
     isDev,
     audit,
     docTasks,
+    plaintextOps,
     skills
   }
   // The vision sidecar orchestrator (image-understanding plan §10). Built here — not inside

--- a/apps/desktop/src/main/ipc/documentSegments.ts
+++ b/apps/desktop/src/main/ipc/documentSegments.ts
@@ -34,7 +34,7 @@ export function buildDocumentSegmentReader(
       ctx.db,
       storeDir,
       documentId,
-      { cipher: ctx.workspace.documentCipher(), ocrEngine: ctx.ocrEngine },
+      { cipher: ctx.workspace.documentCipher(), ocrEngine: ctx.ocrEngine, plaintextOps: ctx.plaintextOps },
       opts?.layout ? { layout: true, maxPages: resolveIngestionLimits().pdfMaxPages } : {}
     )
     return preview.segments.map((s, index) => ({ text: s.text, page: s.pageNumber, index }))
@@ -60,7 +60,8 @@ export function buildOriginalDocumentReader(ctx: AppContext): (documentId: strin
       | undefined
     if (!row || extname(row.title).toLowerCase() !== '.docx') return { format: 'other' }
     const { bytes } = await readStoredDocumentBytes(ctx.db, storeDir, documentId, {
-      cipher: ctx.workspace.documentCipher()
+      cipher: ctx.workspace.documentCipher(),
+      plaintextOps: ctx.plaintextOps
     })
     return { format: 'docx', bytes }
   }

--- a/apps/desktop/src/main/ipc/registerDictationIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDictationIpc.ts
@@ -96,13 +96,17 @@ export function registerDictationIpc(ctx: AppContext, options: DictationIpcOptio
     const timer = setTimeout(() => controller.abort(), maxDurationMs)
 
     const tempPath = join(storeDir, `${randomUUID()}.parse-dictation.wav`)
+    // #237: registered (under the timeout above) so a lock/quit aborts the whisper child too and
+    // sweeps the WAV if the transcription outlives the settle bound.
+    const op = ctx.plaintextOps?.register('dictation', controller.signal)
+    op?.track(tempPath)
     try {
       // PERF-2: write the up-to-64 MiB WAV off the main thread (the handler is already async); the
       // existing try/finally still shreds tempPath on any failure, including a write rejection.
       await writeFile(tempPath, audio)
       const segments = await transcriber.transcribe(tempPath, {
         workDir: storeDir,
-        signal: controller.signal
+        signal: op?.signal ?? controller.signal
       })
       return segments
         .map((s) => s.text)
@@ -117,6 +121,7 @@ export function registerDictationIpc(ctx: AppContext, options: DictationIpcOptio
     } finally {
       clearTimeout(timer)
       shredFile(tempPath)
+      op?.release()
       inFlight = false
     }
   })

--- a/apps/desktop/src/main/ipc/registerDocsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDocsIpc.ts
@@ -275,8 +275,25 @@ export function registerDocsIpc(ctx: AppContext): void {
     transcriber: ctx.transcriber,
     ocrEngine: ctx.ocrEngine,
     onTranscribeProgress: (documentId, percent) => transcribing.set(documentId, percent),
-    signal
+    signal,
+    // #237: prepare/re-index register their `.parse` transient so lock/quit can abort + sweep.
+    plaintextOps: ctx.plaintextOps
   })
+
+  // #237: a preview whose parse straddled a lock/quit must REJECT, never hand text across IPC
+  // after the workspace reported locked — re-check admission after the awaits (the parse may
+  // have been aborted by the teardown, or finished on its own with the latch armed since).
+  const previewUnlessLocked = async <T>(work: () => Promise<T>): Promise<T> => {
+    let out: T
+    try {
+      out = await work()
+    } catch (err) {
+      requireUnlocked()
+      throw err
+    }
+    requireUnlocked()
+    return out
+  }
 
   // Offer a deep-index (tree) build for a freshly-(re)indexed document. This is fire-and-forget
   // and MUST NOT throw into the import/reindex path (the document is already indexed — only the
@@ -665,11 +682,14 @@ export function registerDocsIpc(ctx: AppContext): void {
     requireNotProcessing(documentId)
     log.info('Preview document', { documentId })
     // FE-6: return the BOUNDED first page (+ cursor), never the whole document in one payload.
-    return extractDocumentPreviewPage(ctx.db, storeDir, documentId, 0, DEFAULT_PREVIEW_PAGE_SIZE, {
-      cipher: ctx.workspace.documentCipher(),
-      // Photos re-recognize on preview; OCR'd PDFs read their stored pages.
-      ocrEngine: ctx.ocrEngine
-    })
+    return previewUnlessLocked(() =>
+      extractDocumentPreviewPage(ctx.db, storeDir, documentId, 0, DEFAULT_PREVIEW_PAGE_SIZE, {
+        cipher: ctx.workspace.documentCipher(),
+        // Photos re-recognize on preview; OCR'd PDFs read their stored pages.
+        ocrEngine: ctx.ocrEngine,
+        plaintextOps: ctx.plaintextOps
+      })
+    )
   })
 
   // FE-6: a subsequent bounded page of a preview (the modal's "Show more"). Same guards as the
@@ -679,16 +699,12 @@ export function registerDocsIpc(ctx: AppContext): void {
     async (_e, documentId: string, offset: number, limit: number): Promise<DocumentPreview> => {
       requireUnlocked()
       requireNotProcessing(documentId)
-      return extractDocumentPreviewPage(
-        ctx.db,
-        storeDir,
-        documentId,
-        offset ?? 0,
-        limit ?? DEFAULT_PREVIEW_PAGE_SIZE,
-        {
+      return previewUnlessLocked(() =>
+        extractDocumentPreviewPage(ctx.db, storeDir, documentId, offset ?? 0, limit ?? DEFAULT_PREVIEW_PAGE_SIZE, {
           cipher: ctx.workspace.documentCipher(),
-          ocrEngine: ctx.ocrEngine
-        }
+          ocrEngine: ctx.ocrEngine,
+          plaintextOps: ctx.plaintextOps
+        })
       )
     }
   )
@@ -701,7 +717,8 @@ export function registerDocsIpc(ctx: AppContext): void {
     requireUnlocked()
     requireNotProcessing(documentId)
     const { title, text } = await readStoredDocumentText(ctx.db, storeDir, documentId, {
-      cipher: ctx.workspace.documentCipher()
+      cipher: ctx.workspace.documentCipher(),
+      plaintextOps: ctx.plaintextOps
     })
     const dot = title.lastIndexOf('.')
     const baseName = (dot > 0 ? title.slice(0, dot) : title)
@@ -755,7 +772,8 @@ export function registerDocsIpc(ctx: AppContext): void {
       let bytes: Buffer
       try {
         ;({ title, bytes } = await readStoredDocumentBytes(ctx.db, storeDir, documentId, {
-          cipher: ctx.workspace.documentCipher()
+          cipher: ctx.workspace.documentCipher(),
+          plaintextOps: ctx.plaintextOps
         }))
       } finally {
         releaseDocWork()

--- a/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
+++ b/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
@@ -81,6 +81,29 @@ async function awaitActiveDocTaskSettled(ctx: AppContext): Promise<void> {
   }
 }
 
+/**
+ * Await the aborted plaintext operations (preview / re-index / import prepare / dictation /
+ * export) within the same bound as the doc-task settle, then shred whatever transient is still
+ * registered — a parser that cannot cancel (pdfjs, mammoth) is bounded by this sweep, not by
+ * its signal (#237). Runs while `ctx.db` is open, before the vault re-encrypts. Best-effort.
+ */
+async function settleAndSweepPlaintextOps(ctx: AppContext): Promise<void> {
+  const ops = ctx.plaintextOps
+  if (!ops) return
+  try {
+    const settled = await ops.awaitSettled(LOCK_TASK_SETTLE_TIMEOUT_MS)
+    if (!settled) {
+      log.warn('Lock: plaintext operations still running at the settle bound — sweeping', {
+        live: ops.size()
+      })
+    }
+    const swept = ops.sweepRegistered()
+    if (swept > 0) log.info('Lock: swept registered plaintext transients', { swept })
+  } catch (err) {
+    log.error('Error settling plaintext operations on lock', String(err))
+  }
+}
+
 export function registerWorkspaceIpc(ctx: AppContext): void {
   ipcMain.handle(IPC.getWorkspaceState, (): WorkspaceStateInfo => ctx.workspace.getState())
 
@@ -345,6 +368,15 @@ async function runLockTeardown(ctx: AppContext): Promise<WorkspaceStateInfo> {
   // ~10 GB sidecar with the source text while the vault re-encrypts. stop() also purges the job
   // map so the transient source/translation text does not linger past the lock (vision parity).
   void ctx.translateJobs?.stop()
+  // #237: abort every plaintext operation in flight (a preview, re-index, import prepare,
+  // dictation or export decrypting to / reading a `.parse*` transient) NOW, so it has the whole
+  // teardown to unwind; its settle is awaited (bounded) and its transients swept below, after
+  // the doc-task settle. In-memory; best-effort.
+  try {
+    ctx.plaintextOps?.abortAll()
+  } catch {
+    /* best-effort */
+  }
   // The local API dies FIRST (local-api wave, D7): its stop() aborts active + queued
   // external streams and closes every socket, so no outside caller can reach the model
   // (or hold a stream open) while the sidecars below are torn down and the vault
@@ -400,6 +432,10 @@ async function runLockTeardown(ctx: AppContext): Promise<WorkspaceStateInfo> {
   // synchronously while ctx.db is open) before purge/lock close the DB — bounded so a wedged
   // handler can't hang the lock. Mirrors the in-flight-stream settle await above.
   await awaitActiveDocTaskSettled(ctx)
+  // #237: then the plaintext operations aborted above — settle within the same bound, and shred
+  // whatever `.parse*` transient a parser that cannot cancel still holds. Only registered paths
+  // are touched, never a stored copy.
+  await settleAndSweepPlaintextOps(ctx)
   // RAG-6 (Wave P4) — SECURITY purge: drop the resident decoded-vector cache from main-process
   // RAM. The vectors are derived from chunk text, so like the sidecars' in-memory recent text
   // they must not linger after the vault re-encrypts. The staleness signature does NOT cover

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -14,6 +14,7 @@ import type { SkillRegistry } from './skills/registry'
 import type { VisionService } from './vision'
 import type { TranslateJobService } from './translation/jobs'
 import type { LocalApiServer } from './local-api/server'
+import type { PlaintextOpsRegistry } from './ingestion/plaintext-ops'
 
 // Shared application context assembled at startup and passed to IPC handlers.
 export interface AppContext {
@@ -86,6 +87,13 @@ export interface AppContext {
    * handlers guard with `ctx.docTasks?.hasActiveTask()`.
    */
   docTasks?: DocTaskManager
+  /**
+   * Registry of the operations that materialise decrypted document content (preview, re-index,
+   * import prepare, dictation, export) — the lock/quit teardowns abort it, await its settle and
+   * shred whatever is still registered before the vault re-encrypts (#237). Optional so partial
+   * test contexts stay valid; absent ⇒ nothing is registered and the teardowns skip the step.
+   */
+  plaintextOps?: PlaintextOpsRegistry
   /**
    * In-flight skill-run probe (GAP-5, full-audit 2026-07-11): true while the SkillRunController —
    * module-local to registerSkillsIpc, which assigns this at registration time — has a

--- a/apps/desktop/src/main/services/doctasks/handlers/categorize.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/categorize.ts
@@ -67,7 +67,11 @@ export async function runCategorize(
           db,
           storeDir,
           id,
-          { cipher: ingestion.cipher, ocrEngine: ctx.deps.getOcrEngine?.() ?? ingestion.ocrEngine },
+          {
+            cipher: ingestion.cipher,
+            ocrEngine: ctx.deps.getOcrEngine?.() ?? ingestion.ocrEngine,
+            plaintextOps: ingestion.plaintextOps
+          },
           { layout: opts?.layout }
         )
         return preview.segments.map((s, index) => ({ text: s.text, page: s.pageNumber, index }))

--- a/apps/desktop/src/main/services/doctasks/handlers/ocr.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/ocr.ts
@@ -139,7 +139,8 @@ async function readStoredPdfBytes(documentId: string, ctx: DocTaskCtx): Promise<
       }
     | undefined
   if (!row) throw new Error(tMain('main.task.sourceUnreadable'))
-  const cipher = ctx.deps.getIngestionDeps().cipher ?? null
+  const ingestionDeps = ctx.deps.getIngestionDeps()
+  const cipher = ingestionDeps.cipher ?? null
   const storeDir = ctx.deps.getStoreDir()
   try {
     // ING-8 (perf audit 2026-06-18): read the (potentially huge, up to ~1 GiB) PDF with async
@@ -151,11 +152,15 @@ async function readStoredPdfBytes(documentId: string, ctx: DocTaskCtx): Promise<
       if (stored.encrypted) {
         if (!cipher) throw new Error(tMain('main.task.sourceUnreadable'))
         const transient = join(storeDir, `${documentId}.parse-ocr.pdf`)
+        // #237: registered so a lock/quit that outlasts the doc-task settle still sweeps it.
+        const op = ingestionDeps.plaintextOps?.register('doc-task')
+        op?.track(transient)
         try {
           await cipher.decryptFileAsync(stored.path, transient) // PERF-1: yields between chunks
           return await readFile(transient)
         } finally {
           shredFile(transient)
+          op?.release()
         }
       }
       return await readFile(stored.path)

--- a/apps/desktop/src/main/services/doctasks/handlers/shared.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/shared.ts
@@ -47,7 +47,11 @@ export async function extractTranslationSource(
       ctx.deps.getDb(),
       ctx.deps.getStoreDir(),
       documentId,
-      { cipher: ingestionDeps.cipher ?? null, ocrEngine: ingestionDeps.ocrEngine }
+      {
+        cipher: ingestionDeps.cipher ?? null,
+        ocrEngine: ingestionDeps.ocrEngine,
+        plaintextOps: ingestionDeps.plaintextOps
+      }
     )
     source = {
       segments: preview.segments

--- a/apps/desktop/src/main/services/doctasks/handlers/shared.ts
+++ b/apps/desktop/src/main/services/doctasks/handlers/shared.ts
@@ -127,6 +127,10 @@ export async function materializeDocument(
   const storeDir = ctx.deps.getStoreDir()
   const tempPath = join(storeDir, `${task.status.jobId}.parse.md`)
   let newDocId: string | null = null
+  // #237: the plaintext source lives through the whole import below — registered so a lock/quit
+  // that outlasts the doc-task settle still sweeps it.
+  const op = ctx.deps.getIngestionDeps().plaintextOps?.register('doc-task')
+  op?.track(tempPath)
   try {
     // ING-6 (perf audit 2026-06-18): the in-RAM `markdown` is written to a temp `.parse.md`
     // and re-read/re-parsed/re-chunked by the canonical import path below. This disk round-trip
@@ -175,6 +179,7 @@ export async function materializeDocument(
     throw err
   } finally {
     shredFile(tempPath)
+    op?.release()
     release()
   }
 }

--- a/apps/desktop/src/main/services/ingestion/index.ts
+++ b/apps/desktop/src/main/services/ingestion/index.ts
@@ -48,6 +48,7 @@ import { PDF_SCAN_DETECTED_MESSAGE } from './parsers/pdf'
 import { parseOcrMeta } from './ocr-meta'
 import { chunkSegments, MAX_CHUNKS_PER_DOCUMENT } from './chunker'
 import { resolveIngestionLimits, withParseTimeout, type IngestionLimits } from './limits'
+import type { PlaintextOpsRegistry } from './plaintext-ops'
 import {
   canonicalLeafFor,
   locateOriginal,
@@ -114,6 +115,15 @@ export interface IngestionDeps {
    * a wedged whisper child when no signal is supplied.
    */
   signal?: AbortSignal
+  /**
+   * Registry every plaintext-materialising operation joins (#237): prepare, preview and the
+   * export readers register before writing a `.parse*` transient and release in their
+   * `finally`, so the lock/quit teardowns can abort them, await their settle and shred what
+   * is still on disk. Absent (partial test contexts) ⇒ nothing is registered.
+   */
+  plaintextOps?: PlaintextOpsRegistry
+  /** How `prepareDocument` registers itself: an import (default) or a re-index. */
+  plaintextOpKind?: 'import-prepare' | 'reindex'
 }
 
 // Canonical home of the `.enc` suffix is workspace-vault (the password change
@@ -687,7 +697,17 @@ export function parseWithLimits(
     maxInflatedBytes: ctx.maxInflatedBytes ?? limits.docxMaxInflatedBytes
   }
   if (isAudioPath(source)) return parser.parse(source, cappedCtx)
-  return withParseTimeout(parser.parse(source, cappedCtx), limits.parseTimeoutMs, timeoutMessage)
+  // #237: the timed-out parse is also ABORTED, not just abandoned — the parser sees a signal
+  // that fires on the caller's abort OR the timeout, so a signal-aware parser (photo OCR) stops
+  // its work. pdfjs/mammoth/txt ignore it and are bounded by the lock/quit sweep instead.
+  const timeoutAbort = new AbortController()
+  const signal = ctx.signal ? AbortSignal.any([ctx.signal, timeoutAbort.signal]) : timeoutAbort.signal
+  return withParseTimeout(
+    parser.parse(source, { ...cappedCtx, signal }),
+    limits.parseTimeoutMs,
+    timeoutMessage,
+    () => timeoutAbort.abort(new Error(timeoutMessage))
+  )
 }
 
 /**
@@ -715,6 +735,9 @@ export async function prepareDocument(
   // workspace). Always shredded on the way out — success or failure — so no decrypted
   // document content lingers on the drive.
   const transients: string[] = []
+  // #237: registered for the lock/quit teardowns (aborted, settled within a bound, swept); the
+  // op's signal also follows the caller's `deps.signal` (an import job's abort).
+  const op = deps.plaintextOps?.register(deps.plaintextOpKind ?? 'import-prepare', deps.signal)
 
   const limits = deps.limits ?? resolveIngestionLimits()
 
@@ -794,10 +817,12 @@ export async function prepareDocument(
       )
       parseSource = storedPath
       transients.push(storedPath)
+      op?.track(storedPath) // now a derived copy (the `.enc` is the store) — sweepable (#237)
       storedPath = encPath
     } else if (cipher) {
       // Encrypted stored copy: decrypt to a transient working file for the parser.
       parseSource = join(storeDir, `${documentId}.parse${ext}`)
+      op?.track(parseSource) // registered BEFORE the write (#237)
       await cipher.decryptFileAsync(storedPath, parseSource) // PERF-1: yields between chunks
       transients.push(parseSource)
     } else {
@@ -841,8 +866,9 @@ export async function prepareDocument(
       onProgress: (percent) => deps.onTranscribeProgress?.(documentId, percent),
       // REL-1: cancellation for an unbounded audio transcription. Audio stays EXEMPT from
       // the wall-clock parse timeout, so the signal (+ the transcriber's own idle watchdog)
-      // is the only way to stop a wedged/cancelled whisper child.
-      signal: deps.signal
+      // is the only way to stop a wedged/cancelled whisper child. The registered operation's
+      // signal (#237) fires on the caller's abort AND on a workspace lock/quit.
+      signal: op?.signal ?? deps.signal
       // Per-parser caps (M-2/M-3) and the audio-exempt wall-clock timeout are applied by
       // parseWithLimits — the ONE cap-enforcement point shared with the preview path (MAINT-4).
     }
@@ -981,6 +1007,7 @@ export async function prepareDocument(
     // Shred transient decrypted copies whether parse succeeded or failed — the embed phase
     // reads chunk text from the DB, not these files, so they are no longer needed.
     for (const t of transients) shredFile(t)
+    op?.release()
   }
 }
 
@@ -1150,7 +1177,7 @@ export async function extractDocumentPreview(
   db: Db,
   storeDir: string,
   documentId: string,
-  deps: Pick<IngestionDeps, 'cipher' | 'ocrEngine'> = {},
+  deps: Pick<IngestionDeps, 'cipher' | 'ocrEngine' | 'plaintextOps'> = {},
   opts: ExtractPreviewOptions = {}
 ): Promise<DocumentPreview> {
   const row = getRow(db, documentId)
@@ -1178,6 +1205,9 @@ export async function extractDocumentPreview(
 
   const cipher = deps.cipher ?? null
   const transients: string[] = []
+  // #237: registered for the lock/quit teardowns — they abort this signal, await the release
+  // below within a bound, and shred the tracked transient if the parser outlives the bound.
+  const op = deps.plaintextOps?.register('preview')
   try {
     let parseSource: string
     // #188: resolve through the canonical location first, so a drive that came back under a
@@ -1193,6 +1223,7 @@ export async function extractDocumentPreview(
         // the startup crash sweep (`workspace-vault.ts` matches `name.includes('.parse')`) covering
         // a leak. Every caller uses the returned `parseSource` local, so nothing depends on the name.
         parseSource = join(storeDir, `${documentId}.parse-preview-${randomUUID()}${ext}`)
+        op?.track(parseSource) // registered BEFORE the write (#237)
         await cipher.decryptFileAsync(stored.path, parseSource) // PERF-1: yields between chunks
         transients.push(parseSource)
       } else if (!cipher && stored.encrypted) {
@@ -1217,6 +1248,9 @@ export async function extractDocumentPreview(
     const previewCtx: ParseContext = {
       ocrEngine: deps.ocrEngine,
       ocrPages: isPdfPath(row.title) ? getDocumentOcrPages(db, documentId) : null,
+      // #237: a lock/quit aborts the re-parse (honoured by the photo OCR; text parsers are
+      // bounded by the sweep).
+      signal: op?.signal,
       // Geometry-aware layout reconstruction (plan §3.1, D51) — opt-in, bank-statement-only (D58).
       // In layout mode the caller passes its own page cap; otherwise parseWithLimits injects the
       // default `pdfMaxPages` below — REL-5: the preview path now caps too (it formerly ran uncapped).
@@ -1246,6 +1280,7 @@ export async function extractDocumentPreview(
     }
   } finally {
     for (const t of transients) shredFile(t)
+    op?.release()
   }
 }
 
@@ -1272,7 +1307,7 @@ export async function extractDocumentPreviewPage(
   documentId: string,
   offset: number,
   limit: number,
-  deps: Pick<IngestionDeps, 'cipher' | 'ocrEngine'> = {},
+  deps: Pick<IngestionDeps, 'cipher' | 'ocrEngine' | 'plaintextOps'> = {},
   opts: ExtractPreviewOptions = {}
 ): Promise<DocumentPreview> {
   // REL-5: forward the cap stack so EACH "Show more" page re-parse is bounded (the whole-document
@@ -1353,7 +1388,10 @@ export async function reindexDocument(
   if (!row) throw new Error(`Unknown document: ${documentId}`)
   setDocumentSummary(db, documentId, null)
   setStatus(db, documentId, 'queued')
-  const info = await processDocument(db, storeDir, documentId, deps)
+  const info = await processDocument(db, storeDir, documentId, {
+    ...deps,
+    plaintextOpKind: deps.plaintextOpKind ?? 'reindex'
+  })
   // M1 crash-resume: a crash-interrupted import is re-driven to `indexed` through HERE (the
   // user clicks Re-index on the reconciled `failed` row), NOT through the in-session import
   // loop. So filing-by-pending-destination must happen on this path too, or the doc loses
@@ -1507,7 +1545,7 @@ export async function readStoredDocumentText(
   db: Db,
   storeDir: string,
   documentId: string,
-  deps: Pick<IngestionDeps, 'cipher'> = {}
+  deps: Pick<IngestionDeps, 'cipher' | 'plaintextOps'> = {}
 ): Promise<{ title: string; text: string }> {
   const row = getRow(db, documentId)
   if (!row) throw new Error(`Unknown document: ${documentId}`)
@@ -1519,6 +1557,7 @@ export async function readStoredDocumentText(
 
   const cipher = deps.cipher ?? null
   const transients: string[] = []
+  const op = deps.plaintextOps?.register('export') // #237: sweepable by lock/quit
   try {
     let source: string
     // #188: canonical location first — the recorded absolute path goes stale the moment the
@@ -1533,6 +1572,7 @@ export async function readStoredDocumentText(
         // same-doc export/read must not decrypt into and shred a shared path. `.parse` infix keeps
         // the crash sweep covering it.
         source = join(storeDir, `${documentId}.parse-export-${randomUUID()}${ext}`)
+        op?.track(source) // registered BEFORE the write (#237)
         // DB-7: async decrypt (PERF-1) — a large encrypted DOCX/DOC no longer blocks the main
         // process for the whole decrypt+read; the `finally` shred still runs after the await.
         await cipher.decryptFileAsync(stored.path, source)
@@ -1546,6 +1586,7 @@ export async function readStoredDocumentText(
     return { title: row.title, text: await readFile(source, 'utf8') }
   } finally {
     for (const t of transients) shredFile(t)
+    op?.release()
   }
 }
 
@@ -1564,13 +1605,14 @@ export async function readStoredDocumentBytes(
   db: Db,
   storeDir: string,
   documentId: string,
-  deps: Pick<IngestionDeps, 'cipher'> = {}
+  deps: Pick<IngestionDeps, 'cipher' | 'plaintextOps'> = {}
 ): Promise<{ title: string; mimeType: string | null; bytes: Buffer }> {
   const row = getRow(db, documentId)
   if (!row) throw new Error(`Unknown document: ${documentId}`)
   const ext = extname(row.title).toLowerCase()
   const cipher = deps.cipher ?? null
   const transients: string[] = []
+  const op = deps.plaintextOps?.register('export') // #237: sweepable by lock/quit
   try {
     let source: string
     // #188: canonical location first — this is the exact reader whose stale-path failure was
@@ -1581,6 +1623,7 @@ export async function readStoredDocumentBytes(
         if (!cipher) throw new Error(tMain('main.docs.exportEncrypted'))
         // Unique per call (DB-2): as above — collision-free transient, `.parse` infix for the sweep.
         source = join(storeDir, `${documentId}.parse-export-bin-${randomUUID()}${ext}`)
+        op?.track(source) // registered BEFORE the write (#237)
         // DB-7: async decrypt (PERF-1) — the §22-M1 content boundary is unchanged; the `finally`
         // shred still runs after the await.
         await cipher.decryptFileAsync(stored.path, source)
@@ -1594,6 +1637,7 @@ export async function readStoredDocumentBytes(
     return { title: row.title, mimeType: row.mime_type, bytes: await readFile(source) }
   } finally {
     for (const t of transients) shredFile(t)
+    op?.release()
   }
 }
 

--- a/apps/desktop/src/main/services/ingestion/index.ts
+++ b/apps/desktop/src/main/services/ingestion/index.ts
@@ -735,12 +735,13 @@ export async function prepareDocument(
   // workspace). Always shredded on the way out — success or failure — so no decrypted
   // document content lingers on the drive.
   const transients: string[] = []
-  // #237: registered for the lock/quit teardowns (aborted, settled within a bound, swept); the
-  // op's signal also follows the caller's `deps.signal` (an import job's abort).
-  const op = deps.plaintextOps?.register(deps.plaintextOpKind ?? 'import-prepare', deps.signal)
 
   const limits = deps.limits ?? resolveIngestionLimits()
 
+  // #237: registered for the lock/quit teardowns (aborted, settled within a bound, swept); the
+  // op's signal also follows the caller's `deps.signal` (an import job's abort). Registered
+  // right before the `try` so nothing can throw between the register and the release.
+  const op = deps.plaintextOps?.register(deps.plaintextOpKind ?? 'import-prepare', deps.signal)
   try {
     setStatus(db, documentId, 'extracting')
     // Perf marks identify a document only by its random UUID (perf.ts content rules).

--- a/apps/desktop/src/main/services/ingestion/limits.ts
+++ b/apps/desktop/src/main/services/ingestion/limits.ts
@@ -77,14 +77,30 @@ export function resolveIngestionLimits(env: NodeJS.ProcessEnv = process.env): In
 
 /**
  * Race a parse against a wall-clock timeout, rejecting with `message` (a persist-canonical
- * English string the caller supplies) if the budget elapses first. The underlying work is
- * not cancelled — this only bounds how long the pipeline WAITS, so a wedged parser fails
- * the one document instead of hanging the import loop.
+ * English string the caller supplies) if the budget elapses first. This bounds how long the
+ * pipeline WAITS, so a wedged parser fails the one document instead of hanging the import loop;
+ * `onTimeout` runs when the budget elapses so the caller can also cancel the work (#237 —
+ * `parseWithLimits` aborts the parse signal there). A parser that ignores its signal keeps
+ * running regardless; the lock/quit sweep bounds its transient.
  */
-export function withParseTimeout<T>(work: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+export function withParseTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  message: string,
+  onTimeout?: () => void
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout>
   const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+    timer = setTimeout(() => {
+      // The timeout rejection first, so the race reports `message` — the cancel hook may make
+      // the work reject synchronously with its own error.
+      reject(new Error(message))
+      try {
+        onTimeout?.()
+      } catch {
+        /* the rejection above is the contract; a cancel hook must not mask it */
+      }
+    }, timeoutMs)
   })
   return Promise.race([work, timeout]).finally(() => clearTimeout(timer))
 }

--- a/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
+++ b/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
@@ -1,0 +1,150 @@
+import { statSync } from 'node:fs'
+import { shredFile } from '../workspace-vault'
+
+// Registry of the operations that materialise DECRYPTED document content on the drive
+// (`.parse*` transients under `workspace/documents/`) or hold decoded text in flight: the
+// preview, a re-index, an import's prepare phase, a dictation and the two export readers.
+// "Lock now" and quit used to await chat streams, doc tasks and sidecar stops but held no
+// handle on these, so a parse that straddled the boundary kept a plaintext file on the drive
+// after the workspace reported locked (#237). Every such operation now registers here before
+// it writes, releases in its `finally`, and the lock/quit teardowns abort the registry, await
+// its settle within a bound, then shred whatever is still registered.
+//
+// Parsers that honour the abort signal (photo OCR, audio transcription) stop early; the
+// text parsers (pdfjs, mammoth, txt/csv/markdown) cannot be cancelled and are bounded by the
+// sweep instead — their transient is shredded under them at the settle bound.
+
+export type PlaintextOpKind = 'preview' | 'reindex' | 'import-prepare' | 'dictation' | 'export'
+
+/** One registered operation. Obtained from `PlaintextOpsRegistry.register()`. */
+export interface PlaintextOp {
+  readonly id: string
+  readonly kind: PlaintextOpKind
+  /** Aborted by `abortAll()` (lock/quit) or by the parent signal the op was registered under. */
+  readonly signal: AbortSignal
+  /** Record a transient's path BEFORE writing it, so the lock/quit sweep can shred it. */
+  track(path: string): void
+  /** The operation is over (its own `finally` shredded its transients). Idempotent. */
+  release(): void
+}
+
+export interface PlaintextOpsRegistry {
+  /** Register an operation; `parent` (an import job's abort, a dictation's timeout) aborts it too. */
+  register(kind: PlaintextOpKind, parent?: AbortSignal): PlaintextOp
+  /** Live (registered, not yet released) operations. */
+  size(): number
+  /** Abort every live operation. Idempotent; never throws. */
+  abortAll(): void
+  /**
+   * Wait until every live operation has released, at most `boundMs`. Resolves `true` when all
+   * settled inside the bound, `false` when the bound elapsed first. Never rejects.
+   */
+  awaitSettled(boundMs: number): Promise<boolean>
+  /**
+   * Shred every tracked transient of every live operation that is still on disk (and its
+   * `.tmp` decrypt stage). Touches ONLY registered paths — never a stored copy. Returns the
+   * number of files removed. Never throws.
+   */
+  sweepRegistered(): number
+}
+
+interface LiveOp {
+  readonly op: PlaintextOp
+  readonly controller: AbortController
+  readonly paths: Set<string>
+  readonly settled: Promise<void>
+  readonly resolveSettled: () => void
+  readonly detachParent: () => void
+}
+
+export function createPlaintextOps(): PlaintextOpsRegistry {
+  const live = new Map<string, LiveOp>()
+  let seq = 0
+
+  const register = (kind: PlaintextOpKind, parent?: AbortSignal): PlaintextOp => {
+    const id = `${kind}-${++seq}`
+    const controller = new AbortController()
+    let resolveSettled!: () => void
+    const settled = new Promise<void>((r) => (resolveSettled = r))
+    const paths = new Set<string>()
+    const onParentAbort = (): void => controller.abort(parent?.reason)
+    let detachParent = (): void => undefined
+    if (parent) {
+      if (parent.aborted) controller.abort(parent.reason)
+      else {
+        parent.addEventListener('abort', onParentAbort, { once: true })
+        detachParent = () => parent.removeEventListener('abort', onParentAbort)
+      }
+    }
+    const op: PlaintextOp = {
+      id,
+      kind,
+      signal: controller.signal,
+      track: (path) => {
+        paths.add(path)
+      },
+      release: () => {
+        const entry = live.get(id)
+        if (!entry) return
+        live.delete(id)
+        entry.detachParent()
+        entry.resolveSettled()
+      }
+    }
+    live.set(id, { op, controller, paths, settled, resolveSettled, detachParent })
+    return op
+  }
+
+  const abortAll = (): void => {
+    for (const entry of live.values()) {
+      try {
+        if (!entry.controller.signal.aborted) entry.controller.abort(new Error('Workspace is locking'))
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  const awaitSettled = async (boundMs: number): Promise<boolean> => {
+    if (live.size === 0) return true
+    const pending = [...live.values()].map((e) => e.settled)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), boundMs)
+      timer.unref?.()
+    })
+    try {
+      return await Promise.race([Promise.all(pending).then(() => true as const), timeout])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  const sweepRegistered = (): number => {
+    let swept = 0
+    for (const entry of live.values()) {
+      for (const path of entry.paths) {
+        for (const candidate of [path, `${path}.tmp`]) {
+          try {
+            if (!existsFile(candidate)) continue
+            shredFile(candidate)
+            if (!existsFile(candidate)) swept++
+          } catch {
+            /* best-effort — the lock must proceed */
+          }
+        }
+      }
+    }
+    return swept
+  }
+
+  return { register, size: () => live.size, abortAll, awaitSettled, sweepRegistered }
+}
+
+function existsFile(path: string): boolean {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
+++ b/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
@@ -14,7 +14,14 @@ import { shredFile } from '../workspace-vault'
 // text parsers (pdfjs, mammoth, txt/csv/markdown) cannot be cancelled and are bounded by the
 // sweep instead — their transient is shredded under them at the settle bound.
 
-export type PlaintextOpKind = 'preview' | 'reindex' | 'import-prepare' | 'dictation' | 'export'
+export type PlaintextOpKind =
+  | 'preview'
+  | 'reindex'
+  | 'import-prepare'
+  | 'dictation'
+  | 'export'
+  /** A doc-task's own transient (the OCR source PDF, a materialised output's `.parse.md`). */
+  | 'doc-task'
 
 /** One registered operation. Obtained from `PlaintextOpsRegistry.register()`. */
 export interface PlaintextOp {

--- a/apps/desktop/src/main/shutdown.ts
+++ b/apps/desktop/src/main/shutdown.ts
@@ -25,10 +25,11 @@ export interface ShutdownDeps {
 /**
  * Overall bound on the AWAITED MIDDLE of `performShutdown` (#238, #230;
  * owner decision 13 unanswered → this default, #230): the local-API stop, the sidecar stops, the
- * stream settle and the doc-task settle are raced as ONE section against this deadline. The
- * per-step bounds sum to 20.5 s today (local API ≤ 0.5 s; sidecars ≤ 10 s — the transcriber's
- * suspend timeout; streams 5 s; doc tasks 5 s), so 30 s only ever fires on a step that is not
- * honouring its own bound. When it fires, the teardown logs, ABANDONS the parked promises and
+ * stream settle, the doc-task settle and the plaintext-operation settle (#237) are raced as ONE
+ * section against this deadline. The per-step bounds sum to 25.5 s (local API ≤ 0.5 s; sidecars
+ * ≤ 10 s — the transcriber's suspend timeout; streams 5 s; doc tasks 5 s; plaintext operations
+ * 5 s), so 30 s only ever fires on a step that is not honouring its own bound. When it fires,
+ * the teardown logs, ABANDONS the parked promises and
  * goes straight on to the log flush + the vault lock — the lock is never inside the race (a
  * deadline that abandoned the lock would reproduce the hard-kill outcome it exists to prevent).
  * Whatever a parked sidecar stop left behind is reaped synchronously right before `app.exit`
@@ -65,8 +66,8 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
 
   // AUD-02 — arm the WORKSPACE lock latch FIRST, and in its OWN best-effort try (two latches
   // sharing one `catch` would make whichever runs second silently optional). The teardown below
-  // spends up to ~20.5 s in awaited windows (the local-API stop ≤ 0.5 s, the sidecar stops ≤ 10 s,
-  // the stream settle ≤ 5 s, the doc-task settle ≤ 5 s — bounded as a whole by
+  // spends up to ~25.5 s in awaited windows (the local-API stop ≤ 0.5 s, the sidecar stops ≤ 10 s,
+  // the stream settle ≤ 5 s, the doc-task settle ≤ 5 s, the plaintext-operation settle ≤ 5 s — bounded as a whole by
   // `SHUTDOWN_OVERALL_DEADLINE_MS`) during which the DB is still OPEN, so `isUnlocked()` is still true and every
   // content-surface guard still admits. Most sidecars are safe here because QUIT uses the
   // permanently-latching `stop()` where lock uses the non-latching `suspend()` — a translate or
@@ -116,6 +117,15 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
   } catch {
     /* best-effort */
   }
+  // #237: abort every plaintext operation in flight (a preview, re-index, import prepare,
+  // dictation or export holding a `.parse*` transient) now, so it has the whole teardown to
+  // unwind; its settle is awaited inside the deadline section below and its transients are
+  // swept right before the lock.
+  try {
+    ctx?.plaintextOps?.abortAll()
+  } catch {
+    /* best-effort */
+  }
   // REL-4: abort in-flight chat/RAG streams so each partial reply persists (see the ordering note
   // above). Best-effort per controller — a misbehaving canceller must not block the rest of teardown.
   try {
@@ -125,7 +135,7 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
   } catch (err) {
     log.error('Error aborting in-flight streams on quit', String(err))
   }
-  // #238 / #230: the four awaited steps below are bounded as a WHOLE by
+  // #238 / #230: the five awaited steps below are bounded as a WHOLE by
   // `SHUTDOWN_OVERALL_DEADLINE_MS` (see the constant). The log flush and the lock stay OUTSIDE.
   await withOverallDeadline(async () => {
     // The local API dies BEFORE the sidecars (local-api wave): stop() aborts active + queued
@@ -168,7 +178,12 @@ export async function performShutdown(ctx: AppContext | null, deps: ShutdownDeps
     // while ctx.db is open; awaiting the settle here makes cleanup-before-close the ORDERING, not a
     // race. Bounded (~5 s) so a wedged handler can never hang quit. Mirrors the stream-settle above.
     await awaitActiveDocTaskSettled(ctx, log)
+    // #237: then the plaintext operations aborted above — same bound. A parser that cannot cancel
+    // (pdfjs, mammoth) outlives it; the sweep below (outside this section, so a deadline that
+    // abandons this settle still reaches it) shreds its transient before the lock.
+    await awaitPlaintextOpsSettled(ctx, log)
   }, log)
+  sweepPlaintextOps(ctx, log)
   // #238: by now no window is left (Windows/Linux quit after window-all-closed), so this line
   // is the only visible state of a quit that is locking — and it lands in the encrypted log
   // because it precedes the flush below.
@@ -328,5 +343,33 @@ async function awaitActiveDocTaskSettled(
     await Promise.race([settle.catch(() => undefined), timeout])
   } finally {
     if (timer) clearTimeout(timer)
+  }
+}
+
+/**
+ * Await the aborted plaintext operations (preview / re-index / import prepare / dictation /
+ * export) within `SHUTDOWN_TASK_SETTLE_TIMEOUT_MS` (#237). Best-effort — never throws.
+ */
+async function awaitPlaintextOpsSettled(
+  ctx: AppContext | null,
+  log: Pick<typeof realLog, 'error' | 'info'>
+): Promise<void> {
+  const ops = ctx?.plaintextOps
+  if (!ops) return
+  try {
+    const settled = await ops.awaitSettled(SHUTDOWN_TASK_SETTLE_TIMEOUT_MS)
+    if (!settled) log.info('quit: plaintext operations still running at the settle bound', { live: ops.size() })
+  } catch (err) {
+    log.error('Error settling plaintext operations on quit', String(err))
+  }
+}
+
+/** Shred every still-registered `.parse*` transient (only registered paths — never a stored copy). */
+function sweepPlaintextOps(ctx: AppContext | null, log: Pick<typeof realLog, 'error' | 'info'>): void {
+  try {
+    const swept = ctx?.plaintextOps?.sweepRegistered() ?? 0
+    if (swept > 0) log.info('quit: swept registered plaintext transients', { swept })
+  } catch (err) {
+    log.error('Error sweeping plaintext transients on quit', String(err))
   }
 }

--- a/apps/desktop/tests/integration/ingestion-limits.test.ts
+++ b/apps/desktop/tests/integration/ingestion-limits.test.ts
@@ -281,6 +281,50 @@ describe('parseWithLimits (MAINT-4/REL-5)', () => {
     expect(seen?.signal).toBe(ac.signal)
     expect(seen?.workDir).toBe('/w')
   })
+
+  // #237: the wall-clock timeout used to stop only the WAITING — the parser kept running with
+  // its decrypted transient on disk. It now aborts the parse context's signal as well, so a
+  // signal-aware parser stops its work too (text parsers that cannot cancel are bounded by the
+  // lock/quit sweep instead).
+  it('aborts the parse signal when the wall-clock timeout fires, so a signal-aware parser stops', async () => {
+    let seenSignal: AbortSignal | undefined
+    let stopped = false
+    const parser = fakeParser(
+      (_s, ctx) =>
+        new Promise<ParsedDocument>((_resolve, reject) => {
+          seenSignal = ctx?.signal
+          ctx?.signal?.addEventListener(
+            'abort',
+            () => {
+              stopped = true
+              reject(new Error('parser stopped'))
+            },
+            { once: true }
+          )
+        })
+    )
+    await expect(
+      parseWithLimits(parser, 'doc.txt', {}, { ...DEFAULT_INGESTION_LIMITS, parseTimeoutMs: 20 }, 'timed out')
+    ).rejects.toThrow('timed out')
+    expect(seenSignal?.aborted).toBe(true)
+    expect(stopped).toBe(true)
+  })
+
+  it("a caller's abort reaches a non-audio parser through the timeout wrapper", async () => {
+    const ac = new AbortController()
+    let seen: ParseContext | undefined
+    const parser = fakeParser(
+      (_s, ctx) =>
+        new Promise<ParsedDocument>((_resolve, reject) => {
+          seen = ctx
+          ctx?.signal?.addEventListener('abort', () => reject(new Error('parser stopped')), { once: true })
+        })
+    )
+    const p = parseWithLimits(parser, 'doc.txt', { signal: ac.signal }, DEFAULT_INGESTION_LIMITS, 'timed out')
+    ac.abort()
+    await expect(p).rejects.toThrow('parser stopped')
+    expect(seen?.signal?.aborted).toBe(true)
+  })
 })
 
 describe('preview path cap stack (REL-5)', () => {

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -59,7 +59,9 @@ import { TranslateJobService } from '../../src/main/services/translation/jobs'
 import { VisionService, type VisionAnalyzer } from '../../src/main/services/vision'
 import type { Translator, TranslateOptions } from '../../src/main/services/translation'
 import type { Embedder } from '../../src/main/services/embeddings'
+import type { OcrEngine } from '../../src/main/services/ocr'
 import { createQueuedDocument, documentsDir, processDocument } from '../../src/main/services/ingestion'
+import { createPlaintextOps } from '../../src/main/services/ingestion/plaintext-ops'
 import { performShutdown } from '../../src/main/shutdown'
 import { t } from '../../src/shared/i18n'
 import { invoke, type IpcHandlers } from '../helpers/ipc'
@@ -71,10 +73,14 @@ const ENCRYPTION_REQUIRED: PrivacyPolicy = {
   workspace: { encryptionRequired: true, allowPlaintextDevMode: false }
 }
 
-/** One event-loop turn. Used only as a bounded CEILING for "nothing else happened". */
-const tick = (): Promise<void> => new Promise((r) => setImmediate(r))
+/**
+ * One real macrotask (≥ 1 ms). Used only as a bounded CEILING for "nothing else happened".
+ * A `setImmediate` loop would starve the libuv poll phase where fs callbacks land, so a helper
+ * waiting on real file I/O (the async decrypt of a preview) would never see it progress (#258).
+ */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 1))
 
-/** Drain up to `ceiling` turns, resolving as soon as `pred` holds. Never a fixed sleep. */
+/** Drain up to `ceiling` ticks, resolving as soon as `pred` holds. Never a fixed sleep. */
 async function waitUntil(pred: () => boolean, ceiling = 200): Promise<boolean> {
   for (let i = 0; i < ceiling; i++) {
     if (pred()) return true
@@ -108,6 +114,8 @@ interface Harness {
   ctrl: WorkspaceController
   ctx: AppContext
   documentId: string
+  /** The imported photo (an encrypted stored copy) when an `ocrEngine` was supplied. */
+  photoId: string | null
   translator: Translator & { translate: ReturnType<typeof vi.fn> }
   createRuntime: ReturnType<typeof vi.fn>
   /** Resolves once the lock handler has entered the gated sidecar suspend. */
@@ -130,6 +138,17 @@ interface HarnessOptions {
    * over a still-open workspace without a structural disarm.
    */
   suspendThrowsSync?: boolean
+  /**
+   * An OCR engine for the photo the harness then also imports — the park seam for the
+   * plaintext-operation cases (#237): a photo preview re-recognizes its decrypted stored copy,
+   * so a gated `recognize()` parks the preview with its `.parse-preview-*` transient on disk.
+   */
+  ocrEngine?: OcrEngine
+  /**
+   * Shorten the lock/quit plaintext-operation settle bound (5 s in production) through the
+   * registry seam on ctx, so the sweep-bounded cases do not wait out the real constant.
+   */
+  settleBoundMs?: number
 }
 
 async function harness(opts: HarnessOptions = {}): Promise<Harness> {
@@ -166,6 +185,24 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     cipher: ctrl.documentCipher()
   })
   expect(imported.status).toBe('indexed')
+
+  // The photo for the plaintext-operation cases: imported (and OCR'd once, unparked) so its
+  // stored copy is an `.enc` whose preview must decrypt to a transient. `images/` exists so the
+  // name sweeps below can read it.
+  mkdirSync(join(workspacePath, 'images'), { recursive: true })
+  let photoId: string | null = null
+  if (opts.ocrEngine) {
+    const photoPath = join(root, 'photo.png')
+    writeFileSync(photoPath, validPngBytes())
+    const photo = createQueuedDocument(ctrl.requireDb(), photoPath)
+    const indexed = await processDocument(ctrl.requireDb(), storeDir, photo.id, {
+      embedder: fakeEmbedder,
+      cipher: ctrl.documentCipher(),
+      ocrEngine: opts.ocrEngine
+    })
+    expect(indexed.status).toBe('indexed')
+    photoId = photo.id
+  }
 
   const translate = vi.fn(async (opts: TranslateOptions) => opts.text)
   const translator = {
@@ -215,9 +252,17 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
       }
     },
     translator,
+    ocrEngine: opts.ocrEngine ?? null,
     manifestsDir: null,
     isDev: false
   } as unknown as AppContext
+
+  // The plaintext-operation registry (#237), as `main/index.ts` wires it; optionally with the
+  // settle bound shortened through the seam (the constant itself stays the production value).
+  const ops = createPlaintextOps()
+  const bound = opts.settleBoundMs
+  ctx.plaintextOps =
+    bound === undefined ? ops : { ...ops, awaitSettled: (ms) => ops.awaitSettled(Math.min(ms, bound)) }
 
   ctx.docTasks = new DocTaskManager({
     getDb: () => ctrl.requireDb(),
@@ -253,6 +298,7 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     ctrl,
     ctx,
     documentId: queued.id,
+    photoId,
     translator,
     createRuntime,
     suspendEntered: () => entered,
@@ -566,5 +612,234 @@ describe('admission during the QUIT teardown (AUD-02)', () => {
     h.releaseSuspend()
     await quitP
     expect(h.ctrl.isUnlocked()).toBe(false)
+  })
+})
+
+// ---- #237 — plaintext operations already IN FLIGHT at lock/quit ------------------
+//
+// A preview of an encrypted stored copy decrypts it to a `.parse-preview-<uuid><ext>` transient
+// and shreds it only in its own `finally`. Lock and quit awaited chat streams, doc tasks and the
+// sidecar stops but held no handle on that work: they reported `locked` / resolved (with
+// `app.exit(0)` next) while the parse was still running and the decrypted file sat on the drive,
+// and the preview then delivered its text across IPC after the lock. Now every such operation
+// registers with `ctx.plaintextOps`; lock and quit abort the registry, await its settle within
+// the task-settle bound, and shred whatever is still registered before the vault re-encrypts.
+//
+// The parked document is a photo with a gated OCR engine — there is no parser-injection seam for
+// pdf/docx. Two engine flavours: one that honours the abort signal (the photo and audio parsers
+// forward it) and one that ignores it, modelling pdfjs/mammoth. For the latter the transient is
+// shredded under the parser at the settle bound (sweep-bounded) and the preview handler's
+// admission re-check refuses the text afterwards. The real tesseract `suspend()` would also
+// terminate its worker mid-recognition; the fake's no-op `suspend()`/`stop()` remove that partial
+// mitigation so the photo stands in for the parsers that have none.
+//
+// Does not prove: that quit residue survives a real process exit (asserted at `performShutdown`
+// resolution, the instant `app.exit(0)` would run), nor pdf/docx parses themselves.
+
+interface GatedOcrEngine extends OcrEngine {
+  /** Park the NEXT recognition until `release()` (or its abort signal, when honoured). */
+  parkNext(): void
+  release(): void
+  entered(): boolean
+  abortSeen(): boolean
+}
+
+function gatedOcrEngine(opts: { honoursSignal: boolean }): GatedOcrEngine {
+  let park = false
+  let entered = false
+  let abortSeen = false
+  let release!: () => void
+  const gate = new Promise<void>((r) => (release = r))
+  return {
+    id: 'gated-ocr',
+    languages: ['eng'],
+    recognize: async (_image, o) => {
+      if (!park) return { text: 'SECRET PLAINTEXT', confidence: 90 }
+      park = false
+      entered = true
+      if (opts.honoursSignal) {
+        await new Promise<void>((resolve, reject) => {
+          const onAbort = (): void => {
+            abortSeen = true
+            reject(new Error('recognition aborted'))
+          }
+          if (o?.signal?.aborted) {
+            onAbort()
+            return
+          }
+          o?.signal?.addEventListener('abort', onAbort, { once: true })
+          void gate.then(() => {
+            o?.signal?.removeEventListener('abort', onAbort)
+            resolve()
+          })
+        })
+      } else {
+        o?.signal?.addEventListener(
+          'abort',
+          () => {
+            abortSeen = true
+          },
+          { once: true }
+        )
+        await gate
+      }
+      return { text: 'SECRET PLAINTEXT', confidence: 90 }
+    },
+    suspend: async () => {},
+    stop: async () => {},
+    parkNext: () => {
+      park = true
+    },
+    release: () => release(),
+    entered: () => entered,
+    abortSeen: () => abortSeen
+  }
+}
+
+/** Every decrypted-transient name under `dir` — the same patterns the startup crash sweep uses. */
+function transientNames(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((n) => n.includes('.parse') || n.endsWith('.tmp'))
+    .sort()
+}
+
+/** The encrypted stored copies under `dir` — what the sweep must never touch. */
+function storedCopies(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((n) => n.endsWith('.enc'))
+    .sort()
+}
+
+/** Park a preview of the harness photo on the gated engine, transient on disk. */
+async function parkedPreview(
+  h: Harness,
+  ocr: GatedOcrEngine
+): Promise<{ previewP: Promise<{ result: unknown }>; docs: string; images: string }> {
+  const docs = documentsDir(h.ctx.paths.workspacePath)
+  const images = join(h.ctx.paths.workspacePath, 'images')
+  ocr.parkNext()
+  const previewP = invoke(handlers, IPC.previewDocument, h.photoId)
+  previewP.catch(() => undefined) // asserted later; never an unhandled rejection meanwhile
+  expect(await waitUntil(() => ocr.entered(), 300)).toBe(true)
+  const during = transientNames(docs)
+  expect(during).toHaveLength(1)
+  expect(during[0]).toMatch(/\.parse-preview-/)
+  return { previewP, docs, images }
+}
+
+describe('plaintext operations across the lock boundary (#237)', () => {
+  it('lock aborts a parked preview, waits for it to unwind, and reports locked with no transient on the drive', async () => {
+    const ocr = gatedOcrEngine({ honoursSignal: true })
+    const h = await harness({ ocrEngine: ocr })
+    h.releaseSuspend() // the sidecar gate is not the subject here
+    const { previewP, docs, images } = await parkedPreview(h, ocr)
+    const storedBefore = storedCopies(docs)
+    expect(storedBefore).toHaveLength(2) // the text document + the photo
+
+    const { result } = await invoke(handlers, IPC.lockWorkspace)
+    expect(result).toMatchObject({ state: 'locked' })
+    expect(h.ctrl.isUnlocked()).toBe(false)
+    // At the instant lock reported locked: nothing decrypted is left under documents/ or images/
+    // (a name sweep, not the registry's view of itself).
+    expect(transientNames(docs)).toEqual([])
+    expect(transientNames(images)).toEqual([])
+    // …and the stored copies beside the transient were never touched.
+    expect(storedCopies(docs)).toEqual(storedBefore)
+    // The abort reached the parser — nothing had to release it.
+    expect(ocr.abortSeen()).toBe(true)
+    // The preview REJECTS with the locked copy; it never delivers text after the lock.
+    await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
+  })
+
+  it('lock waits for a parser that ignores the abort until it unwinds — the settle, not merely the bound', async () => {
+    const ocr = gatedOcrEngine({ honoursSignal: false })
+    const h = await harness({ ocrEngine: ocr, settleBoundMs: 10_000 })
+    h.releaseSuspend()
+    const { previewP, docs } = await parkedPreview(h, ocr)
+
+    let lockSettled = false
+    const t0 = Date.now()
+    const lockP = invoke(handlers, IPC.lockWorkspace).finally(() => {
+      lockSettled = true
+    })
+    lockP.catch(() => undefined)
+    // Parser parked, bound not elapsed: the lock is WAITING and the vault is still open.
+    for (let i = 0; i < 50; i++) await tick()
+    expect(lockSettled).toBe(false)
+    expect(h.ctrl.isUnlocked()).toBe(true)
+    expect(ocr.abortSeen()).toBe(true) // it was asked to stop; it just cannot
+
+    ocr.release()
+    const { result } = await lockP
+    expect(result).toMatchObject({ state: 'locked' })
+    expect(Date.now() - t0).toBeLessThan(10_000) // released, not timed out
+    expect(transientNames(docs)).toEqual([])
+    // The parser finished with text in hand — the handler's admission re-check refuses it.
+    await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
+  })
+
+  it('a parser that ignores the abort is sweep-bounded: locked at the bound, its transient shredded under it', async () => {
+    const ocr = gatedOcrEngine({ honoursSignal: false })
+    const h = await harness({ ocrEngine: ocr, settleBoundMs: 100 })
+    h.releaseSuspend()
+    const { previewP, docs, images } = await parkedPreview(h, ocr)
+    const storedBefore = storedCopies(docs)
+
+    const { result } = await invoke(handlers, IPC.lockWorkspace)
+    expect(result).toMatchObject({ state: 'locked' })
+    expect(h.ctrl.isUnlocked()).toBe(false)
+    expect(transientNames(docs)).toEqual([])
+    expect(transientNames(images)).toEqual([])
+    expect(storedCopies(docs)).toEqual(storedBefore)
+
+    // Nothing released the parser: the lock went on at the bound. Let it finish now.
+    ocr.release()
+    await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
+    expect(transientNames(docs)).toEqual([]) // its own finally found nothing left to shred
+  })
+})
+
+describe('plaintext operations across the QUIT boundary (#237)', () => {
+  const quitDeps = {
+    inFlightStreams: new Map<string, AbortController>(),
+    streamSettled: new Map<string, Promise<void>>(),
+    detachVaultKey: (): void => {},
+    log: { error: (): undefined => undefined, info: (): undefined => undefined }
+  }
+
+  it('performShutdown resolves only after the parked preview unwound — no transient left for app.exit', async () => {
+    const ocr = gatedOcrEngine({ honoursSignal: true })
+    const h = await harness({ ocrEngine: ocr })
+    h.releaseSuspend()
+    const { previewP, docs, images } = await parkedPreview(h, ocr)
+    const storedBefore = storedCopies(docs)
+
+    await performShutdown(h.ctx, quitDeps)
+    // The instant `app.exit(0)` would run:
+    expect(h.ctrl.isUnlocked()).toBe(false)
+    expect(transientNames(docs)).toEqual([])
+    expect(transientNames(images)).toEqual([])
+    expect(storedCopies(docs)).toEqual(storedBefore)
+    expect(ocr.abortSeen()).toBe(true)
+    await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
+  })
+
+  it('a parser that ignores the abort is sweep-bounded on quit too', async () => {
+    const ocr = gatedOcrEngine({ honoursSignal: false })
+    const h = await harness({ ocrEngine: ocr, settleBoundMs: 100 })
+    h.releaseSuspend()
+    const { previewP, docs, images } = await parkedPreview(h, ocr)
+    const storedBefore = storedCopies(docs)
+
+    await performShutdown(h.ctx, quitDeps)
+    expect(h.ctrl.isUnlocked()).toBe(false)
+    expect(transientNames(docs)).toEqual([])
+    expect(transientNames(images)).toEqual([])
+    expect(storedCopies(docs)).toEqual(storedBefore)
+
+    ocr.release()
+    await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
+    // The reproduction's post-quit self-heal check, carried: the parser's own shred finds nothing.
+    expect(await waitUntil(() => transientNames(docs).length === 0, 300)).toBe(true)
   })
 })

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -720,7 +720,8 @@ async function parkedPreview(
   ocr.parkNext()
   const previewP = invoke(handlers, IPC.previewDocument, h.photoId)
   previewP.catch(() => undefined) // asserted later; never an unhandled rejection meanwhile
-  expect(await waitUntil(() => ocr.entered(), 300)).toBe(true)
+  // A real async decrypt + row read precede the park — a generous ceiling for a starved runner.
+  expect(await waitUntil(() => ocr.entered(), 1_000)).toBe(true)
   const during = transientNames(docs)
   expect(during).toHaveLength(1)
   expect(during[0]).toMatch(/\.parse-preview-/)
@@ -753,7 +754,8 @@ describe('plaintext operations across the lock boundary (#237)', () => {
 
   it('lock waits for a parser that ignores the abort until it unwinds — the settle, not merely the bound', async () => {
     const ocr = gatedOcrEngine({ honoursSignal: false })
-    const h = await harness({ ocrEngine: ocr, settleBoundMs: 10_000 })
+    // The production bound (5 s) — the release below must be what lets the lock through.
+    const h = await harness({ ocrEngine: ocr })
     h.releaseSuspend()
     const { previewP, docs } = await parkedPreview(h, ocr)
 
@@ -772,7 +774,8 @@ describe('plaintext operations across the lock boundary (#237)', () => {
     ocr.release()
     const { result } = await lockP
     expect(result).toMatchObject({ state: 'locked' })
-    expect(Date.now() - t0).toBeLessThan(10_000) // released, not timed out
+    // Well inside the 5 s `LOCK_TASK_SETTLE_TIMEOUT_MS`: the release let it through, not the bound.
+    expect(Date.now() - t0).toBeLessThan(5_000)
     expect(transientNames(docs)).toEqual([])
     // The parser finished with text in hand — the handler's admission re-check refuses it.
     await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))

--- a/apps/desktop/tests/unit/plaintext-ops.test.ts
+++ b/apps/desktop/tests/unit/plaintext-ops.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createPlaintextOps } from '../../src/main/services/ingestion/plaintext-ops'
+
+// #237 — the registry every plaintext-materialising operation (preview / re-index / import
+// prepare / dictation / export) joins before it writes a `.parse*` transient. Lock and quit
+// abort it, await its settle within a bound and shred whatever is still registered. These are
+// the registry's own contracts; the lock/quit wiring is proven end-to-end in
+// `tests/integration/lock-admission-race.test.ts`.
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), 'hilbertraum-plaintext-ops-'))
+}
+
+describe('plaintext operation registry (#237)', () => {
+  it('register → release: counts live operations; release is idempotent', () => {
+    const ops = createPlaintextOps()
+    expect(ops.size()).toBe(0)
+    const a = ops.register('preview')
+    const b = ops.register('export')
+    expect(ops.size()).toBe(2)
+    expect(a.id).not.toBe(b.id)
+    expect(a.kind).toBe('preview')
+    a.release()
+    a.release()
+    expect(ops.size()).toBe(1)
+    b.release()
+    expect(ops.size()).toBe(0)
+  })
+
+  it('abortAll aborts every live operation, leaves released ones alone, and is idempotent', () => {
+    const ops = createPlaintextOps()
+    const live = ops.register('reindex')
+    const done = ops.register('import-prepare')
+    done.release()
+    expect(live.signal.aborted).toBe(false)
+    ops.abortAll()
+    expect(live.signal.aborted).toBe(true)
+    expect(done.signal.aborted).toBe(false)
+    ops.abortAll() // nothing to re-abort, nothing thrown
+    expect(live.signal.aborted).toBe(true)
+  })
+
+  it('a parent signal aborts the operation too; a parent already aborted yields an aborted op', () => {
+    const ops = createPlaintextOps()
+    const parent = new AbortController()
+    const op = ops.register('dictation', parent.signal)
+    expect(op.signal.aborted).toBe(false)
+    parent.abort(new Error('timed out'))
+    expect(op.signal.aborted).toBe(true)
+    expect((op.signal.reason as Error).message).toBe('timed out')
+
+    const gone = new AbortController()
+    gone.abort()
+    expect(ops.register('dictation', gone.signal).signal.aborted).toBe(true)
+  })
+
+  it('awaitSettled resolves true at once when nothing is live', async () => {
+    const ops = createPlaintextOps()
+    expect(await ops.awaitSettled(1)).toBe(true)
+  })
+
+  it('awaitSettled resolves false once the bound elapses with an operation still live', async () => {
+    const ops = createPlaintextOps()
+    ops.register('preview')
+    expect(await ops.awaitSettled(20)).toBe(false)
+    expect(ops.size()).toBe(1) // the bound does not release anything
+  })
+
+  it('awaitSettled resolves true as soon as the last live operation releases', async () => {
+    const ops = createPlaintextOps()
+    const op = ops.register('preview')
+    const settled = ops.awaitSettled(5_000)
+    setTimeout(() => op.release(), 5)
+    expect(await settled).toBe(true)
+  })
+
+  it('sweepRegistered shreds only the tracked transients (and their .tmp stage) of LIVE operations', () => {
+    const dir = scratch()
+    const ops = createPlaintextOps()
+    const op = ops.register('preview')
+    const transient = join(dir, 'doc-1.parse-preview-abc.pdf')
+    const stage = `${transient}.tmp`
+    const stored = join(dir, 'doc-1.pdf.enc')
+    const neighbour = join(dir, 'doc-2.parse-preview-def.pdf') // a transient nobody registered
+    for (const p of [transient, stage, stored, neighbour]) writeFileSync(p, 'x'.repeat(64))
+    op.track(transient)
+    // A tracked path that never materialised is simply skipped.
+    op.track(join(dir, 'never-written.parse.txt'))
+
+    expect(ops.sweepRegistered()).toBe(2)
+    expect(existsSync(transient)).toBe(false)
+    expect(existsSync(stage)).toBe(false)
+    expect(existsSync(stored)).toBe(true)
+    expect(existsSync(neighbour)).toBe(true)
+    // Idempotent: a second sweep finds nothing.
+    expect(ops.sweepRegistered()).toBe(0)
+  })
+
+  it('a released operation is out of the sweep (its own finally already shredded)', () => {
+    const dir = scratch()
+    const ops = createPlaintextOps()
+    const op = ops.register('export')
+    const transient = join(dir, 'doc-3.parse-export-xyz.txt')
+    writeFileSync(transient, 'plaintext')
+    op.track(transient)
+    op.release()
+    expect(ops.sweepRegistered()).toBe(0)
+    expect(existsSync(transient)).toBe(true)
+  })
+})

--- a/apps/desktop/tests/unit/shutdown.test.ts
+++ b/apps/desktop/tests/unit/shutdown.test.ts
@@ -54,6 +54,20 @@ function fakeCtx(order: string[]): AppContext {
     // Local-api wave: the endpoint's stop() (aborts external streams, closes sockets)
     // runs BEFORE the sidecar stops, so no outside caller holds the model mid-teardown.
     localApi: { stop: stop('localApi.stop') },
+    // #237: the plaintext-operation registry (preview / re-index / import / dictation / export)
+    // is aborted with the other aborts, settled after the doc-task settle, swept before lock.
+    plaintextOps: {
+      abortAll: () => order.push('plaintext.abort'),
+      awaitSettled: async () => {
+        order.push('plaintext.settle')
+        return true
+      },
+      sweepRegistered: () => {
+        order.push('plaintext.sweep')
+        return 0
+      },
+      size: () => 0
+    },
     // Issue #51: quit calls workspace.shutdown() (lock + plaintext checkpoint/close). The
     // ordering event keeps its historical 'lock' label — every assertion below pins it.
     workspace: { shutdown: () => order.push('lock') }
@@ -223,6 +237,25 @@ describe('performShutdown ordering (REL-4)', () => {
     expect(order.indexOf('unwound')).toBeGreaterThan(order.indexOf('runtime.stop'))
     expect(order.indexOf('unwound')).toBeLessThan(order.indexOf('lock'))
     expect(order[order.length - 1]).toBe('lock')
+  })
+
+  // #237: a preview / re-index / import-prepare / dictation / export in flight is aborted with
+  // the other aborts (before any sidecar stop), its settle awaited after the doc-task settle, and
+  // its still-registered transients shredded before the log flush + lock.
+  it('aborts, settles and sweeps the plaintext operations — abort before the sidecars, sweep before lock (#237)', async () => {
+    const order: string[] = []
+    await performShutdown(fakeCtx(order), {
+      inFlightStreams: new Map(),
+      detachVaultKey: () => order.push('detach'),
+      log: quietLog
+    })
+    const i = (label: string): number => order.indexOf(label)
+    expect(i('plaintext.abort')).toBeGreaterThanOrEqual(0)
+    expect(i('plaintext.abort')).toBeLessThan(i('runtime.stop'))
+    expect(i('plaintext.settle')).toBeGreaterThan(i('task-settle'))
+    expect(i('plaintext.sweep')).toBeGreaterThan(i('plaintext.settle'))
+    expect(i('plaintext.sweep')).toBeLessThan(i('detach'))
+    expect(i('lock')).toBe(order.length - 1)
   })
 })
 
@@ -404,6 +437,49 @@ describe('overall teardown deadline (#238 / #230)', () => {
       expect(order[order.length - 1]).toBe('lock')
       expect(order.filter((l) => l === 'lock')).toHaveLength(1)
       expect(order.some((l) => /locking workspace/i.test(l))).toBe(true) // the "quit: locking" line
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // #237: the plaintext-operation settle sits INSIDE the raced section (the deadline can abandon
+  // it) but the sweep sits OUTSIDE, beside the lock — so a settle that never resolves still ends
+  // with the registered transients shredded before the vault re-encrypts.
+  it('sweeps the plaintext operations after a deadline abandoned their settle, before the lock', async () => {
+    const realSetTimeout = setTimeout
+    const realClearTimeout = clearTimeout
+    vi.useFakeTimers()
+    try {
+      const order: string[] = []
+      const ctx = fakeCtx(order) as unknown as {
+        plaintextOps: { awaitSettled: () => Promise<boolean> }
+      }
+      ctx.plaintextOps.awaitSettled = () => {
+        order.push('plaintext.settle(parked)')
+        return new Promise<boolean>(() => {}) // never resolves — abandoned by the deadline
+      }
+      const p = performShutdown(ctx as unknown as AppContext, {
+        inFlightStreams: new Map(),
+        detachVaultKey: () => order.push('detach'),
+        log: quietLog
+      })
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_OVERALL_DEADLINE_MS)
+      let bound: ReturnType<typeof setTimeout> | undefined
+      try {
+        await Promise.race([
+          p,
+          new Promise<never>((_, reject) => {
+            bound = realSetTimeout(() => reject(new Error('the lock did not run after the deadline')), 2_000)
+          })
+        ])
+      } finally {
+        if (bound) realClearTimeout(bound)
+      }
+      const i = (label: string): number => order.indexOf(label)
+      expect(i('plaintext.settle(parked)')).toBeGreaterThan(i('task-settle'))
+      expect(i('plaintext.sweep')).toBeGreaterThan(i('plaintext.settle(parked)'))
+      expect(i('plaintext.sweep')).toBeLessThan(i('detach'))
+      expect(order[order.length - 1]).toBe('lock')
     } finally {
       vi.useRealTimers()
     }

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1019,8 +1019,10 @@ re-encrypts (the bullet below).
   workspace reported locked — and a preview issued before the lock delivered its text across IPC
   after it. Every such operation now registers with the **plaintext-operation registry**
   (`services/ingestion/plaintext-ops.ts`, held as `ctx.plaintextOps`) *before* it writes and
-  releases in its `finally`. Lock and quit **abort** the registry together with the other aborts
-  (before any sidecar stop), **await its settle** after the doc-task settle within the same bound
+  releases in its `finally` (a doc-task's own transients — the OCR source PDF, a materialised
+  output's `.parse.md` — register too, as `doc-task`). Lock and quit **abort** the registry
+  together with the other aborts (before the awaited sidecar stops), **await its settle** after
+  the doc-task settle within the same bound
   (`LOCK_TASK_SETTLE_TIMEOUT_MS` / `SHUTDOWN_TASK_SETTLE_TIMEOUT_MS`, 5 s), then **shred every
   still-registered transient** (and its `.tmp` decrypt stage) — only registered paths, never a
   stored copy — before the vector purge and the lock. On quit the settle sits inside the overall

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -976,7 +976,10 @@ The renderer shows the create-password / unlock gate (`WorkspaceGate`) until `wo
 in-flight generations and stops BOTH sidecars (chat runtime + E5 embedder; a llama-server keeps
 recent prompts in its in-memory KV cache), then locks. Unlock restarts the chat runtime in the
 background (the active-model auto-start); the embedder restarts lazily on the next embed.
-`will-quit` likewise locks (re-encrypt + shred) alongside stopping the sidecars.
+`will-quit` likewise locks (re-encrypt + shred) alongside stopping the sidecars. Both also abort,
+settle and sweep the **plaintext operations** in flight — a document **preview**, a **re-index**,
+an import's **prepare** phase, a **dictation** and the two **export** readers — before the vault
+re-encrypts (the bullet below).
 - **Quit re-entry and the overall deadline (SEC-12 with GAP-2 folded in, audit 2026-09-02).** Both
   app-lifecycle handlers are built by `createAppLifecycleHandlers` (`main/shutdown.ts`) over ONE
   `isShuttingDown` closure. *Re-entry rule:* **every** `will-quit` is `preventDefault()`ed — the
@@ -1008,6 +1011,30 @@ background (the active-model auto-start); the embedder restarts lazily on the ne
   **settle** (bounded ~5 s) before `lock()` re-encrypts, so its materialize/shred of any `.parse`
   transient completes while the DB is still open — mirroring the in-flight-stream settle await.
   `cancelAllDocTasks()` holds no permanent latch: the manager is fully usable again after unlock.
+- **Plaintext operations are aborted, settled and swept on lock/quit (#237, PR #273).** A preview
+  or re-index of an encrypted stored copy, an import's prepare phase, a dictation and the two
+  export readers each decrypt to a `.parse*` transient under `workspace/documents/` and shred it
+  only in their own `finally`. The doc-task registry never covered them (`DocTaskKind` has no
+  preview), so a parse that straddled the boundary kept a decrypted file on the drive after the
+  workspace reported locked — and a preview issued before the lock delivered its text across IPC
+  after it. Every such operation now registers with the **plaintext-operation registry**
+  (`services/ingestion/plaintext-ops.ts`, held as `ctx.plaintextOps`) *before* it writes and
+  releases in its `finally`. Lock and quit **abort** the registry together with the other aborts
+  (before any sidecar stop), **await its settle** after the doc-task settle within the same bound
+  (`LOCK_TASK_SETTLE_TIMEOUT_MS` / `SHUTDOWN_TASK_SETTLE_TIMEOUT_MS`, 5 s), then **shred every
+  still-registered transient** (and its `.tmp` decrypt stage) — only registered paths, never a
+  stored copy — before the vector purge and the lock. On quit the settle sits inside the overall
+  deadline section (worst case now 25.5 s under the 30 s constant); the sweep sits outside it,
+  beside the lock, so a deadline that abandons the settle still sweeps. Which parsers honour the
+  abort: the photo OCR (`engine.recognize` takes the signal) and the audio transcription (the
+  whisper child is killed) stop early; **pdfjs, mammoth and the txt/csv/markdown parsers cannot be
+  cancelled** and are **sweep-bounded** — their transient is shredded under them at the bound and
+  their result is discarded. The parse wall-clock timeout now aborts that same signal instead of
+  only abandoning the wait. The preview IPC re-checks admission after its awaits and rejects with
+  the locked copy rather than returning text. Pinned by `tests/integration/lock-admission-race.test.ts`
+  (a parked photo preview across a real lock and a real `performShutdown`, both engine flavours; a
+  `readdirSync` name sweep of `documents/` and `images/` at the "locked" instant; the stored
+  copies beside the transient survive) and `tests/unit/plaintext-ops.test.ts`.
 
 ### The lock latch — admission during the teardown (AUD-02 / AUD-03)
 
@@ -1066,7 +1093,10 @@ respawning. Two do not, and are the reason the latch is armed there:
   `llama-server`, which then **orphans** at `app.exit(0)`.
 - An admitted **import** decrypts a document to a plaintext transient; `app.exit(0)` landing
   between that write and the `finally` that shreds it **strands plaintext on the drive** until the
-  next launch's crash sweep.
+  next launch's crash sweep. The same held for work **already in flight** when quit began — a
+  preview, re-index, prepare, dictation or export whose parse outlived the teardown — which the
+  latch cannot reach; those are aborted, settled and swept by the plaintext-operation registry
+  (the "Plaintext operations" bullet above, #237).
 Nothing on the quit path clears the latch and the process exits, so arming it is terminal by
 construction. (`WorkspaceController.shutdown()` still calls `lock()` directly; it needs no latch of
 its own.)


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 4: lock/quit quiescence — plaintext operations aborted, settled and swept
Closes #237 (SEC-10; DOC-4 and the dictation/export transients are folded into it and land here)
Closes #258 (TQ-1)
Refs #230 (rider 13 / review rec 2 used on the default: the 30 s constant stays; worst case now 25.5 s)
Tracker: #217

### What
- **New registry** `src/main/services/ingestion/plaintext-ops.ts`, held as `ctx.plaintextOps` (created in `main/index.ts`): `register(kind, parent?)` → `{ id, kind, signal, track(path), release() }`; `abortAll()`, `awaitSettled(boundMs)` (resolves `true`/`false`, never rejects), `sweepRegistered()` (shreds every tracked path of every live op that is still on disk, plus its `.tmp` decrypt stage; only registered paths, never a stored copy), `size()`. Kinds: `preview`, `reindex`, `import-prepare`, `dictation`, `export`, `doc-task`.
- **Every `.parse*` materialisation registers BEFORE writing and releases in its `finally`:** `prepareDocument` (`import-prepare`, or `reindex` via `reindexDocument`; the op's signal follows the import job's abort), `extractDocumentPreview` (`preview`), `readStoredDocumentText` / `readStoredDocumentBytes` (`export`), the dictation WAV (`dictation`, under its own timeout), and — reviewer finding — the OCR task's source PDF and a materialised output's `.parse.md` (`doc-task`).
- **Lock (`runLockTeardown`) and quit (`performShutdown`):** `abortAll()` with the other aborts (before the awaited sidecar stops), then after the doc-task settle `awaitSettled(5 s)` → `sweepRegistered()` → purge / audit / detach / lock as before. The bound is the existing `LOCK_TASK_SETTLE_TIMEOUT_MS` / `SHUTDOWN_TASK_SETTLE_TIMEOUT_MS` (5 s, no new constant). On quit the settle sits inside the 30 s overall-deadline section; the sweep sits outside it, right before the log flush + lock, so a deadline that abandons the settle still sweeps. Worst case of the raced middle: 0.5 + 10 + 5 + 5 + 5 = **25.5 s under the 30 s constant** (4.5 s headroom).
- **Cancellation reaches the parser:** `parseWithLimits` now hands the parser a signal that fires on the caller's abort OR the wall-clock timeout (`withParseTimeout` gained an `onTimeout` hook; the timeout rejection still carries the parse-timeout message). Parsers that honour it: photo OCR (`engine.recognize` takes the signal) and audio (the whisper child is killed). **Sweep-bounded (cannot cancel): pdfjs, mammoth, txt/csv/markdown** — their transient is shredded under them at the bound and their result is discarded; said so in the code and in `security-model.md`.
- **Preview IPC** (`previewDocument`, `previewDocumentPage`) re-checks `workspaceAdmitsWork` after its awaits and rejects with the locked copy instead of returning text.
- **TQ-1:** the integration helper's `tick` is `setTimeout(r, 1)` (a real macrotask), the `waitUntil` ceiling is passed explicitly where the new cases poll.

### Why (finding IDs + the promise line each restores)
- SEC-10 (#237): lock and quit awaited streams, doc tasks and sidecar stops but held no handle on preview / re-index / prepare / dictation / export, so a parse that straddled the boundary kept a decrypted `.parse*` file on the drive after the workspace reported locked (self-healing only at settle, or at the next launch after quit), and a preview issued before the lock delivered plaintext across IPC after it. Restores `security-model.md`'s at-rest promise and the "Lock now" contract (which now lists the five kinds and the sweep-bounded parsers). DOC-4 (folded): the contract never mentioned these operations — it does now.
- TQ-1 (#258): a `setImmediate` tick loop starves the libuv poll phase, so a helper waiting on real file I/O never sees it progress; the first test that needed it is this one.

### Tests
- characterisation (red before, commit `e6aac0f7`): the five B2-inverted cases in `tests/integration/lock-admission-race.test.ts` (lock/quit reported done with the transient on the drive; the lock never waited), the two `performShutdown` ordering pins in `tests/unit/shutdown.test.ts` (incl. a deadline-abandoned settle whose sweep still runs before the lock) and the timeout-cancellation pin in `tests/integration/ingestion-limits.test.ts`. Green by construction there: `tests/unit/plaintext-ops.test.ts` (register/release, abortAll incl. parent link, awaitSettled true/false/late release, sweep touches only tracked live paths + `.tmp`, idempotent) and the caller-abort pass-through pin.
- regression / inverted B2 (real encrypted vault via `createEncryptedVaultOnDisk`, real `node:sqlite`, real `registerDocsIpc`/`registerWorkspaceIpc`, real ingestion, real `performShutdown` with an `info`-capable logger; a `gatedOcrEngine()` park seam added to `HarnessOptions` in two flavours — honours the abort / ignores it, modelling pdfjs/mammoth; a `settleBoundMs` seam that shortens the 5 s bound through the ctx object for the sweep-bounded cases): **lock** — resolves only after the parked parse was aborted (`abortSeen()`) or released (the ignore-signal case polls 50 ticks, asserts the lock is still pending, releases, asserts locked well under the 5 s production bound); a `readdirSync` name sweep of `documents/` AND `images/` finds no `.parse`/`.tmp` name at the instant `lockWorkspace` reports locked; the preview REJECTS with the locked copy; the stored `.enc` copies beside the transient survive; the sweep-bounded case locks at the bound with the transient shredded under the still-parked parser. **quit** — the same three at `performShutdown` resolution (the instant `app.exit(0)` would run), both flavours. The three previously unnamed `expect`s are carried (parked-detection poll, `during.length === 1` + `/\.parse-preview-/`, post-quit self-heal).
- Does not prove: that quit residue survives a real process exit (asserted at `performShutdown` resolution); pdf/docx parses themselves (no parser-injection seam — the photo with a no-op `suspend()` stands in for parsers without tesseract's worker-termination mitigation).
- `npm test` count: **368 files passed / 23 skipped; 5,487 passed / 74 skipped** (Phase 3 baseline 367 / 5,470 / 74: +1 file `plaintext-ops.test.ts`, +17 tests = B2 ×5, shutdown ×2, limits ×2, registry ×8). `npm run typecheck`, `npm run build` green; `npm run dev` launch gate green (workspace resolved, offline posture logged, watchdog exit, 0 Electron processes left). Existing lock-race cases that drain 20 ticks now take ~0.4 s each on Windows (timer granularity) — +2.4 s for the file.

### Docs + BUILD_STATE
`docs/security-model.md`: the "Lock now" paragraph names the plaintext operations; new lifecycle bullet "Plaintext operations are aborted, settled and swept on lock/quit" (registry, bound, the 25.5 s arithmetic, which parsers honour the abort vs. sweep-bounded, the preview re-check, the pins); the quit bullet generalised to work already in flight. `CHANGELOG.md` `[Unreleased]` Fixed. `BUILD_STATE.md`: dated entry (12 lines), §5 item 19 line, §7 test-conventions entry (the real-macrotask tick + the pass-through `vi.mock('node:fs')` wrapper — written once for TQ-1 and TQ-2). Budgets after: preamble 110/200, §5 493/500, §7 16/20, item 19 34/45.

### Owner decisions relied on (issue #, answer or default)
- Review rec 8 (#217): unanswered → **default: the full registry (path set + `sweepRegistered()`) in ONE PR**, no 4-a/4-b split. A lock-time NAME sweep was deliberately not added: `encryptFileAsync` also stages `${dest}.tmp`, so a name sweep at lock time would shred ciphertext-in-progress (an image-history or import encrypt) for no plaintext gain; the acceptance test sweeps by name regardless.
- Review rec 2 / rider 13 (#230): unanswered → **default: `SHUTDOWN_OVERALL_DEADLINE_MS = 30_000` stays**; the new worst case (25.5 s) is recorded in the constant's docblock and the doc.
- Settle bound: the existing 5 s constants reused (no new constant). Parsers that cannot cancel: sweep-bounded and documented (a terminable worker is a follow-up, not this phase).
- Q29 (manual smokes): the lock-mid-preview GUI smoke is **not run** — non-interactive session; in-process equivalent = B2 inverted over the real handlers.

### Landed differently from the plan
- `abortAll()` is placed with the other aborts (before the awaited sidecar stops) rather than after the doc-task settle — the abort is a free in-memory call, and issuing it first gives the parse the whole teardown to unwind, so the later settle wait is usually zero; the settle + sweep are where the plan put them.
- `IngestionDeps.plaintextOpKind` (`import-prepare` | `reindex`) so a re-index registers under its own kind; `doc-task` added for the two transients the plan's line list omitted (reviewer finding).
- Step (8) (remove the user-guide §13 interim clause) is a no-op: Phase 9a has not landed, no clause exists.

### Reviewer pass: Fable tier, read-only — verdict "merge after repairs", 2 repairs + 3 nits, all applied (`4349cde1`), 2 accepted
- (repair) the settle-vs-bound case used `settleBoundMs: 10_000`, which the `Math.min` seam turned into the production 5 s, so its `< 10 s` assertion could not tell "settle" from "bound" → runs against the production bound, asserts `< 5 s`.
- (repair) two `.parse*` writers were not registered: the OCR task's source PDF (`doctasks/handlers/ocr.ts`) and the materialised `.parse.md` (`doctasks/handlers/shared.ts`) → both register as `doc-task`.
- (nit) `prepareDocument` registered before `resolveIngestionLimits()`, outside the `try` → moved to the line before the `try`.
- (nit) parked-detection ceiling 300 → 1 000 ticks for a starved runner.
- (nit) doc wording "before any sidecar stop" → "before the awaited sidecar stops".
- (accepted) the deviations above recorded here and in the ledger; §5 at 493/500 means the next phase must archive before adding its item-19 line.
- Independently verified by the reviewer: red/green per commit, every IPC entry point latched so no op can register after the sweep, `decryptFileAsync`'s `.tmp` stage covered, the legacy-migration branch tracks only after the `.enc` exists, `AbortSignal.any` under Node ≥ 22.12 / Electron 43, listener detach on parent abort and release, the timeout-then-abort ordering, no forbidden mocks, no UNC, the 25.5 s arithmetic, comment hygiene.

### Rollback
Revert the PR: lock and quit return to awaiting only streams, doc tasks and sidecar stops; the preview handlers return text again; the timeout wrapper stops cancelling. No on-disk format changes; the registry is in-memory only.
