### PR TITLE
fix(rekey): v1→v2 password change carries every vault-key ciphertext class (audit 2026-09-02 Phase 6 — REL-5)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -39,7 +39,7 @@ downgrade caveat) + the image-history cross-ref; `data-contracts.md` journal sha
 pre-1.0 note reconciled (v0.1.46 was a tester pre-release, page since removed). Crash cuts are
 parametrised over every class in both directions; B3 inverted. Owner lines blank → defaults
 (delete the rotated log; proceed with the journal shape; refuse a save mid-change). Suite 370 → 370
-files / 5,507 → 5,519 (+12).
+files / 5,507 → 5,522 (+15).
 
 _2026-09-03 — **Audit 2026-09-02 Phase 5b-a — raw-path hardening, the autonomous half: the skills
 picker is unlock-gated and mints a one-time token (`src/main/ipc/picker-tokens.ts`, extracted from

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,18 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-03 — **Audit 2026-09-02 Phase 6 — rekey completeness: the v1→v2 password change now
+carries every vault-key ciphertext class — `listVaultKeyCiphertexts(vaultPaths, db)` enumerates
+`documents/*.enc`, `images/*.enc`, legacy out-of-store stored copies and the rotated log
+(deleted at commit; Q18 default); a `workspace/rekey-journal.json` written before staging lets
+recovery find out-of-store twins; image saves hold the document-work lease (REL-5 #241 with
+DOC-5, DOC-14 folded; PR #276).**_ Record: `security-model.md` "Password change" (classes, journal,
+downgrade caveat) + the image-history cross-ref; `data-contracts.md` journal shape; CHANGELOG's
+pre-1.0 note reconciled (v0.1.46 was a tester pre-release, page since removed). Crash cuts are
+parametrised over every class in both directions; B3 inverted. Owner lines blank → defaults
+(delete the rotated log; proceed with the journal shape; refuse a save mid-change). Suite 370 → 370
+files / 5,507 → 5,519 (+12).
+
 _2026-09-03 — **Audit 2026-09-02 Phase 5b-a — raw-path hardening, the autonomous half: the skills
 picker is unlock-gated and mints a one-time token (`src/main/ipc/picker-tokens.ts`, extracted from
 the documents handler) that `previewSkillPackage` reads and `importSkill` spends, so a renderer
@@ -594,6 +606,15 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     currently-ignored `supports_tools` manifest key (model-policy.md). (d) The §5.4
     thinking-checkpoint criterion is folded into item 8's ratify sequence, not a separate action.
 
+**Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
+the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/
+bring-up/eval/concurrency-probe/translategemma/categorizer/compare/whisper/dictation/OCR/vision/
+real-data smokes — skipped in CI), `npm run build` green. The historical loaded-machine 1–2
+timeout flakes were retired by the fixed-sleep sweep (full-audit 2026-07-10 TS-1; three
+consecutive full runs, zero flakes).** Per-phase gate history (test counts, bundle sizes,
+per-phase test inventories) lives in git history. (This gate paragraph sits above item 19 so the
+open round's item stays the last block of §5.)
+
 19. **Full-audit 2026-09-02 (security/reliability) — REMEDIATION IN PROGRESS** (tracker #217;
     labels `audit-2026-09-02`, `severity:*`, `phase:0`..`phase:9`, `owner-decision`, `follow-up`).
     Working paper, plan and STATE ledger live under the git-ignored `tmp/` for the round; the
@@ -627,14 +648,9 @@ manual release acceptance, one blocked phase (22), one drafted phase (30).** In 
     - **5b-a** (2026-09-03, PR #275): SEC-9 partial (NEW-2, DOC-11, DOC-12 folded) — skills picker
       token + unlock gate, `MAX_DROP_PATHS` 512, bounded walk (#274 for off-thread); the lexical
       UNC/device half = 5b-b, blocked on decision 5 (#222, default) — dated entry above.
-
-**Current gate (2026-07-12, full-audit 2026-07-12 Phase 6 close-out — round complete, durable ledger `docs/architecture.md` §48, both working papers deleted; the round moved the suite 4168 → 4190 across Phases 1–5): typecheck clean, 4190 tests pass (47 skipped —
-the manual tests behind `HILBERTRAUM_*`/`PAID_*` env vars: GPU/thinking/rerank/minsim/RAG-quality/
-bring-up/eval/concurrency-probe/translategemma/categorizer/compare/whisper/dictation/OCR/vision/
-real-data smokes — skipped in CI), `npm run build` green. The historical loaded-machine 1–2
-timeout flakes were retired by the fixed-sleep sweep (full-audit 2026-07-10 TS-1; three
-consecutive full runs, zero flakes).** Per-phase gate history (test counts, bundle sizes,
-per-phase test inventories) lives in git history.
+    - **6** (2026-09-03, PR #276): REL-5 (DOC-5, DOC-14 folded) — the v1→v2 rekey stages every
+      vault-key ciphertext class via `listVaultKeyCiphertexts` + a `rekey-journal.json`; rotated log
+      deleted (Q18 default); image saves take the document-work lease — dated entry above.
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ from its first public `1.0.0` release onward.
 > **Pre-1.0.** HilbertRaum has been public since **2026-07-12** and has shipped releases
 > since that day: **v0.1.50** was the first, **v0.1.59** is current. Versions stay in the
 > `0.1.x` line and SemVer applies from `1.0.0` on — a `0.1.x` bump is a release checkpoint,
-> not a compatibility promise. Tags below `v0.1.50` (and `v0.1.51`) are internal development
-> checkpoints with no GitHub release and no notes.
+> not a compatibility promise. Tags below `v0.1.50` (and `v0.1.51`) have no GitHub release
+> page today and no notes here; one of them, `v0.1.46` (2026-07-10), was a pre-release
+> handed to testers while the repository was still private, and its release page was removed
+> before the public launch (#241).
 
 > **What belongs in this file:** what changed **for the person using the app**, one section
 > per released version. **What does not:** the product's overall feature list (see the
@@ -25,6 +27,15 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **Changing the password of an older encrypted workspace no longer strands its image history.**
+  Workspaces created before June 2026 (the older vault format) are migrated to the current
+  format on their first password change. That migration re-encrypted the database and the
+  document files, but not the saved images of the image-analysis history, nor document copies
+  kept at an older location, so those became unreadable after the change. All of them are now
+  re-encrypted together, a crash at any point still leaves everything on either the old or the
+  new password, and an image being saved while the password changes is refused instead of being
+  written half-way. The previous generation of the encrypted diagnostics log is deleted by that
+  migration (nothing reads it). Workspaces created since June 2026 were never affected.
 - **Adding a skill is bound to the file picker, and a huge drop can no longer freeze the app.**
   The Settings → Skills picker now hands the app a one-time ticket for the file or folder you chose,
   and the preview and the import only accept that ticket, so nothing but your own pick can be read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ from its first public `1.0.0` release onward.
 > `0.1.x` line and SemVer applies from `1.0.0` on — a `0.1.x` bump is a release checkpoint,
 > not a compatibility promise. Tags below `v0.1.50` (and `v0.1.51`) have no GitHub release
 > page today and no notes here; one of them, `v0.1.46` (2026-07-10), was a pre-release
-> handed to testers while the repository was still private, and its release page was removed
-> before the public launch (#241).
+> handed to testers while the repository was still private; its release page has since been
+> removed (#241).
 
 > **What belongs in this file:** what changed **for the person using the app**, one section
 > per released version. **What does not:** the product's overall feature list (see the
@@ -28,14 +28,16 @@ from its first public `1.0.0` release onward.
 ### Fixed
 
 - **Changing the password of an older encrypted workspace no longer strands its image history.**
-  Workspaces created before June 2026 (the older vault format) are migrated to the current
-  format on their first password change. That migration re-encrypted the database and the
-  document files, but not the saved images of the image-analysis history, nor document copies
-  kept at an older location, so those became unreadable after the change. All of them are now
-  re-encrypted together, a crash at any point still leaves everything on either the old or the
-  new password, and an image being saved while the password changes is refused instead of being
-  written half-way. The previous generation of the encrypted diagnostics log is deleted by that
-  migration (nothing reads it). Workspaces created since June 2026 were never affected.
+  Workspaces created with a development build older than 11 June 2026 use an older vault
+  format that is migrated to the current one on their first password change; no released
+  version ever created one. That migration re-encrypted the database and the document files,
+  but not the saved images of the image-analysis history, nor document copies kept at an older
+  location, so those became unreadable after the change. All of them are now re-encrypted
+  together (copies at an older location only when they are reachable at the time of the
+  change), a crash at any point still leaves everything on either the old or the new password,
+  and an image being saved while the password changes is refused instead of being written
+  half-way. The previous generation of the encrypted diagnostics log is deleted by that
+  migration (nothing reads it).
 - **Adding a skill is bound to the file picker, and a huge drop can no longer freeze the app.**
   The Settings → Skills picker now hands the app a one-time ticket for the file or folder you chose,
   and the preview and the import only accept that ticket, so nothing but your own pick can be read.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -170,7 +170,7 @@ function initBackend(): void {
     refuseHashlessMarkers: REFUSE_HASHLESS_MARKERS_ON_COMMERCIAL_DRIVES
   })
   const workspace = new WorkspaceController(
-    vaultPathsFrom({ configPath: paths.configPath, dbPath: paths.dbPath }),
+    vaultPathsFrom({ configPath: paths.configPath, dbPath: paths.dbPath, logsPath: paths.logsPath }),
     policy,
     isDev
   )

--- a/apps/desktop/src/main/ipc/registerImagesIpc.ts
+++ b/apps/desktop/src/main/ipc/registerImagesIpc.ts
@@ -245,7 +245,10 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
             width: width ?? undefined,
             height: height ?? undefined
           },
-          ctx.workspace.documentCipher()
+          ctx.workspace.documentCipher(),
+          // The document-work lease: the encrypted write cannot straddle a password change,
+          // and a save during one is refused (VaultBusyError, logged content-free) (#241).
+          () => ctx.workspace.beginDocumentWork()
         )
       } catch (err) {
         log.warn('Vision history create failed', { code: errCode(err) })

--- a/apps/desktop/src/main/services/ingestion/stored-copy-leaf.ts
+++ b/apps/desktop/src/main/services/ingestion/stored-copy-leaf.ts
@@ -1,0 +1,46 @@
+// The leaf rule for a document's stored copy — dependency-free so both the resolver
+// (`stored-copy.ts`) and the vault rekey (`workspace-vault.ts`, #241) share ONE definition
+// without an import cycle (the resolver imports the vault module for its suffix).
+
+/** The `documents` columns the leaf rule reads. */
+export interface StoredCopyLeafRow {
+  id: string
+  stored_path: string | null
+  stored_name?: string | null
+}
+
+/**
+ * Leaf name of `p`, split on BOTH separators.
+ *
+ * NOT `basename`: a legacy row can carry a path written on ANOTHER OS (a Windows
+ * `Z:\old\documents\<id>.pdf.enc` row read on macOS/Linux, or the reverse), and the host
+ * `basename` only understands the host separator — on posix it would return the whole
+ * Windows string. Same scar as `markerBinaryKey` / `resolveTarBinary` (the cross-platform
+ * path bugs that failed the Ubuntu CI leg): never use host path helpers on a stored string
+ * that may have been written by a different host.
+ */
+export function storedCopyLeaf(p: string): string {
+  const cut = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return cut >= 0 ? p.slice(cut + 1) : p
+}
+
+/**
+ * The canonical leaf for a row, or null when it cannot be trusted.
+ *
+ * SAFETY (this is the guard the shred rests on): the leaf is used to build a path INSIDE the
+ * store dir that `deleteDocument` will overwrite-and-unlink. So it must be a bare file name
+ * belonging to THIS document — it must start with the row's own id, which is a UUID primary
+ * key that is never reused. A name failing any check yields null, and the caller falls back to
+ * the recorded absolute path verbatim (today's behaviour), never to a guess. Without this
+ * guard a malformed/foreign `stored_name` could make the shred destroy ANOTHER document's copy.
+ */
+export function canonicalLeafFor(row: StoredCopyLeafRow): string | null {
+  const raw = row.stored_name ?? (row.stored_path ? storedCopyLeaf(row.stored_path) : null)
+  if (!raw) return null
+  // Bare name only: no separators (a stored_name from a corrupted row), no traversal.
+  if (raw !== storedCopyLeaf(raw)) return null
+  if (raw === '.' || raw === '..' || raw.length === 0) return null
+  // Belongs to THIS document. `<id>` is a UUID; the rest is `<ext>[.enc]`.
+  if (!raw.startsWith(row.id)) return null
+  return raw
+}

--- a/apps/desktop/src/main/services/ingestion/stored-copy.ts
+++ b/apps/desktop/src/main/services/ingestion/stored-copy.ts
@@ -23,8 +23,9 @@ import type { Db } from '../db'
 // This mirrors what the rest of the drive already does — `image_sessions.stored_name` (relative
 // by design), `skills.path` (folder basename), the model checksum cache (`driveRelKey`, CODE-15),
 // the runtime install marker (`markerBinaryKey`), `documents.source_relative_path` (CODE-1) — and
-// what the vault layer already assumed: password-change re-encryption enumerates
-// `workspace/documents/` by DIRECTORY WALK, never by `stored_path`.
+// what the vault layer assumes: password-change re-encryption enumerates `workspace/documents/`
+// by DIRECTORY WALK, plus (since #241) the out-of-store rows this resolver would read from
+// `stored_path` — the same fallback order as `locateStoredCopy`.
 
 /** The columns this module needs. Every reader's row shape is a superset. */
 export interface StoredCopyRow {
@@ -57,41 +58,10 @@ export interface LocatedOriginal {
   contentMatchesImport: boolean | null
 }
 
-/**
- * Leaf name of `p`, split on BOTH separators.
- *
- * NOT `basename`: a legacy row can carry a path written on ANOTHER OS (a Windows
- * `Z:\old\documents\<id>.pdf.enc` row read on macOS/Linux, or the reverse), and the host
- * `basename` only understands the host separator — on posix it would return the whole
- * Windows string. Same scar as `markerBinaryKey` / `resolveTarBinary` (the cross-platform
- * path bugs that failed the Ubuntu CI leg): never use host path helpers on a stored string
- * that may have been written by a different host.
- */
-export function storedCopyLeaf(p: string): string {
-  const cut = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
-  return cut >= 0 ? p.slice(cut + 1) : p
-}
-
-/**
- * The canonical leaf for a row, or null when it cannot be trusted.
- *
- * SAFETY (this is the guard the shred rests on): the leaf is used to build a path INSIDE the
- * store dir that `deleteDocument` will overwrite-and-unlink. So it must be a bare file name
- * belonging to THIS document — it must start with the row's own id, which is a UUID primary
- * key that is never reused. A name failing any check yields null, and the caller falls back to
- * the recorded absolute path verbatim (today's behaviour), never to a guess. Without this
- * guard a malformed/foreign `stored_name` could make the shred destroy ANOTHER document's copy.
- */
-export function canonicalLeafFor(row: StoredCopyRow): string | null {
-  const raw = row.stored_name ?? (row.stored_path ? storedCopyLeaf(row.stored_path) : null)
-  if (!raw) return null
-  // Bare name only: no separators (a stored_name from a corrupted row), no traversal.
-  if (raw !== storedCopyLeaf(raw)) return null
-  if (raw === '.' || raw === '..' || raw.length === 0) return null
-  // Belongs to THIS document. `<id>` is a UUID; the rest is `<ext>[.enc]`.
-  if (!raw.startsWith(row.id)) return null
-  return raw
-}
+// The leaf rule lives in stored-copy-leaf.ts (dependency-free) so the vault rekey can share it
+// without an import cycle (#241); re-exported here for the existing callers.
+import { storedCopyLeaf, canonicalLeafFor } from './stored-copy-leaf'
+export { storedCopyLeaf, canonicalLeafFor }
 
 /**
  * Locate a document's workspace copy, or null when there is none on disk.

--- a/apps/desktop/src/main/services/logging.ts
+++ b/apps/desktop/src/main/services/logging.ts
@@ -13,7 +13,7 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { encrypt, decrypt, serializeBlob, deserializeBlob } from './security/crypto'
-import { shredFile } from './workspace-vault'
+import { ROTATED_ENCRYPTED_LOG_NAME, shredFile } from './workspace-vault'
 
 // Local-only rotating logger (spec §7.11 — diagnostics logs stay on device, never uploaded).
 //
@@ -47,6 +47,7 @@ import { shredFile } from './workspace-vault'
 // and the live buffer/`app.log.enc` reset. `app.1.log.enc` is recovery-only — readLogTail and
 // loadEncrypted read only the live `.enc`/buffer, so the Diagnostics tail shows the current
 // generation. This mirrors the plaintext rotation (the tail reads only `app.log`).
+// A v1→v2 password change deletes the rotated generation instead of re-keying it (#241).
 
 type Level = 'info' | 'warn' | 'error'
 
@@ -249,7 +250,7 @@ function rotateEncryptedIfNeeded(): void {
   try {
     const blob = serializeBlob(encrypt(vaultKey, Buffer.from(buffer, 'utf8')))
     // Atomic, like persistEncrypted — a crash mid-write must not corrupt the rotated copy.
-    writeFileAtomicSync(join(logDir, 'app.1.log.enc'), blob)
+    writeFileAtomicSync(join(logDir, ROTATED_ENCRYPTED_LOG_NAME), blob)
     buffer = ''
     // Drop the live `.enc`; the next persistEncrypted re-creates it from the empty buffer.
     if (existsSync(encLogFile)) rmSync(encLogFile, { force: true })

--- a/apps/desktop/src/main/services/vision/history.ts
+++ b/apps/desktop/src/main/services/vision/history.ts
@@ -3,7 +3,12 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { Db } from '../db'
-import { ENCRYPTED_DOC_SUFFIX, shredFileAsync, type DocumentCipher } from '../workspace-vault'
+import {
+  ENCRYPTED_DOC_SUFFIX,
+  IMAGES_DIR_NAME,
+  shredFileAsync,
+  type DocumentCipher
+} from '../workspace-vault'
 import type {
   ImageAnalyzeRequest,
   ImageSessionDetail,
@@ -22,7 +27,7 @@ import type {
 
 /** Directory that holds workspace copies of analyzed images. Created on demand. */
 export function imagesDir(workspacePath: string): string {
-  const dir = join(workspacePath, 'images')
+  const dir = join(workspacePath, IMAGES_DIR_NAME)
   mkdirSync(dir, { recursive: true })
   return dir
 }
@@ -64,8 +69,28 @@ function getRow(db: Db, id: string): SessionRow | undefined {
  * ASYNC (audit 2026-07-16 F-12): the up-to-~20 MiB file write + AES-GCM encrypt + temp shred run on
  * `fs.promises` + the async cipher/shred twins, yielding between chunks, so storing an image on an
  * encrypted USB workspace no longer freezes the main process at the answer-complete moment.
+ *
+ * `beginWork` is the vault's document-work lease (`WorkspaceController.beginDocumentWork`), taken
+ * synchronously before the first await and released after the row insert, so the encrypted write
+ * can never straddle a password change: the change refuses while the lease is held, and this
+ * throws `VaultBusyError` (nothing written) while a change is running (#241).
  */
 export async function createImageSession(
+  db: Db,
+  dir: string,
+  req: Pick<ImageAnalyzeRequest, 'imageBytes' | 'mimeType' | 'name' | 'width' | 'height'>,
+  cipher: DocumentCipher | null,
+  beginWork?: () => () => void
+): Promise<string> {
+  const release = beginWork?.() ?? null
+  try {
+    return await storeImageSession(db, dir, req, cipher)
+  } finally {
+    release?.()
+  }
+}
+
+async function storeImageSession(
   db: Db,
   dir: string,
   req: Pick<ImageAnalyzeRequest, 'imageBytes' | 'mimeType' | 'name' | 'width' | 'height'>,

--- a/apps/desktop/src/main/services/vision/history.ts
+++ b/apps/desktop/src/main/services/vision/history.ts
@@ -294,7 +294,7 @@ export async function deleteImageSession(db: Db, dir: string, id: string): Promi
  * Clear the WHOLE image history (#122): delete every session row in ONE transaction (turns
  * cascade), then best-effort shred each stored image. Returns the number of sessions removed.
  *
- * Same REL-5 ordering as {@link deleteImageSession} — rows first, shreds only after the commit —
+ * Same row-first ordering as {@link deleteImageSession} — rows first, shreds only after the commit —
  * so a failed transaction destroys nothing (no ghost sessions whose image is already gone), and
  * a file that fails to shred can never resurrect its already-deleted row. The shreds run on
  * `shredFileAsync` (off the main thread, the F-12 posture) sequentially — dozens of ~MB files,

--- a/apps/desktop/src/main/services/workspace-vault.ts
+++ b/apps/desktop/src/main/services/workspace-vault.ts
@@ -3,6 +3,7 @@ import {
   writeFileSync,
   existsSync,
   readdirSync,
+  mkdirSync,
   rmSync,
   renameSync,
   statSync,
@@ -14,7 +15,7 @@ import {
 } from 'node:fs'
 import { open as openFileAsync, rename as renameAsync, rm as rmAsync, stat as statAsync } from 'node:fs/promises'
 import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto'
-import { dirname, join } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative } from 'node:path'
 import { tMain } from './i18n'
 import { perfMark, perfMs } from './perf'
 import type { Db } from './db'
@@ -95,6 +96,9 @@ export interface VaultPaths {
   encPath: string
   /** `workspace/hilbertraum.sqlite` — the decrypted working file (present only while unlocked). */
   dbPath: string
+  /** `logs/` — where the encrypted diagnostics log rotates its previous generation; optional
+   *  so the v1→v2 rekey can account for that ciphertext too (#241). Absent in older callers. */
+  logsPath?: string
 }
 
 /** Thrown by `unlockEncryptedVault` when the password fails the verifier. */
@@ -171,11 +175,12 @@ export class VaultBusyError extends Error {
 }
 
 /** Derive the vault file locations from the resolved workspace paths. */
-export function vaultPathsFrom(paths: { configPath: string; dbPath: string }): VaultPaths {
+export function vaultPathsFrom(paths: { configPath: string; dbPath: string; logsPath?: string }): VaultPaths {
   return {
     descriptorPath: join(paths.configPath, 'workspace.json'),
     encPath: `${paths.dbPath}.enc`,
-    dbPath: paths.dbPath
+    dbPath: paths.dbPath,
+    ...(paths.logsPath ? { logsPath: paths.logsPath } : {})
   }
 }
 
@@ -601,7 +606,7 @@ export function shredStalePlaintext(vaultPaths: VaultPaths): void {
   // the stored copies themselves — only the clearly-transient `.parse`/`.tmp` names (the
   // stored image is `<id><ext>.enc`, which matches neither).
   const workspaceDir = dirname(vaultPaths.dbPath)
-  for (const sub of ['documents', 'images']) {
+  for (const sub of [DOCUMENTS_DIR_NAME, IMAGES_DIR_NAME]) {
     const dir = join(workspaceDir, sub)
     try {
       for (const name of readdirSync(dir)) {
@@ -680,6 +685,14 @@ export function preserveNewerPlaintext(vaultPaths: VaultPaths): void {
 // consistent vault: descriptor still v1 → the staged files are discarded and the OLD
 // password+files win; descriptor already v2 → the staged files are rolled forward and
 // the NEW password wins. Never a mix.
+//
+// What is staged (#241): every file encrypted under the vault data key outside the DB —
+// `listVaultKeyCiphertexts` enumerates the four classes (document sidecars, image-history
+// sidecars, legacy out-of-store stored copies, the rotated diagnostics log). The staged
+// paths are written to `workspace/rekey-journal.json` BEFORE staging, because an
+// out-of-store copy lies where no directory scan finds it at recovery time (the DB is
+// closed then). A build older than #241 does not read the journal: it rolls the DB and
+// `documents/` forward and leaves the other classes staged — see security-model.md.
 
 /** Suffix of a staged (re-encrypted, not yet swapped-in) file during a rekey. */
 export const REKEY_SUFFIX = '.new'
@@ -698,42 +711,183 @@ function fsyncPath(path: string): void {
   }
 }
 
-/** Every encrypted document sidecar (`<id><ext>.enc`) under `workspace/documents/`. */
-function listEncryptedDocSidecars(vaultPaths: VaultPaths): string[] {
-  const docsDir = join(dirname(vaultPaths.dbPath), 'documents')
+/** Directory name of the document store under `workspace/`. */
+export const DOCUMENTS_DIR_NAME = 'documents'
+/** Directory name of the image-history store under `workspace/` (vision/history.ts writes
+ *  there; the drive-status footprint and the rekey read it — one constant, #241). */
+export const IMAGES_DIR_NAME = 'images'
+/** The rotated (previous-generation) encrypted diagnostics log under `logs/`, written by
+ *  logging.ts and sealed under the vault data key. Deleted by the v1→v2 rekey: nothing reads
+ *  it, and it would otherwise stay under the retired key (#241). */
+export const ROTATED_ENCRYPTED_LOG_NAME = 'app.1.log.enc'
+/** The rekey journal under `workspace/`: every `<file>.new` a v1→v2 migration stages plus
+ *  the files it removes at commit. Needed because a legacy stored copy can lie OUTSIDE the
+ *  store, where no directory scan finds its staged twin at recovery (#241). */
+export const REKEY_JOURNAL_NAME = 'rekey-journal.json'
+
+/** The classes of file encrypted under the vault data key, outside the database itself. */
+export type VaultKeyCiphertextKind = 'document' | 'image' | 'out-of-store' | 'rotated-log'
+
+export interface VaultKeyCiphertext {
+  path: string
+  kind: VaultKeyCiphertextKind
+  /** `rekey`: re-encrypt under the new key (staged, then swapped in). `delete`: removed once
+   *  the descriptor commit has happened. */
+  action: 'rekey' | 'delete'
+}
+
+interface RekeyJournal {
+  version: 1
+  /** Absolute `<file>.new` paths the stage writes (in-store and out-of-store). */
+  staged: string[]
+  /** Absolute paths deleted after the commit point. */
+  remove: string[]
+}
+
+function workspaceDirOf(vaultPaths: VaultPaths): string {
+  return dirname(vaultPaths.dbPath)
+}
+
+function rekeyJournalPath(vaultPaths: VaultPaths): string {
+  return join(workspaceDirOf(vaultPaths), REKEY_JOURNAL_NAME)
+}
+
+/** Every `<name>.enc` directly under `dir` (`[]` when the dir does not exist yet). */
+function listEncryptedSidecars(dir: string): string[] {
   try {
-    return readdirSync(docsDir)
+    return readdirSync(dir)
       .filter((n) => n.endsWith(ENCRYPTED_DOC_SUFFIX))
-      .map((n) => join(docsDir, n))
+      .map((n) => join(dir, n))
   } catch {
-    return [] // no documents dir yet
+    return []
   }
 }
 
-/** Every staged `<file>.new` of an (interrupted or in-progress) rekey: DB + documents. */
-function stagedRekeyFiles(vaultPaths: VaultPaths): string[] {
+/** True when `path` lies strictly inside `dir` (both absolute). */
+function isInsideDir(dir: string, path: string): boolean {
+  const rel = relative(dir, path)
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}
+
+/**
+ * Legacy stored copies that resolve OUTSIDE `workspace/documents/` (issue #188 rows keep an
+ * absolute `stored_path`). A row counts only when no canonical `documents/<leaf>` exists —
+ * the fallback order of `locateStoredCopy` (ingestion/stored-copy.ts), so exactly the files
+ * the read paths would decrypt are rekeyed, and nothing a sibling workspace owns.
+ */
+function listOutOfStoreCopies(vaultPaths: VaultPaths, db: Db): string[] {
+  const docsDir = join(workspaceDirOf(vaultPaths), DOCUMENTS_DIR_NAME)
+  const rows = db
+    .prepare('SELECT stored_path, stored_name FROM documents WHERE stored_path IS NOT NULL')
+    .all() as Array<{ stored_path: string; stored_name: string | null }>
   const out: string[] = []
-  if (existsSync(`${vaultPaths.encPath}${REKEY_SUFFIX}`)) {
-    out.push(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
-  }
-  const docsDir = join(dirname(vaultPaths.dbPath), 'documents')
-  try {
-    for (const n of readdirSync(docsDir)) {
-      if (n.endsWith(`${ENCRYPTED_DOC_SUFFIX}${REKEY_SUFFIX}`)) out.push(join(docsDir, n))
+  for (const row of rows) {
+    const path = row.stored_path
+    if (typeof path !== 'string' || !path.endsWith(ENCRYPTED_DOC_SUFFIX) || out.includes(path)) continue
+    if (existsSync(join(docsDir, row.stored_name ?? basename(path)))) continue // canonical copy wins
+    if (isInsideDir(docsDir, path)) continue
+    let isFile = false
+    try {
+      isFile = statSync(path).isFile()
+    } catch {
+      /* gone or unreachable → nothing to rekey */
     }
-  } catch {
-    /* no documents dir yet */
+    if (isFile) out.push(path)
   }
   return out
 }
 
 /**
- * Phase 1 of the v1→v2 migration: re-encrypt the database + every document sidecar
- * under `dataKey`, STAGED next to the originals as `<file>.new`, fsynced. Nothing the
- * current password unlocks is touched. The DB snapshot comes from the live working file
- * (WAL checkpointed first), so it is CURRENT — fresher than the at-rest `.enc` from the
- * last lock. Document sidecars round-trip through a transient plaintext file that is
- * shredded immediately (and covered by the startup sweep on a crash).
+ * Every file outside the database that is encrypted under the vault data key — what a
+ * v1→v2 password change must carry to the new key (#241). Four classes: document sidecars,
+ * image-history sidecars, legacy out-of-store stored copies (read from the open DB) and the
+ * rotated diagnostics log (action `delete` — nothing reads it). `db` must be open.
+ */
+export function listVaultKeyCiphertexts(vaultPaths: VaultPaths, db: Db): VaultKeyCiphertext[] {
+  const ws = workspaceDirOf(vaultPaths)
+  const out: VaultKeyCiphertext[] = []
+  for (const path of listEncryptedSidecars(join(ws, DOCUMENTS_DIR_NAME))) {
+    out.push({ path, kind: 'document', action: 'rekey' })
+  }
+  for (const path of listEncryptedSidecars(join(ws, IMAGES_DIR_NAME))) {
+    out.push({ path, kind: 'image', action: 'rekey' })
+  }
+  for (const path of listOutOfStoreCopies(vaultPaths, db)) {
+    out.push({ path, kind: 'out-of-store', action: 'rekey' })
+  }
+  if (vaultPaths.logsPath) {
+    const rotated = join(vaultPaths.logsPath, ROTATED_ENCRYPTED_LOG_NAME)
+    if (existsSync(rotated)) out.push({ path: rotated, kind: 'rotated-log', action: 'delete' })
+  }
+  return out
+}
+
+function readRekeyJournal(vaultPaths: VaultPaths): RekeyJournal | null {
+  const path = rekeyJournalPath(vaultPaths)
+  if (!existsSync(path)) return null
+  const strings = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<RekeyJournal>
+    return { version: 1, staged: strings(parsed.staged), remove: strings(parsed.remove) }
+  } catch {
+    return { version: 1, staged: [], remove: [] } // unreadable: the directory scans still apply
+  }
+}
+
+/** Atomic (temp + fsync + rename), like the descriptor: recovery must never read half a journal. */
+function writeRekeyJournal(vaultPaths: VaultPaths, journal: RekeyJournal): void {
+  const path = rekeyJournalPath(vaultPaths)
+  const tmp = `${path}.tmp`
+  const fd = openSync(tmp, 'w')
+  try {
+    writeSync(fd, Buffer.from(JSON.stringify(journal, null, 2), 'utf8'))
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  renameSync(tmp, path)
+}
+
+function clearRekeyJournal(vaultPaths: VaultPaths): void {
+  rmSync(`${rekeyJournalPath(vaultPaths)}.tmp`, { force: true })
+  rmSync(rekeyJournalPath(vaultPaths), { force: true })
+}
+
+/** Every staged `<file>.new` of an (interrupted or in-progress) rekey: the DB, the in-store
+ *  sidecars (`documents/`, `images/` — by scan, so a journal-less stage still resolves) and
+ *  the journal's entries (the only way to find an out-of-store one). */
+function stagedRekeyFiles(vaultPaths: VaultPaths): string[] {
+  const ws = workspaceDirOf(vaultPaths)
+  const out = new Set<string>()
+  if (existsSync(`${vaultPaths.encPath}${REKEY_SUFFIX}`)) {
+    out.add(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
+  }
+  for (const sub of [DOCUMENTS_DIR_NAME, IMAGES_DIR_NAME]) {
+    const dir = join(ws, sub)
+    try {
+      for (const n of readdirSync(dir)) {
+        if (n.endsWith(`${ENCRYPTED_DOC_SUFFIX}${REKEY_SUFFIX}`)) out.add(join(dir, n))
+      }
+    } catch {
+      /* dir not created yet */
+    }
+  }
+  for (const staged of readRekeyJournal(vaultPaths)?.staged ?? []) {
+    if (existsSync(staged)) out.add(staged)
+  }
+  return [...out]
+}
+
+/**
+ * Phase 1 of the v1→v2 migration: re-encrypt the database + every vault-key ciphertext
+ * (`listVaultKeyCiphertexts`) under `dataKey`, STAGED next to the originals as `<file>.new`,
+ * fsynced. Nothing the current password unlocks is touched. The DB snapshot comes from the
+ * live working file (WAL checkpointed first), so it is CURRENT — fresher than the at-rest
+ * `.enc` from the last lock. Sidecars round-trip through a transient plaintext file that is
+ * shredded immediately; it always lands under the store (`documents/` for an out-of-store
+ * copy) and ends in `.tmp`, so the startup sweep covers a crash. The journal is written
+ * FIRST — recovery must know every staged path before any of them exists.
  */
 export function stageRekey(vaultPaths: VaultPaths, db: Db, oldKey: Buffer, dataKey: Buffer): void {
   db.exec('PRAGMA wal_checkpoint(TRUNCATE);')
@@ -752,14 +906,27 @@ export function stageRekey(vaultPaths: VaultPaths, db: Db, oldKey: Buffer, dataK
         'database (it may have been overwritten).'
     )
   }
-  encryptFile(vaultPaths.dbPath, `${vaultPaths.encPath}${REKEY_SUFFIX}`, dataKey)
-  fsyncPath(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
-  for (const enc of listEncryptedDocSidecars(vaultPaths)) {
-    const plain = `${enc}${REKEY_PLAINTEXT_SUFFIX}`
+  const targets = listVaultKeyCiphertexts(vaultPaths, db)
+  const stagedDb = `${vaultPaths.encPath}${REKEY_SUFFIX}`
+  writeRekeyJournal(vaultPaths, {
+    version: 1,
+    staged: [stagedDb, ...targets.filter((t) => t.action === 'rekey').map((t) => `${t.path}${REKEY_SUFFIX}`)],
+    remove: targets.filter((t) => t.action === 'delete').map((t) => t.path)
+  })
+  encryptFile(vaultPaths.dbPath, stagedDb, dataKey)
+  fsyncPath(stagedDb)
+  const docsDir = join(workspaceDirOf(vaultPaths), DOCUMENTS_DIR_NAME)
+  for (const target of targets) {
+    if (target.action !== 'rekey') continue
+    let plain = `${target.path}${REKEY_PLAINTEXT_SUFFIX}`
+    if (target.kind === 'out-of-store') {
+      mkdirSync(docsDir, { recursive: true })
+      plain = join(docsDir, `${basename(target.path)}${REKEY_PLAINTEXT_SUFFIX}`)
+    }
     try {
-      decryptFile(enc, plain, oldKey)
-      encryptFile(plain, `${enc}${REKEY_SUFFIX}`, dataKey)
-      fsyncPath(`${enc}${REKEY_SUFFIX}`)
+      decryptFile(target.path, plain, oldKey)
+      encryptFile(plain, `${target.path}${REKEY_SUFFIX}`, dataKey)
+      fsyncPath(`${target.path}${REKEY_SUFFIX}`)
     } finally {
       shredFile(plain)
     }
@@ -780,6 +947,16 @@ export function stageRekey(vaultPaths: VaultPaths, db: Db, oldKey: Buffer, dataK
  * most a genuinely-stuck file is deferred to recovery, never the whole tail of the list.
  */
 export function applyPendingRekey(vaultPaths: VaultPaths): void {
+  const journal = readRekeyJournal(vaultPaths)
+  // Committed, so the files the migration retires go first (idempotent, best-effort): a
+  // later crash can then never skip them. Today that is the rotated log (#241).
+  for (const doomed of journal?.remove ?? []) {
+    try {
+      rmSync(doomed, { force: true })
+    } catch {
+      /* locked: stays under the retired key; nothing reads it */
+    }
+  }
   const swapOne = (staged: string): void => {
     const target = staged.slice(0, -REKEY_SUFFIX.length)
     shredFile(target)
@@ -801,18 +978,26 @@ export function applyPendingRekey(vaultPaths: VaultPaths): void {
   }
   // Anything still unswapped (a persistently locked file) is left staged for recoverPendingRekey
   // on the next unlock; surface the failure so the caller logs it (the swap is old-or-new per
-  // file, never mixed within a file).
+  // file, never mixed within a file). The journal stays with it.
   if (pending.length > 0) {
     throw lastErr instanceof Error ? lastErr : new Error('applyPendingRekey: incomplete swap')
   }
+  // A journal entry with neither its `.new` nor its target on disk sits on a location that
+  // is unreachable right now (a detached legacy drive) — keep the journal so a later
+  // recovery can still finish that swap; clear it once every entry is accounted for.
+  const unreachable = (journal?.staged ?? []).some(
+    (staged) => !existsSync(staged) && !existsSync(staged.slice(0, -REKEY_SUFFIX.length))
+  )
+  if (!unreachable) clearRekeyJournal(vaultPaths)
 }
 
-/** Roll back an uncommitted rekey: delete the staged files. Plain delete is enough —
- *  they are ciphertext under a data key that was never persisted anywhere. */
+/** Roll back an uncommitted rekey: delete the staged files and the journal. Plain delete
+ *  is enough — they are ciphertext under a data key that was never persisted anywhere. */
 export function discardPendingRekey(vaultPaths: VaultPaths): void {
   for (const staged of stagedRekeyFiles(vaultPaths)) {
     rmSync(staged, { force: true })
   }
+  clearRekeyJournal(vaultPaths)
 }
 
 /**
@@ -820,12 +1005,15 @@ export function discardPendingRekey(vaultPaths: VaultPaths): void {
  * the descriptor decides which side of the commit point the crash landed on. v2
  * descriptor + staged files ⇒ committed ⇒ roll FORWARD (the new password's files win);
  * v1 descriptor ⇒ uncommitted ⇒ roll BACK (the old password + old files stay intact).
+ * A journal with nothing left staged still needs the roll-forward's deletions (#241).
  */
 export function recoverPendingRekey(vaultPaths: VaultPaths, descriptor: VaultDescriptor | null): void {
   // encryptFile's own atomic-write temp for the staged DB (a crash mid-stage leaves it;
-  // the document-dir equivalents end in `.tmp` and are swept by shredStalePlaintext).
+  // the document-dir equivalents end in `.tmp` and are swept by shredStalePlaintext), and
+  // the journal's own write temp.
   rmSync(`${vaultPaths.encPath}${REKEY_SUFFIX}.tmp`, { force: true })
-  if (stagedRekeyFiles(vaultPaths).length === 0) return
+  rmSync(`${rekeyJournalPath(vaultPaths)}.tmp`, { force: true })
+  if (stagedRekeyFiles(vaultPaths).length === 0 && !existsSync(rekeyJournalPath(vaultPaths))) return
   if (descriptor && descriptor.version >= VAULT_VERSION_ENVELOPE && descriptor.dataKey) {
     applyPendingRekey(vaultPaths)
   } else {

--- a/apps/desktop/src/main/services/workspace-vault.ts
+++ b/apps/desktop/src/main/services/workspace-vault.ts
@@ -15,8 +15,9 @@ import {
 } from 'node:fs'
 import { open as openFileAsync, rename as renameAsync, rm as rmAsync, stat as statAsync } from 'node:fs/promises'
 import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto'
-import { basename, dirname, isAbsolute, join, relative } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { tMain } from './i18n'
+import { canonicalLeafFor } from './ingestion/stored-copy-leaf'
 import { perfMark, perfMs } from './perf'
 import type { Db } from './db'
 import { openDatabase } from './db'
@@ -55,8 +56,9 @@ import {
 /** Legacy descriptor format: data encrypted directly under the password-derived key. */
 export const VAULT_VERSION = 1
 /**
- * Envelope format: a random 32-byte DATA key encrypts the DB +
- * document sidecars; the password-derived key (KEK) only WRAPS it in the descriptor.
+ * Envelope format: a random 32-byte DATA key encrypts the DB + every sidecar class
+ * (documents, image history, legacy out-of-store copies, the rotated log — see
+ * `listVaultKeyCiphertexts`); the password-derived key (KEK) only WRAPS it in the descriptor.
  * A password change then re-wraps one blob (O(1)) instead of re-encrypting the corpus.
  * New vaults are created v2; v1 vaults migrate on their FIRST password change (never on
  * unlock — a vault that never changes its password is never touched).
@@ -771,20 +773,25 @@ function isInsideDir(dir: string, path: string): boolean {
 
 /**
  * Legacy stored copies that resolve OUTSIDE `workspace/documents/` (issue #188 rows keep an
- * absolute `stored_path`). A row counts only when no canonical `documents/<leaf>` exists —
- * the fallback order of `locateStoredCopy` (ingestion/stored-copy.ts), so exactly the files
- * the read paths would decrypt are rekeyed, and nothing a sibling workspace owns.
+ * absolute `stored_path`). The rule is `locateStoredCopy`'s fallback order (ingestion/
+ * stored-copy.ts): a row counts only when its canonical `documents/<leaf>` (the shared
+ * `canonicalLeafFor` rule) is absent and `stored_path` names an existing regular file
+ * outside the store — i.e. exactly the file the read paths would decrypt at this moment.
+ * Limits: a copy on a drive that is detached NOW is not seen and stays under the old key if
+ * it returns later; the guard is name presence, not ownership — a row pointing into another
+ * vault's store is rekeyed like any other file it names.
  */
 function listOutOfStoreCopies(vaultPaths: VaultPaths, db: Db): string[] {
   const docsDir = join(workspaceDirOf(vaultPaths), DOCUMENTS_DIR_NAME)
   const rows = db
-    .prepare('SELECT stored_path, stored_name FROM documents WHERE stored_path IS NOT NULL')
-    .all() as Array<{ stored_path: string; stored_name: string | null }>
-  const out: string[] = []
+    .prepare('SELECT id, stored_path, stored_name FROM documents WHERE stored_path IS NOT NULL')
+    .all() as Array<{ id: string; stored_path: string; stored_name: string | null }>
+  const out = new Set<string>()
   for (const row of rows) {
     const path = row.stored_path
-    if (typeof path !== 'string' || !path.endsWith(ENCRYPTED_DOC_SUFFIX) || out.includes(path)) continue
-    if (existsSync(join(docsDir, row.stored_name ?? basename(path)))) continue // canonical copy wins
+    if (typeof path !== 'string' || !path.endsWith(ENCRYPTED_DOC_SUFFIX) || out.has(path)) continue
+    const leaf = canonicalLeafFor(row)
+    if (leaf && existsSync(join(docsDir, leaf))) continue // the canonical copy wins
     if (isInsideDir(docsDir, path)) continue
     let isFile = false
     try {
@@ -792,9 +799,9 @@ function listOutOfStoreCopies(vaultPaths: VaultPaths, db: Db): string[] {
     } catch {
       /* gone or unreachable → nothing to rekey */
     }
-    if (isFile) out.push(path)
+    if (isFile) out.add(path)
   }
-  return out
+  return [...out]
 }
 
 /**
@@ -822,17 +829,36 @@ export function listVaultKeyCiphertexts(vaultPaths: VaultPaths, db: Db): VaultKe
   return out
 }
 
-function readRekeyJournal(vaultPaths: VaultPaths): RekeyJournal | null {
+/** A journal read back from disk; `corrupt` = unparseable or an unknown version. */
+type RekeyJournalRead = RekeyJournal & { corrupt: boolean }
+
+function readRekeyJournal(vaultPaths: VaultPaths): RekeyJournalRead | null {
   const path = rekeyJournalPath(vaultPaths)
   if (!existsSync(path)) return null
   const strings = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<RekeyJournal>
-    return { version: 1, staged: strings(parsed.staged), remove: strings(parsed.remove) }
+    if (parsed.version !== 1) return { version: 1, staged: [], remove: [], corrupt: true }
+    return {
+      version: 1,
+      // Only `<file>.new` entries can be swapped; anything else would be shredded by name.
+      staged: strings(parsed.staged).filter((s) => s.endsWith(REKEY_SUFFIX)),
+      remove: strings(parsed.remove),
+      corrupt: false
+    }
   } catch {
-    return { version: 1, staged: [], remove: [] } // unreadable: the directory scans still apply
+    // Unreadable: the directory scans still resolve the in-store classes; the file itself is
+    // quarantined (never deleted) by clearRekeyJournal so its out-of-store entries are not lost.
+    return { version: 1, staged: [], remove: [], corrupt: true }
   }
+}
+
+/** A path key that folds spelling differences (`..` segments, drive-letter case on Windows)
+ *  so one physical staged file is never listed — and swapped — twice (#241). */
+function pathKey(path: string): string {
+  const resolved = resolve(path)
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved
 }
 
 /** Atomic (temp + fsync + rename), like the descriptor: recovery must never read half a journal. */
@@ -849,34 +875,45 @@ function writeRekeyJournal(vaultPaths: VaultPaths, journal: RekeyJournal): void 
   renameSync(tmp, path)
 }
 
-function clearRekeyJournal(vaultPaths: VaultPaths): void {
-  rmSync(`${rekeyJournalPath(vaultPaths)}.tmp`, { force: true })
-  rmSync(rekeyJournalPath(vaultPaths), { force: true })
+/** Remove the journal — or, when it could not be parsed, quarantine it as `.corrupt` beside
+ *  the vault so the out-of-store paths it may name are never destroyed with it. */
+function clearRekeyJournal(vaultPaths: VaultPaths, journal: RekeyJournalRead | null): void {
+  const path = rekeyJournalPath(vaultPaths)
+  rmSync(`${path}.tmp`, { force: true })
+  if (journal?.corrupt && existsSync(path)) {
+    rmSync(`${path}.corrupt`, { force: true })
+    renameSync(path, `${path}.corrupt`)
+    return
+  }
+  rmSync(path, { force: true })
 }
 
 /** Every staged `<file>.new` of an (interrupted or in-progress) rekey: the DB, the in-store
  *  sidecars (`documents/`, `images/` — by scan, so a journal-less stage still resolves) and
  *  the journal's entries (the only way to find an out-of-store one). */
-function stagedRekeyFiles(vaultPaths: VaultPaths): string[] {
+function stagedRekeyFiles(vaultPaths: VaultPaths, journal = readRekeyJournal(vaultPaths)): string[] {
   const ws = workspaceDirOf(vaultPaths)
-  const out = new Set<string>()
-  if (existsSync(`${vaultPaths.encPath}${REKEY_SUFFIX}`)) {
-    out.add(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
+  // Keyed on the folded path: the scan and the journal may spell one file two ways, and a
+  // file listed twice would be shredded by its own second swap.
+  const out = new Map<string, string>()
+  const add = (p: string): void => {
+    if (!out.has(pathKey(p))) out.set(pathKey(p), p)
   }
+  if (existsSync(`${vaultPaths.encPath}${REKEY_SUFFIX}`)) add(`${vaultPaths.encPath}${REKEY_SUFFIX}`)
   for (const sub of [DOCUMENTS_DIR_NAME, IMAGES_DIR_NAME]) {
     const dir = join(ws, sub)
     try {
       for (const n of readdirSync(dir)) {
-        if (n.endsWith(`${ENCRYPTED_DOC_SUFFIX}${REKEY_SUFFIX}`)) out.add(join(dir, n))
+        if (n.endsWith(`${ENCRYPTED_DOC_SUFFIX}${REKEY_SUFFIX}`)) add(join(dir, n))
       }
     } catch {
       /* dir not created yet */
     }
   }
-  for (const staged of readRekeyJournal(vaultPaths)?.staged ?? []) {
-    if (existsSync(staged)) out.add(staged)
+  for (const staged of journal?.staged ?? []) {
+    if (existsSync(staged)) add(staged)
   }
-  return [...out]
+  return [...out.values()]
 }
 
 /**
@@ -957,12 +994,17 @@ export function applyPendingRekey(vaultPaths: VaultPaths): void {
       /* locked: stays under the retired key; nothing reads it */
     }
   }
+  // encryptFile's write temp beside an out-of-store target (the in-store ones are swept).
+  for (const staged of journal?.staged ?? []) rmSync(`${staged}.tmp`, { force: true })
   const swapOne = (staged: string): void => {
+    // Already swapped (or listed under two spellings): shredding the target now would
+    // destroy the NEW ciphertext.
+    if (!existsSync(staged)) return
     const target = staged.slice(0, -REKEY_SUFFIX.length)
     shredFile(target)
     renameSync(staged, target)
   }
-  let pending = stagedRekeyFiles(vaultPaths)
+  let pending = stagedRekeyFiles(vaultPaths, journal)
   let lastErr: unknown = null
   for (let attempt = 0; attempt < 2 && pending.length > 0; attempt++) {
     const failed: string[] = []
@@ -988,16 +1030,18 @@ export function applyPendingRekey(vaultPaths: VaultPaths): void {
   const unreachable = (journal?.staged ?? []).some(
     (staged) => !existsSync(staged) && !existsSync(staged.slice(0, -REKEY_SUFFIX.length))
   )
-  if (!unreachable) clearRekeyJournal(vaultPaths)
+  if (!unreachable) clearRekeyJournal(vaultPaths, journal)
 }
 
 /** Roll back an uncommitted rekey: delete the staged files and the journal. Plain delete
  *  is enough — they are ciphertext under a data key that was never persisted anywhere. */
 export function discardPendingRekey(vaultPaths: VaultPaths): void {
-  for (const staged of stagedRekeyFiles(vaultPaths)) {
+  const journal = readRekeyJournal(vaultPaths)
+  for (const staged of stagedRekeyFiles(vaultPaths, journal)) {
     rmSync(staged, { force: true })
   }
-  clearRekeyJournal(vaultPaths)
+  for (const staged of journal?.staged ?? []) rmSync(`${staged}.tmp`, { force: true })
+  clearRekeyJournal(vaultPaths, journal)
 }
 
 /**

--- a/apps/desktop/src/main/services/workspace.ts
+++ b/apps/desktop/src/main/services/workspace.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
 import { readdir, stat, statfs } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { DriveStatus } from '../../shared/types'
+import { IMAGES_DIR_NAME } from './workspace-vault'
 
 // Workspace / drive manager (spec §7.2 drive detector + §7.9 workspace manager).
 // Resolves where models + the workspace live, supporting three layouts:
@@ -108,7 +109,7 @@ async function freeBytes(dir: string): Promise<number | null> {
  * is a cheap sum of file sizes. `0` when the dir doesn't exist yet; `null` only when unreadable.
  */
 async function imagesFootprintBytes(workspacePath: string): Promise<number | null> {
-  const dir = join(workspacePath, 'images')
+  const dir = join(workspacePath, IMAGES_DIR_NAME)
   try {
     const entries = await readdir(dir, { withFileTypes: true })
     let total = 0

--- a/apps/desktop/tests/integration/images-ipc.test.ts
+++ b/apps/desktop/tests/integration/images-ipc.test.ts
@@ -433,6 +433,7 @@ describe('registerImagesIpc — history persistence', () => {
       isDev: false,
       workspace: {
         isUnlocked: () => unlocked,
+        beginDocumentWork: () => () => {},
         documentCipher: () => ({
           encryptFile: (s: string, d: string) => encryptFile(s, d, key),
           decryptFile: (s: string, d: string) => decryptFile(s, d, key),

--- a/apps/desktop/tests/integration/password-change.test.ts
+++ b/apps/desktop/tests/integration/password-change.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { getSettings, updateSettings } from '../../src/main/services/settings'
@@ -14,6 +14,8 @@ import {
   stageRekey,
   rewrapVaultKey,
   applyPendingRekey,
+  discardPendingRekey,
+  listVaultKeyCiphertexts,
   shredFile,
   WorkspaceController,
   WrongPasswordError,
@@ -25,10 +27,19 @@ import {
 } from '../../src/main/services/workspace-vault'
 import {
   decrypt,
+  encrypt,
+  serializeBlob,
+  deserializeBlob,
   deriveKey,
   generateDataKey,
   type KdfParams
 } from '../../src/main/services/security/crypto'
+import {
+  createImageSession,
+  getImageSession,
+  imagesDir,
+  listImageSessions
+} from '../../src/main/services/vision/history'
 
 // Phase 32 — vault password change (wave-3 plan §5, decision D24): the v2 envelope
 // descriptor (random data key wrapped by the password-derived KEK), the O(1) re-wrap on
@@ -470,6 +481,325 @@ describe('descriptor/.enc scan — passwords and keys stay memory-only (extended
         expect(artifact.includes(secret)).toBe(false)
       }
     }
+    ctl.lock()
+  })
+})
+
+// ---- every vault-key ciphertext class survives the v1→v2 rekey (#241) --------------------
+//
+// The v1→v2 migration used to stage `documents/*.enc` only. Image-history sidecars under
+// `images/`, legacy stored copies whose `stored_path` lies outside the store, and the rotated
+// diagnostics log all share the vault key, so the first password change of a v1 vault left
+// them under a zeroed key. These tests drive the REAL `changePassword` over a `legacyV1`
+// vault that carries one of each class. They do not prove that any real user holds a v1 vault.
+
+const IMAGE_A = new Uint8Array([0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8])
+const IMAGE_B = new Uint8Array([0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9])
+/** On-disk names this test pins: the rotated diagnostics log and the rekey journal file. */
+const ROTATED_LOG = 'app.1.log.enc'
+const REKEY_JOURNAL = 'rekey-journal.json'
+
+/** A temp workspace layout whose vault paths also know the `logs/` dir (rotated log class). */
+function freshVaultWithLogs(): { vp: VaultPaths; root: string } {
+  const root = mkdtempSync(join(tmpdir(), 'hilbertraum-rekey-classes-'))
+  for (const d of ['config', 'workspace', 'logs']) mkdirSync(join(root, d), { recursive: true })
+  const logsPath = join(root, 'logs')
+  const vp: VaultPaths = {
+    ...vaultPathsFrom({ configPath: join(root, 'config'), dbPath: join(root, 'workspace', 'hilbertraum.sqlite') }),
+    logsPath
+  }
+  return { vp, root }
+}
+
+interface ClassFixture {
+  vp: VaultPaths
+  root: string
+  ctl: WorkspaceController
+  imageA: string
+  imageB: string
+  /** `<images dir>/<stored_name>` of each image session. */
+  imageFiles: Record<string, string>
+  outside: string
+  doc: string
+  rotated: string
+}
+
+function imagesDirOf(root: string): string {
+  return imagesDir(join(root, 'workspace'))
+}
+
+function imageFile(ctl: WorkspaceController, root: string, id: string): string {
+  const row = ctl.requireDb().prepare('SELECT stored_name FROM image_sessions WHERE id = ?').get(id) as
+    | { stored_name: string }
+    | undefined
+  return join(imagesDirOf(root), row!.stored_name)
+}
+
+async function readImage(ctl: WorkspaceController, root: string, id: string): Promise<Uint8Array | null> {
+  const detail = await getImageSession(ctl.requireDb(), imagesDirOf(root), id, ctl.documentCipher())
+  return detail ? detail.imageBytes : null
+}
+
+/** Names under a dir that are rekey staging or transient plaintext leftovers. */
+function transientNames(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir).filter((n) => n.endsWith(REKEY_SUFFIX) || n.endsWith('.tmp'))
+}
+
+/** A legacy v1 vault carrying one of every vault-key ciphertext class, still unlocked. */
+async function v1VaultWithEveryClass(): Promise<ClassFixture> {
+  const { vp, root } = freshVaultWithLogs()
+  const ctl = unlockedController(vp, 'old-password', FAST_SCRYPT, { legacyV1: true })
+  const db = ctl.requireDb()
+  const imgDir = imagesDirOf(root)
+  // Two images through the REAL history writer (encrypt-then-write under the vault cipher).
+  const imageA = await createImageSession(
+    db,
+    imgDir,
+    { imageBytes: IMAGE_A, mimeType: 'image/png', name: 'a', width: 2, height: 2 },
+    ctl.documentCipher()
+  )
+  const imageB = await createImageSession(
+    db,
+    imgDir,
+    { imageBytes: IMAGE_B, mimeType: 'image/jpeg', name: 'b', width: 3, height: 3 },
+    ctl.documentCipher()
+  )
+  // An ordinary document sidecar in the store.
+  const doc = addEncryptedDoc(ctl, vp, 'doc-classes', 'DOCUMENT-SURVIVES')
+  // A legacy out-of-store copy: hand-encrypted under `workspace/legacy-store/` with a row whose
+  // `stored_path` names it (the on-disk shape `locateStoredCopy`'s fallback reads).
+  const legacyDir = join(root, 'workspace', 'legacy-store')
+  mkdirSync(legacyDir, { recursive: true })
+  const plain = join(legacyDir, 'outside.src')
+  writeFileSync(plain, 'OUTSIDE-SURVIVES', 'utf8')
+  const outside = join(legacyDir, 'outside.txt.enc')
+  ctl.documentCipher()!.encryptFile(plain, outside)
+  shredFile(plain)
+  const now = new Date().toISOString()
+  db.prepare(
+    `INSERT INTO documents (id, title, original_path, stored_path, mime_type, size_bytes, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run('doc-outside', 'outside', null, outside, 'text/plain', 16, 'indexed', now, now)
+  // The rotated diagnostics log: the logging module's own frame (one AEAD blob under the vault key).
+  const rotated = join(vp.logsPath!, ROTATED_LOG)
+  writeFileSync(rotated, serializeBlob(encrypt(ctl.encryptionKey()!, Buffer.from('ROTATED-LOG', 'utf8'))))
+  return {
+    vp,
+    root,
+    ctl,
+    imageA,
+    imageB,
+    imageFiles: { [imageA]: imageFile(ctl, root, imageA), [imageB]: imageFile(ctl, root, imageB) },
+    outside,
+    doc,
+    rotated
+  }
+}
+
+function reopen(vp: VaultPaths, password: string): WorkspaceController {
+  const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+  ctl.init()
+  ctl.unlock(password)
+  return ctl
+}
+
+function rotatedLogText(ctl: WorkspaceController, rotated: string): string {
+  return decrypt(ctl.encryptionKey()!, deserializeBlob(readFileSync(rotated))).toString('utf8')
+}
+
+/** Every class readable through a controller holding the CURRENT key; nothing staged anywhere. */
+async function expectEveryClassReadable(f: ClassFixture, ctl: WorkspaceController): Promise<void> {
+  expect(await readImage(ctl, f.root, f.imageA)).toEqual(IMAGE_A)
+  expect(await readImage(ctl, f.root, f.imageB)).toEqual(IMAGE_B)
+  expect(readEncryptedDoc(ctl, f.outside)).toBe('OUTSIDE-SURVIVES')
+  expect(readEncryptedDoc(ctl, f.doc)).toBe('DOCUMENT-SURVIVES')
+  expect(transientNames(imagesDirOf(f.root))).toEqual([])
+  expect(transientNames(join(f.root, 'workspace', 'documents'))).toEqual([])
+  expect(transientNames(join(f.root, 'workspace', 'legacy-store'))).toEqual([])
+  expect(existsSync(`${f.vp.encPath}${REKEY_SUFFIX}`)).toBe(false)
+  expect(existsSync(join(f.root, 'workspace', REKEY_JOURNAL))).toBe(false)
+}
+
+describe('changePassword — every vault-key ciphertext class survives the v1→v2 migration (#241)', () => {
+  it('images, an out-of-store copy, a document and the rotated log all decrypt under the new password', async () => {
+    const f = await v1VaultWithEveryClass()
+    expect(readVaultDescriptor(f.vp.descriptorPath)!.version).toBe(VAULT_VERSION)
+    // Byte-exact before the change (the fixture itself is sound).
+    expect(await readImage(f.ctl, f.root, f.imageA)).toEqual(IMAGE_A)
+    expect(await readImage(f.ctl, f.root, f.imageB)).toEqual(IMAGE_B)
+    expect(rotatedLogText(f.ctl, f.rotated)).toBe('ROTATED-LOG')
+
+    expect(f.ctl.changePassword('old-password', 'new-password', FAST_ARGON).state).toBe('unlocked')
+    f.ctl.lock()
+
+    const ctl = reopen(f.vp, 'new-password')
+    expect(readVaultDescriptor(f.vp.descriptorPath)!.version).toBe(VAULT_VERSION_ENVELOPE)
+    // The session rows survive and both images decrypt byte-exact under the NEW key.
+    expect(listImageSessions(ctl.requireDb()).map((s) => s.id).sort()).toEqual([f.imageA, f.imageB].sort())
+    await expectEveryClassReadable(f, ctl)
+    // The rotated log is either gone or readable under the new key — never stranded.
+    if (existsSync(f.rotated)) expect(rotatedLogText(ctl, f.rotated)).toBe('ROTATED-LOG')
+    ctl.lock()
+  })
+
+  it('the rotated log is deleted by the v1→v2 change (nothing reads it) and untouched by a v2 re-wrap', async () => {
+    const f = await v1VaultWithEveryClass()
+    f.ctl.changePassword('old-password', 'new-password', FAST_ARGON)
+    expect(existsSync(f.rotated)).toBe(false)
+    // A v2→v2 change keeps the data key, so a rotated generation written afterwards stays.
+    writeFileSync(f.rotated, serializeBlob(encrypt(f.ctl.encryptionKey()!, Buffer.from('AGAIN', 'utf8'))))
+    f.ctl.changePassword('new-password', 'third-password', FAST_ARGON)
+    expect(rotatedLogText(f.ctl, f.rotated)).toBe('AGAIN')
+    f.ctl.lock()
+  })
+
+  it('listVaultKeyCiphertexts enumerates the four classes; stageRekey journals every staged path', async () => {
+    const f = await v1VaultWithEveryClass()
+    const db = f.ctl.requireDb()
+    const listed = listVaultKeyCiphertexts(f.vp, db)
+    const byKind = (kind: string): string[] =>
+      listed
+        .filter((c) => c.kind === kind)
+        .map((c) => c.path)
+        .sort()
+    expect(byKind('document')).toEqual([f.doc])
+    expect(byKind('image')).toEqual(Object.values(f.imageFiles).sort())
+    expect(byKind('out-of-store')).toEqual([f.outside])
+    expect(byKind('rotated-log')).toEqual([f.rotated])
+    expect(listed.filter((c) => c.action === 'delete').map((c) => c.path)).toEqual([f.rotated])
+    f.ctl.lock()
+
+    const { db: db2, key } = unlockEncryptedVault(f.vp, 'old-password')
+    stageRekey(f.vp, db2, key, generateDataKey())
+    db2.close()
+    const journalPath = join(f.root, 'workspace', REKEY_JOURNAL)
+    const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as { staged: string[]; remove: string[] }
+    const expectedStaged = [f.vp.encPath, f.doc, f.outside, ...Object.values(f.imageFiles)]
+      .map((p) => `${p}${REKEY_SUFFIX}`)
+      .sort()
+    expect([...journal.staged].sort()).toEqual(expectedStaged)
+    for (const staged of expectedStaged) expect(existsSync(staged)).toBe(true)
+    expect(journal.remove).toEqual([f.rotated])
+    // The rotated log is still there: nothing is deleted before the commit point.
+    expect(existsSync(f.rotated)).toBe(true)
+
+    discardPendingRekey(f.vp)
+    expect(existsSync(journalPath)).toBe(false)
+    for (const staged of expectedStaged) expect(existsSync(staged)).toBe(false)
+    expect(existsSync(f.rotated)).toBe(true)
+  })
+})
+
+// Crash at every cut of the journal, over every class. Before the commit the OLD password and
+// files win (rollback); from the commit on the NEW ones do (roll-forward), whichever files a
+// crash left swapped or staged.
+type SwapClass = 'db' | 'document' | 'image' | 'outside'
+const CUTS: Array<{ cut: string; committed: boolean; swapped: SwapClass[] }> = [
+  { cut: 'after staging, before the commit', committed: false, swapped: [] },
+  { cut: 'after the commit, before any swap', committed: true, swapped: [] },
+  { cut: 'mid-swap: only the DB swapped', committed: true, swapped: ['db'] },
+  { cut: 'mid-swap: only the document swapped', committed: true, swapped: ['document'] },
+  { cut: 'mid-swap: only one image swapped', committed: true, swapped: ['image'] },
+  { cut: 'mid-swap: only the out-of-store copy swapped', committed: true, swapped: ['outside'] },
+  { cut: 'after every swap, before the journal is cleared', committed: true, swapped: ['db', 'document', 'image', 'outside'] }
+]
+
+describe('changePassword — crash at every journal cut, every ciphertext class (#241)', () => {
+  it.each(CUTS)('$cut', async ({ committed, swapped }) => {
+    const f = await v1VaultWithEveryClass()
+    f.ctl.lock()
+    const { db, key } = unlockEncryptedVault(f.vp, 'old-password')
+    const dataKey = generateDataKey()
+    stageRekey(f.vp, db, key, dataKey)
+    if (committed) rewrapVaultKey(f.vp, dataKey, 'new-password', FAST_ARGON) // COMMIT
+    db.close()
+    const targetFor: Record<SwapClass, string> = {
+      db: f.vp.encPath,
+      document: f.doc,
+      image: f.imageFiles[f.imageA],
+      outside: f.outside
+    }
+    for (const cls of swapped) {
+      shredFile(targetFor[cls])
+      renameSync(`${targetFor[cls]}${REKEY_SUFFIX}`, targetFor[cls])
+    }
+    // The rotated log is only ever removed by the roll-forward, never by a stage or a rollback.
+    expect(existsSync(f.rotated)).toBe(true)
+
+    if (committed) {
+      const ctl = reopen(f.vp, 'new-password') // recovery rolls FORWARD before the unlock decrypt
+      await expectEveryClassReadable(f, ctl)
+      expect(existsSync(f.rotated)).toBe(false)
+      ctl.lock()
+      expect(() => ctl.unlock('old-password')).toThrow(WrongPasswordError)
+    } else {
+      const ctl = reopen(f.vp, 'old-password') // recovery rolls BACK: staged files discarded
+      await expectEveryClassReadable(f, ctl)
+      expect(rotatedLogText(ctl, f.rotated)).toBe('ROTATED-LOG')
+      ctl.lock()
+    }
+  })
+})
+
+// An image save cannot straddle the swap: the write holds the document-work lease, so a
+// password change refuses while a save is in flight, and a save refuses while a change runs.
+describe('image writes vs the password change — the document-work lease (#241)', () => {
+  it('a password change is refused while an image save is in flight; the save completes and later rekeys cleanly', async () => {
+    const { vp, root } = freshVaultWithLogs()
+    const ctl = unlockedController(vp, 'old-password', FAST_SCRYPT, { legacyV1: true })
+    const imgDir = imagesDirOf(root)
+    const saving = createImageSession(
+      ctl.requireDb(),
+      imgDir,
+      { imageBytes: IMAGE_A, mimeType: 'image/png', name: 'a', width: 2, height: 2 },
+      ctl.documentCipher(),
+      () => ctl.beginDocumentWork()
+    )
+    expect(() => ctl.changePassword('old-password', 'new-password', FAST_ARGON)).toThrow(VaultBusyError)
+    const id = await saving
+    expect(await readImage(ctl, root, id)).toEqual(IMAGE_A)
+    expect(transientNames(imgDir)).toEqual([])
+    // Lease released with the save → the change goes through and the image follows the key.
+    expect(ctl.changePassword('old-password', 'new-password', FAST_ARGON).state).toBe('unlocked')
+    expect(await readImage(ctl, root, id)).toEqual(IMAGE_A)
+    ctl.lock()
+    const again = reopen(vp, 'new-password')
+    expect(await readImage(again, root, id)).toEqual(IMAGE_A)
+    again.lock()
+  })
+
+  it('an image save admitted while a REAL password change runs is refused with VaultBusyError and writes nothing', async () => {
+    const { vp, root } = freshVaultWithLogs()
+    const ctl = unlockedController(vp, 'pw-one', FAST_SCRYPT)
+    const imgDir = imagesDirOf(root)
+    // Trap the private flag (the idiom of the race-guard test above): at the instant the REAL
+    // changePassword flips it true, start a save that takes the lease.
+    let backing = false
+    let attempted: Promise<string> | null = null
+    Object.defineProperty(ctl, 'changingPassword', {
+      configurable: true,
+      get: () => backing,
+      set: (v: boolean) => {
+        backing = v
+        if (v && !attempted) {
+          attempted = createImageSession(
+            ctl.requireDb(),
+            imgDir,
+            { imageBytes: IMAGE_B, mimeType: 'image/png', name: 'b', width: 3, height: 3 },
+            ctl.documentCipher(),
+            () => ctl.beginDocumentWork()
+          )
+          attempted.catch(() => undefined) // asserted below; keep the rejection from going unhandled
+        }
+      }
+    })
+    expect(ctl.changePassword('pw-one', 'pw-two', FAST_ARGON).state).toBe('unlocked')
+    expect(attempted).not.toBeNull()
+    await expect(attempted!).rejects.toBeInstanceOf(VaultBusyError)
+    // Nothing partial: no session row, no `.enc`, no `<id>.tmp`.
+    expect(listImageSessions(ctl.requireDb())).toEqual([])
+    expect(existsSync(imgDir) ? readdirSync(imgDir) : []).toEqual([])
     ctl.lock()
   })
 })

--- a/apps/desktop/tests/integration/password-change.test.ts
+++ b/apps/desktop/tests/integration/password-change.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { mkdtempSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { getSettings, updateSettings } from '../../src/main/services/settings'
 import { DEFAULT_POLICY } from '../../src/main/services/policy'
 import type { PrivacyPolicy } from '../../src/shared/types'
@@ -800,6 +800,75 @@ describe('image writes vs the password change — the document-work lease (#241)
     // Nothing partial: no session row, no `.enc`, no `<id>.tmp`.
     expect(listImageSessions(ctl.requireDb())).toEqual([])
     expect(existsSync(imgDir) ? readdirSync(imgDir) : []).toEqual([])
+    ctl.lock()
+  })
+})
+
+// Journal edge cases from the #241 review: one physical file listed twice, an entry whose
+// location is unreachable at recovery, and a journal that cannot be parsed.
+describe('rekey journal — aliases, unreachable entries, corruption (#241)', () => {
+  /** Stage + commit a full-class v1 vault and hand back the journal path. */
+  async function committedStage(): Promise<ClassFixture & { journalPath: string }> {
+    const f = await v1VaultWithEveryClass()
+    f.ctl.lock()
+    const { db, key } = unlockEncryptedVault(f.vp, 'old-password')
+    const dataKey = generateDataKey()
+    stageRekey(f.vp, db, key, dataKey)
+    rewrapVaultKey(f.vp, dataKey, 'new-password', FAST_ARGON) // COMMIT
+    db.close()
+    return { ...f, journalPath: join(f.root, 'workspace', REKEY_JOURNAL) }
+  }
+
+  it('a journal entry that spells a staged file differently is swapped once, never shredded by its twin', async () => {
+    const f = await committedStage()
+    const journal = JSON.parse(readFileSync(f.journalPath, 'utf8')) as { staged: string[]; remove: string[] }
+    // The same physical files through a `..` segment (and, on Windows, a different case).
+    const alias = (p: string): string => {
+      const viaParent = join(dirname(p), '..', basename(dirname(p)), basename(p))
+      return process.platform === 'win32' ? viaParent.toUpperCase() : viaParent
+    }
+    journal.staged.push(alias(`${f.vp.encPath}${REKEY_SUFFIX}`), alias(`${f.imageFiles[f.imageA]}${REKEY_SUFFIX}`))
+    writeFileSync(f.journalPath, JSON.stringify(journal), 'utf8')
+
+    const ctl = reopen(f.vp, 'new-password') // a double swap would have shredded the DB itself
+    await expectEveryClassReadable(f, ctl)
+    ctl.lock()
+  })
+
+  it('an out-of-store copy on an unreachable location keeps the journal; a later recovery finishes the swap', async () => {
+    const f = await committedStage()
+    const legacyDir = dirname(f.outside)
+    const away = `${legacyDir}.away`
+    renameSync(legacyDir, away) // the legacy location is "detached" at recovery time
+
+    const ctl = reopen(f.vp, 'new-password')
+    expect(await readImage(ctl, f.root, f.imageA)).toEqual(IMAGE_A)
+    expect(readEncryptedDoc(ctl, f.doc)).toBe('DOCUMENT-SURVIVES')
+    expect(existsSync(f.rotated)).toBe(false)
+    expect(existsSync(f.journalPath)).toBe(true) // kept: one entry could not be accounted for
+    expect(existsSync(join(away, `outside.txt.enc${REKEY_SUFFIX}`))).toBe(true) // twin intact
+    ctl.lock()
+
+    renameSync(away, legacyDir) // the location returns → the next recovery completes it
+    const again = reopen(f.vp, 'new-password')
+    await expectEveryClassReadable(f, again)
+    again.lock()
+  })
+
+  it('a journal that cannot be parsed is quarantined as .corrupt, never deleted; in-store classes still roll forward', async () => {
+    const f = await committedStage()
+    writeFileSync(f.journalPath, '{ not json', 'utf8')
+
+    const ctl = reopen(f.vp, 'new-password')
+    expect(await readImage(ctl, f.root, f.imageA)).toEqual(IMAGE_A)
+    expect(await readImage(ctl, f.root, f.imageB)).toEqual(IMAGE_B)
+    expect(readEncryptedDoc(ctl, f.doc)).toBe('DOCUMENT-SURVIVES')
+    expect(existsSync(f.journalPath)).toBe(false)
+    expect(readFileSync(`${f.journalPath}.corrupt`, 'utf8')).toBe('{ not json')
+    // The out-of-store twin was only ever named by the journal: it stays staged beside the
+    // original (nothing lost) until someone acts on the quarantined file.
+    expect(existsSync(`${f.outside}${REKEY_SUFFIX}`)).toBe(true)
+    expect(existsSync(f.outside)).toBe(true)
     ctl.lock()
   })
 })

--- a/apps/desktop/tests/integration/vision-security.test.ts
+++ b/apps/desktop/tests/integration/vision-security.test.ts
@@ -96,6 +96,7 @@ function ctxFor(
     isDev: false,
     workspace: {
       isUnlocked: () => unlocked,
+      beginDocumentWork: () => () => {},
       documentCipher: () => ({
         encryptFile: (s: string, d: string) => encryptFile(s, d, key),
         decryptFile: (s: string, d: string) => decryptFile(s, d, key),

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -572,7 +572,10 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
   and additive — older callers omit it; without it the rekey does not account for the rotated log).
 - **Rekey journal (on-disk, #241):** `workspace/rekey-journal.json` — `{ version: 1, staged: string[],
   remove: string[] }`, absolute paths; written atomically by `stageRekey` BEFORE any `<file>.new` is
-  staged, cleared by `applyPendingRekey`/`discardPendingRekey` once every entry is accounted for.
+  staged, cleared by `applyPendingRekey`/`discardPendingRekey` once every entry is accounted for
+  (an unreachable entry keeps it; an unparseable or unknown-`version` file is renamed to
+  `rekey-journal.json.corrupt`, never deleted; only `staged` entries ending in `.new` are honoured;
+  staged paths from the scan and the journal are de-duplicated on a folded spelling).
   `listVaultKeyCiphertexts(vaultPaths, db) → VaultKeyCiphertext[]` = `{ path, kind: 'document' |
   'image' | 'out-of-store' | 'rotated-log', action: 'rekey' | 'delete' }` is the class registry the
   stage journals. The descriptor is unchanged. **Downgrade caveat:** a build older than the #241 fix

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -567,8 +567,21 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 ✅ **`services/workspace-vault.ts`** (spec §7.9) — the lock/unlock lifecycle.
 - **Descriptor:** `VaultDescriptor { version, mode:'encrypted', kdf, saltB64, verifier }` at
   **`config/workspace.json`** (unencrypted; the only pre-unlock artifact).
-  `readVaultDescriptor`/`writeVaultDescriptor` (atomic). `vaultPathsFrom({configPath,dbPath})` →
-  `VaultPaths { descriptorPath, encPath = <dbPath>.enc, dbPath }`.
+  `readVaultDescriptor`/`writeVaultDescriptor` (atomic). `vaultPathsFrom({configPath,dbPath,logsPath?})` →
+  `VaultPaths { descriptorPath, encPath = <dbPath>.enc, dbPath, logsPath? }` (`logsPath` is optional
+  and additive — older callers omit it; without it the rekey does not account for the rotated log).
+- **Rekey journal (on-disk, #241):** `workspace/rekey-journal.json` — `{ version: 1, staged: string[],
+  remove: string[] }`, absolute paths; written atomically by `stageRekey` BEFORE any `<file>.new` is
+  staged, cleared by `applyPendingRekey`/`discardPendingRekey` once every entry is accounted for.
+  `listVaultKeyCiphertexts(vaultPaths, db) → VaultKeyCiphertext[]` = `{ path, kind: 'document' |
+  'image' | 'out-of-store' | 'rotated-log', action: 'rekey' | 'delete' }` is the class registry the
+  stage journals. The descriptor is unchanged. **Downgrade caveat:** a build older than the #241 fix
+  never reads the journal — on a pending migration it rolls only the DB + `documents/` forward and
+  leaves `images/` and out-of-store twins staged (a current build finishes them); a completed
+  migration is a plain v2 vault. Constants: `REKEY_JOURNAL_NAME`, `IMAGES_DIR_NAME`,
+  `DOCUMENTS_DIR_NAME`, `ROTATED_ENCRYPTED_LOG_NAME` (`app.1.log.enc`, deleted at the commit).
+  `createImageSession(db, dir, req, cipher, beginWork?)` — the optional fifth argument is the
+  document-work lease factory (`() => ctl.beginDocumentWork()`), taken before the first await.
 - **File crypto + hygiene:** `encryptFile`/`decryptFile` (atomic temp+rename), `shredFile`
   (overwrite-random + unlink, best-effort), `cleanSidecars` (shred `-wal`/`-shm`).
 - **Lifecycle:** `createEncryptedVaultOnDisk(vaultPaths, password, kdf?)` (writes descriptor + seeds

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -422,7 +422,10 @@ the same data key). After a *successful* change the IPC handler calls `rekeyVaul
 re-seals the **same in-memory buffer** under the now-current key **without re-loading from disk** —
 the buffer already holds the full session-plus-history log, so a re-load would discard history under
 a rotated key, or **double** it under an unchanged one. On a *failed* change the key never moved, so
-the log is left untouched (it keeps writing under the unchanged live key).
+the log is left untouched (it keeps writing under the unchanged live key). The rotated generation
+`app.1.log.enc` is **deleted** by a v1→v2 migration (at its commit, journaled — see "Password
+change"): nothing reads it, and re-sealing the live buffer cannot reach it (#241). A v2→v2 change
+keeps the data key, so the rotated file stays readable and is left alone.
 
 **Migration:** an older (pre-encryption) build, or a crash before this build's first lock, can leave
 a plaintext `app.log`/`app.1.log` on an encrypted drive. `attachVaultKey` **shreds** them on the
@@ -813,6 +816,11 @@ sidecar and writes no temp; only the history copy lands on disk).
   `imageGetJob`/`imageCancel` are gated on unlock like the other vision handlers.
 - **Crash recovery:** both temps end in `.tmp`, so the startup `shredStalePlaintext` sweep of
   `workspace/images/` removes any leftover from a process killed mid-write or mid-read.
+- **Password change:** the sidecars share the vault data key, so the v1→v2 migration stages and
+  swaps `images/*.enc` exactly like the document sidecars — one of the four ciphertext classes
+  the "Password change" section below enumerates (#241; before that fix a v1 vault's images were
+  stranded under the retired key on its first change). The write holds the document-work lease,
+  so a save never straddles the swap.
 - **Delete:** removing a history entry **shreds** the stored image and cascade-removes its turns
   (`image_turns.session_id` FK `ON DELETE CASCADE`); shredding is best-effort (a missing/locked copy
   never blocks the DB cleanup), matching `deleteDocument`.
@@ -942,19 +950,45 @@ audited as `workspace_unlock_failed`, never a new event). Hidden entirely in `pl
   fsync, rename). No data file is touched; the in-memory key is unchanged; no re-lock needed.
 - **v1 vault → one-time journaled migration to v2:** composed from the existing primitives
   (`encryptFile`'s `.tmp`-then-rename, `shredFile`, the startup sweep):
-  1. **Stage:** checkpoint the WAL, re-encrypt the live DB and every `<id><ext>.enc` document
-     sidecar under a fresh random data key, each written as `<file>.new` and fsynced. The
-     transient plaintext per sidecar ends in `.tmp`, so `shredStalePlaintext` covers a crash.
+  1. **Stage:** checkpoint the WAL, then re-encrypt the live DB and **every vault-key
+     ciphertext class** under a fresh random data key, each written as `<file>.new` and
+     fsynced. `listVaultKeyCiphertexts(vaultPaths, db)` enumerates the classes (#241; before
+     the #241 fix only the first was staged, so the other three were left under a zeroed key):
+     `documents/<id><ext>.enc` sidecars; `images/<id><ext>.enc` image-history sidecars (the
+     section above); legacy stored copies whose `documents.stored_path` resolves **outside**
+     the store (issue #188 rows — only those the resolver would actually read, i.e. with no
+     canonical `documents/<leaf>` present); and the rotated diagnostics log
+     `logs/app.1.log.enc`, which is **deleted at commit** rather than re-keyed (nothing reads
+     it — the Diagnostics tail reads the live generation only; a v2→v2 change keeps the data
+     key and leaves it alone). The transient plaintext per sidecar always lands under the
+     store and ends in `.tmp`, so `shredStalePlaintext` covers a crash. Before any file is
+     staged the **journal file** `workspace/rekey-journal.json` is written atomically: every
+     `<file>.new` path plus the files to remove at commit. It exists because an out-of-store
+     copy lies where no directory scan finds its staged twin at recovery (the DB is closed
+     then); the in-store classes are still found by scan, so a journal-less stage resolves too.
   2. **Commit:** the atomic v2-descriptor replace — the *single* commit point.
-  3. **Swap:** shred each old file, rename `<file>.new` into place.
+  3. **Swap:** delete the journal's remove-list (the rotated log; best-effort, idempotent),
+     then shred each old file and rename `<file>.new` into place; clear the journal once every
+     entry is accounted for (an entry whose location is unreachable — a detached legacy
+     drive — keeps the journal so a later recovery finishes that swap).
   **Crash recovery** (`recoverPendingRekey`, run at startup and before every unlock decrypt):
-  staged `.new` files with a **v1** descriptor mean the crash was pre-commit → discard them,
-  the old password + old files win; with a **v2** descriptor the commit happened → roll the
-  staged files forward, the new password wins. Old-or-new, never a mix — tests cut the journal
-  at every step and prove both directions.
+  staged `.new` files (or a journal) with a **v1** descriptor mean the crash was pre-commit →
+  discard them and the journal, the old password + old files win; with a **v2** descriptor the
+  commit happened → roll the staged files forward and apply the deletions, the new password
+  wins. Old-or-new, never a mix — tests cut the journal at every step, over every class, and
+  prove both directions (`password-change.test.ts`).
+  **Downgrade caveat (on-disk format, #241):** the journal file and the staged `images/` and
+  out-of-store twins are new on-disk shapes. A build older than the #241 fix that starts on a
+  vault with a *pending* migration rolls the DB and `documents/` forward but never reads the
+  journal, so it leaves the other classes staged under the retired key (their `.new` twins
+  intact beside them) and the journal file in place; running a current build again finishes
+  the swap. A *completed* migration is a plain v2 vault to any build since Phase 32.
 - **Race guard:** an import/re-index job writes `.enc` sidecars, so `changePassword` refuses
   to start while document work holds a lease (`beginDocumentWork`), and document work refuses
-  to start mid-change — both with friendly copy (`VaultBusyError`), never corruption.
+  to start mid-change — both with friendly copy (`VaultBusyError`), never corruption. Image
+  saves (`createImageSession`) hold the same lease across their encrypted write (#241): a
+  save in flight makes the change refuse, and a save started while a change runs is refused
+  and writes nothing — the analysis still answers; only the history entry is skipped.
 - **Audit:** success records the additive `workspace_password_changed` — id-free and
   content-free; passwords never appear in any log or audit row.
 - **Compatibility note:** a pre-Phase-32 build cannot open a v2 vault (the unlock fails with a

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -956,8 +956,10 @@ audited as `workspace_unlock_failed`, never a new event). Hidden entirely in `pl
      the #241 fix only the first was staged, so the other three were left under a zeroed key):
      `documents/<id><ext>.enc` sidecars; `images/<id><ext>.enc` image-history sidecars (the
      section above); legacy stored copies whose `documents.stored_path` resolves **outside**
-     the store (issue #188 rows — only those the resolver would actually read, i.e. with no
-     canonical `documents/<leaf>` present); and the rotated diagnostics log
+     the store (issue #188 rows — only those the resolver would read *at that moment*, i.e.
+     with no canonical `documents/<leaf>` present and the file reachable; a copy on a drive
+     that is detached while the password changes is not seen and stays under the old key if
+     it returns — the guard is name presence, not ownership); and the rotated diagnostics log
      `logs/app.1.log.enc`, which is **deleted at commit** rather than re-keyed (nothing reads
      it — the Diagnostics tail reads the live generation only; a v2→v2 change keeps the data
      key and leaves it alone). The transient plaintext per sidecar always lands under the
@@ -970,7 +972,10 @@ audited as `workspace_unlock_failed`, never a new event). Hidden entirely in `pl
   3. **Swap:** delete the journal's remove-list (the rotated log; best-effort, idempotent),
      then shred each old file and rename `<file>.new` into place; clear the journal once every
      entry is accounted for (an entry whose location is unreachable — a detached legacy
-     drive — keeps the journal so a later recovery finishes that swap).
+     drive — keeps the journal so a later recovery finishes that swap; a journal that cannot
+     be parsed is quarantined as `rekey-journal.json.corrupt`, never deleted, and the in-store
+     classes still resolve by scan). Staged paths are de-duplicated on a folded spelling so a
+     file the scan and the journal name differently is never swapped twice.
   **Crash recovery** (`recoverPendingRekey`, run at startup and before every unlock decrypt):
   staged `.new` files (or a journal) with a **v1** descriptor mean the crash was pre-commit →
   discard them and the journal, the old password + old files win; with a **v2** descriptor the


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 6: rekey completeness
Closes #241
Tracker: #217

### What
- `workspace-vault.ts`: `listVaultKeyCiphertexts(vaultPaths, db): VaultKeyCiphertext[]` — the registry of every file encrypted under the vault data key outside the DB, in four classes: `documents/*.enc`, `images/*.enc`, legacy out-of-store stored copies (rows whose `stored_path` resolves outside the store and has no canonical `documents/<leaf>` — the same fallback order as `locateStoredCopy`), and the rotated diagnostics log `logs/app.1.log.enc` (action `delete`). `stageRekey` stages every `rekey` entry; a new journal file `workspace/rekey-journal.json` (`{ version: 1, staged: string[], remove: string[] }`, written atomically BEFORE any `.new` exists) records every staged path and the commit-time deletions, because an out-of-store copy is invisible to the directory scans at recovery (the DB is closed then). `stagedRekeyFiles` = the DB twin + scans of `documents/` and `images/` + the journal's entries; `applyPendingRekey` deletes the remove-list first (best-effort, idempotent), swaps, and clears the journal once every entry is accounted for (an unreachable location keeps it); `discardPendingRekey` clears it; `recoverPendingRekey` also runs when only a journal is left. `VaultPaths.logsPath?` (optional, additive) and `vaultPathsFrom({…, logsPath?})`; `index.ts` passes the logs dir. Shared constants `DOCUMENTS_DIR_NAME`, `IMAGES_DIR_NAME`, `ROTATED_ENCRYPTED_LOG_NAME`, `REKEY_JOURNAL_NAME` (the `images` literal in `history.ts`, `workspace.ts` and the sweep now share one; `logging.ts` writes the rotated log under the shared name).
- NEW `ingestion/stored-copy-leaf.ts` (the leaf rule, dependency-free; `stored-copy.ts` re-exports it).
- `vision/history.ts`: `createImageSession(db, dir, req, cipher, beginWork?)` takes the document-work lease synchronously before its first await and releases it after the row insert (the body moved to `storeImageSession`). `registerImagesIpc.ts` passes `() => ctx.workspace.beginDocumentWork()`; a save during a password change is refused (`VaultBusyError`, logged content-free by the existing catch — the analysis still answers).
- The old key is kept until every staged file is journal-accounted: verified — the in-memory key swap happens after the descriptor commit, and the journal + staged files survive until the swap completes.

### Why (finding IDs + the promise line each restores)
- **REL-5** (#241): "Old-or-new, never a mix" and the image-history section's "same vault key" (`security-model.md`) — after a v1 vault's first password change its images and out-of-store copies were neither: their key was zeroed. Rotated log (folded): re-sealed nothing; now deleted at commit (Q18 default — nothing reads it; a v2→v2 change leaves it alone).
- **DOC-5** (folded): the image-history section now cross-references the rekey classes; the rekey section enumerates all four.
- **DOC-14** (folded): CHANGELOG's pre-1.0 note said tags below v0.1.50 had "no GitHub release"; BUILD_STATE and build-log record v0.1.46 as a published tester pre-release (5 assets, 2026-07-10); the GitHub API shows the tag exists and the release page does not. CHANGELOG was the wrong one and now says so (a tester pre-release whose page has since been removed).

### Tests
- characterisation (red before, commit `a0f01490`): `tests/integration/password-change.test.ts` — a `legacyV1` vault carrying two images (real `createImageSession`), a document, a hand-encrypted out-of-store copy under `workspace/legacy-store/` with its `documents` row, and a rotated log blob; after the real `changePassword` + lock + reopen the images failed with the GCM authentication error, recovery left `images/` and the out-of-store twin staged, the lease was not taken, the registry did not exist (11 red / 19 green).
- regression / inverted B-row: B3 inverted (descriptor v1 → v2, both images byte-exact, `image_sessions` ids survive, the out-of-store copy and a `documents/*.enc` decrypt, the rotated log absent-or-readable, nothing staged); the rotated-log default pinned (deleted by v1→v2, untouched by v2→v2); the registry's four classes + the journal shape; crash cuts `it.each` over 7 cut points (before commit; after commit before any swap; mid-swap with only the DB / document / image / out-of-store swapped; after every swap before the journal is cleared) × every class, both directions; the lease both ways (a change refuses while a save is in flight, the save completes and later rekeys cleanly; a save admitted mid-change rejects with `VaultBusyError` and writes no row, no `.enc`, no `.tmp`).
- `npm test` count: 5,522 passed / 74 skipped / 370 files (baseline 5,507 / 74 / 370; +15 = the 12 above + 3 journal edge cases from the review: a journal entry spelling a staged file differently is swapped once; an unreachable out-of-store entry keeps the journal and a later recovery finishes it; an unparseable journal is quarantined). `npm run typecheck`, `npm run build` and the dev launch (workspace resolved, offline posture logged, 0 electron.exe left after the watchdog) green at both heads.

### Docs + BUILD_STATE
`docs/security-model.md` ("Password change" rewritten: classes, journal, swap order, downgrade caveat, image-save lease; image-history cross-ref; rotated-log deletion in the log section), `docs/data-contracts.md` (journal shape, `VaultPaths.logsPath?`, registry type, `createImageSession` fifth argument), `CHANGELOG.md` (Unreleased Fixed + the pre-1.0 note), `BUILD_STATE.md` (dated entry, item-19 line; the 2026-07-12 gate paragraph moved above item 19 — it was never part of the item but the hygiene test's split counted it, leaving no room for the line).

### Owner decisions relied on (issue #, answer or default)
- Q18 (#241) — blank → default: delete the rotated log at the v1→v2 commit and document it.
- Journal shape (an on-disk format note) — blank → default: proceed; the downgrade caveat is recorded in `security-model.md` and `data-contracts.md`.
- Image writes during a password change — blank → default: refused with `VaultBusyError`, not queued.
- Decisions 4/11 (#221, #228) and 5 (#222) — unanswered; 5a and 5b-b stay blocked (not this PR).
- Q29 — blank; the manual GUI smoke (scratch encrypted workspace → add an image → change password → lock/unlock → open the history entry) was not run in this non-interactive session; the in-process equivalent is B3 inverted over the real writer + real `changePassword`.

### Reviewer pass: Fable, findings + repairs
12 findings — 1 blocking, 7 should-fix, 4 nits. Blocking (repaired): the scan and the journal could list one physical staged file under two spellings (a `..` segment, drive-letter case, an alias) and the second swap would shred the freshly swapped file — staged paths are now keyed on a folded spelling (`resolve` + lower-case on Windows) and `swapOne` skips a twin that no longer exists. Should-fixes (all repaired): the out-of-store rule now reuses `canonicalLeafFor` (moved with `storedCopyLeaf` to a dependency-free `ingestion/stored-copy-leaf.ts`, re-exported by `stored-copy.ts`, so a guard-failing `stored_name` falls to `stored_path` exactly like the resolver); `stored-copy.ts` header no longer says the rekey never reads `stored_path`; the registry docblock states the real rule (name presence, not ownership) and the detached-at-stage-time limit, now also in `security-model.md` and the CHANGELOG; an unparseable or unknown-version journal is quarantined as `rekey-journal.json.corrupt` (never deleted) and only `.new` entries are honoured; out-of-store `encryptFile` write temps are removed on apply/discard; tests for the unreachable-keeps-journal rule and the corrupt branch added; CHANGELOG dates corrected (the v2 envelope landed 2026-06-11; no released version ever created a v1 vault; "since removed" instead of an inferred date). Nits: the vault header comment restated, `Set` instead of `includes`, a pre-existing `history.ts` comment citing an older round's REL-5 de-audited in passing. Accepted as-is: the B3 either-or assertion on the rotated log (the plan keeps it as written until Q18 is ruled; the deletion is pinned in the next test); image reads (`getImageSession`) and the async delete shred do not hold the lease — a pre-existing residual of the same class as document preview reads, never a mixed file, recorded in the ledger.

### Rollback
Revert the PR only when no workspace holds a pending journal (`workspace/rekey-journal.json` absent and no `.new` twins under `images/` or beside an out-of-store copy). A completed migration is a plain v2 vault to any build since Phase 32. On-disk: the journal file and the two new staged classes are the only format change; the descriptor is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
