### PR TITLE
Audit 2026-09-02 — Phase 7: recovery preservation and durability (REL-8, REL-9)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -39,7 +39,7 @@ and unlock re-runs the salvage then refuses with `VaultRecoveryBlockedError` →
 `drive-layout.md` **Filesystem** paragraph and `troubleshooting.md` held-recovery entry document
 exFAT non-durability on decision 6's default (REL-9 #243, DOC-15 folded; #243 stays open);
 `data-contracts.md` reason union. No format change; single `.recovery` name (Q20 default); Q24
-copy in the PR body. Suite +3 (guards file 2 → 5): 370 → 370 / 5,522 → 5,525 / 74.
+copy in the PR body. Suite +4 (guards file 2 → 6): 370 → 370 / 5,522 → 5,526 / 74.
 
 _2026-09-03 — **Audit 2026-09-02 Phase 6 — rekey completeness: the v1→v2 password change now
 carries every vault-key ciphertext class — `listVaultKeyCiphertexts(vaultPaths, db)` enumerates

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,18 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-03 — **Audit 2026-09-02 Phase 7 — recovery preservation + durability docs: a held
+`.recovery` no longer costs the last session's newest data after a failed lock —
+`preserveNewerPlaintext` now returns `preserved`/`not-needed`/`failed`; on `failed` `init()`
+skips the crash sweep and the pending-rekey recovery and marks the controller recovery-blocked,
+and unlock re-runs the salvage then refuses with `VaultRecoveryBlockedError` → IPC reason
+`vault_recovery_blocked` + EN/DE copy, retry = the next unlock (REL-8 #242; PR #277).**_ Record:
+`security-model.md` "Lock failure & durability" (the refuse path) + the exFAT pointer;
+`drive-layout.md` **Filesystem** paragraph and `troubleshooting.md` held-recovery entry document
+exFAT non-durability on decision 6's default (REL-9 #243, DOC-15 folded; #243 stays open);
+`data-contracts.md` reason union. No format change; single `.recovery` name (Q20 default); Q24
+copy in the PR body. Suite +3 (guards file 2 → 5): 370 → 370 / 5,522 → 5,525 / 74.
+
 _2026-09-03 — **Audit 2026-09-02 Phase 6 — rekey completeness: the v1→v2 password change now
 carries every vault-key ciphertext class — `listVaultKeyCiphertexts(vaultPaths, db)` enumerates
 `documents/*.enc`, `images/*.enc`, legacy out-of-store stored copies and the rotated log
@@ -651,6 +663,9 @@ open round's item stays the last block of §5.)
     - **6** (2026-09-03, PR #276): REL-5 (DOC-5, DOC-14 folded) — the v1→v2 rekey stages every
       vault-key ciphertext class via `listVaultKeyCiphertexts` + a `rekey-journal.json`; rotated log
       deleted (Q18 default); image saves take the document-work lease — dated entry above.
+    - **7** (2026-09-03, PR #277): REL-8 (TQ-2 folded) — a held `.recovery` no longer costs a
+      failed lock's fresh copy (tri-state `preserveNewerPlaintext`; `init()` refuses to sweep/open;
+      unlock reason `vault_recovery_blocked`) + REL-9/DOC-15 exFAT durability docs — dated entry above.
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **A held file can no longer make the app lose your newest data after a failed lock.** When
+  locking the workspace fails (for example on a nearly-full drive), the app keeps that
+  session's newest data as a recovery file and secures it at the next unlock. If another
+  program was holding an earlier recovery file open — antivirus or a search indexer scanning
+  the drive is the usual cause — the app could previously delete the newest copy while trying
+  to set it aside. It now detects that case, leaves your data in place, and **refuses to open
+  the workspace until the hold clears** rather than falling back to the older copy. Close
+  whatever is scanning the drive and unlock again; nothing is lost. A new message on the unlock
+  screen explains this when it happens.
 - **Changing the password of an older encrypted workspace no longer strands its image history.**
   Workspaces created with a development build older than 11 June 2026 use an older vault
   format that is migrated to the current one on their first password change; no released

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -176,6 +176,11 @@ function initBackend(): void {
   )
   workspace.init()
   log.info('Workspace state', workspace.getState())
+  if (workspace.isRecoveryBlocked()) {
+    // #242: the salvage of the last session's newest data is blocked by a held recovery
+    // file; the crash sweep was skipped and the unlock IPC refuses until a retry lands it.
+    log.warn('Workspace recovery blocked: a recovery file is held by another program')
+  }
 
   // Settings are readable right away on a plaintext workspace — resolve the UI language
   // for main-side emissions (tMain) now. Encrypted workspaces stay on the OS-locale

--- a/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
+++ b/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
@@ -1,7 +1,13 @@
 import { ipcMain } from 'electron'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
-import { VaultBusyError, VaultDamagedError, WrongPasswordError, workspaceAdmitsWork } from '../services/workspace-vault'
+import {
+  VaultBusyError,
+  VaultDamagedError,
+  VaultRecoveryBlockedError,
+  WrongPasswordError,
+  workspaceAdmitsWork
+} from '../services/workspace-vault'
 import { maybeRunFirstBenchmark } from './registerBenchmarkIpc'
 import { maybeAutoStartActiveModel } from './registerModelIpc'
 import { maybeStartLocalApi } from '../services/local-api/lifecycle'
@@ -163,6 +169,22 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
           ok: false,
           reason: 'vault_damaged',
           message: tMain('main.workspace.vaultDamaged')
+        }
+      }
+      // #242: the startup salvage is blocked — another program holds the recovery file the
+      // last session's newest data must be moved onto, so opening now would decrypt the
+      // stale snapshot over it. Its own reason + copy (close the holder, retry; nothing is
+      // lost). instanceof PLUS the name — the bundle-duplication quirk again.
+      if (
+        err instanceof VaultRecoveryBlockedError ||
+        (err instanceof Error && err.name === 'VaultRecoveryBlockedError')
+      ) {
+        log.warn('Workspace unlock refused: a recovery file is held by another program')
+        ctx.audit?.('workspace_unlock_failed', 'Workspace unlock refused (recovery blocked)')
+        return {
+          ok: false,
+          reason: 'vault_recovery_blocked',
+          message: tMain('main.workspace.recoveryBlocked')
         }
       }
       log.error('Workspace unlock failed', String(err))

--- a/apps/desktop/src/main/services/workspace-vault.ts
+++ b/apps/desktop/src/main/services/workspace-vault.ts
@@ -148,6 +148,24 @@ export class VaultDamagedError extends Error {
 }
 
 /**
+ * Thrown by `WorkspaceController.unlock()` while the startup salvage is BLOCKED (#242): a
+ * working file newer than `.enc` — the only fresh copy of the last session's data — could
+ * not be moved aside as `.recovery`, because another program holds the spent `.recovery`
+ * already sitting on that name (a Windows AV/indexer hold refusing the overwrite, the
+ * unlink and the rename). `init()` then skips the crash sweep, and an unlock must not
+ * proceed either: decrypting the stale `.enc` would land on top of that fresh file.
+ * Content-free ON PURPOSE (like `VaultLockError`): the IPC layer maps it to the
+ * `vault_recovery_blocked` result + `main.workspace.recoveryBlocked`. The retry is simply
+ * the next unlock — `unlock()` re-runs the salvage first, so it clears once the hold is gone.
+ */
+export class VaultRecoveryBlockedError extends Error {
+  constructor() {
+    super('A recovery file is held by another program; the workspace cannot be opened safely yet')
+    this.name = 'VaultRecoveryBlockedError'
+  }
+}
+
+/**
  * Thrown by a `DocumentCipher` closure invoked AFTER `lock()` zeroed the vault key
  * (full-audit 2026-07-12 SEC-1). The closures re-read the live key per invocation, so a
  * cipher captured by an in-flight import fails CLOSED when "Lock now" lands mid-job —
@@ -645,8 +663,8 @@ function fileHasSqliteHeader(path: string): boolean {
  *
  * Detect exactly that state and move the file aside as `<db>.recovery`, which the sweep
  * never matches; `unlockEncryptedVault` rolls it FORWARD once the key exists. The
- * failed-lock signature is deliberately narrow — every check must hold, else fall through
- * to the shred (today's behavior):
+ * failed-lock signature is deliberately narrow — every check must hold, else the file is
+ * derived data and the sweep may shred it (`'not-needed'`):
  *   • the working file is strictly NEWER than `.enc` (mtime) — else it is derived data;
  *   • NO live `-wal`/`-shm` sidecars — lock's checkpoint + close flushed and removed them.
  *     Live sidecars are the MID-SESSION crash state instead: the main file can be
@@ -655,26 +673,37 @@ function fileHasSqliteHeader(path: string): boolean {
  *     (docs/security-model.md "Lock failure & durability");
  *   • the file starts with the SQLite header — a failed shred's random-overwrite must
  *     never be re-encrypted over the good `.enc`.
+ *
+ * Returns what happened, because the caller's next step depends on it (#242): `'preserved'`
+ * (moved aside; sweep safe), `'not-needed'` (no such file; sweep safe), or `'failed'` — the
+ * signature held (or could not even be probed) but the move did NOT land: the working file
+ * is still the only fresh copy, so the caller must refuse to sweep and refuse to open.
+ * Before #242 that last case fell through to the sweep, which shredded the fresh copy.
  */
