### PR TITLE
fix: Phase 8 small items — archive-name containment, settings key gate, pack CSP meta, local-API body deadline, async text export, CSP parity (audit 2026-09-02 Phase 8)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-a) — small code items: SEC-2 #245 the engine
+archive's on-disk name is `archiveNameFromUrl` (last URL path segment, percent-decoded, must match
+`^[A-Za-z0-9._-]{1,128}$`, else `<binary>-<version>-<os>-<arch>.zip`) and `zipDest` goes through
+`resolveWithinRoot`; `runtime-sources.yaml` urls must be https at parse time; SEC-5 #251
+`Object.hasOwn` key gate + the 256 KB cap on every non-primitive settings write; SEC-7 #253
+`default-src 'none'; style-src 'unsafe-inline'` meta in the pack head; REL-1 #255
+`BODY_TOTAL_TIMEOUT_MS = 120_000` beside the idle timer (seam `bodyTotalTimeoutMs`); REL-2 #256
+`saveTextExport` shares the async atomic `writeAtomic` tail; SEC-14 #266 `form-action 'none'` in
+both headers + the four-directive tail in every baked meta; GAP-3 #254 recorded as a confirmed
+residual (no code) and closed (PR #278).**_ Record: `security-model.md` CSP section + manifest
+section (3); `local-api.md` §6.1 bounds table (+ Host wording); §8 L-7 clause. Suite: see the
+Phase 8 (PR 8-b) entry for the combined count.
+
 _2026-09-03 — **Audit 2026-09-02 Phase 7 — recovery preservation + durability docs: a held
 `.recovery` no longer costs the last session's newest data after a failed lock —
 `preserveNewerPlaintext` now returns `preserved`/`not-needed`/`failed`; on `failed` `init()`
@@ -756,7 +769,8 @@ the offline/privacy guarantees:
   FAILURE: an unverifiable engine archive is discarded, never installed), and the OS `tar`
   refuses `..` members by default — containment rests on tar's *implicit* behavior rather
   than the explicit member check this fix calls for; symlink members are the residual soft