-export function preserveNewerPlaintext(vaultPaths: VaultPaths): void {
+export type PreserveOutcome = 'preserved' | 'not-needed' | 'failed'
+
+export function preserveNewerPlaintext(vaultPaths: VaultPaths): PreserveOutcome {
   try {
-    if (!existsSync(vaultPaths.dbPath) || !existsSync(vaultPaths.encPath)) return
-    if (existsSync(`${vaultPaths.dbPath}-wal`) || existsSync(`${vaultPaths.dbPath}-shm`)) return
-    if (statSync(vaultPaths.dbPath).mtimeMs <= statSync(vaultPaths.encPath).mtimeMs) return
-    if (!fileHasSqliteHeader(vaultPaths.dbPath)) return
+    if (!existsSync(vaultPaths.dbPath) || !existsSync(vaultPaths.encPath)) return 'not-needed'
+    if (existsSync(`${vaultPaths.dbPath}-wal`) || existsSync(`${vaultPaths.dbPath}-shm`)) return 'not-needed'
+    if (statSync(vaultPaths.dbPath).mtimeMs <= statSync(vaultPaths.encPath).mtimeMs) return 'not-needed'
+    if (!fileHasSqliteHeader(vaultPaths.dbPath)) return 'not-needed'
     const recoveryPath = `${vaultPaths.dbPath}${RECOVERY_SUFFIX}`
     // full-audit 2026-07-12 REL-1 — shred a pre-existing `.recovery` BEFORE the rename. Any
     // `.recovery` coexisting with a working dbPath is spent or garbage (an intervening unlock
     // consumed or out-dated it; this runs only from init(), single-threaded, before any IPC).
     // On success the rename would overwrite it anyway; the pre-shred covers the case where the
     // target is HELD (Windows AV/indexer without FILE_SHARE_DELETE; likelier on exFAT/FAT32) —
-    // an unshreddable held target still fails the rename into the swallowing catch below, but
-    // a merely-lingering spent leftover no longer makes this rename fail and hand the ONLY
-    // fresh copy of the session's data to shredStalePlaintext.
+    // a merely-lingering spent leftover no longer makes this rename fail. A target the hold
+    // keeps through the overwrite, the unlink AND the rename still fails the rename into the
+    // catch below, which now reports `'failed'` instead of handing the ONLY fresh copy of the
+    // session's data to shredStalePlaintext (#242).
     shredFile(recoveryPath)
     renameSync(vaultPaths.dbPath, recoveryPath)
+    return 'preserved'
   } catch {
-    /* best-effort: on any doubt fall through to the sweep (today's behavior) */
+    // On any doubt refuse the sweep (#242) — the caller blocks and the next unlock retries.
+    return 'failed'
   }
 }
 
@@ -1455,6 +1484,14 @@ export class WorkspaceController {
   /** True while `changePassword` runs (defensive: it is synchronous today). */
   private changingPassword = false
   /**
+   * #242 — set by {@link init} when the startup salvage FAILED: a working file newer than
+   * `.enc` (the only fresh copy of the last session's data) could not be moved aside because
+   * a held `.recovery` sits on the target. While set, the crash sweep and the pending-rekey
+   * recovery are skipped and {@link unlock} is refused — it re-runs the salvage first, so the
+   * user's next unlock clears the state once the hold is gone.
+   */
+  private _recoveryBlocked = false
+  /**
    * AUD-02 — armed by {@link beginLock} as the FIRST act of the interactive lock path, before
    * any await, and read by {@link workspaceAdmitsWork}. See that function for why `isUnlocked()`
    * alone cannot express "a lock is under way": the DB stays open for the whole teardown.
@@ -1489,6 +1526,11 @@ export class WorkspaceController {
 
   isUnlocked(): boolean {
     return this._db !== null
+  }
+
+  /** True while the startup salvage is blocked by a held `.recovery` (#242) — see {@link _recoveryBlocked}. */
+  isRecoveryBlocked(): boolean {
+    return this._recoveryBlocked
   }
 
   /**
@@ -1580,7 +1622,11 @@ export class WorkspaceController {
       // — EXCEPT the failed-lock state (full-audit 2026-07-11 CODE-1b): a cleanly-closed
       // working file NEWER than `.enc` is the only fresh copy of the last session's data,
       // so it is moved aside FIRST and rolled forward at unlock instead of shredded.
-      preserveNewerPlaintext(this.vaultPaths)
+      // #242: when that move FAILS (a held `.recovery` on the target) refuse to sweep — the
+      // working file is still the only fresh copy — and refuse to open until a retry lands
+      // it; the pending-rekey recovery waits as well (unlock runs it once admitted).
+      this._recoveryBlocked = preserveNewerPlaintext(this.vaultPaths) === 'failed'
+      if (this._recoveryBlocked) return // locked AND blocked; unlock() re-runs this salvage
       shredStalePlaintext(this.vaultPaths)
       // And resolve any password change the crash interrupted (roll forward or back per
       // the descriptor — unlock would do this too; doing it here keeps disk state clean
@@ -1617,6 +1663,12 @@ export class WorkspaceController {
     // between a mid-teardown unlock and a re-opened admission window; only the lock handler
     // (via `cancelLock()`) and a genuine closed → open transition may clear the latch.
     if (this.isUnlocked()) return this.getState()
+    // #242: a blocked salvage is retried here — the hold may have cleared since init(). Still
+    // blocked → refuse: unlockEncryptedVault would decrypt the stale `.enc` over the fresh file.
+    if (this._recoveryBlocked) {
+      this.init()
+      if (this._recoveryBlocked) throw new VaultRecoveryBlockedError()
+    }
     const { db, key, descriptor } = unlockEncryptedVault(this.vaultPaths, password)
     this._db = db
     this.key = key

--- a/apps/desktop/src/main/services/workspace-vault.ts
+++ b/apps/desktop/src/main/services/workspace-vault.ts
@@ -1292,11 +1292,9 @@ export function unlockEncryptedVault(vaultPaths: VaultPaths, password: string): 
     // full-audit 2026-07-12 REL-2 — the freshness PROBE is exception-guarded: a Windows
     // AV/indexer hold without FILE_SHARE_READ (or the file vanishing between existsSync and
     // openSync) throws EBUSY/EPERM/ENOENT here, which used to fail the whole unlock raw
-    // (generic openFailed) until the hold cleared. A probe error means "can't decide" —
-    // `fresher` stays null, `.recovery` is left IN PLACE (never shredded on a probe error,
-    // never rolled forward unverified), and the unlock proceeds normally; the next unlock
-    // retries the probe. Only the probe is wrapped: a roll-forward encryptFile failure
-    // (e.g. disk still full) keeps failing the unlock so the snapshot survives untouched.
+    // (generic openFailed) until the hold cleared. Only the probe is wrapped: a roll-forward
+    // encryptFile failure (e.g. disk still full) keeps failing the unlock so the snapshot
+    // survives untouched.
     let fresher: boolean | null = null
     try {
       fresher =
@@ -1304,7 +1302,25 @@ export function unlockEncryptedVault(vaultPaths: VaultPaths, password: string): 
         (!existsSync(vaultPaths.encPath) ||
           statSync(recoveryPath).mtimeMs > statSync(vaultPaths.encPath).mtimeMs)
     } catch {
-      /* probe error → can't decide → don't touch `.recovery`; unlock normally */
+      // #242 — a probe error means we cannot read the header. If `.recovery` could still be
+      // the fresh failed-lock delta — newer than `.enc`, `.enc` missing, or the mtime
+      // unreadable too — we must NOT unlock into the stale `.enc` and leave the snapshot to
+      // be shredded once a later lock makes `.enc` newer: refuse exactly as the init()
+      // salvage does, and let the next unlock retry once the hold clears. Only when `.enc`
+      // is demonstrably newer (a spent leftover) is it safe to proceed and unlock normally.
+      let encStrictlyNewer = false
+      try {
+        encStrictlyNewer =
+          existsSync(vaultPaths.encPath) &&
+          statSync(vaultPaths.encPath).mtimeMs > statSync(recoveryPath).mtimeMs
+      } catch {
+        /* even the stat failed → treat as possibly fresh → refuse */
+      }
+      if (!encStrictlyNewer) {
+        fileKey.fill(0)
+        throw new VaultRecoveryBlockedError()
+      }
+      /* `.enc` newer → spent leftover → leave it in place, unlock normally */
     }
     if (fresher !== null) {
       if (fresher) encryptFile(recoveryPath, vaultPaths.encPath, fileKey)

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2019,6 +2019,12 @@ export const de: Record<keyof typeof en, string> = {
     'beschädigt und konnten nicht geöffnet werden. Das Passwort erneut einzugeben hilft ' +
     'nicht. Lege keinen neuen Arbeitsbereich an — lass die Dateien unverändert und stelle ' +
     'den Ordner „workspace“ aus einem Backup wieder her.',
+  // #242: see en.ts — the recovery file is held by another program; nothing is lost.
+  'main.workspace.recoveryBlocked':
+    'Der Arbeitsbereich konnte noch nicht geöffnet werden: Ein anderes Programm hält eine ' +
+    'Wiederherstellungsdatei mit deinen neuesten Daten fest. Schließe alles, was das Laufwerk ' +
+    'gerade prüft (Virenscanner, Suchindex, ein Dateifenster mit dem Ordner „workspace“), ' +
+    'warte kurz und versuch es dann noch einmal. Es ist nichts verloren.',
   'main.workspace.createFailed': 'Der Arbeitsbereich konnte nicht erstellt werden.',
   'main.workspace.passwordTooShort': 'Das Passwort muss mindestens {min} Zeichen lang sein.',
   'main.workspace.newPasswordTooShort':

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1976,6 +1976,12 @@ export const en = {
     'Your password is correct, but the workspace data on the drive is damaged and could ' +
     'not be opened. Retyping the password will not help. Do not create a new workspace — ' +
     'keep the files as they are and restore the workspace folder from a backup.',
+  // #242: the start-up salvage could not move the last session's newest data aside because
+  // another program holds the recovery file on that name; opening now would lose that data.
+  'main.workspace.recoveryBlocked':
+    'Could not open the workspace yet: another program is holding a recovery file with your ' +
+    'newest data. Close anything that may be scanning the drive (antivirus, search indexing, ' +
+    'a file window on the workspace folder), wait a moment, then try again. Nothing is lost.',
   'main.workspace.createFailed': 'Could not create the workspace.',
   'main.workspace.passwordTooShort': 'Password must be at least {min} characters.',
   'main.workspace.newPasswordTooShort': 'The new password must be at least {min} characters.',

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -206,10 +206,18 @@ export interface WorkspaceStateInfo {
 /** Result of an unlock/create action (a wrong password is a normal, non-throwing result).
  *  `vault_damaged` (#208): the password verified but the vault ciphertext did not decrypt
  *  to an openable database — structurally NOT a password problem, and the copy must say so
- *  (retyping the password cannot help; restoring from a backup can). */
+ *  (retyping the password cannot help; restoring from a backup can).
+ *  `vault_recovery_blocked` (#242): the last session's newest data still waits to be salvaged
+ *  and another program holds the recovery file it must be moved onto — the unlock is refused
+ *  (opening would decrypt the stale snapshot over it); close that program and retry, nothing
+ *  is lost. */
 export type WorkspaceActionResult =
   | { ok: true; state: WorkspaceStateInfo }
-  | { ok: false; reason: 'wrong_password' | 'vault_damaged' | 'refused' | 'error'; message: string }
+  | {
+      ok: false
+      reason: 'wrong_password' | 'vault_damaged' | 'vault_recovery_blocked' | 'refused' | 'error'
+      message: string
+    }
 
 export interface DriveStatus {
   /** Root directory that holds models + workspace (drive root or app-data fallback). */

--- a/apps/desktop/tests/integration/vault-recovery-guards.test.ts
+++ b/apps/desktop/tests/integration/vault-recovery-guards.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   mkdtempSync,
   mkdirSync,
   existsSync,
   writeFileSync,
   readFileSync,
+  statSync,
   utimesSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -16,35 +17,61 @@ import {
   lockEncryptedVault,
   WorkspaceController,
   RECOVERY_SUFFIX,
+  VaultLockError,
+  VaultRecoveryBlockedError,
   type VaultPaths
 } from '../../src/main/services/workspace-vault'
 import { getSettings, updateSettings } from '../../src/main/services/settings'
 import { DEFAULT_POLICY } from '../../src/main/services/policy'
+import { IPC } from '../../src/shared/ipc'
+import { registerWorkspaceIpc } from '../../src/main/ipc/registerWorkspaceIpc'
+import { invoke, type IpcHandlers } from '../helpers/ipc'
 import type { PrivacyPolicy } from '../../src/shared/types'
 import type { KdfParams } from '../../src/main/services/security/crypto'
+import type { AppContext } from '../../src/main/services/context'
 
-// full-audit 2026-07-12 REL-1 / REL-2 — forced-failure guards on the `.recovery` salvage path.
-// Both findings are Windows-hold edges (AV/search indexer holding a spent `.recovery` without
-// FILE_SHARE_DELETE / FILE_SHARE_READ), impossible to reproduce portably with a real hold, so
-// this file uses the workspace-vault-durability.test.ts idiom: `vi.mock('node:fs')` with
-// pass-through wrappers that fail ONLY the targeted `.recovery` operation — everything else
-// hits the real filesystem. Kept separate so the module mock cannot leak into the behavioral
-// vault suites.
+// full-audit 2026-07-12 REL-1 / REL-2 — forced-failure guards on the `.recovery` salvage path,
+// plus the held-recovery-file and full-drive cases of #242.
+// The findings are Windows-hold edges (AV/search indexer holding a spent `.recovery` without
+// FILE_SHARE_DELETE / FILE_SHARE_READ) and a full drive at the exact lock write — neither is
+// reproducible portably with a real hold or a real full disk, so this file uses the
+// workspace-vault-durability.test.ts idiom: `vi.mock('node:fs')` with pass-through wrappers
+// that fail ONLY the targeted operation — everything else hits the real filesystem. Kept
+// separate so the module mock cannot leak into the behavioral vault suites. Every armed
+// wrapper counts its refusals, so a test can PROVE its injection was reached instead of
+// inferring it (a successful pre-shred used to make the rename target vanish, after which the
+// rename wrapper saw nothing and the case silently proved nothing — #242).
 //
 // REL-1: `preserveNewerPlaintext`'s rename onto a pre-existing (held) `.recovery` used to
 // throw into the swallowing catch, after which `shredStalePlaintext` destroyed the working
-// file — the ONLY fresh copy of the session's data. The fix pre-shreds the spent leftover.
+// file — the ONLY fresh copy of the session's data. The first fix pre-shreds the spent
+// leftover; #242 covers the hold the pre-shred cannot beat (the salvage now refuses to sweep).
 // REL-2: unlock's roll-forward freshness probe (`fileHasSqliteHeader` + `statSync`) was not
 // exception-guarded — an EBUSY on the held file failed the whole unlock raw. The fix treats a
 // probe error as "can't decide": leave `.recovery` in place, unlock normally, retry next time.
+//
+// What these injections do NOT prove: that a real AV/indexer hold produces exactly this fault
+// set (which of open / unlink / rename a given hold refuses is the holder's share mode).
 
 const failures = vi.hoisted(() => ({
-  /** REL-1: renameSync throws EPERM iff the TARGET ends with `.recovery` and already exists
-   *  (the held-target semantics; a successful pre-shred makes the target vanish → real rename). */
+  /** renameSync throws EPERM iff the TARGET ends with `.recovery` and already exists (the
+   *  held-target semantics; a successful pre-shred makes the target vanish → real rename). */
   renameThrowOnExistingRecoveryTarget: false,
-  /** REL-2: openSync throws EBUSY for any `.recovery` path (an AV hold without FILE_SHARE_READ),
-   *  which makes `fileHasSqliteHeader`'s probe throw. */
-  openThrowOnRecoveryPath: false
+  /** openSync throws EBUSY for any `.recovery` path (an AV hold without FILE_SHARE_READ):
+   *  `fileHasSqliteHeader`'s probe throws, and so does `shredFile`'s overwrite open. */
+  openThrowOnRecoveryPath: false,
+  /** rmSync throws EPERM for any `.recovery` path (a hold without FILE_SHARE_DELETE). `shredFile`
+   *  swallows a failed overwrite AND a failed unlink, so this is the wrapper that actually keeps
+   *  a spent leftover sitting on the rename target (#242). */
+  rmThrowOnRecoveryPath: false,
+  /** writeSync throws ENOSPC on every descriptor opened for an `.enc.tmp` while armed — a full
+   *  drive at the exact lock write, inside the real `encryptFile` (#242). */
+  enospcOnEncTmpWrite: false,
+  /** Descriptors opened on an `.enc.tmp` while `enospcOnEncTmpWrite` was armed. */
+  encTmpFds: new Set<number>(),
+  /** How often each armed wrapper actually refused — an injection that was never reached
+   *  proves nothing, so the tests assert these. */
+  hits: { renameSync: 0, openSync: 0, rmSync: 0, writeSync: 0 }
 }))
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -54,26 +81,71 @@ vi.mock('node:fs', async (importOriginal) => {
     err.code = code
     return err
   }
+  const isRecovery = (p: unknown): boolean => String(p).endsWith('.recovery')
   const mocked = {
     ...actual,
     renameSync: vi.fn((from: Parameters<typeof actual.renameSync>[0], to: Parameters<typeof actual.renameSync>[1]) => {
-      if (
-        failures.renameThrowOnExistingRecoveryTarget &&
-        String(to).endsWith('.recovery') &&
-        actual.existsSync(to)
-      ) {
+      if (failures.renameThrowOnExistingRecoveryTarget && isRecovery(to) && actual.existsSync(to)) {
+        failures.hits.renameSync += 1
         throw errnoError('EPERM', 'EPERM: operation not permitted, rename (held .recovery target)')
       }
       return actual.renameSync(from, to)
     }),
     openSync: vi.fn((path: Parameters<typeof actual.openSync>[0], flags: Parameters<typeof actual.openSync>[1], mode?: Parameters<typeof actual.openSync>[2]) => {
-      if (failures.openThrowOnRecoveryPath && String(path).endsWith('.recovery')) {
+      if (failures.openThrowOnRecoveryPath && isRecovery(path)) {
+        failures.hits.openSync += 1
         throw errnoError('EBUSY', 'EBUSY: resource busy or locked, open (held .recovery)')
       }
-      return actual.openSync(path, flags, mode)
+      const fd = actual.openSync(path, flags, mode)
+      if (failures.enospcOnEncTmpWrite && String(path).endsWith('.enc.tmp')) failures.encTmpFds.add(fd)
+      return fd
+    }),
+    rmSync: vi.fn((path: Parameters<typeof actual.rmSync>[0], options?: Parameters<typeof actual.rmSync>[1]) => {
+      if (failures.rmThrowOnRecoveryPath && isRecovery(path)) {
+        failures.hits.rmSync += 1
+        throw errnoError('EPERM', 'EPERM: operation not permitted, unlink (held .recovery)')
+      }
+      return actual.rmSync(path, options)
+    }),
+    writeSync: vi.fn((fd: number, ...rest: unknown[]) => {
+      if (failures.encTmpFds.has(fd)) {
+        failures.hits.writeSync += 1
+        throw errnoError('ENOSPC', 'ENOSPC: no space left on device, write')
+      }
+      return (actual.writeSync as unknown as (...args: unknown[]) => number)(fd, ...rest)
+    }),
+    closeSync: vi.fn((fd: number) => {
+      failures.encTmpFds.delete(fd)
+      return actual.closeSync(fd)
     })
   }
   return { ...mocked, default: mocked }
+})
+
+// The unlock IPC over a genuinely blocked controller: only `ipcMain.handle` is needed.
+const ipcState = vi.hoisted(() => ({ handlers: new Map<string, unknown>() }))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: unknown) => ipcState.handlers.set(channel, fn),
+    removeHandler: (channel: string) => ipcState.handlers.delete(channel)
+  }
+}))
+const handlers = ipcState.handlers as unknown as IpcHandlers
+
+/** A hold that refuses the overwrite, the unlink AND the rename onto the `.recovery` — the
+ *  conjunction the pre-shred alone cannot beat (#242). */
+function holdRecovery(on: boolean): void {
+  failures.openThrowOnRecoveryPath = on
+  failures.rmThrowOnRecoveryPath = on
+  failures.renameThrowOnExistingRecoveryTarget = on
+}
+
+beforeEach(() => {
+  holdRecovery(false)
+  failures.enospcOnEncTmpWrite = false
+  failures.encTmpFds.clear()
+  failures.hits = { renameSync: 0, openSync: 0, rmSync: 0, writeSync: 0 }
+  ipcState.handlers.clear()
 })
 
 // Fast KDF so the suite stays quick (the workspace-vault.test.ts fixture).
@@ -94,15 +166,36 @@ function freshVault(): VaultPaths {
   return vaultPathsFrom({ configPath, dbPath: join(workspacePath, 'hilbertraum.sqlite') })
 }
 
+/** The minimal AppContext the unlock handler's failure path reads. */
+function ctxWith(ctrl: WorkspaceController): AppContext {
+  return {
+    workspace: ctrl,
+    runtime: { stop: async () => {}, activeModelId: () => null },
+    embedder: { stop: async () => {} }
+  } as unknown as AppContext
+}
+
 /** The exact disk state a failed lock leaves behind: a checkpointed, cleanly CLOSED plaintext
- *  working file (no -wal/-shm) newer than the stale `.enc` (the workspace-vault.test.ts helper). */
-function failedLockState(vp: VaultPaths): void {
+ *  working file (no -wal/-shm) holding `marker`, newer than the stale `.enc` (the
+ *  workspace-vault.test.ts helper). */
+function failedLockState(vp: VaultPaths, marker = 7171): void {
   const { db } = unlockEncryptedVault(vp, 'pw')
-  updateSettings(db, { contextTokens: 7171 })
+  updateSettings(db, { contextTokens: marker })
   db.exec('PRAGMA wal_checkpoint(TRUNCATE);')
   db.close()
   const past = new Date(Date.now() - 60_000)
   utimesSync(vp.encPath, past, past)
+}
+
+/** The spent leftover of an earlier salvage whose best-effort unlink failed (Windows hold),
+ *  still sitting on the rename target at the next launch. Backdated like `.enc`. */
+const LEFTOVER = 'spent leftover that outlived its unlink'
+function plantLeftover(vp: VaultPaths): string {
+  const recoveryPath = `${vp.dbPath}${RECOVERY_SUFFIX}`
+  writeFileSync(recoveryPath, LEFTOVER)
+  const past = new Date(Date.now() - 60_000)
+  utimesSync(recoveryPath, past, past)
+  return recoveryPath
 }
 
 describe('`.recovery` guards (full-audit 2026-07-12 REL-1/REL-2)', () => {
@@ -110,32 +203,43 @@ describe('`.recovery` guards (full-audit 2026-07-12 REL-1/REL-2)', () => {
     const vp = freshVault()
     createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
     failedLockState(vp) // the working file (7171) is the only fresh copy
+    const recoveryPath = plantLeftover(vp)
 
-    // The spent leftover of an earlier salvage whose best-effort unlink failed (Windows hold),
-    // still sitting on the rename target at the next launch.
-    const recoveryPath = `${vp.dbPath}${RECOVERY_SUFFIX}`
-    writeFileSync(recoveryPath, 'spent leftover that outlived its unlink')
-    const past = new Date(Date.now() - 60_000)
-    utimesSync(recoveryPath, past, past)
-
+    // A hold WITHOUT delete sharing but WITH write sharing: the pre-shred's random overwrite
+    // goes through, its unlink fails, and the rename onto the still-present target fails —
+    // the conjunction the pre-shred alone cannot beat. (This case used to arm only the rename
+    // failure: the real pre-shred removed the leftover first, the rename target was gone, and
+    // the injection was never reached — the case proved nothing about the conjunction. #242)
+    failures.rmThrowOnRecoveryPath = true
     failures.renameThrowOnExistingRecoveryTarget = true
     try {
       const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
       ctl.init()
+      // Both injections were reached.
+      expect(failures.hits.rmSync).toBeGreaterThan(0)
+      expect(failures.hits.renameSync).toBeGreaterThan(0)
 
-      // Pre-fix: the rename threw into the swallowing catch and `shredStalePlaintext`
-      // destroyed the fresh working file — 7171 unrecoverable. Post-fix: the pre-shred
-      // removed the spent leftover, the rename landed, and the salvage snapshot is the
-      // FRESH data (not the leftover bytes).
+      // Before #242: the rename threw into the swallowing catch and `shredStalePlaintext`
+      // destroyed the fresh working file — 7171 unrecoverable. Now: the salvage reports
+      // failure, the sweep is skipped, the working file stays in place, and the overwritten
+      // leftover (shred garbage, never unlinked) is neither rolled forward nor mistaken for
+      // the fresh copy.
+      expect(existsSync(vp.dbPath)).toBe(true)
       expect(existsSync(recoveryPath)).toBe(true)
       expect(readFileSync(recoveryPath).includes(Buffer.from('spent leftover'))).toBe(false)
+      expect(ctl.isRecoveryBlocked()).toBe(true)
+      expect(() => ctl.unlock('pw')).toThrow(VaultRecoveryBlockedError)
 
-      // The roll-forward consumes it: nothing since the failed lock was lost.
+      // Hold cleared → the retry's pre-shred removes the garbage, the rename lands, and the
+      // roll-forward consumes the salvage: nothing since the failed lock was lost.
+      failures.rmThrowOnRecoveryPath = false
+      failures.renameThrowOnExistingRecoveryTarget = false
       ctl.unlock('pw')
       expect(getSettings(ctl.requireDb()).contextTokens).toBe(7171)
       expect(existsSync(recoveryPath)).toBe(false)
       ctl.lock()
     } finally {
+      failures.rmThrowOnRecoveryPath = false
       failures.renameThrowOnExistingRecoveryTarget = false
     }
   })
@@ -174,6 +278,140 @@ describe('`.recovery` guards (full-audit 2026-07-12 REL-1/REL-2)', () => {
     ctl2.unlock('pw')
     expect(getSettings(ctl2.requireDb()).contextTokens).toBe(6161)
     expect(existsSync(recoveryPath)).toBe(false)
+    ctl2.lock()
+  })
+})
+
+describe('a held .recovery: the startup salvage refuses to sweep instead of losing the fresh copy (#242)', () => {
+  it('a hold defeating the pre-shred AND the rename leaves the working file in place and blocks the unlock until it clears', async () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    failedLockState(vp, 7171) // the working file (7171) is the only fresh copy
+    const recoveryPath = plantLeftover(vp)
+    const leftoverSize = statSync(recoveryPath).size
+    const workingBytes = readFileSync(vp.dbPath)
+    const encBefore = readFileSync(vp.encPath) // the stale snapshot (3072, the seeded default)
+    expect(existsSync(vp.dbPath)).toBe(true)
+
+    holdRecovery(true)
+    try {
+      const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+      ctl.init()
+      // All three injections were reached: the overwrite open, the unlink, the rename.
+      expect(failures.hits.openSync).toBeGreaterThan(0)
+      expect(failures.hits.rmSync).toBeGreaterThan(0)
+      expect(failures.hits.renameSync).toBeGreaterThan(0)
+
+      // Before #242 the working file was gone here (shredded by the sweep) and the unlock
+      // below opened the stale snapshot — everything since the failed lock silently lost.
+      expect(existsSync(vp.dbPath)).toBe(true)
+      expect(readFileSync(vp.dbPath).equals(workingBytes)).toBe(true)
+      // The held leftover is untouched (the overwrite was refused too), and so is `.enc`.
+      expect(readFileSync(recoveryPath, 'utf8')).toBe(LEFTOVER)
+      expect(statSync(recoveryPath).size).toBe(leftoverSize)
+      expect(existsSync(vp.encPath)).toBe(true)
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+      // The controller reports the blocked state and stays locked.
+      expect(ctl.isRecoveryBlocked()).toBe(true)
+      expect(ctl.getState().state).toBe('locked')
+
+      // A subsequent unlock is REFUSED — the typed error at the controller, its own reason
+      // and copy at the IPC — rather than decrypting the stale `.enc` over the fresh file.
+      expect(() => ctl.unlock('pw')).toThrow(VaultRecoveryBlockedError)
+      registerWorkspaceIpc(ctxWith(ctl))
+      const { result } = await invoke(handlers, IPC.unlockWorkspace, 'pw')
+      expect(result).toMatchObject({ ok: false, reason: 'vault_recovery_blocked' })
+      expect((result as { message: string }).message).toMatch(/recovery file/i)
+      expect(ctl.isUnlocked()).toBe(false)
+      expect(readFileSync(vp.dbPath).equals(workingBytes)).toBe(true)
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+
+      // Hold released → the retry (an unlock re-runs the startup salvage) preserves the
+      // working file and the roll-forward yields the fresh data.
+      holdRecovery(false)
+      ctl.unlock('pw')
+      expect(ctl.isRecoveryBlocked()).toBe(false)
+      expect(getSettings(ctl.requireDb()).contextTokens).toBe(7171)
+      expect(existsSync(recoveryPath)).toBe(false)
+      ctl.lock()
+      // Durable: a later plain unlock still has the salvaged data.
+      ctl.unlock('pw')
+      expect(getSettings(ctl.requireDb()).contextTokens).toBe(7171)
+      ctl.lock()
+    } finally {
+      holdRecovery(false)
+    }
+  })
+
+  it('control: without the hold the salvage preserves the working file and the roll-forward yields the fresh data', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    failedLockState(vp, 7171)
+    const recoveryPath = plantLeftover(vp)
+
+    const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    ctl.init()
+    expect(failures.hits).toEqual({ renameSync: 0, openSync: 0, rmSync: 0, writeSync: 0 })
+    // The spent leftover was pre-shredded and the working file moved onto its name.
+    expect(existsSync(vp.dbPath)).toBe(false)
+    expect(existsSync(recoveryPath)).toBe(true)
+    expect(readFileSync(recoveryPath).includes(Buffer.from('spent leftover'))).toBe(false)
+    expect(ctl.isRecoveryBlocked()).toBe(false)
+
+    ctl.unlock('pw')
+    expect(getSettings(ctl.requireDb()).contextTokens).toBe(7171)
+    expect(existsSync(recoveryPath)).toBe(false)
+    ctl.lock()
+  })
+
+  it('a full drive at the lock write: the failed lock is reported, the stale snapshot and the plaintext working file survive, and the next launch salvages it', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    ctl.init()
+    ctl.unlock('pw')
+    updateSettings(ctl.requireDb(), { contextTokens: 8181 })
+    const encBefore = readFileSync(vp.encPath)
+
+    // ENOSPC inside the REAL encryptFile, at its first write to `.enc.tmp` (the controller's
+    // encryptFileImpl seam is not used: the point is the write itself failing).
+    failures.enospcOnEncTmpWrite = true
+    try {
+      expect(() => ctl.lock()).toThrow(VaultLockError)
+      expect(failures.hits.writeSync).toBeGreaterThan(0)
+      // The stale snapshot is intact, the partial temp is gone, nothing was shredded …
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+      expect(existsSync(`${vp.encPath}.tmp`)).toBe(false)
+      expect(existsSync(vp.dbPath)).toBe(true)
+      // … and the controller is consistently unlocked and usable with the session's data.
+      expect(ctl.getState().state).toBe('unlocked')
+      expect(getSettings(ctl.requireDb()).contextTokens).toBe(8181)
+
+      // Quit while the drive is still full: the failed lock rethrows out of shutdown() and
+      // the working file rests cleanly closed (no -wal/-shm), newer than `.enc`.
+      expect(() => ctl.shutdown()).toThrow(VaultLockError)
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+      expect(existsSync(vp.dbPath)).toBe(true)
+      expect(existsSync(`${vp.dbPath}-wal`)).toBe(false)
+      expect(existsSync(`${vp.dbPath}-shm`)).toBe(false)
+    } finally {
+      failures.enospcOnEncTmpWrite = false
+      failures.encTmpFds.clear()
+    }
+
+    // Next launch (space freed): the salvage preserves the working file and the unlock rolls
+    // it forward — nothing since the failed lock is lost. (`.enc` backdated for a
+    // deterministic mtime order on coarse-timestamp filesystems, as in failedLockState.)
+    const past = new Date(Date.now() - 60_000)
+    utimesSync(vp.encPath, past, past)
+    const ctl2 = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    ctl2.init()
+    expect(ctl2.isRecoveryBlocked()).toBe(false)
+    expect(existsSync(vp.dbPath)).toBe(false)
+    expect(existsSync(`${vp.dbPath}${RECOVERY_SUFFIX}`)).toBe(true)
+    ctl2.unlock('pw')
+    expect(getSettings(ctl2.requireDb()).contextTokens).toBe(8181)
+    expect(existsSync(`${vp.dbPath}${RECOVERY_SUFFIX}`)).toBe(false)
     ctl2.lock()
   })
 })

--- a/apps/desktop/tests/integration/vault-recovery-guards.test.ts
+++ b/apps/desktop/tests/integration/vault-recovery-guards.test.ts
@@ -244,23 +244,28 @@ describe('`.recovery` guards (full-audit 2026-07-12 REL-1/REL-2)', () => {
     }
   })
 
-  it('REL-2: a probe error on .recovery no longer fails the unlock; the snapshot is preserved for retry', () => {
+  it('REL-2: a probe error on a SPENT (older) .recovery no longer fails the unlock; the snapshot is preserved for retry', () => {
     const vp = freshVault()
     createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
     const { db, key } = unlockEncryptedVault(vp, 'pw')
     updateSettings(db, { contextTokens: 6161 })
-    lockEncryptedVault(vp, db, key) // `.enc` holds 6161
+    lockEncryptedVault(vp, db, key) // `.enc` holds 6161 (mtime ~now)
 
-    // A `.recovery` leftover exists; the AV hold means the probe cannot even OPEN it.
+    // A SPENT `.recovery` leftover, OLDER than `.enc` (a consumed roll-forward whose unlink
+    // failed); the AV hold means the probe cannot even OPEN it. `.enc` is demonstrably newer,
+    // so unlocking into it loses nothing — the leftover is left for a later probe to shred.
     const recoveryPath = `${vp.dbPath}${RECOVERY_SUFFIX}`
     writeFileSync(recoveryPath, 'held leftover the probe cannot read')
+    const past = new Date(Date.now() - 60_000)
+    utimesSync(recoveryPath, past, past)
 
     failures.openThrowOnRecoveryPath = true
     try {
       const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
       ctl.init()
       // Pre-fix: fileHasSqliteHeader's openSync threw EBUSY raw out of unlockEncryptedVault
-      // → generic openFailed; the user could not unlock until the hold cleared.
+      // → generic openFailed; the user could not unlock until the hold cleared. Now: `.enc`
+      // is strictly newer, so the probe error is safe to ignore and the unlock proceeds.
       const state = ctl.unlock('pw')
       expect(state.state).toBe('unlocked')
       expect(getSettings(ctl.requireDb()).contextTokens).toBe(6161)
@@ -279,6 +284,42 @@ describe('`.recovery` guards (full-audit 2026-07-12 REL-1/REL-2)', () => {
     expect(getSettings(ctl2.requireDb()).contextTokens).toBe(6161)
     expect(existsSync(recoveryPath)).toBe(false)
     ctl2.lock()
+  })
+
+  it('a hold on a FRESH .recovery at unlock refuses instead of opening the stale snapshot and later shredding the fresh copy (#242)', () => {
+    const vp = freshVault()
+    createEncryptedVaultOnDisk(vp, 'pw', FAST_KDF)
+    failedLockState(vp, 4242) // working file (4242) newer than the stale `.enc` (3072)
+
+    // No hold at init → the working file is preserved as `.recovery` (newer than `.enc`).
+    const ctl = new WorkspaceController(vp, ENCRYPTION_REQUIRED, false)
+    ctl.init()
+    const recoveryPath = `${vp.dbPath}${RECOVERY_SUFFIX}`
+    expect(existsSync(recoveryPath)).toBe(true)
+    expect(existsSync(vp.dbPath)).toBe(false)
+    const recoveryBytes = readFileSync(recoveryPath)
+    const encBefore = readFileSync(vp.encPath)
+
+    // Now a hold denies the header read at unlock. Before #242 the unlock proceeded into the
+    // stale `.enc`, and the user's next lock made `.enc` newer, so the following unlock
+    // shredded this never-rolled-forward fresh copy — 4242 silently lost. Now the unlock is
+    // REFUSED (the snapshot could be fresh and cannot be judged) and the copy stays intact.
+    failures.openThrowOnRecoveryPath = true
+    try {
+      expect(() => ctl.unlock('pw')).toThrow(VaultRecoveryBlockedError)
+      expect(readFileSync(recoveryPath).equals(recoveryBytes)).toBe(true)
+      expect(readFileSync(vp.encPath).equals(encBefore)).toBe(true)
+      expect(ctl.isUnlocked()).toBe(false)
+    } finally {
+      failures.openThrowOnRecoveryPath = false
+    }
+
+    // Hold cleared → the probe reads the header, sees a fresh newer snapshot, rolls it
+    // forward, and the unlock yields 4242. Nothing lost.
+    ctl.unlock('pw')
+    expect(getSettings(ctl.requireDb()).contextTokens).toBe(4242)
+    expect(existsSync(recoveryPath)).toBe(false)
+    ctl.lock()
   })
 })
 

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -599,9 +599,11 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 ✅ **IPC** `ipc/registerWorkspaceIpc.ts` — `getWorkspaceState` (`workspace:getState`) →
   `WorkspaceStateInfo`; `unlockWorkspace(password)` / `createWorkspace(password, mode)` →
   **`WorkspaceActionResult`** (`{ok:true,state}` | `{ok:false, reason:'wrong_password'|
-  'vault_damaged'|'refused'|'error', message}` — a wrong password / policy refusal is a normal
-  result, not a throw; `vault_damaged` (#208) is the password-verified-but-undecryptable-to-a-
-  database unlock failure, deliberately distinct from `wrong_password`);
+  'vault_damaged'|'vault_recovery_blocked'|'refused'|'error', message}` — a wrong password /
+  policy refusal is a normal result, not a throw; `vault_damaged` (#208) is the
+  password-verified-but-undecryptable-to-a-database unlock failure, deliberately distinct from
+  `wrong_password`; `vault_recovery_blocked` (#242) is the unlock refused because a held
+  `.recovery` file blocks the failed-lock salvage — retry once the hold clears, nothing lost);
   `lockWorkspace` → `WorkspaceStateInfo`. Registered in `initBackend()`; exposed on preload `api` +
   `PreloadApi`.
 - **Types** (`shared/types.ts`): `WorkspaceStateName` (`uninitialized|locked|unlocked`),

--- a/docs/drive-layout.md
+++ b/docs/drive-layout.md
@@ -274,6 +274,25 @@ carries ONLY the language data under `ocr/`:
 - Path separators handled via `node:path`; works on Windows/macOS/Linux.
 - The SQLite file is self-contained, so moving the `workspace/` folder moves all data.
 
+### Filesystem
+For a kit that must be read and written on Windows, macOS **and** Linux, format the drive as
+**exFAT** — it is the one filesystem all three write natively. (A single-OS drive can use that
+OS's native filesystem — NTFS, APFS, ext4 — which the app also supports.)
+
+exFAT carries one durability caveat worth stating where the format is chosen. The app commits
+every durability-critical write by fsyncing the file and then renaming it into place, so the
+data inside a file is flushed before the rename. It does **not** flush the containing
+directory afterwards: there is no directory-flush primitive exposed through Node on Windows,
+and the write-through rename primitive (`MoveFileEx` with `MOVEFILE_WRITE_THROUGH`) is not
+reachable from the runtime. On exFAT/FAT32 that leaves a narrow window in which a **hard power
+cut or unplug** immediately after a rename can roll the new name back to the old one. The
+design is old-or-new by construction — the **last successfully locked snapshot always
+survives** a rollback; you never get a torn mix — so the exposure is the changes since that
+lock, the same window a mid-session crash already carries (see
+[`security-model.md`](security-model.md) "Lock failure & durability"). The practical
+mitigation is the ordinary one: quit the app and eject the drive safely before unplugging
+(see [`troubleshooting.md`](troubleshooting.md) "Windows asks to scan and fix the drive").
+
 ## First real-drive bring-up — durable lessons (design record, 2026-06-10)
 
 _Moved here from `BUILD_STATE.md` §9 on 2026-08-20 (doc-lifecycle rule: durable

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -678,6 +678,13 @@ explicitly:
   shred can leave a spent `.recovery` behind, e.g. a Windows AV/indexer holding the file —
   it must never roll the vault back to a stale snapshot or encrypt shred-garbage over the
   good `.enc`). Anything not matching that narrow signature is shredded as before.
+  When the move-aside itself cannot land — another program holds the spent `.recovery`
+  already on that name through the overwrite, the unlink **and** the rename (a Windows
+  AV/indexer without delete sharing) — the startup salvage reports failure: `init()` skips
+  the sweep (the working file is still the only fresh copy) and an unlock is **refused**
+  with `vault_recovery_blocked` rather than decrypting the stale `.enc` on top of it. The
+  retry is simply the next unlock, which re-runs the salvage; it clears once the hold is
+  gone and nothing is lost (#242).
   **Part of this decision is a confidentiality trade:** after a failed lock + quit, the
   session's data rests on the drive **in plaintext** as `<db>.recovery` until the next
   successful unlock secures it — previously that leftover was shredded at the next launch
@@ -720,6 +727,11 @@ explicitly:
   intact stale `.enc` with garbage, so it is deliberately shredded instead. Confidentiality
   is chosen over mid-session durability here; the mitigations are the clean quit path
   (lock-on-quit + the `uncaughtException` crash lock) and the safe-eject guidance above.
+  A separate, filesystem-level durability limit — a rename that has not yet reached the
+  directory metadata can roll back after a power cut on exFAT/FAT32, and no directory-flush
+  primitive is exposed through Node on Windows — is covered in
+  [`drive-layout.md`](drive-layout.md) under **Filesystem** (the last successfully locked
+  snapshot always survives) (#243).
 
 ### Vault-overwrite guards & single instance (issue #208)
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -678,13 +678,20 @@ explicitly:
   shred can leave a spent `.recovery` behind, e.g. a Windows AV/indexer holding the file —
   it must never roll the vault back to a stale snapshot or encrypt shred-garbage over the
   good `.enc`). Anything not matching that narrow signature is shredded as before.
-  When the move-aside itself cannot land — another program holds the spent `.recovery`
+  When the salvage cannot judge or move the fresh copy safely because a program holds the
+  `.recovery` file, the app **refuses to open** rather than losing it (#242). Two legs: at
+  startup, if the move-aside cannot land — another program holds the spent `.recovery`
   already on that name through the overwrite, the unlink **and** the rename (a Windows
-  AV/indexer without delete sharing) — the startup salvage reports failure: `init()` skips
-  the sweep (the working file is still the only fresh copy) and an unlock is **refused**
-  with `vault_recovery_blocked` rather than decrypting the stale `.enc` on top of it. The
-  retry is simply the next unlock, which re-runs the salvage; it clears once the hold is
-  gone and nothing is lost (#242).
+  AV/indexer without delete sharing) — `init()` skips the sweep (the working file is still
+  the only fresh copy); and at unlock, if a hold denies reading the `.recovery` header while
+  the file could still be the fresh snapshot (newer than `.enc`, or `.enc` missing), the
+  unlock refuses instead of decrypting the stale `.enc` and letting a later lock make `.enc`
+  newer so the next probe shreds the never-rolled-forward copy. Both surface
+  `vault_recovery_blocked`; the retry is simply the next unlock, and it clears once the hold
+  is gone — nothing is lost. Only a `.recovery` demonstrably OLDER than `.enc` (a spent
+  leftover) is treated as safe to ignore. While a startup salvage is blocked the crash sweep
+  does not run, so the ordinary transient plaintext it clears (`<db>.tmp`, `documents/*.parse*`,
+  `images/*.tmp`) can linger until the retry succeeds.
   **Part of this decision is a confidentiality trade:** after a failed lock + quit, the
   session's data rests on the drive **in plaintext** as `<db>.recovery` until the next
   successful unlock secures it — previously that leftover was shredded at the next launch

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,6 +202,29 @@ kept safely on the drive and secured at the next unlock — you don't lose the s
 
 ---
 
+## "Could not open the workspace yet: another program is holding a recovery file"
+
+You see this on the unlock screen when a previous session's lock did not finish (see "Could
+not lock the workspace" above) and the app kept your newest data as a recovery file to secure
+at the next unlock — but another program on your computer is holding that file open, so the app
+cannot move it into place. Opening the workspace anyway would fall back to the older,
+already-secured copy and lose the newest changes, so the app **refuses to open until the hold
+clears**. Your data is safe; nothing is deleted.
+
+This is almost always antivirus or a search indexer scanning the drive, or a file-manager
+window left open on the `workspace` folder — most common on Windows.
+
+What to do:
+
+- Close anything that might be scanning or reading the drive: antivirus, the search indexer,
+  and any Explorer / Finder window showing the `workspace` folder.
+- Wait a few seconds and press **Unlock** again with your usual password. Each unlock retries
+  the recovery, so once the hold is gone it succeeds and your newest data is restored.
+- If it keeps happening, quit the app, safely eject and re-attach the drive (which releases any
+  lingering handle), then start the app and unlock.
+
+---
+
 ## "The model is busy" — one job at a time
 
 HilbertRaum runs **one** local model, and it does **one job at a time**. When you start something
@@ -479,6 +502,12 @@ What to do:
   hard unplug interrupted a write. Start the app and check your documents are present. Model
   weight files can always be re-downloaded or re-provisioned if one was damaged; your workspace
   data cannot — which is exactly why the quit-then-eject habit is worth it.
+- exFAT has a narrow durability limit that makes the habit matter: a hard power cut immediately
+  after the app saves can, on rare occasions, roll that one save back to the previous one. The
+  app is built so the **last cleanly locked version of your workspace always survives** such a
+  rollback (you never get a corrupt mix), so at worst you lose the changes since that lock —
+  the same window a mid-session crash carries. See [`drive-layout.md`](drive-layout.md) under
+  **Filesystem** for the detail.
 
 ---
 


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 7: recovery preservation and durability

Closes #242
Refs #243 (docs land on the default; the issue stays open until decision 6 is answered)
Tracker: #217

### What
When a workspace lock fails (realistically a nearly-full drive), the app keeps that session's
newest data as `<db>.recovery` and rolls it forward at the next unlock. If another program held
an earlier `.recovery` open — antivirus or a search indexer scanning the drive, a file window on
`workspace/` — the startup salvage could delete the fresh copy while trying to set it aside, and
the next unlock then opened the older, already-secured snapshot: everything since the failed lock
silently lost.

- `preserveNewerPlaintext` now returns `'preserved' | 'not-needed' | 'failed'`.
- On `'failed'`, `WorkspaceController.init()` **does not sweep and does not run the pending-rekey
  recovery**, and marks the controller recovery-blocked. The working file stays in place — it is
  still the only fresh copy.
- `unlock()` re-runs the salvage first (the hold may have cleared); still blocked, it throws the
  new typed `VaultRecoveryBlockedError`. The unlock IPC maps it to a new
  `WorkspaceActionResult` reason `vault_recovery_blocked` with localized EN/DE copy. **The retry
  is simply the next unlock.** No format change; `.recovery` keeps its single name (Q20 default).
- The unlock roll-forward's probe-error path (a prior-round `.recovery` freshness probe) now
  refuses the same way when the held `.recovery` could still be the fresh snapshot (newer than
  `.enc`, `.enc` missing, or mtime unreadable), and proceeds only when `.enc` is demonstrably
  newer (a spent leftover) — so a hold at unlock cannot open the stale `.enc` and let a later
  lock make it newer so the next probe shreds the never-rolled-forward copy (reviewer repair).

### Why (finding IDs + the promise restored)
- **REL-8 (#242).** Restores `security-model.md` "Lock failure & durability": a working file newer
  than `.enc` after a failed lock "is moved aside FIRST and rolled forward at unlock instead of
  shredded." When the move-aside itself fails, the fix refuses rather than shredding the fresh
  copy — the promise now holds even under a persistent hold. Folds TQ-2 (the shipped test's fault
  injection was never reached).
- **REL-9 / DOC-15 (#243), decision 6 default = document.** exFAT is assumed in three docs and
  chosen nowhere; the durability caveat (a rename can roll back after a power cut on exFAT/FAT32 —
  no directory-flush primitive is reachable through Node on Windows — while the last locked
  snapshot always survives) is now stated where the format is chosen.

### Tests
- **Characterisation (red before):** in `vault-recovery-guards.test.ts`, a hold that defeats the
  pre-shred overwrite, the unlink **and** the rename onto `.recovery`; the shipped REL-1 case
  taught to reach its injection (its old form let the real pre-shred remove the target, so the
  rename wrapper saw nothing — every armed wrapper now counts its refusals and the tests assert
  the counts); an ENOSPC injected inside the real `encryptFile` write. Red at HEAD: the working
  file is shredded in both held cases.
- **Inverted / regression (green):** after `init()` — working DB still present and byte-identical,
  `.enc` intact, the held `.recovery` untouched, the controller reports blocked, and a subsequent
  unlock is **refused** with `vault_recovery_blocked` (not opened into the stale snapshot); with
  the hold released and the salvage re-run, unlock yields the fresh `contextTokens` (7171);
  control without the hold unchanged; the ENOSPC lock reports `VaultLockError`, preserves the
  stale `.enc` and the plaintext DB, shreds nothing, and the next launch salvages it.
- Ported from the paper's B4 recipe in its asserted form; the `.enc`-exists assertion added; the
  "does not prove a real AV/indexer hold produces exactly this fault set" caveat carried into the
  file header.
- **`npm test` count:** excluding the environment-gated real-Electron smoke `evidence-pack-pdf-
  smoke.test.ts` (which spawns Electron and skips on CI): **369 files / 5,520 passed / 74
  skipped** — the Phase 6 baseline (370 / 5,522 / 74) minus that one file plus this phase's **+4
  tests** (the held-recovery init-leg case, its control, the ENOSPC-at-lock case, the unlock-leg
  held-`.recovery` refuse; the guards file went 2 → 6). Full-suite equivalent 370 / 5,526 / 74.
  `typecheck` and `build` green. A live GUI launch
  could not run in this session: an application-control policy on this machine blocks the unsigned
  dev `electron.exe` from executing (build + suite are the proof; CI runs no GUI launch).

### Docs + BUILD_STATE
- `security-model.md` "Lock failure & durability" — the refuse-to-open state; a pointer to the new
  `drive-layout.md` Filesystem paragraph for the exFAT caveat.
- `drive-layout.md` — new **Filesystem** paragraph (exFAT for cross-OS kits + the power-cut
  durability caveat; the last locked snapshot survives).
- `troubleshooting.md` — a "recovery file is held by another program" entry beside the lock-failure
  one; a durability sentence in the exFAT "scan and fix" entry.
- `data-contracts.md` — `vault_recovery_blocked` in the `WorkspaceActionResult` reason union.
- `CHANGELOG.md` `[Unreleased]` Fixed — user-facing entry.
- `BUILD_STATE.md` — one dated entry + one line under §5 item 19.

### Owner decisions relied on (issue #, answer or default)
The `**DECISION:**` query on #223, #242, #243, #221, #228, #222 and #217 was empty at kickoff, so
every owner line runs on its plan default (a default is never upgraded to a ruling):
- **Decision 6 (#223, REL-9):** default = **document** exFAT non-durability (the spike, if ever
  ratified, is Phase F). #243 stays open.
- **Q20 (#242):** default = **single `.recovery` name** (the tri-state refuse path alone removes
  the loss; no roll-forward-reader / test-helper churn).
- **Q24 (#242):** the `vault_recovery_blocked` copy, drafted here for owner review — shipped as one
  i18n key each, a one-key change if reworded:
  - **EN** (`main.workspace.recoveryBlocked`): "Could not open the workspace yet: another program
    is holding a recovery file with your newest data. Close anything that may be scanning the
    drive (antivirus, search indexing, a file window on the workspace folder), wait a moment, then
    try again. Nothing is lost."
  - **DE** (`main.workspace.recoveryBlocked`): "Der Arbeitsbereich konnte noch nicht geöffnet
    werden: Ein anderes Programm hält eine Wiederherstellungsdatei mit deinen neuesten Daten fest.
    Schließe alles, was das Laufwerk gerade prüft (Virenscanner, Suchindex, ein Dateifenster mit
    dem Ordner „workspace"), warte kurz und versuch es dann noch einmal. Es ist nichts verloren."

### Reviewer pass
Fable tier, on the final diff. No BLOCKING. One should-fix repaired: the unlock roll-forward's
probe-error path could still lose a fresh held `.recovery` (see the last What bullet) — now
refuses consistently. Nits: the security-model note records both refuse legs and that the crash
sweep's transient plaintext can linger while a startup salvage is blocked. Verified: every armed
fs wrapper is reached (asserted via a hit counter), the ENOSPC injection hits the real
`encryptFile` write, the pending-rekey deferral is safe, i18n parity is compile-enforced.

### Rollback
Revert the PR; no on-disk format change (the additive reason and the tri-state are the whole
change). `.recovery` stays a single name unless Q20 is later adopted, when the roll-forward reader
travels with it.