-  spot. (The skills importer does NOT share this gap — it enumerates and validates every
+  spot; the archive's own *name* is guarded since #245 (audit 2026-09-02 SEC-2, Phase 8).
+  (The skills importer does NOT share this gap — it enumerates and validates every
   member's path/symlink before inflating, arch §22-A2.) Fix: list/extract members with an
   explicit containment check.
   **Update (close-out 2026-07-12):** Phase 5 (`032b014`) added the explicit in-app containment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ from its first public `1.0.0` release onward.
   carry a download address whose file name walked up the folder tree, the downloaded archive
   could land anywhere on that disk on Windows. The archive is now always saved under its own
   engine folder, and the list only accepts secure `https://` addresses.
-- **Exported evidence packs carry a content-security header.** An exported pack opened in a
+- **Exported evidence packs carry a content-security policy.** An exported pack opened in a
   web browser now tells the browser to load and run nothing beyond the pack's own embedded
   styling, as a second safeguard on top of the escaping the pack already applies.
 - **A slow upload to the local API is cut off.** A client that sent a request body one byte at a
@@ -102,7 +102,7 @@ from its first public `1.0.0` release onward.
 - **Two small hardening steps with no visible effect.** The app window's content policy now
   also forbids form submissions, plugins, base-address changes and framing in its built-in
   fallback layer, and the settings store ignores inherited object names and caps the size of
-  every stored setting rather than only three of them.
+  every stored object or list rather than only three of them.
 - **Spell-checking in the message box is switched off.** The built-in browser engine would
   otherwise download a spelling dictionary from a Google server on Windows and Linux the first
   time you type — against the promise that nothing leaves the space. Shipping dictionaries on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **A tampered engine list can no longer write outside the engine folder.** The file that
+  names where to download the AI engine from lives on the drive. If it had been edited to
+  carry a download address whose file name walked up the folder tree, the downloaded archive
+  could land anywhere on that disk on Windows. The archive is now always saved under its own
+  engine folder, and the list only accepts secure `https://` addresses.
+- **Exported evidence packs carry a content-security header.** An exported pack opened in a
+  web browser now tells the browser to load and run nothing beyond the pack's own embedded
+  styling, as a second safeguard on top of the escaping the pack already applies.
+- **A slow upload to the local API is cut off.** A client that sent a request body one byte at a
+  time could hold one of the sixteen connection slots for as long as it liked. Uploads now have a
+  two-minute total limit in addition to the existing thirty-second inactivity limit.
+- **Large exports no longer stall the window.** Saving a big chat transcript, audit log or
+  document export to a slow USB drive used to freeze the app for the duration of the write. The
+  write now runs in the background and the file appears only once it is complete.
 - **A held file can no longer make the app lose your newest data after a failed lock.** When
   locking the workspace fails (for example on a nearly-full drive), the app keeps that
   session's newest data as a recovery file and secures it at the next unlock. If another
@@ -85,6 +99,10 @@ from its first public `1.0.0` release onward.
 
 ### Changed
 
+- **Two small hardening steps with no visible effect.** The app window's content policy now
+  also forbids form submissions, plugins, base-address changes and framing in its built-in
+  fallback layer, and the settings store ignores inherited object names and caps the size of
+  every stored setting rather than only three of them.
 - **Spell-checking in the message box is switched off.** The built-in browser engine would
   otherwise download a spelling dictionary from a Google server on Windows and Linux the first
   time you type — against the promise that nothing leaves the space. Shipping dictionaries on the

--- a/apps/desktop/src/main/ipc/save-export.ts
+++ b/apps/desktop/src/main/ipc/save-export.ts
@@ -1,5 +1,4 @@
 import { BrowserWindow, dialog } from 'electron'
-import { writeFileSync } from 'node:fs'
 import { open as openFileAsync, rename as renameAsync, rm as rmAsync } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 
@@ -39,7 +38,9 @@ export function bomFor(filePath: string): string {
 /**
  * Show a save dialog (parented to the focused window when there is one) and write
  * `content` to the chosen file. Returns the saved path, or null when the user
- * cancelled.
+ * cancelled. The write is the same async atomic tail as `saveBinaryExport` (#256): it used
+ * to be `writeFileSync` on the Electron MAIN thread, so a multi-megabyte export to a slow
+ * USB drive stalled every window and every pending IPC reply for the whole write.
  */
 export async function saveTextExport(
   options: SaveExportDialogOptions,
@@ -48,8 +49,43 @@ export async function saveTextExport(
   const win = BrowserWindow.getFocusedWindow()
   const result = win ? await dialog.showSaveDialog(win, options) : await dialog.showSaveDialog(options)
   if (result.canceled || !result.filePath) return null
-  writeFileSync(result.filePath, bomFor(result.filePath) + content, 'utf8')
+  await writeAtomic(result.filePath, Buffer.from(bomFor(result.filePath) + content, 'utf8'))
   return result.filePath
+}
+
+/**
+ * The evidence-pack `writePackFileAtomic` tail: tmp sibling in the destination's own
+ * directory (same volume ⇒ the rename is atomic) → short-write check → fsync → rename, so a
+ * failure up to the rename leaves NO destination file and no half-written export can ever
+ * exist. The tmp sibling carries a per-call random token (the AUD-17 posture): two
+ * concurrent exports to one destination share no scratch file — the later rename simply
+ * replaces the earlier file, as any second save to one path does.
+ */
+async function writeAtomic(destPath: string, bytes: Buffer): Promise<void> {
+  const tmpPath = `${destPath}.${randomUUID().replace(/-/g, '')}.tmp`
+  try {
+    const fd = await openFileAsync(tmpPath, 'w')
+    try {
+      const { bytesWritten } = await fd.write(bytes, 0, bytes.length, null)
+      // POSIX permits short writes; a truncated export must refuse, not half-succeed.
+      if (bytesWritten !== bytes.length) {
+        throw new Error(`export: short write (${bytesWritten}/${bytes.length} bytes)`)
+      }
+      await fd.sync()
+    } finally {
+      // Never swallow a close failure: an unclosed handle keeps the tmp sibling locked on
+      // Windows and would defeat the cleanup below.
+      await fd.close()
+    }
+    await renameAsync(tmpPath, destPath)
+  } catch (err) {
+    try {
+      await rmAsync(tmpPath, { force: true })
+    } catch {
+      /* best-effort cleanup — the original failure is the error that matters */
+    }
+    throw err
+  }
 }
 
 /**
@@ -62,9 +98,8 @@ export async function saveTextExport(
  *
  * Callers (#90 hoist): the document original export (`docs:exportOriginal`) and the skills
  * same-format DOCX export (previously a module-local closure in `registerSkillsIpc`, which
- * wrote non-atomically). The tmp sibling carries a per-call random token (the AUD-17
- * posture): two concurrent exports to one destination share no scratch file — the later
- * rename simply replaces the earlier file, as any second save to one path does.
+ * wrote non-atomically). The atomic tail itself is `writeAtomic` (shared with the text
+ * writer since #256).
  */
 export async function saveBinaryExport(
   options: SaveExportDialogOptions,
@@ -73,31 +108,6 @@ export async function saveBinaryExport(
   const win = BrowserWindow.getFocusedWindow()
   const result = win ? await dialog.showSaveDialog(win, options) : await dialog.showSaveDialog(options)
   if (result.canceled || !result.filePath) return null
-  const destPath = result.filePath
-  const tmpPath = `${destPath}.${randomUUID().replace(/-/g, '')}.tmp`
-  try {
-    const fd = await openFileAsync(tmpPath, 'w')
-    try {
-      const bytes = Buffer.isBuffer(content) ? content : Buffer.from(content)
-      const { bytesWritten } = await fd.write(bytes, 0, bytes.length, null)
-      // POSIX permits short writes; a truncated export must refuse, not half-succeed.
-      if (bytesWritten !== bytes.length) {
-        throw new Error(`binary export: short write (${bytesWritten}/${bytes.length} bytes)`)
-      }
-      await fd.sync()
-    } finally {
-      // Never swallow a close failure: an unclosed handle keeps the tmp sibling locked on
-      // Windows and would defeat the cleanup below.
-      await fd.close()
-    }
-    await renameAsync(tmpPath, destPath)
-    return destPath
-  } catch (err) {
-    try {
-      await rmAsync(tmpPath, { force: true })
-    } catch {
-      /* best-effort cleanup — the original failure is the error that matters */
-    }
-    throw err
-  }
+  await writeAtomic(result.filePath, Buffer.isBuffer(content) ? content : Buffer.from(content))
+  return result.filePath
 }

--- a/apps/desktop/src/main/services/assets.ts
+++ b/apps/desktop/src/main/services/assets.ts
@@ -277,6 +277,28 @@ function resolveWithinRoot(rootPath: string, relPath: string): string {
   return full
 }
 
+/** A plain archive filename: one path segment, no separators, no drive/UNC syntax (#245). */
+const ARCHIVE_NAME_RULE = /^[A-Za-z0-9._-]{1,128}$/
+
+/**
+ * The on-disk name for a runtime archive, derived from the download URL (#245). The last
+ * path segment (query stripped, percent-decoded) is used ONLY when it is a plain filename
+ * per `ARCHIVE_NAME_RULE`; anything else — traversal, separators, a drive letter, an empty
+ * or over-long segment, an unparseable URL — yields `fallback`. `runtime-sources.yaml` is
+ * user-writable, and a raw basename with `..\` segments used to walk out of the guarded
+ * extraction root on Windows. Pure (no I/O).
+ */
+export function archiveNameFromUrl(url: string, fallback: string): string {
+  let segment: string
+  try {
+    segment = decodeURIComponent(new URL(url).pathname.split('/').pop() ?? '')
+  } catch {
+    return fallback
+  }
+  if (!ARCHIVE_NAME_RULE.test(segment) || segment === '.' || segment === '..') return fallback
+  return segment
+}
+
 /**
  * Plan the runtime (sidecar) download for a selected build. Resolves the extraction dir
  * + the final binary path under the drive root (escape-guarded). No network or I/O.
@@ -293,8 +315,13 @@ export function planRuntimeDownload(
   // Name the downloaded archive after the URL's basename so a .tar.gz (the format the
   // macOS/Linux release assets use in current llama.cpp releases) is not saved — and
   // mis-extracted — as a .zip. Synthetic fallback for URLs without a usable basename.
-  const urlBase = build.url.split('/').pop()?.split('?')[0]?.trim()
-  const zipDest = join(extractTo, urlBase || `${binaryBase}-${version}-${build.os}-${build.arch}.zip`)
+  // The archive path is root-guarded like `extract_to` (#245): the fallback embeds the
+  // manifest's `version`, which is user-writable too.
+  const archiveName = archiveNameFromUrl(
+    build.url,
+    `${binaryBase}-${version}-${build.os}-${build.arch}.zip`
+  )
+  const zipDest = resolveWithinRoot(extractTo, archiveName)
   const binaryPath = join(extractTo, sidecarBinaryName(binaryBase, build.os))
   return {
     version,

--- a/apps/desktop/src/main/services/evidence-pack/render-html.ts
+++ b/apps/desktop/src/main/services/evidence-pack/render-html.ts
@@ -191,6 +191,10 @@ export function renderEvidencePackHtml(model: EvidencePackModel): string {
   push(`<html lang="${lang}">`)
   push('<head>')
   push('<meta charset="utf-8">')
+  // Self-containment made structural (#253): a pack opened in a browser outside the app can
+  // load or run nothing but its own embedded stylesheet. The print window renders the same
+  // string under this policy.
+  push(`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">`)
   push('<meta name="viewport" content="width=device-width, initial-scale=1">')
   push(`<title>${esc(model.title)} — ${s('packExport.docTitle')}</title>`)
   push(`<style>${PACK_CSS}</style>`)

--- a/apps/desktop/src/main/services/local-api/server.ts
+++ b/apps/desktop/src/main/services/local-api/server.ts
@@ -61,6 +61,7 @@ export interface LocalApiServerDeps {
   queueWaitMs?: number
   drainTimeoutMs?: number
   headersTimeoutMs?: number
+  bodyTotalTimeoutMs?: number
   /** Node only SWEEPS for expired header phases every connectionsCheckingInterval (30 s by
    *  default), so a test that shortens headersTimeoutMs must shorten this too or it would wait
    *  out the sweep. Test-only: production keeps Node's default. */
@@ -71,6 +72,10 @@ const HEADERS_TIMEOUT_MS = 10_000
 /** Idle bound on the BODY phase only — cleared once the body arrived, because a CPU
  *  prefill legitimately produces no bytes for minutes (PERF-H1). */
 const BODY_IDLE_TIMEOUT_MS = 30_000
+/** Total bound on the BODY phase (#255): the idle timer resets on every byte, so a 1 B /
+ *  25 s trickle held a socket forever and sixteen of them exhausted the listener. Counted
+ *  from the end of the header phase; the 1 MiB body cap ends a fast body long before. */
+export const BODY_TOTAL_TIMEOUT_MS = 120_000
 /** A stalled SSE reader disarms the per-read watchdogs (PERF-H3/SEC-F2): awaiting drain
  *  is bounded, and expiry aborts the generation + frees the admission slot. */
 const DRAIN_TIMEOUT_MS = 15_000
@@ -316,9 +321,20 @@ export class LocalApiServer {
     try {
       res.setHeader('server', `HilbertRaum/${this.deps.appVersion}`)
 
-      // Bound the BODY phase only; the generation phase may be silent for minutes.
+      // Bound the BODY phase only; the generation phase may be silent for minutes. Two
+      // timers: idle (reset by every byte) and total (#255, never reset); both are cleared
+      // once the body has arrived.
       req.setTimeout(BODY_IDLE_TIMEOUT_MS, () => req.destroy())
-      req.once('end', () => req.setTimeout(0))
+      const bodyDeadline = setTimeout(
+        () => req.destroy(),
+        this.deps.bodyTotalTimeoutMs ?? BODY_TOTAL_TIMEOUT_MS
+      )
+      bodyDeadline.unref()
+      req.once('end', () => {
+        req.setTimeout(0)
+        clearTimeout(bodyDeadline)
+      })
+      req.once('close', () => clearTimeout(bodyDeadline))
 
       // `this.port` is set the moment the v4 listener binds, so it is never null while a
       // request can arrive; the fallback only satisfies the type.

--- a/apps/desktop/src/main/services/settings.ts
+++ b/apps/desktop/src/main/services/settings.ts
@@ -82,8 +82,9 @@ export function updateSettings(db: Db, patch: Partial<AppSettings>): AppSettings
     // Non-null values must match the default's primitive type; the null-default keys carry
     // no type information in DEFAULT_SETTINGS, so each gets an explicit shape check
     // (bounded string / plain object; `contextTokensOverride` has its own clamp below).
-    // Unknown/mistyped entries are dropped.
-    if (!(key in DEFAULT_SETTINGS)) continue
+    // Unknown/mistyped entries are dropped. OWN keys only (#251): `in` also matched
+    // inherited names, so a JSON.parse-built `{"__proto__": …}` patch persisted a junk row.
+    if (!Object.hasOwn(DEFAULT_SETTINGS, key)) continue
     const def = (DEFAULT_SETTINGS as unknown as Record<string, unknown>)[key]
     if (value === null) {
       if (def !== null) continue
@@ -116,6 +117,11 @@ export function updateSettings(db: Db, patch: Partial<AppSettings>): AppSettings
     if (Array.isArray(def)) {
       if (!Array.isArray(value)) continue
       toStore = (value as unknown[]).filter((x) => typeof x === 'string').slice(0, MAX_SETTINGS_ARRAY)
+    }
+    // The same serialized-size cap for EVERY non-primitive write (#251) — an array of long
+    // strings, or any future object-valued setting, must not bloat the blob either.
+    if (typeof toStore === 'object' && toStore !== null) {
+      if (JSON.stringify(toStore).length > MAX_SETTINGS_OBJECT_BYTES) continue
     }
     // Enum-valued keys get an exact-value check (a renderer bug must not persist junk
     // like `gpuMode: 'banana'` — readers treat anything !== 'auto' as off, which fails

--- a/apps/desktop/src/main/services/settings.ts
+++ b/apps/desktop/src/main/services/settings.ts
@@ -57,6 +57,9 @@ export function getSettings(db: Db): AppSettings {
   }>
   const stored: Record<string, unknown> = {}
   for (const r of rows) {
+    // Own settings keys only (#251): a `__proto__` row written by an older build would
+    // otherwise set `stored`'s prototype here and be parsed on every unlock.
+    if (!Object.hasOwn(DEFAULT_SETTINGS, r.key)) continue
     try {
       stored[r.key] = JSON.parse(r.value_json)
     } catch {
@@ -100,13 +103,13 @@ export function updateSettings(db: Db, patch: Partial<AppSettings>): AppSettings
     // Bound the object-valued settings (CODE-16, full-audit 2026-07-11). `checksumCache` has a
     // non-null object default, so an ARRAY slips through the generic `typeof value !== typeof def`
     // gate above (arrays report `object`) — reject it here; the null-default `lastBenchmark`/
-    // `gpuProbe` pair reject arrays above, so this re-check is harmless for them. Then cap the
-    // SERIALIZED size of all three (SEC-1 bounding style) so a renderer can't bloat the encrypted
-    // blob these start-hot readers touch. `value === null` (a legitimate clear of the null-default
-    // pair) is accepted upstream and never reaches here.
+    // `gpuProbe` pair reject arrays above, so this re-check is harmless for them. The SERIALIZED
+    // size cap (SEC-1 bounding style, so a renderer can't bloat the encrypted blob these
+    // start-hot readers touch) is applied once, below, to every non-primitive write (#251).
+    // `value === null` (a legitimate clear of the null-default pair) is accepted upstream and
+    // never reaches here.
     if ((key === 'lastBenchmark' || key === 'gpuProbe' || key === 'checksumCache') && value !== null) {
       if (typeof value !== 'object' || Array.isArray(value)) continue
-      if (JSON.stringify(value).length > MAX_SETTINGS_OBJECT_BYTES) continue
     }
     // Array-typed defaults (any future `string[]` setting) pass the
     // `typeof === 'object'` check above, so validate them element-wise: require an actual

--- a/apps/desktop/src/main/window-security.ts
+++ b/apps/desktop/src/main/window-security.ts
@@ -57,14 +57,20 @@ export const SECURE_WINDOW_WEB_PREFERENCES = Object.freeze({
  * meta tags must move in lockstep (the effective policy is the intersection of all of them).
  */
 export function buildCsp(isDev: boolean): string {
+  // `form-action 'none'` (#266): a form submit is a navigation the guard below already
+  // refuses; the directive is the second, independent layer. Both header variants carry it.
   return isDev
     ? "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
         "style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:* http://localhost:*; " +
-        "img-src 'self' data:; font-src 'self'"
+        "img-src 'self' data:; font-src 'self'; form-action 'none'"
     : "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
         "connect-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; " +
-        "base-uri 'none'; frame-ancestors 'none'"
+        "base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
 }
+
+/** The hardening tail every baked meta carries, dev and prod (#266): the meta is the
+ *  fallback layer if the header wiring ever regresses, so it denies the same things. */
+const META_CSP_TAIL = "object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
 
 /**
  * The CSP that ships INSIDE the HTML (`<meta http-equiv="Content-Security-Policy">`) of
@@ -97,9 +103,9 @@ export function buildMetaCsp(isDev: boolean, page: 'index' | 'ocr'): string {
   const connectSrc = isDev ? "'self' ws://localhost:* http://localhost:*" : "'self'"
   return page === 'index'
     ? `default-src 'self'; script-src 'self'; connect-src ${connectSrc}; ` +
-        "img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'"
+        `img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; ${META_CSP_TAIL}`
     : `default-src 'self'; script-src 'self'; connect-src ${connectSrc}; ` +
-        "img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'"
+        `img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; ${META_CSP_TAIL}`
 }
 
 /**

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -14,7 +14,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'"
+      content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />

--- a/apps/desktop/src/renderer/ocr.html
+++ b/apps/desktop/src/renderer/ocr.html
@@ -13,7 +13,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'"
+      content="default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
     />
     <title>OCR rasterizer</title>
   </head>

--- a/apps/desktop/src/shared/runtime-sources.ts
+++ b/apps/desktop/src/shared/runtime-sources.ts
@@ -8,7 +8,7 @@
 // Parsed with the pure-JS `yaml` package (like the model manifests). The validator is
 // hand-written + pure (no I/O) so it is shared + unit-tested without the filesystem.
 
-import { isRealSha256 } from './manifest'
+import { isHttpsUrl, isRealSha256 } from './manifest'
 
 /** Sidecar OS keys — must match `services/runtime/sidecar.ts` `llamaOsDir`. */
 export type RuntimeOs = 'win' | 'mac' | 'linux'
@@ -131,8 +131,9 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
         errors.push(`${where}.backend is required and must be a non-empty string`)
       }
       const url = b['url']
-      if (typeof url !== 'string' || url.trim() === '') {
-        errors.push(`${where}.url is required and must be a non-empty string`)
+      if (typeof url !== 'string' || !isHttpsUrl(url)) {
+        // https-only at PARSE time (#245): the downloader refuses cleartext again at fetch time.
+        errors.push(`${where}.url is required and must be an https:// URL`)
       }
       const shaRaw = b['sha256']
       if (typeof shaRaw !== 'string' || shaRaw.trim() === '') {
@@ -207,8 +208,8 @@ function validateOcrFamily(
         errors.push(`${where}.lang must be a traineddata language code (e.g. deu)`)
       }
       const url = f['url']
-      if (typeof url !== 'string' || url.trim() === '') {
-        errors.push(`${where}.url is required and must be a non-empty string`)
+      if (typeof url !== 'string' || !isHttpsUrl(url)) {
+        errors.push(`${where}.url is required and must be an https:// URL`)
       }
       const sha = f['sha256']
       if (typeof sha !== 'string' || sha.trim() === '') {

--- a/apps/desktop/tests/fixtures/evidence-packs/german.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/german.html
@@ -2,6 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Vertragsfragen — Nachweispaket</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/fixtures/evidence-packs/missing-source.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/missing-source.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contract questions — Evidence pack</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/fixtures/evidence-packs/outdated-acknowledged.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/outdated-acknowledged.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contract questions — Evidence pack</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/fixtures/evidence-packs/partial-coverage.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/partial-coverage.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contract questions — Evidence pack</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/fixtures/evidence-packs/relevance.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/relevance.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contract questions — Evidence pack</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/fixtures/evidence-packs/whole-doc.html
+++ b/apps/desktop/tests/fixtures/evidence-packs/whole-doc.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contract questions — Evidence pack</title>
 <style>:root { color-scheme: light; }

--- a/apps/desktop/tests/integration/assets.test.ts
+++ b/apps/desktop/tests/integration/assets.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi } from 'vitest'
 import { createHash } from 'node:crypto'
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 } from 'node:path'
 import { parse } from 'yaml'
 import {
+  archiveNameFromUrl,
   planModelDownloads,
   selectRuntimeBuild,
   selectRuntimeBuilds,
@@ -1026,5 +1027,80 @@ describe('formatAssetPlan', () => {
   it('notes when no runtime build matched', () => {
     const report = formatAssetPlan([], null)
     expect(report).toContain('no matching build')
+  })
+})
+
+// The archive's on-disk name comes from the URL (#245). A hostile `runtime-sources.yaml`
+// used to put a raw basename with `..\` segments under the guarded extraction root and walk
+// out of it on Windows. The name is now the URL's last path segment ONLY when it is a plain
+// filename; anything else gets the synthetic fallback, and `planRuntimeDownload` passes the
+// result through the same root guard as `extract_to`.
+describe('archiveNameFromUrl (#245)', () => {
+  const FALLBACK = 'llama-server-b1234-win-x64.zip'
+  // A Windows extraction root as a STRING only: the name rule is checked with `path.win32`
+  // on every platform, and no filesystem call is ever made with it.
+  const WIN_ROOT = 'C:\\Users\\u\\AppData\\Roaming\\hilbertraum\\runtime\\llama.cpp\\win'
+  const NAME_RULE = /^[A-Za-z0-9._-]{1,128}$/
+
+  function staysInside(name: string): boolean {
+    const full = win32.resolve(WIN_ROOT, name)
+    return win32.dirname(full) === WIN_ROOT && win32.basename(full) === name
+  }
+
+  it('control: a release-asset URL with a query string yields exactly its basename', () => {
+    const name = archiveNameFromUrl(
+      'https://github.com/ggml-org/llama.cpp/releases/download/b1234/llama-b1234-win-x64.zip?download=true',
+      FALLBACK
+    )
+    expect(name).toBe('llama-b1234-win-x64.zip')
+    expect(staysInside(name)).toBe(true)
+  })
+
+  const hostile: Array<[string, string]> = [
+    ['backslash traversal', 'https://example.test/dl/..%5C..%5C..%5Cevil.exe'],
+    ['bare ..', 'https://example.test/dl/..'],
+    ['empty basename', 'https://example.test/dl/?download=true'],
+    ['percent-encoded ..', 'https://example.test/dl/%2e%2e%5cevil.exe'],
+    ['drive-letter basename', 'https://example.test/dl/C:evil.exe'],
+    ['UNC-looking basename', 'https://example.test/dl/%5C%5Chost%5Cshare%5Cevil.exe']
+  ]
+  for (const [label, url] of hostile) {
+    it(`${label}: the synthetic fallback, never a name that leaves the root`, () => {
+      const name = archiveNameFromUrl(url, FALLBACK)
+      expect(name).toBe(FALLBACK)
+      expect(name).toMatch(NAME_RULE)
+      expect(staysInside(name)).toBe(true)
+    })
+  }
+
+  it('a raw backslash basename is normalised by the URL parser and still ends as a plain filename', () => {
+    // `new URL` treats `\` as `/` in an https path and resolves the `..` segments itself.
+    const name = archiveNameFromUrl('https://example.test/dl/..\\..\\..\\evil.exe', FALLBACK)
+    expect(name).toMatch(NAME_RULE)
+    expect(staysInside(name)).toBe(true)
+  })
+
+  it('an unparseable URL and an over-long basename fall back too', () => {
+    expect(archiveNameFromUrl('not a url', FALLBACK)).toBe(FALLBACK)
+    expect(archiveNameFromUrl(`https://example.test/${'a'.repeat(125)}.zip`, FALLBACK)).toBe(FALLBACK)
+    expect(archiveNameFromUrl(`https://example.test/${'a'.repeat(124)}.zip`, FALLBACK)).toBe(
+      `${'a'.repeat(124)}.zip`
+    )
+  })
+
+  it('planRuntimeDownload guards the archive path like extract_to (a hostile fallback cannot escape either)', () => {
+    const root = tempDir('hilbertraum-rt-')
+    const build = {
+      os: 'win' as const,
+      arch: 'x64',
+      backend: 'cpu',
+      url: 'https://example.test/dl/',
+      sha256: 'x',
+      extractTo: 'runtime/llama.cpp/win'
+    }
+    // The fallback embeds the manifest's `version`, which is attacker-writable as well.
+    expect(() => planRuntimeDownload(root, build, '../../../../x')).toThrow(/escapes the drive root/)
+    const plan = planRuntimeDownload(root, build, 'b1')
+    expect(plan.zipDest).toBe(join(root, 'runtime', 'llama.cpp', 'win', 'llama-server-b1-win-x64.zip'))
   })
 })

--- a/apps/desktop/tests/integration/assets.test.ts
+++ b/apps/desktop/tests/integration/assets.test.ts
@@ -1057,7 +1057,7 @@ describe('archiveNameFromUrl (#245)', () => {
   })
 
   const hostile: Array<[string, string]> = [
-    ['backslash traversal', 'https://example.test/dl/..%5C..%5C..%5Cevil.exe'],
+    ['percent-encoded backslash traversal', 'https://example.test/dl/..%5C..%5C..%5Cevil.exe'],
     ['bare ..', 'https://example.test/dl/..'],
     ['empty basename', 'https://example.test/dl/?download=true'],
     ['percent-encoded ..', 'https://example.test/dl/%2e%2e%5cevil.exe'],
@@ -1074,10 +1074,25 @@ describe('archiveNameFromUrl (#245)', () => {
   }
 
   it('a raw backslash basename is normalised by the URL parser and still ends as a plain filename', () => {
+    // This is the form that escaped before the fix: the raw `split('/').pop()` kept
+    // `..\..\..\evil.exe` verbatim and `path.join` walked up from the root on Windows.
     // `new URL` treats `\` as `/` in an https path and resolves the `..` segments itself.
     const name = archiveNameFromUrl('https://example.test/dl/..\\..\\..\\evil.exe', FALLBACK)
-    expect(name).toMatch(NAME_RULE)
+    expect(name).toBe('evil.exe')
     expect(staysInside(name)).toBe(true)
+  })
+
+  it('every shipped runtime-sources.yaml build keeps its real basename (no silent fallback)', () => {
+    const file = join(__dirname, '..', '..', '..', '..', 'model-manifests', 'runtime-sources.yaml')
+    const res = validateRuntimeSources(parse(readFileSync(file, 'utf8')))
+    expect(res.ok).toBe(true)
+    const builds = [...(res.sources?.builds ?? []), ...(res.whisper?.builds ?? [])]
+    expect(builds.length).toBeGreaterThan(0)
+    for (const b of builds) {
+      const name = archiveNameFromUrl(b.url, 'FALLBACK')
+      expect(name, b.url).not.toBe('FALLBACK')
+      expect(b.url.endsWith(`/${name}`)).toBe(true)
+    }
   })
 
   it('an unparseable URL and an over-long basename fall back too', () => {

--- a/apps/desktop/tests/integration/local-api-hardening.test.ts
+++ b/apps/desktop/tests/integration/local-api-hardening.test.ts
@@ -313,9 +313,12 @@ describe('local API hardening — hostile wire input is bounded', () => {
     }, 25)
     const startedAt = Date.now()
     const closedByServer = await new Promise<boolean>((resolve) => {
-      socket.once('close', () => resolve(true))
       const timer = setTimeout(() => resolve(false), 5000)
       timer.unref?.()
+      socket.once('close', () => {
+        clearTimeout(timer)
+        resolve(true)
+      })
     })
     clearInterval(trickle)
     socket.destroy()

--- a/apps/desktop/tests/integration/local-api-hardening.test.ts
+++ b/apps/desktop/tests/integration/local-api-hardening.test.ts
@@ -38,7 +38,7 @@ interface Harness {
 }
 
 async function makeHarness(
-  opts: { echoAnswer?: string; headersTimeoutMs?: number } = {}
+  opts: { echoAnswer?: string; headersTimeoutMs?: number; bodyTotalTimeoutMs?: number } = {}
 ): Promise<Harness> {
   const logged: string[] = []
   const mgr = new RuntimeManager((startOpts) => ({
@@ -71,6 +71,7 @@ async function makeHarness(
     estimateBusySeconds: () => 30,
     appVersion: '0.0.0-test',
     headersTimeoutMs: opts.headersTimeoutMs,
+    bodyTotalTimeoutMs: opts.bodyTotalTimeoutMs,
     // Without a matching sweep interval Node would not notice the expiry for 30 s.
     connectionsCheckIntervalMs: opts.headersTimeoutMs != null ? 100 : undefined,
     // Capture EVERYTHING the server would write to the app log.
@@ -284,6 +285,46 @@ describe('local API hardening — hostile wire input is bounded', () => {
       headers: authed(h.token),
       body
     })
+    expect(ok.status).toBe(200)
+  })
+
+  it('the SERVER cuts off a body that trickles forever — a total deadline, not only the idle timer (#255)', async () => {
+    // One byte every 25 ms keeps the idle timer reset for as long as the client likes, and
+    // sixteen such sockets exhaust the listener. Only a TOTAL body deadline ends it. The seam
+    // shortens that deadline so the test can watch the server hang up; without the deadline
+    // the socket stays open and this test fails on its own timer.
+    const h = await makeHarness({ bodyTotalTimeoutMs: 400 })
+    const socket = net.connect(h.port, '127.0.0.1')
+    socket.on('error', () => {}) // an RST is a valid way for the server to end it
+    await new Promise<void>((r) => socket.once('connect', r))
+    socket.write(
+      [
+        'POST /v1/chat/completions HTTP/1.1',
+        `host: 127.0.0.1:${h.port}`,
+        `authorization: Bearer ${h.token}`,
+        'content-type: application/json',
+        'content-length: 100000', // far below the body cap: the cap never ends this
+        '',
+        ''
+      ].join('\r\n')
+    )
+    const trickle = setInterval(() => {
+      if (!socket.destroyed) socket.write('x')
+    }, 25)
+    const startedAt = Date.now()
+    const closedByServer = await new Promise<boolean>((resolve) => {
+      socket.once('close', () => resolve(true))
+      const timer = setTimeout(() => resolve(false), 5000)
+      timer.unref?.()
+    })
+    clearInterval(trickle)
+    socket.destroy()
+    expect(closedByServer).toBe(true)
+    expect(Date.now() - startedAt).toBeLessThan(5000)
+
+    // No generation was ever started, and the listener is unharmed.
+    expect(h.mgr.isGenerating()).toBe(false)
+    const ok = await fetch(`${h.base}/v1/models`, { headers: authed(h.token) })
     expect(ok.status).toBe(200)
   })
 

--- a/apps/desktop/tests/unit/evidence-pack-html.test.ts
+++ b/apps/desktop/tests/unit/evidence-pack-html.test.ts
@@ -141,6 +141,9 @@ describe('injection suite (spec §29.4)', () => {
     // Every internal anchor stays index-derived even with a hostile source KEY.
     expect(html).not.toMatch(/href="(?!#)/)
     expect(html).toContain('id="src-1"')
+    // The CSP meta survives the hostile render unchanged and unduplicated (#253).
+    expect(html.match(/http-equiv="Content-Security-Policy"/g)).toHaveLength(1)
+    expect(html).toContain(`content="default-src 'none'; style-src 'unsafe-inline'"`)
   })
 
   it('keeps hostile markdown inert (rendered as escaped plain text, never as markup)', () => {
@@ -171,6 +174,17 @@ describe('self-containment (spec §17.2) + print contract (plan §4 D-1)', () =>
     expect(html.match(/<style>/g)).toHaveLength(1)
     expect(html).toContain('<meta charset="utf-8">')
     expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+  })
+
+  // A pack opened in a browser outside the app gets the same self-containment the print
+  // window enforces: the meta forbids every resource class except the embedded stylesheet,
+  // so an escaping failure could never fetch or run anything (#253).
+  it('carries a CSP meta that forbids every active resource, ahead of the stylesheet (#253)', () => {
+    const CSP = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">`
+    expect(html).toContain(CSP)
+    expect(html.match(/http-equiv="Content-Security-Policy"/g)).toHaveLength(1)
+    expect(html.indexOf(CSP)).toBeLessThan(html.indexOf('<style>'))
+    expect(html.indexOf(CSP)).toBeLessThan(html.indexOf('</head>'))
   })
 
   it('honors the D-1 print contract: @page A4, break-inside, system fonts', () => {

--- a/apps/desktop/tests/unit/ocr.test.ts
+++ b/apps/desktop/tests/unit/ocr.test.ts
@@ -798,7 +798,7 @@ describe('runtime-sources.yaml ocr: block (D32)', () => {
     llama_cpp: {
       version: 'b1',
       builds: [
-        { os: 'win', arch: 'x64', backend: 'cpu', url: 'u', sha256: 'h', extract_to: 'runtime/llama.cpp/win' }
+        { os: 'win', arch: 'x64', backend: 'cpu', url: 'https://x/f.gz', sha256: 'h', extract_to: 'runtime/llama.cpp/win' }
       ]
     }
   }
@@ -835,8 +835,8 @@ describe('runtime-sources.yaml ocr: block (D32)', () => {
         ocr: {
           version: 'v',
           files: [
-            { lang: 'deu', url: 'u', sha256: 'h', dest: 'ocr/a.gz' },
-            { lang: 'deu', url: 'u', sha256: 'h', dest: 'ocr/b.gz' }
+            { lang: 'deu', url: 'https://x/f.gz', sha256: 'h', dest: 'ocr/a.gz' },
+            { lang: 'deu', url: 'https://x/f.gz', sha256: 'h', dest: 'ocr/b.gz' }
           ]
         }
       }).ok
@@ -844,7 +844,7 @@ describe('runtime-sources.yaml ocr: block (D32)', () => {
     expect(
       validateRuntimeSources({
         ...base,
-        ocr: { version: 'v', files: [{ lang: 'deu', url: 'u', sha256: 'h', dest: '../escape.gz' }] }
+        ocr: { version: 'v', files: [{ lang: 'deu', url: 'https://x/f.gz', sha256: 'h', dest: '../escape.gz' }] }
       }).ok
     ).toBe(false)
   })
@@ -898,7 +898,7 @@ describe('planOcrDownloads (assets.ts)', () => {
     await expect(
       planOcrDownloads(root, {
         version: 'v',
-        files: [{ lang: 'deu', url: 'u', sha256: 'h', dest: '../outside.gz' }]
+        files: [{ lang: 'deu', url: 'https://x/f.gz', sha256: 'h', dest: '../outside.gz' }]
       })
     ).rejects.toThrow(/escapes the drive root/)
   })

--- a/apps/desktop/tests/unit/runtime-sources.test.ts
+++ b/apps/desktop/tests/unit/runtime-sources.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parse } from 'yaml'
 import { validateRuntimeSources } from '../../src/shared/runtime-sources'
 
 function build(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -195,6 +198,38 @@ describe('validateRuntimeSources', () => {
       llama_cpp: { version: 'b9196', builds: [build({ backend: 'cpu' })] },
       whisper_cpp: { version: 'v1.8.6', builds: [whisperBuild()] }
     })
+    expect(res.ok).toBe(true)
+  })
+
+  // The download layer already refuses cleartext at fetch time; the parser now refuses it at
+  // validation time too, so a tampered manifest never reaches the planner (#245).
+  it('rejects a non-https url in every family (#245)', () => {
+    const llama = validateRuntimeSources(sources({ builds: [build({ url: 'http://example.test/llama.zip' })] }))
+    expect(llama.ok).toBe(false)
+    expect(llama.errors.some((e) => e.includes('builds[0].url') && e.includes('https'))).toBe(true)
+
+    const whisper = validateRuntimeSources({
+      ...sources(),
+      whisper_cpp: { version: 'v1', builds: [build({ url: 'ftp://example.test/w.zip' })] }
+    })
+    expect(whisper.ok).toBe(false)
+    expect(whisper.errors.some((e) => e.includes('whisper_cpp.builds[0].url'))).toBe(true)
+
+    const ocr = validateRuntimeSources({
+      ...sources(),
+      ocr: {
+        version: '4',
+        files: [{ lang: 'deu', url: 'http://example.test/deu.traineddata.gz', sha256: 'x', dest: 'ocr/deu.traineddata' }]
+      }
+    })
+    expect(ocr.ok).toBe(false)
+    expect(ocr.errors.some((e) => e.includes('ocr.files[0].url'))).toBe(true)
+  })
+
+  it('every entry of the shipped runtime-sources.yaml still validates', () => {
+    const file = join(__dirname, '..', '..', '..', '..', 'model-manifests', 'runtime-sources.yaml')
+    const res = validateRuntimeSources(parse(readFileSync(file, 'utf8')))
+    expect(res.errors).toEqual([])
     expect(res.ok).toBe(true)
   })
 })

--- a/apps/desktop/tests/unit/save-export.test.ts
+++ b/apps/desktop/tests/unit/save-export.test.ts
@@ -13,6 +13,26 @@ const dialogState = vi.hoisted(() => ({
   result: { canceled: true as boolean, filePath: undefined as string | undefined },
   lastOptions: null as Record<string, unknown> | null
 }))
+// Pass-through `node:fs` wrapper that only RECORDS the synchronous write-side calls — every
+// call still hits the real filesystem (#256, the pattern of the evidence-pack async-fs test).
+const syncCalls = vi.hoisted(() => ({ list: [] as Array<{ fn: string; path: string }> }))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  const record = <A extends unknown[], R>(name: string, fn: (...args: A) => R) =>
+    ((...args: A): R => {
+      syncCalls.list.push({ fn: name, path: String(args[0]) })
+      return fn(...args)
+    }) as (...args: A) => R
+  const mocked = {
+    ...actual,
+    openSync: record('openSync', actual.openSync),
+    writeFileSync: record('writeFileSync', actual.writeFileSync),
+    appendFileSync: record('appendFileSync', actual.appendFileSync),
+    copyFileSync: record('copyFileSync', actual.copyFileSync),
+    renameSync: record('renameSync', actual.renameSync)
+  }
+  return { ...mocked, default: mocked }
+})
 vi.mock('electron', () => ({
   BrowserWindow: { getFocusedWindow: () => null },
   dialog: {
@@ -113,5 +133,37 @@ describe('saveTextExport (unchanged semantics pin)', () => {
     expect(saved).toBe(dest)
     expect(readFileSync(dest, 'utf8')).toBe(`${bomFor(dest)}hallo ausschließlich`)
     expect(bomFor(dest)).toBe('﻿')
+  })
+})
+
+// The text writer used `writeFileSync` on the Electron main thread: a multi-megabyte export
+// to a slow USB drive stalled every window and every pending IPC reply for the whole write,
+// the defect the print path had already fixed one file away. It now shares the binary
+// writer's async atomic tail (#256).
+describe('saveTextExport writes off the synchronous fs API (#256)', () => {
+  it('no synchronous write reaches the destination directory during the export', async () => {
+    const dir = freshDir()
+    const dest = join(dir, 'big.md')
+    dialogState.result = { canceled: false, filePath: dest }
+    const content = 'ausschließlich '.repeat(200_000) // ~3 MB
+
+    syncCalls.list.length = 0
+    const saved = await saveTextExport(OPTIONS, content)
+    const touched = syncCalls.list.filter((c) => c.path.startsWith(dir))
+    expect(touched).toEqual([])
+    expect(saved).toBe(dest)
+    expect(readFileSync(dest, 'utf8')).toBe(`﻿${content}`)
+    // Atomic like the binary path: no tmp sibling survives a success.
+    expect(readdirSync(dir)).toEqual(['big.md'])
+  })
+
+  it('a failed write rejects and leaves NO destination file and NO tmp residue', async () => {
+    const dir = freshDir()
+    const dest = join(dir, 'no-such-subdir', 'export.txt')
+    dialogState.result = { canceled: false, filePath: dest }
+
+    await expect(saveTextExport(OPTIONS, 'x')).rejects.toThrow()
+    expect(existsSync(dest)).toBe(false)
+    expect(readdirSync(dir)).toEqual([])
   })
 })

--- a/apps/desktop/tests/unit/settings-write-gate.test.ts
+++ b/apps/desktop/tests/unit/settings-write-gate.test.ts
@@ -263,6 +263,19 @@ describe('settings write gate — inherited keys are not settings (#251)', () =>
     expect(rowFor(db, '__proto__')).toBeUndefined()
   })
 
+  it('a `__proto__` row left by an older build is ignored on read and sets no prototype', () => {
+    const db = freshDb()
+    db.prepare('INSERT INTO settings (key, value_json, updated_at) VALUES (?, ?, ?)').run(
+      '__proto__',
+      '{"theme":"PWNED","polluted":1}',
+      new Date().toISOString()
+    )
+    const s = getSettings(db)
+    expect(s.theme).toBe(DEFAULT_SETTINGS.theme)
+    expect((s as unknown as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.getPrototypeOf(s)).toBe(Object.prototype)
+  })
+
   it('F: the settings still read back after all of that (smoke)', () => {
     const db = freshDb()
     updateSettings(db, protoPatch('{"__proto__": {"polluted": 1}}'))

--- a/apps/desktop/tests/unit/settings-write-gate.test.ts
+++ b/apps/desktop/tests/unit/settings-write-gate.test.ts
@@ -11,6 +11,7 @@ import {
   seedSettings,
   updateSettings
 } from '../../src/main/services/settings'
+import { DEFAULT_SETTINGS, type AppSettings } from '../../src/shared/types'
 
 // BE-1 (full-audit 2026-07-10): the write gate's generic type check had two holes —
 // (a) `value === null` bypassed it for EVERY key, so `{ checksumCache: null }` persisted over
@@ -193,5 +194,89 @@ describe('local API settings (local-api P2)', () => {
     const serialized = JSON.stringify(s)
     expect(serialized).not.toContain(token)
     expect(serialized).not.toContain('hr-')
+  })
+})
+
+// The key allowlist used `key in DEFAULT_SETTINGS`, which is true for INHERITED names: a
+// renderer patch built as JSON.parse('{"__proto__": …}') carries an own `__proto__` property
+// and passed the gate. No prototype pollution (JSON.parse never assigns a prototype), but a
+// junk row of unbounded size in the encrypted settings blob, parsed on every unlock (#251).
+// The gate is `Object.hasOwn` now and the byte cap applies to every non-primitive write.
+// The pre-fix behaviour was reproduced during the review that raised #251 by a scratch test
+// whose output was not archived; this block is its inverted, durable form.
+describe('settings write gate — inherited keys are not settings (#251)', () => {
+  function rowFor(db: Db, key: string): string | undefined {
+    const row = db.prepare('SELECT value_json FROM settings WHERE key = ?').get(key) as
+      | { value_json: string }
+      | undefined
+    return row?.value_json
+  }
+  // Built with JSON.parse: an object LITERAL `{ __proto__: … }` would set the prototype
+  // instead of creating an own property, which is not what the IPC boundary delivers.
+  function protoPatch(json: string): Partial<AppSettings> {
+    const patch = JSON.parse(json) as Record<string, unknown>
+    expect(Object.hasOwn(patch, '__proto__')).toBe(true)
+    return patch as Partial<AppSettings>
+  }
+
+  it('A: a `__proto__` key writes no row', () => {
+    const db = freshDb()
+    updateSettings(db, protoPatch('{"__proto__": {"polluted": 1}}'))
+    expect(rowFor(db, '__proto__')).toBeUndefined()
+  })
+
+  it('B: Object.prototype is untouched and the read-back carries no junk (control)', () => {
+    const db = freshDb()
+    updateSettings(db, protoPatch('{"__proto__": {"polluted": 1}}'))
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    const s = getSettings(db) as unknown as Record<string, unknown>
+    expect(s.polluted).toBeUndefined()
+    expect(Object.hasOwn(s, 'polluted')).toBe(false)
+  })
+
+  it('C: a known key cannot be overridden through the prototype chain on a later read (control)', () => {
+    const db = freshDb()
+    updateSettings(db, protoPatch('{"__proto__": {"theme": "PWNED", "allowNetwork": false}}'))
+    const s = getSettings(db)
+    expect(s.theme).toBe(DEFAULT_SETTINGS.theme)
+    expect(s.allowNetwork).toBe(true)
+  })
+
+  it('D: a `constructor` payload writes no row and pollutes nothing', () => {
+    const db = freshDb()
+    updateSettings(db, { constructor: { prototype: { polluted2: 1 } } } as unknown as Partial<AppSettings>)
+    expect(rowFor(db, 'constructor')).toBeUndefined()
+    expect(({} as Record<string, unknown>).polluted2).toBeUndefined()
+  })
+
+  it('E: a 2 MB `__proto__` value is not stored (it used to persist unbounded)', () => {
+    const db = freshDb()
+    const patch = JSON.parse('{"__proto__": null}') as Record<string, unknown>
+    Object.defineProperty(patch, '__proto__', {
+      value: { junk: 'x'.repeat(2_000_000) },
+      enumerable: true,
+      writable: true,
+      configurable: true
+    })
+    expect(Object.hasOwn(patch, '__proto__')).toBe(true)
+    updateSettings(db, patch as Partial<AppSettings>)
+    expect(rowFor(db, '__proto__')).toBeUndefined()
+  })
+
+  it('F: the settings still read back after all of that (smoke)', () => {
+    const db = freshDb()
+    updateSettings(db, protoPatch('{"__proto__": {"polluted": 1}}'))
+    updateSettings(db, { constructor: {} } as unknown as Partial<AppSettings>)
+    const s = getSettings(db)
+    expect(s).toBeDefined()
+    expect(s.localApiPort).toBe(4980)
+  })
+
+  it('the byte cap covers every non-primitive write, not only the three named object keys', () => {
+    const db = freshDb()
+    updateSettings(db, { skillInfoSeen: ['x'.repeat(MAX_SETTINGS_OBJECT_BYTES + 1)] })
+    expect(getSettings(db).skillInfoSeen).toEqual([])
+    updateSettings(db, { skillInfoSeen: ['a', 'b'] })
+    expect(getSettings(db).skillInfoSeen).toEqual(['a', 'b'])
   })
 })

--- a/apps/desktop/tests/unit/window-security.test.ts
+++ b/apps/desktop/tests/unit/window-security.test.ts
@@ -41,7 +41,7 @@ describe('buildCsp', () => {
     expect(buildCsp(false)).toBe(
       "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; " +
         "connect-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; " +
-        "base-uri 'none'; frame-ancestors 'none'"
+        "base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
     )
   })
 
@@ -49,7 +49,7 @@ describe('buildCsp', () => {
     expect(buildCsp(true)).toBe(
       "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
         "style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:* http://localhost:*; " +
-        "img-src 'self' data:; font-src 'self'"
+        "img-src 'self' data:; font-src 'self'; form-action 'none'"
     )
   })
 
@@ -79,25 +79,29 @@ describe('buildMetaCsp (BE-2, ocr-audit 2026-07-18 — the meta tags baked into 
   // production renderer posture. electron.vite.config.ts rewrites both pages' meta tags
   // from this function at build time; tests/integration/csp-build-output.test.ts proves
   // the built HTML matches these strings byte for byte.
+  // #266: both metas carry the header's hardening tail (`object-src`/`base-uri`/
+  // `frame-ancestors`) plus `form-action`, so the fallback layer denies the same things.
+  const TAIL = "object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
+
   it('index page: prod is the dev policy with the localhost connect-src entries stripped', () => {
     expect(buildMetaCsp(false, 'index')).toBe(
       "default-src 'self'; script-src 'self'; connect-src 'self'; " +
-        "img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'"
+        `img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; ${TAIL}`
     )
     expect(buildMetaCsp(true, 'index')).toBe(
       "default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; " +
-        "img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'"
+        `img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; ${TAIL}`
     )
   })
 
   it('ocr page: same split, plus the pdfjs allowances (worker-src blob:, img-src blob:)', () => {
     expect(buildMetaCsp(false, 'ocr')).toBe(
       "default-src 'self'; script-src 'self'; connect-src 'self'; " +
-        "img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'"
+        `img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; ${TAIL}`
     )
     expect(buildMetaCsp(true, 'ocr')).toBe(
       "default-src 'self'; script-src 'self'; connect-src 'self' ws://localhost:* http://localhost:*; " +
-        "img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'"
+        `img-src 'self' data: blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; ${TAIL}`
     )
   })
 
@@ -114,6 +118,50 @@ describe('buildMetaCsp (BE-2, ocr-audit 2026-07-18 — the meta tags baked into 
       // And prod allows NO scheme://host origin at all (blob:/data: carry no host).
       expect(prod).not.toMatch(/[a-z]+:\/\//)
     }
+  })
+})
+
+// #266: the header is the enforced layer and the meta is the fallback if the header wiring
+// ever regresses, so the hardening tail must exist in BOTH with the same values — and
+// neither carried `form-action` before. Behavioural: the directives are parsed, not the
+// exact strings compared (those pins live above).
+describe('CSP hardening tail — header/meta parity (#266)', () => {
+  const directives = (csp: string): Map<string, string> =>
+    new Map(
+      csp
+        .split(';')
+        .map((d) => d.trim())
+        .filter(Boolean)
+        .map((d) => {
+          const [name, ...rest] = d.split(/\s+/)
+          return [name, rest.join(' ')] as [string, string]
+        })
+    )
+  const TAIL = ['object-src', 'base-uri', 'frame-ancestors', 'form-action']
+
+  it("the production header refuses plugins, base changes, framing and form submits ('none' each)", () => {
+    const header = directives(buildCsp(false))
+    for (const name of TAIL) expect(header.get(name), name).toBe("'none'")
+  })
+
+  it('the dev header carries form-action too (HMR needs none of the four)', () => {
+    expect(directives(buildCsp(true)).get('form-action')).toBe("'none'")
+  })
+
+  it('every baked meta carries the same tail with the same values, dev and prod', () => {
+    for (const page of ['index', 'ocr'] as const) {
+      for (const isDev of [false, true]) {
+        const meta = directives(buildMetaCsp(isDev, page))
+        for (const name of TAIL) {
+          expect(meta.get(name), `${page} ${isDev ? 'dev' : 'prod'} ${name}`).toBe("'none'")
+        }
+      }
+    }
+  })
+
+  it('the KaTeX style allowance and the pdfjs worker allowance survive', () => {
+    expect(directives(buildCsp(false)).get('style-src')).toBe("'self' 'unsafe-inline'")
+    expect(directives(buildMetaCsp(false, 'ocr')).get('worker-src')).toBe("'self' blob:")
   })
 })
 
@@ -164,6 +212,9 @@ describe('call-site wiring (the flags cannot be re-inlined)', () => {
   // The unit pins above are worthless if index.ts stops using the module — so pin the
   // wiring at source level too (idiom: ocr.test.ts preload-channel contract). A
   // re-inlined `sandbox: false` after the spread would fail the no-inline-literal scan.
+  // watch-item (#266): these are source-text pins, brittle by design — index.ts cannot be
+  // imported without Electron, so a behavioural form is not small. Re-check them whenever
+  // the CSP builders or the window call sites move.
   const indexSrc = readFileSync(join(__dirname, '../../src/main/index.ts'), 'utf8')
   const rasterizerSrc = readFileSync(
     join(__dirname, '../../src/main/services/ocr/rasterizer.ts'),

--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -272,8 +272,9 @@ section is the same thing written for a client author.
   is on (the default). The comparison is constant-time. With the requirement off, a present
   `Authorization` header is ignored rather than validated (SDKs always send one).
 - `Content-Type: application/json` is required on POST; a `; charset=utf-8` suffix is fine.
-- The `Host` header must name a loopback address **and the port actually bound**; an absent or
-  empty `Host` is refused. Send the URL as printed and any normal HTTP client does this for you.
+- The `Host` header must name a loopback address, and **when it carries a port, that port must be
+  the one actually bound**; an absent or empty `Host` is refused. Send the URL as printed and any
+  normal HTTP client does this for you.
 
 ### 6.2 `GET /v1/models`
 
@@ -385,7 +386,8 @@ it is clamped to 5–180 s.
 |---|---|---|
 | Request body | **1 MB**, counted as bytes arrive (`Content-Length` is never trusted) | A chunked body makes a header check meaningless |
 | Header phase | 10 s | Slow-loris |
-| Body idle | 30 s (body phase only) | A stalled upload should not hold a socket |
+| Body idle | 30 s of **inactivity** (body phase only; reset by every byte) | A stalled upload should not hold a socket |
+| Body total | **120 s** from the end of the header phase (#255) | A slow but steady trickle resets the idle timer forever; sixteen of them would exhaust the listener. The 1 MB body cap ends a fast body long before |
 | Generation | **no timeout** | A legitimate CPU generation can run for minutes; Node's 300 s default would kill it. Wedge detection is done app-side instead |
 | SSE reader stall | 15 s of unrelieved backpressure → the request is aborted and the slot reclaimed | One stalled reader must not wedge the model |
 | Concurrent connections | 16 | Cheap flood ceiling |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -84,11 +84,15 @@ the intersection of both**. All four policy strings live in `main/window-securit
 
 - **Production header** (strict): `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
   connect-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'none';
-  frame-ancestors 'none'`. No remote origins are reachable from the renderer. The production
+  frame-ancestors 'none'; form-action 'none'`. No remote origins are reachable from the renderer. The production
   **meta** policies match the checked-in page metas minus the localhost entries (the `ocr` page
   keeps `worker-src 'self' blob:` / `img-src 'self' data: blob:` — the bundled pdfjs allowances;
   its worker itself resolves as a plain same-origin asset, and a packaged-build rasterization
-  was verified under the stricter header intersection).
+  was verified under the stricter header intersection). **Header/meta parity (#266):** every
+  baked meta, dev and prod, carries the same hardening tail as the header — `object-src 'none';
+  base-uri 'none'; frame-ancestors 'none'; form-action 'none'` — so the fallback layer denies
+  the same things if the header wiring ever regresses; `form-action 'none'` is the second,
+  independent refusal of a form submit (the navigation guard is the first).
   **Why prod keeps `style-src 'unsafe-inline'` (audit 2026-07-16 F-39 — investigated, kept):** it is
   load-bearing for **KaTeX** math. `katex.renderToString` (used via `@streamdown/math` → rehype-katex
   in `AssistantMarkdown`) emits many per-expression inline `style="height:…;vertical-align:…"`
@@ -104,7 +108,8 @@ the intersection of both**. All four policy strings live in `main/window-securit
 - **Development** (HMR-compatible): both layers relax `connect-src` to allow `ws://localhost:*` /
   `http://localhost:*`, and the header additionally adds `'unsafe-inline'`/`'unsafe-eval'` to
   `script-src` for Vite hot-reload (and omits the prod hardening tail `object-src`/`base-uri`/
-  `frame-ancestors`). Without this split, `npm run dev` would break. The localhost `connect-src`
+  `frame-ancestors`, keeping only `form-action 'none'`; the dev META carries the whole tail,
+  #266). Without this split, `npm run dev` would break. The localhost `connect-src`
   relaxation is the ONLY dev/prod difference in the meta layer, and no policy in either layer
   ever names a non-localhost origin (test-pinned).
 
@@ -363,9 +368,9 @@ enumerated this class.
   offline posture cannot give this round, so no flag was added; (ii) `<link rel="dns-prefetch">` /
   `preconnect` hints are outside CSP3 (`prefetch-src` was withdrawn) — metadata egress only if
   injected, and no CSP mitigation exists; (iii) found on the way: the production header carries
-  `object-src 'none'`, `base-uri 'none'` and `frame-ancestors 'none'` while the baked meta does
-  not, and neither carries `form-action` — that parity + `form-action 'none'` hardening is
-  follow-up SEC-14 (#266). Both channels require a compromised renderer first (`script-src
+  `object-src 'none'`, `base-uri 'none'` and `frame-ancestors 'none'` while the baked meta did
+  not, and neither carried `form-action` — that parity + `form-action 'none'` hardening landed
+  as #266 (see "Content-Security-Policy (dev vs prod)" above). Both channels require a compromised renderer first (`script-src
   'self'`, sandbox, context isolation, no `window.open` into the app), which is the boundary the
   rest of this section rests on.
 
@@ -1719,6 +1724,13 @@ a `C:`-style drive letter, a UNC root) or contains a `..` segment, so `discoverM
 loop wraps `computeInstallState` in try/catch, so any manifest that still throws becomes an errored
 entry rather than failing the whole list — mirroring the existing `pendingHashBytes` pre-pass.
 `weightPath`/`safeDrivePath` keep their own runtime escape guard (defense in depth).
+**(3)** The runtime list `runtime-sources.yaml` in the same folder (#245): the downloaded engine
+archive's on-disk name is taken from the URL's last path segment only when it is a plain filename
+(`^[A-Za-z0-9._-]{1,128}$` after percent-decoding, never `.`/`..`); anything else gets a synthetic
+`<binary>-<version>-<os>-<arch>.zip` name, and the archive path goes through the same drive-root
+guard as `extract_to` — a raw basename with `..\` segments used to walk out of the extraction
+folder on Windows. Every `url` must be `https://` at parse time as well as at fetch time. The
+archive's *members* are BUILD_STATE §8 L-7's separate question.
 
 ## Least-privilege hardening of the renderer↔main file/network seams (vuln-scan 2026-06-21, option D)
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -89,7 +89,7 @@ the intersection of both**. All four policy strings live in `main/window-securit
   keeps `worker-src 'self' blob:` / `img-src 'self' data: blob:` — the bundled pdfjs allowances;
   its worker itself resolves as a plain same-origin asset, and a packaged-build rasterization
   was verified under the stricter header intersection). **Header/meta parity (#266):** every
-  baked meta, dev and prod, carries the same hardening tail as the header — `object-src 'none';
+  baked meta, dev and prod, carries the same hardening tail as the production header — `object-src 'none';
   base-uri 'none'; frame-ancestors 'none'; form-action 'none'` — so the fallback layer denies
   the same things if the header wiring ever regresses; `form-action 'none'` is the second,
   independent refusal of a form submit (the navigation guard is the first).


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 8 (PR 8-a): small code items
Closes #245, #251, #253, #254, #255, #256, #266
Tracker: #217

### What
- **#245 (SEC-2)** `apps/desktop/src/main/services/assets.ts`: new pure `archiveNameFromUrl(url, fallback)` — the URL's last path segment (query stripped, percent-decoded) is the archive name only when it matches `^[A-Za-z0-9._-]{1,128}$` and is not `.`/`..`; otherwise the synthetic `<binary>-<version>-<os>-<arch>.zip`. `planRuntimeDownload` now passes the result through `resolveWithinRoot(extractTo, name)` like `extract_to`. `src/shared/runtime-sources.ts`: every `url` in `llama_cpp`, `whisper_cpp` and `ocr` must be `https://` at parse time (the downloader keeps its fetch-time refusal). The shipped `model-manifests/runtime-sources.yaml` has no `http://` entry and still validates (test-pinned).
- **#251 (SEC-5)** `settings.ts`: the key allowlist is `Object.hasOwn(DEFAULT_SETTINGS, key)` (was `in`, which matched inherited names); the 256 KB serialized-size cap now applies to every non-primitive write (arrays included), not only `lastBenchmark`/`gpuProbe`/`checksumCache`.
- **#253 (SEC-7)** `evidence-pack/render-html.ts`: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">` right after the charset meta, ahead of the stylesheet. The six golden packs gained exactly that one line each.
- **#255 (REL-1)** `local-api/server.ts`: `BODY_TOTAL_TIMEOUT_MS = 120_000` armed beside the idle timer when the header phase ends, cleared on `end`/`close`; test seam `bodyTotalTimeoutMs` next to `headersTimeoutMs`.
- **#256 (REL-2)** `ipc/save-export.ts`: `saveTextExport` no longer calls `writeFileSync` on the main thread; both writers share the async atomic `writeAtomic` tail (tmp sibling → short-write check → fsync → rename; cleanup on failure). The BOM behaviour is unchanged.
- **#266 (SEC-14)** `window-security.ts`: `form-action 'none'` in both header variants; `object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'` in every baked meta (dev and prod, `index` and `ocr`). The checked-in `index.html`/`ocr.html` metas follow (they are rewritten at build time anyway). Both renderer `<form onSubmit>` sites call `preventDefault`, so nothing submits.
- **#254 (GAP-3)** no code — the Phase 0 investigation outcome (confirmed residual: WebRTC and dns-prefetch/preconnect are outside CSP, unused by the renderer, reachable only after a renderer compromise; no flag adopted; the cheap hardening became #266) is written on the issue; the residual-egress list wording stays with the Phase 9a docs sweep.

### Why (finding → promise restored)
SEC-2: `model-manifests/` is the threat model's first attacker surface; the derived archive name was the one path not root-guarded. SEC-5: no junk row of unbounded size in the encrypted settings blob (parsed on every unlock). SEC-7: pack self-containment is structural, not only by escaping. REL-1: a trickling client can no longer hold a listener slot forever (16 would exhaust the local API). REL-2: a multi-MB export to a slow USB drive no longer stalls every window and IPC reply. SEC-14: the meta fallback layer denies what the header denies.

### Tests
- characterisation (red before, commit `dde7c156`): `assets.test.ts` "archiveNameFromUrl (#245)" — six hostile cases (backslash traversal, bare `..`, empty basename, `%2e%2e`, drive-letter, UNC-looking — strings only, checked under `path.win32`, never passed to the filesystem) + the `…/llama-b1234-win-x64.zip?download=true` control + the `planRuntimeDownload` guard; `runtime-sources.test.ts` non-https refused in all three families + the shipped yaml valid; `settings-write-gate.test.ts` "inherited keys are not settings (#251)" A–F (A and E were red; B, C, D, F are controls — C proves a known key cannot be overridden through the chain) + the cap on an array write; `evidence-pack-html.test.ts` CSP meta present once, ahead of `<style>`, and unchanged in the hostile render; `local-api-hardening.test.ts` a 1 B / 25 ms trickle is cut at a 400 ms injected deadline and the listener survives; `save-export.test.ts` a pass-through `vi.mock('node:fs')` records that no synchronous write touches the destination directory, plus the atomic-failure pin; `window-security.test.ts` header/meta exact pins moved + a behavioural parity describe (directives parsed) + a `// watch-item` on the source-text wiring pins.
- print path: `evidence-pack-print-pdf.test.ts` / `evidence-pack-print-cleanup.test.ts` green (fake Electron); the real-Electron PDF smoke could not run on this machine (see below).
- `npm test`: **369 files / 5,549 passed / 74 skipped** excluding `evidence-pack-pdf-smoke.test.ts` (baseline 369 / 5,520 / 74 → +29, all new; the raw run says 80 skipped = 74 + the smoke file's 6); the smoke file fails in its `beforeAll` with `spawn UNKNOWN` because an application-control policy on this machine blocks the unsigned dev `electron.exe` (its 6 tests report as skipped). `npm run typecheck` and `npm run build` pass.
- `npm run dev` with `ELECTRON_RUN_AS_NODE` stripped: blocked by the same policy (PowerShell: "Eine Anwendungssteuerungsrichtlinie hat diese Datei blockiert"); recorded, not required for 8-a.

### Docs + BUILD_STATE
`docs/security-model.md` (CSP section: production header string + a header/meta parity paragraph; the dev paragraph; the GAP-3 bullet's (iii) clause now says #266 landed; manifest section bullet (3) for the archive-name rule), `docs/local-api.md` (§6.1 `Host` wording: the port is compared only when the header carries one; the bounds table gains "Body total 120 s" and words the idle row as inactivity), `BUILD_STATE.md` (dated entry; §8 L-7 clause), `CHANGELOG.md` (four Fixed entries + one Changed line).

### Owner decisions relied on (issue #, answer or default)
None needed by Phase 8. Checked at kickoff: `**DECISION:**` empty on #217, #221, #228, #222, #254, #266, #252 → decisions 4/11 and 5 still unanswered (5a, 5b-b stay blocked); review rec 5 (#221 time-box) and rec 9 (SEC-6 with the ban test) on their defaults; SEC-14 rides here (default); `BODY_TOTAL_TIMEOUT_MS = 120_000` (default).

### Reviewer pass
Opus tier (independent, read-only): 11 findings, none blocking. Repaired in `a06009a6`: (3) `getSettings` now also skips rows whose key is not an own `DEFAULT_SETTINGS` key — a `__proto__` row written by an older build set the merge object's prototype and was parsed on every unlock — plus a test; (4) the three named keys are no longer serialized twice, one cap covers every non-primitive write; (5) the percent-encoded case is named as such and the raw-backslash case pins `evil.exe` and says it is the form that escaped before the fix; (6) every shipped build keeps its real basename (a `+`, `~` or space in a future asset name would otherwise fall back silently); (8) CHANGELOG wording; (9) security-model wording; (11) the trickle test clears its fallback timer.

Recorded, not repaired: (1) the §5 item-19 line for Phase 8 is written by PR 8-b for both PRs (the phase plan; the item-19 block sits at 43 of 45 lines and takes exactly one two-line entry); (2) a manual PDF export cannot run on this machine (an application-control policy blocks `electron.exe`) — mechanically the policy allows exactly what the print window needs (`PACK_CSS` has no `url()`, `@import` or `@font-face`; system font names are not CSP-checked; `executeJavaScript` is embedder-initiated), and "export one evidence pack as PDF" joins the owner-runnable smoke list; (7) commit ordering (the golden refresh lands after the fix; squash-merge makes it cosmetic); (10) the whole-string `Buffer.from` costs the same as the previous `writeFileSync` call, not a regression.

### Rollback
Revert the PR; each item is independently revertable (one file each, plus its test). No on-disk format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
