### PR TITLE
fix(ipc): every ipcMain.handle checks the sender — guardedHandle over all 18 registrars (audit 2026-09-02 Phase 8 — SEC-6)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,19 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-b) — SEC-6 #252: every `ipcMain.handle` in the
+main process goes through `guardedHandle(channel, handler, { trustedSenders, log })`
+(`src/main/ipc/guarded-handle.ts`): the body runs only when `event.sender.id` is in
+`ctx.trustedSenders`, which `createWindow` fills with the main window's `webContents.id` (the
+OCR window only `send`s, the print window has no preload); a refused invoke rejects with a
+content-free `UntrustedSenderError`. 18 registrars converted by codemod (`const ipcHandle =
+guardedHandleFor(ctx)`, 137 registrations, no `ipcMain` import left); `repo-hygiene.test.ts` bans
+a bare `ipcMain.handle(` under `src/main/ipc/**`; the two `ipcMain.on` sites stay. Tests:
+`guarded-handle.test.ts` (foreign id refused, main id passes, a real registrar through a
+non-permissive set); harness `makeEvent(senderId?)` + `ANY_SENDER` in 36 fake contexts (PR #279).**_
+Launch smoke NOT run: this machine's application-control policy blocks the dev `electron.exe`
+(substitute proof in the PR body; the smoke joins the owner list). Phase 8 suite: 370 / 5,559 / 74.
+
 _2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-a) — small code items: SEC-2 #245 the engine
 archive's on-disk name is `archiveNameFromUrl` (last URL path segment, percent-decoded, must match
 `^[A-Za-z0-9._-]{1,128}$`, else `<binary>-<version>-<os>-<arch>.zip`) and `zipDest` goes through
@@ -679,6 +692,8 @@ open round's item stays the last block of §5.)
     - **7** (2026-09-03, PR #277): REL-8 (TQ-2 folded) — a held `.recovery` no longer costs a
       failed lock's fresh copy (tri-state `preserveNewerPlaintext`; `init()` refuses to sweep/open;
       unlock reason `vault_recovery_blocked`) + REL-9/DOC-15 exFAT durability docs — dated entry above.
+    - **8** (2026-09-03, PRs #278 + #279): SEC-2, SEC-5, SEC-7, REL-1, REL-2, SEC-14 fixed, GAP-3 a
+      confirmed residual (8-a); SEC-6 `guardedHandle` over all 137 registrations + the hygiene ban (8-b) — dated entries above.
 
 
 ---

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -40,7 +40,7 @@ a bare `ipcMain.handle(` under `src/main/ipc/**`; the two `ipcMain.on` sites sta
 `guarded-handle.test.ts` (foreign id refused, main id passes, a real registrar through a
 non-permissive set); harness `makeEvent(senderId?)` + `ANY_SENDER` in 36 fake contexts (PR #279).**_
 Launch smoke NOT run: this machine's application-control policy blocks the dev `electron.exe`
-(substitute proof in the PR body; the smoke joins the owner list). Phase 8 suite: 370 / 5,559 / 74.
+(substitute proof in the PR body; the smoke joins the owner list). Phase 8 suite: 370 / 5,561 / 74.
 
 _2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-a) — small code items: SEC-2 #245 the engine
 archive's on-disk name is `archiveNameFromUrl` (last URL path segment, percent-decoded, must match

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ from its first public `1.0.0` release onward.
 
 ### Changed
 
+- **Every request from the app window to the main process now checks where it came from.**
+  Only the app's own window can invoke the internal commands (opening documents, reading
+  settings, running the models); a request from anywhere else is refused before it runs. Nothing
+  else can send such requests today, so nothing changes in use — this closes the door before it
+  is ever needed.
 - **Two small hardening steps with no visible effect.** The app window's content policy now
   also forbids form submissions, plugins, base-address changes and framing in its built-in
   fallback layer, and the settings store ignores inherited object names and caps the size of

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import { vaultPathsFrom, workspaceAdmitsWork, WorkspaceController } from './serv
 import { assertOfflinePosture } from './services/offlineGuard'
 import { initLogging, log, usesPlaintextLog, detachVaultKey } from './services/logging'
 import { initPerf, perfMark, perfMs } from './services/perf'
+import { createTrustedSenders } from './ipc/guarded-handle'
 import { registerCoreIpc } from './ipc/registerCoreIpc'
 import { registerWorkspaceIpc } from './ipc/registerWorkspaceIpc'
 import { maybeAutoStartActiveModel, registerModelIpc } from './ipc/registerModelIpc'
@@ -117,6 +118,9 @@ if (!isPrimaryInstance) {
 initBinaryVerification(isDev)
 
 let mainWindow: BrowserWindow | null = null
+// WebContents ids allowed to invoke `handle` channels (#252): the main window's, added in
+// createWindow. The OCR rasterizer window only `send`s and the print window has no preload.
+const trustedSenders = createTrustedSenders()
 let ctx: AppContext | null = null
 
 // The three model resolvers + the four availability-driven service selectors that used to
@@ -482,6 +486,7 @@ function initBackend(): void {
   // reachable after the renderer's unlock gate reports the workspace ready.
   ctx = {
     paths,
+    trustedSenders,
     get db() {
       return workspace.requireDb()
     },
@@ -660,6 +665,7 @@ function createWindow(): void {
   // index.html meta tag, spec §3.5). The strings live in window-security.ts (TS-2),
   // pinned by tests/unit/window-security.test.ts — edit them THERE.
   const csp = buildCsp(isDev)
+  trustedSenders.add(mainWindow.webContents.id)
   mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {

--- a/apps/desktop/src/main/ipc/guarded-handle.ts
+++ b/apps/desktop/src/main/ipc/guarded-handle.ts
@@ -1,4 +1,5 @@
 import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { log as appLog } from '../services/logging'
 
 // Every `ipcMain.handle` in the main process goes through `guardedHandle` (#252): the
 // handler body runs only for an event whose `sender` (a WebContents) is in the trusted
@@ -51,7 +52,7 @@ export type GuardedHandler = (event: IpcMainInvokeEvent, ...args: never[]) => un
 
 export interface GuardedHandleOptions {
   trustedSenders: TrustedSenders
-  /** Content-free refusal log (channel name only — never arguments). */
+  /** Content-free refusal log (channel name only — never arguments); the app log by default. */
   log?: { warn(msg: string, meta?: unknown): void }
 }
 
@@ -64,7 +65,8 @@ export function guardedHandle(
   handler: GuardedHandler,
   opts: GuardedHandleOptions
 ): void {
-  const { trustedSenders, log } = opts
+  const { trustedSenders } = opts
+  const log = opts.log ?? appLog
   if (typeof trustedSenders?.isTrusted !== 'function') {
     // Fail closed and LOUD at registration: a context without the set would otherwise
     // refuse every invoke at runtime with no hint where the wiring went missing.
@@ -73,7 +75,7 @@ export function guardedHandle(
   ipcMain.handle(channel, (event: IpcMainInvokeEvent, ...args: unknown[]) => {
     const id = (event as { sender?: { id?: unknown } } | null | undefined)?.sender?.id
     if (!trustedSenders.isTrusted(typeof id === 'number' ? id : undefined)) {
-      log?.warn('IPC refused: untrusted sender', { channel })
+      log.warn('IPC refused: untrusted sender', { channel })
       throw new UntrustedSenderError()
     }
     return handler(event, ...(args as never[]))

--- a/apps/desktop/src/main/ipc/guarded-handle.ts
+++ b/apps/desktop/src/main/ipc/guarded-handle.ts
@@ -1,0 +1,88 @@
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+
+// Every `ipcMain.handle` in the main process goes through `guardedHandle` (#252): the
+// handler body runs only for an event whose `sender` (a WebContents) is in the trusted
+// set — today the main window alone. The OCR rasterizer window's preload only `send`s
+// (its replies are `ipcMain.on` listeners that check identity themselves) and the print
+// window has no preload, so neither is trusted for `handle` channels. Today no other
+// WebContents can invoke; the guard is load-bearing the moment a webview or a second
+// window exists. The repo-hygiene test bans bare `ipcMain.handle(` under `src/main/ipc/**`
+// so a registrar cannot bypass it.
+
+/** The set of WebContents ids allowed to invoke `handle` channels. */
+export interface TrustedSenders {
+  isTrusted(webContentsId: number | undefined): boolean
+}
+
+export interface MutableTrustedSenders extends TrustedSenders {
+  add(webContentsId: number): void
+  delete(webContentsId: number): void
+  size(): number
+}
+
+/** Production set: empty until `createWindow` adds the main window's `webContents.id`. */
+export function createTrustedSenders(): MutableTrustedSenders {
+  const ids = new Set<number>()
+  return {
+    add: (id) => {
+      ids.add(id)
+    },
+    delete: (id) => {
+      ids.delete(id)
+    },
+    size: () => ids.size,
+    isTrusted: (id) => typeof id === 'number' && ids.has(id)
+  }
+}
+
+/** Test-only: the fake IPC harness passes senders with no `webContents.id`. Never used in
+ *  production (`index.ts` builds the real set). */
+export const ANY_SENDER: TrustedSenders = { isTrusted: () => true }
+
+export class UntrustedSenderError extends Error {
+  constructor() {
+    super('IPC refused: untrusted sender')
+    this.name = 'UntrustedSenderError'
+  }
+}
+
+/** Handler shape `ipcMain.handle` accepts. */
+export type GuardedHandler = (event: IpcMainInvokeEvent, ...args: never[]) => unknown
+
+export interface GuardedHandleOptions {
+  trustedSenders: TrustedSenders
+  /** Content-free refusal log (channel name only — never arguments). */
+  log?: { warn(msg: string, meta?: unknown): void }
+}
+
+/**
+ * `ipcMain.handle(channel, …)` with the sender check in front. A refused invoke rejects
+ * the renderer's promise with a content-free error and never runs `handler`.
+ */
+export function guardedHandle(
+  channel: string,
+  handler: GuardedHandler,
+  opts: GuardedHandleOptions
+): void {
+  const { trustedSenders, log } = opts
+  if (typeof trustedSenders?.isTrusted !== 'function') {
+    // Fail closed and LOUD at registration: a context without the set would otherwise
+    // refuse every invoke at runtime with no hint where the wiring went missing.
+    throw new Error(`guardedHandle(${channel}): no trustedSenders in the context`)
+  }
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+    const id = (event as { sender?: { id?: unknown } } | null | undefined)?.sender?.id
+    if (!trustedSenders.isTrusted(typeof id === 'number' ? id : undefined)) {
+      log?.warn('IPC refused: untrusted sender', { channel })
+      throw new UntrustedSenderError()
+    }
+    return handler(event, ...(args as never[]))
+  })
+}
+
+/** The registrar-side binding: `const handle = guardedHandleFor(ctx)` then `handle(ch, fn)`. */
+export function guardedHandleFor(
+  ctx: GuardedHandleOptions
+): (channel: string, handler: GuardedHandler) => void {
+  return (channel, handler) => guardedHandle(channel, handler, ctx)
+}

--- a/apps/desktop/src/main/ipc/registerAuditIpc.ts
+++ b/apps/desktop/src/main/ipc/registerAuditIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { AuditEvent } from '../../shared/types'
@@ -14,6 +14,7 @@ import { saveTextExport } from './save-export'
 // exporting are the only ways it leaves the workspace DB, both user actions.
 
 export function registerAuditIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // F16 (audit-postmerge-2026-06-29): both handlers touch ctx.db (listAuditEvents). The ctx.db
   // getter already fail-closes when locked, but it throws the raw English vault-getter string;
   // mirror every other DB-touching handler with an explicit requireUnlocked() so a locked call
@@ -27,7 +28,7 @@ export function registerAuditIpc(ctx: AppContext): void {
 
   // Newest-first page; `beforeId` is the pagination cursor ("Load more"). The type
   // filter lives in the renderer (client-side over loaded pages).
-  ipcMain.handle(
+  ipcHandle(
     IPC.getAuditEvents,
     (_e, limit?: number, beforeId?: string | null): AuditEvent[] => {
       requireUnlocked()
@@ -38,7 +39,7 @@ export function registerAuditIpc(ctx: AppContext): void {
   // Save the whole retained log to a user-chosen file (the exportConversation
   // precedent: dialog in MAIN, returns the path or null on cancel). JSON — the log is
   // structured data; a compliance reader wants machine-readable.
-  ipcMain.handle(IPC.exportAuditLog, async (): Promise<string | null> => {
+  ipcHandle(IPC.exportAuditLog, async (): Promise<string | null> => {
     requireUnlocked()
     const events = listAuditEvents(ctx.db, { limit: AUDIT_MAX_ROWS })
     const filePath = await saveTextExport(

--- a/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
+++ b/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { clearSpeculativeSuppression } from '../services/runtime/factory'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
@@ -161,6 +161,7 @@ export async function tryGpuAgain(ctx: AppContext): Promise<AppSettings> {
 }
 
 export function registerBenchmarkIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // SEC-N2: both handlers touch ctx.db (via updateSettings/getSettings). The ctx.db getter already
   // fail-closes when the workspace is locked, but it throws a raw English string; mirror every other
   // DB-touching handler with an explicit requireUnlocked() so a locked call surfaces the localized
@@ -171,11 +172,11 @@ export function registerBenchmarkIpc(ctx: AppContext): void {
     // lazily respawns the sidecars that teardown just killed. This module's copy is unchanged.
     if (!workspaceAdmitsWork(ctx.workspace)) throw new Error(tMain('main.benchmark.locked'))
   }
-  ipcMain.handle(IPC.runBenchmark, (): Promise<BenchmarkResult> => {
+  ipcHandle(IPC.runBenchmark, (): Promise<BenchmarkResult> => {
     requireUnlocked()
     return runAndPersistBenchmark(ctx)
   })
-  ipcMain.handle(IPC.tryGpuAgain, (): Promise<AppSettings> => {
+  ipcHandle(IPC.tryGpuAgain, (): Promise<AppSettings> => {
     requireUnlocked()
     return tryGpuAgain(ctx)
   })

--- a/apps/desktop/src/main/ipc/registerChatIpc.ts
+++ b/apps/desktop/src/main/ipc/registerChatIpc.ts
@@ -1,4 +1,5 @@
-import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { type IpcMainInvokeEvent } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import {
@@ -61,6 +62,7 @@ import { loadResultTable } from '../services/tables/store'
 // service boundary clean.
 
 export function registerChatIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // Active stream cancellers (shared with the RAG path so stopGeneration cancels either).
   const inFlight = inFlightStreams
 
@@ -78,7 +80,7 @@ export function registerChatIpc(ctx: AppContext): void {
     }
   }
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.createConversation,
     (
       _e,
@@ -113,7 +115,7 @@ export function registerChatIpc(ctx: AppContext): void {
 
   // Persist a conversation's composite source scope (plan D1 — the multi-select picker).
   // Null clears it; an empty DocumentScope is the explicit "All documents" choice.
-  ipcMain.handle(
+  ipcHandle(
     IPC.setConversationScope,
     (_e, conversationId: string, scope: DocumentScope | null): Conversation => {
       requireUnlocked()
@@ -128,7 +130,7 @@ export function registerChatIpc(ctx: AppContext): void {
   )
 
   // Persist a conversation's creation-anchor project (plan §13.4).
-  ipcMain.handle(
+  ipcHandle(
     IPC.setConversationCollection,
     (_e, conversationId: string, collectionId: string | null): Conversation => {
       requireUnlocked()
@@ -138,7 +140,7 @@ export function registerChatIpc(ctx: AppContext): void {
 
   // Replace the "ask selected documents" scope (spec §10.4) — chip removal
   // in the UI. Null/empty clears back to whole-corpus retrieval.
-  ipcMain.handle(
+  ipcHandle(
     IPC.updateConversationScope,
     (_e, conversationId: string, documentIds: string[] | null): Conversation => {
       requireUnlocked()
@@ -155,7 +157,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // clears it. Validated against the registry: an unknown/disabled/unavailable id is rejected to
   // null so a stale pick never becomes the default (the resolver also skips it, but keep the
   // persisted value honest). App + user skills are both selectable.
-  ipcMain.handle(
+  ipcHandle(
     IPC.setConversationDefaultSkill,
     (_e, conversationId: string, installId: string | null): void => {
       requireUnlocked()
@@ -168,7 +170,7 @@ export function registerChatIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.listConversations, (): Conversation[] => {
+  ipcHandle(IPC.listConversations, (): Conversation[] => {
     requireUnlocked()
     return listConversations(ctx.db)
   })
@@ -180,7 +182,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // still-processing attachment is surfaced by the renderer's pending chip (import polling).
   // CODE-21 (full audit 2026-07-11): id-targeted — this used to materialize the whole library
   // (the PF-5 load-all) per conversation switch to return a handful of linked docs.
-  ipcMain.handle(IPC.listAttachments, (_e, conversationId: string): DocumentInfo[] => {
+  ipcHandle(IPC.listAttachments, (_e, conversationId: string): DocumentInfo[] => {
     requireUnlocked()
     const ids = conversationAttachmentIds(ctx.db, conversationId)
     if (ids.length === 0) return []
@@ -190,12 +192,12 @@ export function registerChatIpc(ctx: AppContext): void {
   // Full-text search across conversations. The query and the returned snippets are
   // chat CONTENT: this handler must never log them and never writes an audit event
   // (reads are not audited — the audit privacy rule).
-  ipcMain.handle(IPC.searchConversations, (_e, query: string): ConversationSearchResult[] => {
+  ipcHandle(IPC.searchConversations, (_e, query: string): ConversationSearchResult[] => {
     requireUnlocked()
     return searchMessages(ctx.db, typeof query === 'string' ? query : '')
   })
 
-  ipcMain.handle(IPC.listMessages, (_e, conversationId: string): Message[] => {
+  ipcHandle(IPC.listMessages, (_e, conversationId: string): Message[] => {
     requireUnlocked()
     return listMessages(ctx.db, conversationId)
   })
@@ -204,7 +206,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // Read-only, no model call: the assembled-prompt estimate over the launched window. Falls back to
   // settings.contextTokens when no runtime is up. Returns null for an unknown conversation so the
   // renderer hides the meter rather than showing a system-prompt-only sliver for a vanished chat.
-  ipcMain.handle(
+  ipcHandle(
     IPC.getConversationContextUsage,
     (_e, conversationId: string): ContextUsage | null => {
       requireUnlocked()
@@ -216,7 +218,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // The transcript summary marker (context-compaction plan §5.3, D-b): the latest checkpoint's
   // summary + where the divider sits, or null when none / compaction is disabled. The summary is
   // local context — this read is never logged or audited (chat content, like listMessages).
-  ipcMain.handle(
+  ipcHandle(
     IPC.getConversationSummary,
     (_e, conversationId: string): ConversationSummaryMarker | null => {
       requireUnlocked()
@@ -224,7 +226,7 @@ export function registerChatIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.sendChatMessage,
     async (
       event: IpcMainInvokeEvent,
@@ -312,7 +314,7 @@ export function registerChatIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.deleteConversation, (_e, conversationId: string): void => {
+  ipcHandle(IPC.deleteConversation, (_e, conversationId: string): void => {
     requireUnlocked()
     // A stream writing into this conversation would persist its assistant turn after
     // the delete (FK violation / resurrection) — refuse while one is in flight; the
@@ -325,7 +327,7 @@ export function registerChatIpc(ctx: AppContext): void {
     ctx.audit?.('conversation_deleted', 'Conversation deleted', { conversationId })
   })
 
-  ipcMain.handle(IPC.stopGeneration, (_e, conversationId: string): void => {
+  ipcHandle(IPC.stopGeneration, (_e, conversationId: string): void => {
     const controller = inFlight.get(conversationId)
     if (controller) {
       log.info('Generation stop requested', { conversationId })
@@ -336,7 +338,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // Recover an in-flight generation after the Chat screen was unmounted (the user
   // navigated away and back). Returns the live accumulated answer/reasoning snapshot, or
   // null when nothing is generating for this conversation. Read-only; never mutates.
-  ipcMain.handle(
+  ipcHandle(
     IPC.getActiveStream,
     (_e, conversationId: string): ActiveStreamSnapshot | null => {
       const buf = streamBuffers.get(conversationId)
@@ -350,12 +352,12 @@ export function registerChatIpc(ctx: AppContext): void {
   // reply streams invisibly. In-memory only + workspace-agnostic, so it intentionally skips
   // requireUnlocked (like stopGeneration/getActiveStream). Insertion-ordered: the LAST id is the
   // most recently started stream. Returns [] when nothing is generating.
-  ipcMain.handle(IPC.listActiveStreamConversations, (): string[] => [...inFlight.keys()])
+  ipcHandle(IPC.listActiveStreamConversations, (): string[] => [...inFlight.keys()])
 
   // Export a transcript to a user-chosen file (spec §7.6). The save dialog
   // runs in MAIN (the renderer has no fs/dialog access); returns the saved path, or
   // null when the user cancelled.
-  ipcMain.handle(IPC.exportConversation, async (_e, conversationId: string): Promise<string | null> => {
+  ipcHandle(IPC.exportConversation, async (_e, conversationId: string): Promise<string | null> => {
     requireUnlocked()
     const { title, markdown } = exportTranscript(ctx.db, conversationId)
     const safeName = title.replace(/[^\p{L}\p{N} _-]/gu, '').trim().slice(0, 60) || 'chat'
@@ -386,7 +388,7 @@ export function registerChatIpc(ctx: AppContext): void {
   // CSV path (tableToCsv, incl. formula-injection neutralization) and the save dialog is the
   // consent, exactly like the transcript export above. Returns the saved path, or null when the
   // user cancelled or the message carries no (readable) table.
-  ipcMain.handle(IPC.exportMessageTable, async (_e, messageId: string): Promise<string | null> => {
+  ipcHandle(IPC.exportMessageTable, async (_e, messageId: string): Promise<string | null> => {
     requireUnlocked()
     if (typeof messageId !== 'string' || messageId.length === 0) return null
     const table = loadResultTable(ctx.db, messageId)

--- a/apps/desktop/src/main/ipc/registerCollectionsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerCollectionsIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { Collection } from '../../shared/types'
@@ -24,6 +24,7 @@ import { workspaceAdmitsWork } from '../services/workspace-vault'
 // test in tests/integration/audit-ipc.test.ts.
 
 export function registerCollectionsIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // DB-backed handlers require an unlocked workspace; surface a clean message instead of
   // the raw "Workspace is locked" the `ctx.db` getter would throw mid-operation.
   const requireUnlocked = (): void => {
@@ -35,12 +36,12 @@ export function registerCollectionsIpc(ctx: AppContext): void {
     }
   }
 
-  ipcMain.handle(IPC.listCollections, (): Collection[] => {
+  ipcHandle(IPC.listCollections, (): Collection[] => {
     requireUnlocked()
     return listCollections(ctx.db)
   })
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.createCollection,
     (_e, name: string, opts?: { description?: string | null; color?: string | null }): Collection => {
       requireUnlocked()
@@ -54,14 +55,14 @@ export function registerCollectionsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.renameCollection, (_e, id: string, name: string): Collection => {
+  ipcHandle(IPC.renameCollection, (_e, id: string, name: string): Collection => {
     requireUnlocked()
     const coll = renameCollection(ctx.db, id, name)
     ctx.audit?.('collection_renamed', 'Project renamed', { collectionId: coll.id, type: coll.type })
     return coll
   })
 
-  ipcMain.handle(IPC.setCollectionArchived, (_e, id: string, archived: boolean): Collection => {
+  ipcHandle(IPC.setCollectionArchived, (_e, id: string, archived: boolean): Collection => {
     requireUnlocked()
     const coll = setCollectionArchived(ctx.db, id, archived)
     ctx.audit?.('collection_archived', 'Project archive state changed', {
@@ -76,7 +77,7 @@ export function registerCollectionsIpc(ctx: AppContext): void {
   //  - 'membershipOnly': drop the collection + its memberships (CASCADE); keep every doc.
   //  - 'withDocuments':  additionally delete ONLY genuinely project-only docs (C2 predicate
   //    — never a Library member). The actual shred reuses ingestion `deleteDocument`.
-  ipcMain.handle(
+  ipcHandle(
     IPC.deleteCollection,
     (_e, id: string, mode: 'membershipOnly' | 'withDocuments'): void => {
       requireUnlocked()

--- a/apps/desktop/src/main/ipc/registerCoreIpc.ts
+++ b/apps/desktop/src/main/ipc/registerCoreIpc.ts
@@ -1,4 +1,5 @@
-import { ipcMain, app, clipboard } from 'electron'
+import { app, clipboard } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import { buildDriveStatus } from '../services/workspace'
@@ -17,6 +18,7 @@ import type { AppSettings, AppStatus, PolicyStatus, PreflightResult } from '../.
 // IPC for app/drive status + settings, the privacy policy surface (`getPolicy`),
 // and the policy-aware `offlineMode` (spec §9.1, §3.6).
 export function registerCoreIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // The user's allowNetwork setting lives inside the (possibly locked) DB. When the
   // workspace is locked we can't read it — fall back to the safe default (false), which
   // keeps the offline ceiling intact until the workspace is unlocked.
@@ -35,7 +37,7 @@ export function registerCoreIpc(ctx: AppContext): void {
     if (!workspaceAdmitsWork(ctx.workspace)) throw new Error(tMain('main.settings.locked'))
   }
 
-  ipcMain.handle(IPC.getAppStatus, (): AppStatus => {
+  ipcHandle(IPC.getAppStatus, (): AppStatus => {
     const ws = ctx.workspace.getState()
     const unlocked = ctx.workspace.isUnlocked()
     const s = unlocked ? getSettings(ctx.db) : null
@@ -81,29 +83,29 @@ export function registerCoreIpc(ctx: AppContext): void {
     }
   })
 
-  ipcMain.handle(IPC.getDriveStatus, () => buildDriveStatus(ctx.paths))
+  ipcHandle(IPC.getDriveStatus, () => buildDriveStatus(ctx.paths))
 
   // The friendly, non-blocking launch preflight (spec §11.4). Reuses the drive
   // status + benchmark probe; surfaced on Home for a non-technical first run.
-  ipcMain.handle(
+  ipcHandle(
     IPC.runPreflight,
     (): Promise<PreflightResult> => runPreflight({ rootPath: ctx.paths.rootPath })
   )
 
-  ipcMain.handle(IPC.getPolicy, (): PolicyStatus =>
+  ipcHandle(IPC.getPolicy, (): PolicyStatus =>
     buildPolicyStatus(ctx.paths.configPath, allowNetworkSetting(), (m) => log.warn(m), {
       isDev: ctx.isDev
     })
   )
 
   // Spec §7.11 "show recent local logs" — read-only, local, never uploaded.
-  ipcMain.handle(IPC.getLogTail, (): string[] => readLogTail())
+  ipcHandle(IPC.getLogTail, (): string[] => readLogTail())
 
   // Copy text to the OS clipboard. Done in MAIN because the sandboxed preload has no access
   // to Electron's `clipboard` module and `navigator.clipboard` is unreliable in the
   // file://-loaded renderer (it threw the "can't copy" error). Returns false on failure so
   // the renderer can show a friendly message rather than throw.
-  ipcMain.handle(IPC.writeClipboard, (_e, text: string): boolean => {
+  ipcHandle(IPC.writeClipboard, (_e, text: string): boolean => {
     try {
       clipboard.writeText(String(text ?? ''))
       return true
@@ -116,7 +118,7 @@ export function registerCoreIpc(ctx: AppContext): void {
   // hand diagnostics to support without unsealing the workspace. The dialog + write run in
   // MAIN (saveTextExport). The on-disk log stays encrypted; this writes a copy the user
   // deliberately places outside the vault (spec §7.11 — logs are FOR THE USER).
-  ipcMain.handle(IPC.exportLog, async (): Promise<string | null> => {
+  ipcHandle(IPC.exportLog, async (): Promise<string | null> => {
     const filePath = await saveTextExport(
       {
         title: tMain('main.dialog.exportLog'),
@@ -132,12 +134,12 @@ export function registerCoreIpc(ctx: AppContext): void {
     return filePath
   })
 
-  ipcMain.handle(IPC.getSettings, () => {
+  ipcHandle(IPC.getSettings, () => {
     requireUnlocked()
     return getSettings(ctx.db)
   })
 
-  ipcMain.handle(IPC.updateSettings, (_e, patch: Partial<AppSettings>) => {
+  ipcHandle(IPC.updateSettings, (_e, patch: Partial<AppSettings>) => {
     requireUnlocked()
     // BE-1 (full-audit 2026-07-10): shape-check the patch BEFORE touching it —
     // `Object.keys(null)` threw a raw TypeError out of the handler; reject junk with the

--- a/apps/desktop/src/main/ipc/registerDictationIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDictationIpc.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import { documentsDir } from '../services/ingestion'
@@ -66,6 +66,7 @@ export interface DictationIpcOptions {
 }
 
 export function registerDictationIpc(ctx: AppContext, options: DictationIpcOptions = {}): void {
+  const ipcHandle = guardedHandleFor(ctx)
   const storeDir = documentsDir(ctx.paths.workspacePath)
   const maxDurationMs = resolveDictationTimeoutMs(options.maxDurationMs)
   // Single-flight guard: whisper is NOT internally serialized, so without this a second
@@ -73,7 +74,7 @@ export function registerDictationIpc(ctx: AppContext, options: DictationIpcOptio
   // than queue it — dictation is interactive, a stale queued result would surprise the user.
   let inFlight = false
 
-  ipcMain.handle(IPC.transcribeDictation, async (_e, audio: unknown): Promise<string> => {
+  ipcHandle(IPC.transcribeDictation, async (_e, audio: unknown): Promise<string> => {
     // S3: refuse on a locked vault BEFORE any disk write — a transient plaintext WAV must
     // never land in the workspace documents dir while it holds only `.enc` sidecars. AUD-02:
     // `workspaceAdmitsWork`, not a bare `isUnlocked()` — the DB stays open for the whole

--- a/apps/desktop/src/main/ipc/registerDocTasksIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDocTasksIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import { tMain } from '../services/i18n'
@@ -27,6 +27,7 @@ import { aggregateExtractions } from '../services/analysis/extract'
 // them. The manager records the ids-only `document_task_*` audit events itself.
 
 export function registerDocTasksIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // Guard throws are ephemeral IPC emissions — localized via tMain (i18n record §3.3).
   const requireTasks = () => {
     if (!ctx.docTasks) throw new Error(tMain('main.task.unavailable'))
@@ -42,24 +43,24 @@ export function registerDocTasksIpc(ctx: AppContext): void {
     }
   }
 
-  ipcMain.handle(IPC.startDocTask, (_e, req: StartDocTaskRequest): { jobId: string } => {
+  ipcHandle(IPC.startDocTask, (_e, req: StartDocTaskRequest): { jobId: string } => {
     requireUnlocked()
     return requireTasks().startDocTask(req)
   })
 
-  ipcMain.handle(IPC.getDocTask, (_e, jobId: string): DocTaskStatus =>
+  ipcHandle(IPC.getDocTask, (_e, jobId: string): DocTaskStatus =>
     requireTasks().getDocTask(typeof jobId === 'string' ? jobId : '')
   )
 
   // Reload adoption: the RUNNING task's status (a copy) or null — the #38 chain-adopt read.
   // A safe read — never starts anything.
-  ipcMain.handle(IPC.getActiveDocTask, (): DocTaskStatus | null => requireTasks().getActiveDocTask())
+  ipcHandle(IPC.getActiveDocTask, (): DocTaskStatus | null => requireTasks().getActiveDocTask())
 
   // #157 (DT-5): the file-translation reload-adoption read (FA-3 / F-3) — running + queued
   // tasks in lane order, so a translation QUEUED behind a foreign task is adoptable too.
-  ipcMain.handle(IPC.listActiveDocTasks, (): DocTaskStatus[] => requireTasks().listActiveDocTasks())
+  ipcHandle(IPC.listActiveDocTasks, (): DocTaskStatus[] => requireTasks().listActiveDocTasks())
 
-  ipcMain.handle(IPC.cancelDocTask, (_e, jobId?: string | null): void => {
+  ipcHandle(IPC.cancelDocTask, (_e, jobId?: string | null): void => {
     const manager = requireTasks()
     const id = typeof jobId === 'string' && jobId.length > 0 ? jobId : null
     // A PRESENT id is a TARGETED cancel: exact-id, running OR queued (#157 DT-2 — the old
@@ -74,7 +75,7 @@ export function registerDocTasksIpc(ctx: AppContext): void {
   // Read-only coverage + provenance of a document's CURRENT summary (whole-document-analysis
   // plan §5.1, Phase 2). No model call — pure DB reads. Coverage/provenance are CONTENT-derived
   // (counts + source-chunk lineage), so this handler never logs or audits them.
-  ipcMain.handle(
+  ipcHandle(
     IPC.documentCoverage,
     (_e, documentId: string): DocumentCoverage | null => {
       requireUnlocked()
@@ -96,7 +97,7 @@ export function registerDocTasksIpc(ctx: AppContext): void {
   // pure GROUP BY over the precomputed `extraction_records` for one record type, scoped via the
   // shared buildScopeFilter (M3). ZERO model calls. The aggregated values are CONTENT — never
   // logged or audited (only the ids/counts of the precompute pass are).
-  ipcMain.handle(
+  ipcHandle(
     IPC.listAllExtractions,
     (_e, req: ExtractionListingRequest): ExtractionListing | null => {
       requireUnlocked()

--- a/apps/desktop/src/main/ipc/registerDocsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDocsIpc.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { BrowserWindow, dialog } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import { createPickerTokens } from './picker-tokens'
@@ -135,6 +136,7 @@ function filterDocuments(docs: DocumentInfo[], filter?: DocumentListFilter): Doc
 }
 
 export function registerDocsIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   const storeDir = documentsDir(ctx.paths.workspacePath)
   // Surface the dev force-reindex escape hatch once at startup so it's obvious WHY every document
   // suddenly reports "needs re-index" (listDocuments forces `staleEmbeddings` while it's set).
@@ -305,7 +307,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // Open the OS file/folder picker in the main process (renderer has no dialog access).
   // Windows cannot mix file + directory selection in one dialog, so the caller chooses a
   // mode: 'files' (default) or 'folder'.
-  ipcMain.handle(
+  ipcHandle(
     IPC.pickDocuments,
     async (_e, mode?: 'files' | 'folder'): Promise<PickDocumentsResult> => {
       const exts = supportedExtensions().map((e) => e.replace(/^\./, ''))
@@ -334,7 +336,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.importDocuments, (_e, paths: string[], options?: ImportOptions): ImportJob => {
+  ipcHandle(IPC.importDocuments, (_e, paths: string[], options?: ImportOptions): ImportJob => {
     requireUnlocked()
     // Race guard: the whole import job holds a document-work lease so a vault
     // password change (which re-encrypts `.enc` sidecars) refuses to start while we
@@ -524,7 +526,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     return { jobId, documentIds }
   })
 
-  ipcMain.handle(IPC.getImportJob, (_e, jobId: string): ImportJobStatus => {
+  ipcHandle(IPC.getImportJob, (_e, jobId: string): ImportJobStatus => {
     const status = jobs.get(jobId)
     if (status) return status
     // Unknown/expired job — report it as done so pollers stop gracefully.
@@ -534,11 +536,11 @@ export function registerDocsIpc(ctx: AppContext): void {
   // DOC-1 (#141): the in-flight import (or null), parameterless — the Documents screen's mount
   // effect re-attaches its progress poll with this, mirroring getReindexAllJob. At most one
   // import runs at a time (beginDocumentWork serialises them), so "first not-done" is THE job.
-  ipcMain.handle(IPC.getActiveImportJob, (): ImportJobStatus | null => {
+  ipcHandle(IPC.getActiveImportJob, (): ImportJobStatus | null => {
     return [...jobs.values()].find((j) => !j.done) ?? null
   })
 
-  ipcMain.handle(IPC.listDocuments, (_e, filter?: DocumentListFilter): DocumentInfo[] => {
+  ipcHandle(IPC.listDocuments, (_e, filter?: DocumentListFilter): DocumentInfo[] => {
     requireUnlocked()
     // Reconcile stuck rows whenever NOTHING is actually running: a row left in an
     // active status (queued/extracting/…) with no live job/re-index belongs to a killed
@@ -601,7 +603,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // #240: with a live picker token the count runs over the main-vetted paths (the renderer's
   // array is ignored, the token is NOT spent — `importDocuments` spends it); without one this is
   // the raw seam and the array is capped before any filesystem call.
-  ipcMain.handle(IPC.importPreflight, (_e, paths: string[], pickerToken?: string): ImportPreflight => {
+  ipcHandle(IPC.importPreflight, (_e, paths: string[], pickerToken?: string): ImportPreflight => {
     requireUnlocked()
     const picked = pickerTokens.peek(pickerToken)
     if (picked !== undefined) return summarizeImportPaths(picked)
@@ -610,7 +612,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     return summarizeImportPaths(safePaths)
   })
 
-  ipcMain.handle(IPC.deleteDocument, (_e, documentId: string): void => {
+  ipcHandle(IPC.deleteDocument, (_e, documentId: string): void => {
     requireUnlocked()
     requireNotProcessing(documentId)
     requireNoActiveTask(documentId)
@@ -624,7 +626,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // "Move" is composed renderer-side as add + remove (no separate channel). Audit records
   // ids + counts ONLY — never the collection/project name (plan §17).
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.addToCollection,
     (_e, documentIds: string[], collectionId: string): void => {
       requireUnlocked()
@@ -638,7 +640,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.removeFromCollection,
     (_e, documentIds: string[], collectionId: string): void => {
       requireUnlocked()
@@ -652,7 +654,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.setDocumentLifecycle,
     (_e, documentIds: string[], lifecycle: DocumentLifecycle): DocumentInfo[] => {
       requireUnlocked()
@@ -676,7 +678,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // against racing an in-flight ingestion of the same document (it rewrites the stored
   // copy); in an encrypted workspace the transient decrypted file is shredded inside
   // the service. Nothing is written to the DB and no external viewer ever sees bytes.
-  ipcMain.handle(IPC.previewDocument, async (_e, documentId: string): Promise<DocumentPreview> => {
+  ipcHandle(IPC.previewDocument, async (_e, documentId: string): Promise<DocumentPreview> => {
     requireUnlocked()
     requireNotProcessing(documentId)
     log.info('Preview document', { documentId })
@@ -693,7 +695,7 @@ export function registerDocsIpc(ctx: AppContext): void {
 
   // FE-6: a subsequent bounded page of a preview (the modal's "Show more"). Same guards as the
   // first page; returns the slice at [offset, offset+limit) plus the next cursor.
-  ipcMain.handle(
+  ipcHandle(
     IPC.previewDocumentPage,
     async (_e, documentId: string, offset: number, limit: number): Promise<DocumentPreview> => {
       requireUnlocked()
@@ -712,7 +714,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // exportConversation pattern: dialog + fs in MAIN, never the renderer). Built for
   // materialized translations (always Markdown); any plain-text document qualifies.
   // Resolves with the saved path, or null when the user cancelled.
-  ipcMain.handle(IPC.exportDocument, async (_e, documentId: string): Promise<string | null> => {
+  ipcHandle(IPC.exportDocument, async (_e, documentId: string): Promise<string | null> => {
     requireUnlocked()
     requireNotProcessing(documentId)
     const { title, text } = await readStoredDocumentText(ctx.db, storeDir, documentId, {
@@ -755,7 +757,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // password-change re-key of the `.enc` sidecar (the import-job posture); the lease is
   // released BEFORE the dialog opens — the unbounded dialog wait must not wedge a
   // password change, and the decrypted bytes are already in memory by then.
-  ipcMain.handle(
+  ipcHandle(
     IPC.exportDocumentOriginal,
     async (_e, documentId: string): Promise<string | null> => {
       requireUnlocked()
@@ -814,7 +816,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // exportDocument pattern: dialog + fs in MAIN, never the renderer). The summary is
   // CONTENT — only the id is audited, never the text or the chosen path. Resolves with
   // the saved path, or null when the user cancelled or there is no summary.
-  ipcMain.handle(IPC.exportSummary, async (_e, documentId: string): Promise<string | null> => {
+  ipcHandle(IPC.exportSummary, async (_e, documentId: string): Promise<string | null> => {
     requireUnlocked()
     requireNotProcessing(documentId)
     const summary = getDocumentSummary(ctx.db, documentId)
@@ -873,7 +875,7 @@ export function registerDocsIpc(ctx: AppContext): void {
     return info
   }
 
-  ipcMain.handle(IPC.reindexDocument, async (_e, documentId: string): Promise<DocumentInfo> => {
+  ipcHandle(IPC.reindexDocument, async (_e, documentId: string): Promise<DocumentInfo> => {
     requireUnlocked()
     requireNotProcessing(documentId)
     requireNoActiveTask(documentId)
@@ -896,7 +898,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // running job rather than launching a second loop. The work is sequential (multi-document
   // re-embedding contends on the single embedder), so it reuses the same one-at-a-time discipline
   // as the import loop, holding ONE beginDocumentWork lease for the whole batch.
-  ipcMain.handle(IPC.startReindexAll, (_e, documentIds: string[]): ReindexJobStatus => {
+  ipcHandle(IPC.startReindexAll, (_e, documentIds: string[]): ReindexJobStatus => {
     requireUnlocked()
     if (reindexJob && !reindexJob.done) return reindexJob // idempotent while running
     const ids = safeIdArray(documentIds)
@@ -955,11 +957,11 @@ export function registerDocsIpc(ctx: AppContext): void {
     return reindexJob
   })
 
-  ipcMain.handle(IPC.getReindexAllJob, (): ReindexJobStatus | null => reindexJob)
+  ipcHandle(IPC.getReindexAllJob, (): ReindexJobStatus | null => reindexJob)
 
   // Stop the in-flight bulk re-index. Aborts at the next iteration boundary (the current document
   // finishes); no-op when nothing is running. The job then settles with `cancelled: true`.
-  ipcMain.handle(IPC.cancelReindexAll, (): void => {
+  ipcHandle(IPC.cancelReindexAll, (): void => {
     if (reindexJob && !reindexJob.done) {
       log.info('Re-index all cancel requested', { jobId: reindexJob.jobId })
       reindexAbort?.abort()

--- a/apps/desktop/src/main/ipc/registerDownloadIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDownloadIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { DownloadJob } from '../../shared/types'
@@ -19,6 +19,7 @@ import { log } from '../services/logging'
 // semantics) for manifests whose `license_review.status` is not `approved`.
 
 export function registerDownloadIpc(ctx: AppContext, manager?: DownloadManager): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // Production injects the global fetch; tests pass a manager with a fake (CI is
   // zero-network — nothing in the suite ever constructs the default). The audit hook
   // routes the manager's background started/verified/failed outcomes to the app
@@ -43,7 +44,7 @@ export function registerDownloadIpc(ctx: AppContext, manager?: DownloadManager):
     return { policyAllows: policy.network.allowModelDownloads, settingAllows }
   }
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.downloadModel,
     async (_e, modelId: string, opts?: { licenseAccepted?: boolean }): Promise<DownloadJob> => {
       if (!ctx.manifestsDir) throw new Error(tMain('main.models.noManifests'))
@@ -63,7 +64,7 @@ export function registerDownloadIpc(ctx: AppContext, manager?: DownloadManager):
     }
   )
 
-  ipcMain.handle(IPC.getDownloadJob, (_e, jobId: string): DownloadJob => downloads.get(jobId))
+  ipcHandle(IPC.getDownloadJob, (_e, jobId: string): DownloadJob => downloads.get(jobId))
 
-  ipcMain.handle(IPC.cancelDownload, (_e, jobId: string): DownloadJob => downloads.cancel(jobId))
+  ipcHandle(IPC.cancelDownload, (_e, jobId: string): DownloadJob => downloads.cancel(jobId))
 }

--- a/apps/desktop/src/main/ipc/registerEngineIpc.ts
+++ b/apps/desktop/src/main/ipc/registerEngineIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { EngineDownloadJob, EngineStatus } from '../../shared/types'
@@ -44,6 +44,7 @@ export function whisperSidecarInUse(): boolean {
 }
 
 export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManager): void {
+  const ipcHandle = guardedHandleFor(ctx)
   const engine =
     manager ?? new EngineDownloadManager({ fetchImpl: fetch, log: (m, meta) => log.info(m, meta) })
 
@@ -53,12 +54,12 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
     return { policyAllows: policy.network.allowModelDownloads, settingAllows }
   }
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.getEngineStatus,
     (): EngineStatus => engineStatus(ctx.paths.rootPath, ctx.manifestsDir ?? null)
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.downloadEngine,
     (): Promise<EngineDownloadJob> =>
       engine.start({
@@ -78,9 +79,9 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
       })
   )
 
-  ipcMain.handle(IPC.getEngineJob, (_e, jobId: string): EngineDownloadJob => engine.get(jobId))
+  ipcHandle(IPC.getEngineJob, (_e, jobId: string): EngineDownloadJob => engine.get(jobId))
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.cancelEngineDownload,
     (_e, jobId: string): EngineDownloadJob => engine.cancel(jobId)
   )

--- a/apps/desktop/src/main/ipc/registerEvidenceReviewsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerEvidenceReviewsIpc.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type {
@@ -159,6 +160,7 @@ function sanitizeLinkInput(value: unknown): EvidenceLinkInput {
 }
 
 export function registerEvidenceReviewsIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // Every handler is DB-backed; refuse with the friendly localized copy while locked
   // (ipc-lock-coverage.test.ts drives every channel here against a locked ctx).
   const requireUnlocked = (): void => {
@@ -170,7 +172,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   }
 
-  ipcMain.handle(IPC.createEvidenceReview, (_e, messageId: unknown): EvidenceReviewDetail => {
+  ipcHandle(IPC.createEvidenceReview, (_e, messageId: unknown): EvidenceReviewDetail => {
     requireUnlocked()
     const id = safeId(messageId)
     if (!id) throw new Error(tMain('main.evidenceReviews.invalidRequest'))
@@ -211,14 +213,14 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   const outdatedOverlay = (reviewId: string): boolean =>
     computeEvidenceReviewFreshness(ctx.db, reviewId)?.outdated === true
 
-  ipcMain.handle(IPC.getEvidenceReview, (_e, reviewId: unknown): EvidenceReviewDetail | null => {
+  ipcHandle(IPC.getEvidenceReview, (_e, reviewId: unknown): EvidenceReviewDetail | null => {
     requireUnlocked()
     const id = safeId(reviewId)
     const detail = id ? getEvidenceReview(ctx.db, id) : null
     return detail ? { ...detail, outdated: outdatedOverlay(detail.id) } : null
   })
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.getEvidenceReviewForMessage,
     (_e, messageId: unknown): EvidenceReviewSummary | null => {
       requireUnlocked()
@@ -234,7 +236,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // a full item-row load plus a freshness recompute, so opening a long documents-mode
   // conversation paid a serial cost proportional to its history. The derived overlay is
   // applied per review here, exactly as the single-message read does.
-  ipcMain.handle(
+  ipcHandle(
     IPC.getEvidenceReviewSummariesForConversation,
     (_e, conversationId: unknown): EvidenceReviewSummary[] => {
       requireUnlocked()
@@ -247,7 +249,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.updateEvidenceReview,
     (_e, reviewId: unknown, patch: unknown): EvidenceReview | null => {
       requireUnlocked()
@@ -256,7 +258,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.updateEvidenceReviewItem,
     (_e, itemId: unknown, patch: unknown): EvidenceReviewItem | null => {
       requireUnlocked()
@@ -270,7 +272,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // failing write) part-way through left the review HALF-swept — a state no user action can
   // produce and none can explain. Refuses (null) on an unknown id, an unrecognized action,
   // and on a READY review, matching the per-item write guard.
-  ipcMain.handle(
+  ipcHandle(
     IPC.applyEvidenceReviewBulkAction,
     (_e, reviewId: unknown, action: unknown): EvidenceReviewItem[] | null => {
       requireUnlocked()
@@ -280,7 +282,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.createEvidenceSelection,
     (_e, reviewId: unknown, input: unknown): EvidenceReviewItem | null => {
       requireUnlocked()
@@ -290,13 +292,13 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.deleteEvidenceSelection, (_e, itemId: unknown): boolean => {
+  ipcHandle(IPC.deleteEvidenceSelection, (_e, itemId: unknown): boolean => {
     requireUnlocked()
     const id = safeId(itemId)
     return id ? deleteEvidenceSelection(ctx.db, id) : false
   })
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.setEvidenceLink,
     (_e, itemId: unknown, evidenceKey: unknown, input: unknown): EvidenceReviewItem | null => {
       requireUnlocked()
@@ -306,7 +308,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.removeEvidenceLink,
     (_e, itemId: unknown, evidenceKey: unknown): boolean => {
       requireUnlocked()
@@ -316,7 +318,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.markEvidenceReviewReady,
     (_e, reviewId: unknown): { review: EvidenceReview; gate: EvidenceReadyGate } | null => {
       requireUnlocked()
@@ -337,7 +339,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.reopenEvidenceReview, (_e, reviewId: unknown): EvidenceReview | null => {
+  ipcHandle(IPC.reopenEvidenceReview, (_e, reviewId: unknown): EvidenceReview | null => {
     requireUnlocked()
     const id = safeId(reviewId)
     return id ? reopenEvidenceReview(ctx.db, id) : null
@@ -346,7 +348,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // The REAL freshness engine (Phase 4, spec §21.2): snapshot vs workspace from STORED
   // facts only — never re-hashes, never reads source files, never touches the model
   // runtime or network. Unresolved-identity sources stay 'unverifiable' (never 'changed').
-  ipcMain.handle(
+  ipcHandle(
     IPC.refreshEvidenceReviewState,
     (_e, reviewId: unknown): EvidenceReviewFreshness | null => {
       requireUnlocked()
@@ -360,7 +362,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // unchanged. Never rewrites status/completed_at/updated_at (§18.4) — deliberately NOT
   // subject to the ready-state write-guard (it is lifecycle metadata, not a decision
   // edit). No audit event: reads/acknowledge carry no spec §22 audit type.
-  ipcMain.handle(
+  ipcHandle(
     IPC.acknowledgeEvidenceReviewFreshness,
     (_e, reviewId: unknown): EvidenceReviewFreshness | null => {
       requireUnlocked()
@@ -374,7 +376,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // reads the STORED extraction (chunks table) around the persisted excerpt — no
   // renderer-supplied document ids, no paths, no source-file reads. Unknown review/key and
   // unresolved-identity sources read as null.
-  ipcMain.handle(
+  ipcHandle(
     IPC.getEvidenceSourceContext,
     (_e, reviewId: unknown, sourceKey: unknown): EvidenceSourceContext | null => {
       requireUnlocked()
@@ -384,7 +386,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.deleteEvidenceReview, (_e, reviewId: unknown): boolean => {
+  ipcHandle(IPC.deleteEvidenceReview, (_e, reviewId: unknown): boolean => {
     requireUnlocked()
     const id = safeId(reviewId)
     if (!id) return false
@@ -398,7 +400,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // D-2 (spec §25.4, plan §7.6): the conversation-delete confirm names how many reviews the
   // cascade will remove. A pure COUNT — no titles, notes, or content ever cross this channel;
   // a malformed id reads as "no reviews" (0), matching the other unknown-id results.
-  ipcMain.handle(
+  ipcHandle(
     IPC.countEvidenceReviewsForConversation,
     (_e, conversationId: unknown): number => {
       requireUnlocked()
@@ -421,7 +423,7 @@ export function registerEvidenceReviewsIpc(ctx: AppContext): void {
   // the chosen extension decides the effective one (`packFormatForDestination`). Audit
   // is {reviewId, format} ONLY: the chosen path and the review TITLE (which seeds the
   // suggested file name) are content and never recorded (sentinel-tested).
-  ipcMain.handle(
+  ipcHandle(
     IPC.exportEvidencePack,
     async (_e, reviewId: unknown, options: unknown): Promise<EvidenceExportRecord | null> => {
       requireUnlocked()

--- a/apps/desktop/src/main/ipc/registerImagesIpc.ts
+++ b/apps/desktop/src/main/ipc/registerImagesIpc.ts
@@ -2,7 +2,8 @@ import { statSync } from 'node:fs'
 import { open, type FileHandle } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { basename } from 'node:path'
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { BrowserWindow, dialog } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC, STREAM } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type {
@@ -64,6 +65,7 @@ const clampImageDim = (v: unknown): number | null =>
   typeof v === 'number' && Number.isFinite(v) && v >= 1 && v <= MAX_IMAGE_DIM ? Math.floor(v) : null
 
 export function registerImagesIpc(ctx: AppContext, service?: VisionService): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // WARNING (#119): this `??` fallback constructs a VisionService WITHOUT the
   // `isWorkspaceLocking` latch (AUD-02). Production always wires the LATCHED instance via
   // `ctx.vision` (main/index.ts), so the fallback is TEST-ONLY today — do not "simplify" the
@@ -122,9 +124,9 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
     }
   }
 
-  ipcMain.handle(IPC.imageGetStatus, (): Promise<VisionStatus> => getVisionStatus(ctx))
+  ipcHandle(IPC.imageGetStatus, (): Promise<VisionStatus> => getVisionStatus(ctx))
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.imageChooseImage,
     async (): Promise<{ token: string; name: string; sizeBytes: number } | null> => {
       // #119: chooseImage is a FILE handler and follows the module's documented invariant
@@ -165,7 +167,7 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
   // NOT a path — so it cannot make main read an arbitrary file (confused deputy, threat #1).
   // We still re-validate extension + byte cap in MAIN (SEC-3), now on the OPEN fd so the cap
   // can't be bypassed by growing the file between stat and read (TOCTOU).
-  ipcMain.handle(IPC.imageReadBytes, async (_e, token: unknown): Promise<Uint8Array> => {
+  ipcHandle(IPC.imageReadBytes, async (_e, token: unknown): Promise<Uint8Array> => {
     requireUnlocked()
     const path = consumeImageToken(token)
     if (path === null || !isSupportedImagePath(path)) {
@@ -207,7 +209,7 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
   const errCode = (err: unknown): string | undefined =>
     err instanceof Error ? ((err as NodeJS.ErrnoException).code ?? err.name) : undefined
 
-  ipcMain.handle(IPC.imageAnalyze, (event, req: ImageAnalyzeRequest): ImageJob => {
+  ipcHandle(IPC.imageAnalyze, (event, req: ImageAnalyzeRequest): ImageJob => {
     requireUnlocked()
 
     // History persistence (image-understanding history): a NEW image (no sessionId) stores the
@@ -291,23 +293,23 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
   // Gated on unlock (MEDIUM vuln-scan-2026-06-21), consistent with imageAnalyze and the history
   // handlers: a job (and its answer) is workspace-scoped, so it must not be reachable once the
   // vault is locked. (stop() also clears the job map at lock, so there is nothing to return.)
-  ipcMain.handle(IPC.imageGetJob, (_e, jobId: unknown): ImageJob => {
+  ipcHandle(IPC.imageGetJob, (_e, jobId: unknown): ImageJob => {
     requireUnlocked()
     return vision.getJob(typeof jobId === 'string' ? jobId : '')
   })
 
-  ipcMain.handle(IPC.imageCancel, (_e, jobId: unknown): ImageJob => {
+  ipcHandle(IPC.imageCancel, (_e, jobId: unknown): ImageJob => {
     requireUnlocked()
     return vision.cancel(typeof jobId === 'string' ? jobId : '')
   })
 
   // --- Image-analysis history (local-only, encrypted at rest, user-deletable) ---
-  ipcMain.handle(IPC.imageListSessions, (): ImageSessionSummary[] => {
+  ipcHandle(IPC.imageListSessions, (): ImageSessionSummary[] => {
     requireUnlocked()
     return listImageSessions(ctx.db)
   })
 
-  ipcMain.handle(IPC.imageGetSession, (_e, id: unknown): Promise<ImageSessionDetail | null> => {
+  ipcHandle(IPC.imageGetSession, (_e, id: unknown): Promise<ImageSessionDetail | null> => {
     requireUnlocked()
     if (typeof id !== 'string') return Promise.resolve(null)
     // ASYNC (audit 2026-07-16 F-12): decrypt+read off the main thread.
@@ -319,7 +321,7 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
     )
   })
 
-  ipcMain.handle(IPC.imageDeleteSession, async (_e, id: unknown): Promise<void> => {
+  ipcHandle(IPC.imageDeleteSession, async (_e, id: unknown): Promise<void> => {
     requireUnlocked()
     // ASYNC (audit 2026-07-16 F-12): the post-commit shred runs off the main thread.
     if (typeof id === 'string') await deleteImageSession(ctx.db, imagesDir(ctx.paths.workspacePath), id)
@@ -328,7 +330,7 @@ export function registerImagesIpc(ctx: AppContext, service?: VisionService): voi
   // #122: the bulk "Clear image history" action — one transactional row sweep, post-commit
   // best-effort shreds (REL-5 ordering preserved; see clearImageSessions). Gated like its
   // history siblings.
-  ipcMain.handle(IPC.imageClearSessions, async (): Promise<number> => {
+  ipcHandle(IPC.imageClearSessions, async (): Promise<number> => {
     requireUnlocked()
     return clearImageSessions(ctx.db, imagesDir(ctx.paths.workspacePath))
   })

--- a/apps/desktop/src/main/ipc/registerLocalApiIpc.ts
+++ b/apps/desktop/src/main/ipc/registerLocalApiIpc.ts
@@ -1,4 +1,5 @@
-import { ipcMain, clipboard } from 'electron'
+import { clipboard } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import { workspaceAdmitsWork } from '../services/workspace-vault'
@@ -20,6 +21,7 @@ import { getSettings } from '../services/settings'
 const CLIPBOARD_CLEAR_MS = 60_000
 
 export function registerLocalApiIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // AUD-02: the token store lives in the workspace DB, so every handler here needs the
   // admits-work predicate (unlocked ∧ not locking), never a bare isUnlocked().
   const requireUnlocked = (): void => {
@@ -34,7 +36,7 @@ export function registerLocalApiIpc(ctx: AppContext): void {
     return getSettings(ctx.db).localApiPort ?? DEFAULT_SETTINGS.localApiPort
   }
 
-  ipcMain.handle(IPC.localApiConnectionInfo, (): LocalApiConnectionInfo => {
+  ipcHandle(IPC.localApiConnectionInfo, (): LocalApiConnectionInfo => {
     requireUnlocked()
     const settings = getSettings(ctx.db)
     // Mint on demand only when a key is actually required; with auth off we show the
@@ -46,7 +48,7 @@ export function registerLocalApiIpc(ctx: AppContext): void {
     }
   })
 
-  ipcMain.handle(IPC.localApiCopyKey, (): boolean => {
+  ipcHandle(IPC.localApiCopyKey, (): boolean => {
     requireUnlocked()
     try {
       const token = getOrCreateToken(ctx.db)
@@ -66,7 +68,7 @@ export function registerLocalApiIpc(ctx: AppContext): void {
     }
   })
 
-  ipcMain.handle(IPC.localApiRegenerateToken, (): LocalApiConnectionInfo => {
+  ipcHandle(IPC.localApiRegenerateToken, (): LocalApiConnectionInfo => {
     requireUnlocked()
     const token = rotateToken(ctx.db)
     // The old key is dead the instant rotateToken returns — but auth is checked ONCE at

--- a/apps/desktop/src/main/ipc/registerModelIpc.ts
+++ b/apps/desktop/src/main/ipc/registerModelIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { statSync } from 'node:fs'
 import { EVENTS, IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
@@ -312,6 +312,7 @@ export function maybeAutoStartActiveModel(ctx: AppContext): void {
 }
 
 export function registerModelIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // #108: persistence is a property of RECORDING — the observer fires on every sample
   // (including one from a background download's cold-file hash, which has no model IPC
   // afterwards to piggyback on). The explicit persistEffectiveRead calls after
@@ -330,7 +331,7 @@ export function registerModelIpc(ctx: AppContext): void {
     if (!workspaceAdmitsWork(ctx.workspace)) throw new Error(tMain('main.models.locked'))
   }
 
-  ipcMain.handle(IPC.listModels, async (event, lazyVerify?: boolean): Promise<ModelInfo[]> => {
+  ipcHandle(IPC.listModels, async (event, lazyVerify?: boolean): Promise<ModelInfo[]> => {
     requireUnlocked()
     if (!ctx.manifestsDir) {
       log.warn('No model-manifests directory found; returning empty model list')
@@ -374,7 +375,7 @@ export function registerModelIpc(ctx: AppContext): void {
     return models
   })
 
-  ipcMain.handle(IPC.selectModel, (_e, modelId: string) => {
+  ipcHandle(IPC.selectModel, (_e, modelId: string) => {
     requireUnlocked()
     if (!ctx.manifestsDir) throw new Error(tMain('main.models.noManifests'))
     log.info('Select model', { modelId })
@@ -386,7 +387,7 @@ export function registerModelIpc(ctx: AppContext): void {
   // Forced re-verify (the "Verify checksum" button): drop the cached hash for this
   // model's weight file and re-hash it for real. `listModels` alone would read the
   // cache back and confirm nothing.
-  ipcMain.handle(IPC.verifyModel, async (_e, modelId: string): Promise<ModelState> => {
+  ipcHandle(IPC.verifyModel, async (_e, modelId: string): Promise<ModelState> => {
     requireUnlocked()
     if (!ctx.manifestsDir) throw new Error(tMain('main.models.noManifests'))
     const { manifests } = discoverManifests(ctx.manifestsDir)
@@ -410,7 +411,7 @@ export function registerModelIpc(ctx: AppContext): void {
     return state
   })
 
-  ipcMain.handle(IPC.startRuntime, (_e, modelId: string): Promise<RuntimeStatus> => {
+  ipcHandle(IPC.startRuntime, (_e, modelId: string): Promise<RuntimeStatus> => {
     requireUnlocked()
     // Starting/switching the runtime tears down the current llama-server. A yielding
     // deep-index build holds that slot and is pinned to the current model (M12) — abort it
@@ -428,7 +429,7 @@ export function registerModelIpc(ctx: AppContext): void {
   // chatting; collapsing them removes the ambiguity. Selected models already auto-start at launch,
   // and chat-send never auto-starts (registerChatIpc contract), so the merged action MUST start the
   // runtime — a select alone would still leave the runtime down mid-session.
-  ipcMain.handle(IPC.useModel, async (_e, modelId: string): Promise<RuntimeStatus> => {
+  ipcHandle(IPC.useModel, async (_e, modelId: string): Promise<RuntimeStatus> => {
     requireUnlocked()
     if (!ctx.manifestsDir) throw new Error(tMain('main.models.noManifests'))
     // Reject a non-chat role BEFORE any persist (mirrors startModelRuntime's guard): an automatic
@@ -457,7 +458,7 @@ export function registerModelIpc(ctx: AppContext): void {
     return startModelRuntime(ctx, modelId)
   })
 
-  ipcMain.handle(IPC.stopRuntime, async (): Promise<void> => {
+  ipcHandle(IPC.stopRuntime, async (): Promise<void> => {
     log.info('Stop runtime')
     const modelId = ctx.runtime.activeModelId()
     ctx.docTasks?.abortActiveBuild()
@@ -472,7 +473,7 @@ export function registerModelIpc(ctx: AppContext): void {
   // so the Chat composer knows whether to offer the Deep answer mode. Manifest reads
   // happen only while a runtime is actually running (the ChatScreen's not-running
   // poll stays I/O-free), and a read failure just leaves the flag absent.
-  ipcMain.handle(IPC.getRuntimeStatus, (): RuntimeStatus => {
+  ipcHandle(IPC.getRuntimeStatus, (): RuntimeStatus => {
     const status = ctx.runtime.status()
     if (status.running && status.modelId && ctx.manifestsDir) {
       try {
@@ -519,7 +520,7 @@ export function registerModelIpc(ctx: AppContext): void {
 
   // Which sidecar build the drive carries (the .hilbertraum-runtime.json install marker) —
   // the Diagnostics "runtime build" line. Null on unmarked/DIY drives.
-  ipcMain.handle(
+  ipcHandle(
     IPC.getRuntimeInstall,
     (): RuntimeInstallInfo | null => readRuntimeMarker(llamaServerDir(ctx.paths.rootPath))
   )

--- a/apps/desktop/src/main/ipc/registerRagIpc.ts
+++ b/apps/desktop/src/main/ipc/registerRagIpc.ts
@@ -1,4 +1,5 @@
-import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { type IpcMainInvokeEvent } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC, STREAM } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import {
@@ -120,6 +121,7 @@ function readyTreeCountInScope(db: Db, scope: RetrievalScope): number {
 // the "start a model" empty state.
 
 export function registerRagIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   // The FAITHFUL content reach a tool-skill analysis handler needs (full-doc-skills §3.2): a
   // document's ordered, non-overlapping, newline-preserving parser segments, re-extracted from the
   // stored copy — the SAME reader the skills-run IPC injects (`documentSegments.ts`), so the chat
@@ -128,7 +130,7 @@ export function registerRagIpc(ctx: AppContext): void {
   // rows. Content stays main-side: only the tool ever sees it.
   const readDocumentSegments = buildDocumentSegmentReader(ctx)
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.askDocuments,
     async (
       event: IpcMainInvokeEvent,

--- a/apps/desktop/src/main/ipc/registerSkillsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerSkillsIpc.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { writeFile } from 'node:fs/promises'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
@@ -59,6 +60,7 @@ import {
 // payload. Both invariants are covered by the sentinel-grep test.
 
 export function registerSkillsIpc(ctx: AppContext): void {
+  const ipcHandle = guardedHandleFor(ctx)
   const requireUnlocked = (): void => {
     // AUD-02: `workspaceAdmitsWork`, never a bare `isUnlocked()` — the workspace DB stays
     // OPEN for the whole multi-second lock teardown, so a bare check admits work that then
@@ -156,7 +158,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
     appVersion
   })
 
-  ipcMain.handle(IPC.listSkills, (): SkillInfo[] => {
+  ipcHandle(IPC.listSkills, (): SkillInfo[] => {
     requireUnlocked()
     // ctx.skills.list() reconciles disk→DB once per session on first read (the ratified
     // post-unlock lazy reconcile); project each row to SkillInfo with its duplicate-id flag.
@@ -167,7 +169,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
     return records.map((r) => recordToInfo(r, (idCounts.get(r.id) ?? 0) > 1, appVersion))
   })
 
-  ipcMain.handle(IPC.getSkill, (_e, installId: string): SkillInfo | null => {
+  ipcHandle(IPC.getSkill, (_e, installId: string): SkillInfo | null => {
     requireUnlocked()
     const record = ctx.skills!.get(installId)
     return record ? skillInfo(ctx.db, record, appVersion) : null
@@ -177,7 +179,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // resolved MAIN-side from the conversationId (§22-C4); the draft `question` is content and is
   // scored but NEVER logged or audited (reads aren't audited). Returns at most one OFFER — the
   // picker pins it and the user taps to accept; nothing is applied here.
-  ipcMain.handle(
+  ipcHandle(
     IPC.suggestSkills,
     (_e, conversationId: string, question?: string): SkillSuggestion[] => {
       requireUnlocked()
@@ -208,7 +210,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // precedent; renderer has no dialog access). Windows can't mix file+dir in one dialog, so the
   // caller chooses a mode. Returns `{ token, path }` (the path is renderer display only) or null
   // (cancelled). Unlock-gated like every consumer: no dialog opens while locked (#240).
-  ipcMain.handle(IPC.pickSkillPackage, async (_e, mode?: 'file' | 'folder'): Promise<SkillPickResult | null> => {
+  ipcHandle(IPC.pickSkillPackage, async (_e, mode?: 'file' | 'folder'): Promise<SkillPickResult | null> => {
     requireUnlocked()
     const options =
       mode === 'folder'
@@ -231,7 +233,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // Validate an import source FULLY in a transient dir, WITHOUT writing (OQ-2). Never throws on a
   // bad package — returns `ok: false` with structural reasons so the renderer can show them. The
   // one throw is a non-token argument (#240): that is not a package problem, so it is refused.
-  ipcMain.handle(IPC.previewSkillPackage, (_e, token: string): SkillPreview => {
+  ipcHandle(IPC.previewSkillPackage, (_e, token: string): SkillPreview => {
     requireUnlocked()
     const source = requirePickedSource(token, /* spend */ false)
     return previewSkillPackage(ctx.db, source, installerDeps(), { developerMode: developerMode() })
@@ -239,7 +241,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
 
   // Validate → unzip/copy into user-skills/<id>/ → install enabled-with-warning (DS7). A failed
   // import persists nothing (the staging dir is deleted). Throws a friendly structural reason.
-  ipcMain.handle(IPC.importSkill, (_e, token: string): SkillInfo => {
+  ipcHandle(IPC.importSkill, (_e, token: string): SkillInfo => {
     requireUnlocked()
     const source = requirePickedSource(token, /* spend */ true)
     try {
@@ -271,7 +273,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   })
 
   // Export a skill as a `.skill.zip` (package tree only — §9.5). Save dialog runs in MAIN.
-  ipcMain.handle(IPC.exportSkill, async (_e, installId: string): Promise<string | null> => {
+  ipcHandle(IPC.exportSkill, async (_e, installId: string): Promise<string | null> => {
     requireUnlocked()
     const record = ctx.skills!.get(installId)
     if (!record) throw new Error(SKILL_IMPORT_ERRORS.notFound)
@@ -290,7 +292,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
     return result.filePath
   })
 
-  ipcMain.handle(IPC.deleteSkill, (_e, installId: string): void => {
+  ipcHandle(IPC.deleteSkill, (_e, installId: string): void => {
     requireUnlocked()
     const record = ctx.skills!.get(installId)
     if (!record) return
@@ -305,7 +307,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // Enable a skill, enforcing one-active-per-id (DS12): enabling X disables every other installed
   // skill sharing its declared id. Deterministic + server-guaranteed (the S5 UI surfaces it as an
   // "offer to disable the other"). Returns the updated SkillInfo.
-  ipcMain.handle(IPC.enableSkill, (_e, installId: string): SkillInfo => {
+  ipcHandle(IPC.enableSkill, (_e, installId: string): SkillInfo => {
     requireUnlocked()
     const record = getSkill(ctx.db, installId)
     if (!record) throw new Error(SKILL_IMPORT_ERRORS.notFound)
@@ -323,7 +325,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
     return skillInfo(ctx.db, updated, appVersion)
   })
 
-  ipcMain.handle(IPC.disableSkill, (_e, installId: string): SkillInfo => {
+  ipcHandle(IPC.disableSkill, (_e, installId: string): SkillInfo => {
     requireUnlocked()
     const record = getSkill(ctx.db, installId)
     if (!record) throw new Error(SKILL_IMPORT_ERRORS.notFound)
@@ -338,7 +340,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // simply never appeared (no toast, no log, no badge). COUNTS + fixed reason codes only, NEVER a
   // folder name or package content (§22-M1; an invalid folder name is arbitrary user text). The
   // `list()` call first ensures the lazy post-unlock reconcile has actually run this session.
-  ipcMain.handle(IPC.skillReconcileStatus, () => {
+  ipcHandle(IPC.skillReconcileStatus, () => {
     requireUnlocked()
     ctx.skills!.list()
     return ctx.skills!.reconcileStatus()
@@ -346,7 +348,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
 
   // Acknowledge a user skill's import warning (DS7) — clears the persistent "review what it can do"
   // state. App skills are pre-acknowledged; this is a no-op for them.
-  ipcMain.handle(IPC.acknowledgeSkillWarning, (_e, installId: string): SkillInfo => {
+  ipcHandle(IPC.acknowledgeSkillWarning, (_e, installId: string): SkillInfo => {
     requireUnlocked()
     const record = getSkill(ctx.db, installId)
     if (!record) throw new Error(SKILL_IMPORT_ERRORS.notFound)
@@ -368,7 +370,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // tools). Drives the calm transcript run affordance + its target name/chooser. The ids are
   // content-free (the §6 ids/counts posture); the renderer maps them to NAMES from its own loaded
   // document list, so a title never crosses this boundary.
-  ipcMain.handle(
+  ipcHandle(
     IPC.listRunnableTools,
     (_e, skillInstallId: string, conversationId: string): RunnableToolSet => {
       requireUnlocked()
@@ -388,7 +390,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
 
   // Start a run. Resolves the document scope MAIN-side, confirm-gates write/export tools, and hands a
   // content-free runner to the controller. Returns ids/counts only (never the extracted rows).
-  ipcMain.handle(IPC.startSkillRun, (_e, req: StartSkillRunRequest): StartSkillRunResult => {
+  ipcHandle(IPC.startSkillRun, (_e, req: StartSkillRunRequest): StartSkillRunResult => {
     requireUnlocked()
     const skillInstallId = typeof req?.skillInstallId === 'string' ? req.skillInstallId : ''
     const toolName = typeof req?.toolName === 'string' ? req.toolName : ''
@@ -530,7 +532,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
     }
   })
 
-  ipcMain.handle(IPC.getSkillRun, (_e, runHandle: string): SkillRunState | null => {
+  ipcHandle(IPC.getSkillRun, (_e, runHandle: string): SkillRunState | null => {
     requireUnlocked()
     return runController.get(typeof runHandle === 'string' ? runHandle : '')
   })
@@ -538,7 +540,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // All runs main currently holds (running + terminal-unacknowledged), ids/counts only — a freshly
   // reloaded renderer re-adopts them so an in-flight run keeps its bar and a finished run's outcome is
   // still shown/acknowledgeable (SKA-17; the `listActiveStreamConversations` precedent for skill runs).
-  ipcMain.handle(IPC.listSkillRuns, (): SkillRunState[] => {
+  ipcHandle(IPC.listSkillRuns, (): SkillRunState[] => {
     requireUnlocked()
     return runController.list()
   })
@@ -546,7 +548,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // Cancel a run by handle. SKA-25: a NON-EMPTY handle is REQUIRED at the IPC boundary — the no-arg
   // cancel-all (a pre-A2 relic that aborted every in-flight run across all documents/windows) is now
   // internal/test-only. An empty/absent handle is refused (no-op) rather than blasting every run.
-  ipcMain.handle(IPC.cancelSkillRun, (_e, runHandle?: string | null): void => {
+  ipcHandle(IPC.cancelSkillRun, (_e, runHandle?: string | null): void => {
     requireUnlocked()
     if (typeof runHandle !== 'string' || runHandle.length === 0) return
     runController.cancel(runHandle)
@@ -555,7 +557,7 @@ export function registerSkillsIpc(ctx: AppContext): void {
   // Drop a terminal run once the renderer has shown its outcome (the acknowledge handshake — the
   // controller keeps a terminal run readable until this clears it). No-op on a still-running handle.
   // SKA-25: a non-empty handle is required here too (the no-arg clear-all stays internal/test-only).
-  ipcMain.handle(IPC.clearSkillRun, (_e, runHandle?: string | null): void => {
+  ipcHandle(IPC.clearSkillRun, (_e, runHandle?: string | null): void => {
     requireUnlocked()
     if (typeof runHandle !== 'string' || runHandle.length === 0) return
     runController.clear(runHandle)

--- a/apps/desktop/src/main/ipc/registerTranslateIpc.ts
+++ b/apps/desktop/src/main/ipc/registerTranslateIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC, STREAM } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { TranslateJob, TranslateRequest } from '../../shared/types'
@@ -15,6 +15,7 @@ import { workspaceAdmitsWork } from '../services/workspace-vault'
 // service logs ids/kinds only.
 
 export function registerTranslateIpc(ctx: AppContext, service?: TranslateJobService): void {
+  const ipcHandle = guardedHandleFor(ctx)
   const jobs =
     service ??
     new TranslateJobService({
@@ -64,7 +65,7 @@ export function registerTranslateIpc(ctx: AppContext, service?: TranslateJobServ
     }
   }
 
-  ipcMain.handle(IPC.translateStart, (event, req: TranslateRequest): TranslateJob => {
+  ipcHandle(IPC.translateStart, (event, req: TranslateRequest): TranslateJob => {
     requireUnlocked()
     // L3: the stream events (trToken/trDone/trError) are bound to THIS sender for the job's life.
     // The app is multi-window: if the starting window is destroyed, those events would drop
@@ -118,7 +119,7 @@ export function registerTranslateIpc(ctx: AppContext, service?: TranslateJobServ
     return job
   })
 
-  ipcMain.handle(IPC.translateCancel, (_e, jobId: unknown): TranslateJob => {
+  ipcHandle(IPC.translateCancel, (_e, jobId: unknown): TranslateJob => {
     const id = typeof jobId === 'string' ? jobId : ''
     const result = jobs.cancel(id)
     // The cancel terminal emits nothing, so detach the destroyed listener here (F-4).
@@ -129,5 +130,5 @@ export function registerTranslateIpc(ctx: AppContext, service?: TranslateJobServ
   // Remount recovery (the chat `getActiveStream` precedent): a Translate screen that mounts fresh
   // after a full renderer reload has lost its module store — this returns the still-running job
   // (accumulated text + window progress) so it can re-adopt and re-subscribe. Null when idle.
-  ipcMain.handle(IPC.translateGetActive, (): TranslateJob | null => jobs.getActiveJob())
+  ipcHandle(IPC.translateGetActive, (): TranslateJob | null => jobs.getActiveJob())
 }

--- a/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
+++ b/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import {
@@ -111,9 +111,10 @@ async function settleAndSweepPlaintextOps(ctx: AppContext): Promise<void> {
 }
 
 export function registerWorkspaceIpc(ctx: AppContext): void {
-  ipcMain.handle(IPC.getWorkspaceState, (): WorkspaceStateInfo => ctx.workspace.getState())
+  const ipcHandle = guardedHandleFor(ctx)
+  ipcHandle(IPC.getWorkspaceState, (): WorkspaceStateInfo => ctx.workspace.getState())
 
-  ipcMain.handle(IPC.unlockWorkspace, (_e, password: string): WorkspaceActionResult => {
+  ipcHandle(IPC.unlockWorkspace, (_e, password: string): WorkspaceActionResult => {
     // The renderer is the untrusted boundary in Electron (M-S2): args are TS-typed but
     // arrive unvalidated. A non-string password would throw deep in the vault; reject it
     // here as a clean wrong-password result instead.
@@ -193,7 +194,7 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
     }
   })
 
-  ipcMain.handle(
+  ipcHandle(
     IPC.createWorkspace,
     (_e, password: string, mode: WorkspaceMode): WorkspaceActionResult => {
       // M-S2: validate the renderer-supplied shapes FIRST. `password.length` used to be
@@ -252,7 +253,7 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
   // new event, never the password). On a legacy v1 vault the first change runs the
   // one-time journaled migration to the v2 envelope — it can take a while on a big
   // document corpus, so the renderer shows honest progress copy while this resolves.
-  ipcMain.handle(
+  ipcHandle(
     IPC.changeWorkspacePassword,
     (_e, currentPassword: string, nextPassword: string): WorkspaceActionResult => {
       // M-S2: a non-string current password would throw in the vault verifier — treat it
@@ -315,7 +316,7 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
     }
   )
 
-  ipcMain.handle(IPC.lockWorkspace, async (): Promise<WorkspaceStateInfo> => {
+  ipcHandle(IPC.lockWorkspace, async (): Promise<WorkspaceStateInfo> => {
     // AUD-02 — arm the lock latch FIRST, before any await. Everything below this line is an
     // awaited teardown that can take seconds (sidecar suspends, stream settles, the doc-task
     // settle), and an async ipcMain handler yields the main thread at every one of those awaits,

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -12,6 +12,7 @@ import type { AuditRecorder } from './audit'
 import type { DocTaskManager } from './doctasks'
 import type { SkillRegistry } from './skills/registry'
 import type { VisionService } from './vision'
+import type { TrustedSenders } from '../ipc/guarded-handle'
 import type { TranslateJobService } from './translation/jobs'
 import type { LocalApiServer } from './local-api/server'
 import type { PlaintextOpsRegistry } from './ingestion/plaintext-ops'
@@ -19,6 +20,12 @@ import type { PlaintextOpsRegistry } from './ingestion/plaintext-ops'
 // Shared application context assembled at startup and passed to IPC handlers.
 export interface AppContext {
   paths: ResolvedPaths
+  /**
+   * WebContents ids allowed to invoke `ipcMain.handle` channels (#252): the main window's,
+   * added in `createWindow`. Every registrar registers through `guardedHandleFor(ctx)`;
+   * the fake test harness passes the permissive `ANY_SENDER`.
+   */
+  trustedSenders: TrustedSenders
   /**
    * The live workspace database. Backed by a getter over `workspace`: in
    * `plaintext_dev` mode it is open from startup; in `encrypted` mode it throws until

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -23,7 +23,7 @@ export interface AppContext {
   /**
    * WebContents ids allowed to invoke `ipcMain.handle` channels (#252): the main window's,
    * added in `createWindow`. Every registrar registers through `guardedHandleFor(ctx)`;
-   * the fake test harness passes the permissive `ANY_SENDER`.
+   * the fake test harness passes its permissive set (never used in production).
    */
   trustedSenders: TrustedSenders
   /**

--- a/apps/desktop/tests/helpers/ipc.ts
+++ b/apps/desktop/tests/helpers/ipc.ts
@@ -9,6 +9,11 @@ import { EventEmitter } from 'node:events'
 // exercises the REAL handler glue (guards, the in-flight concurrency map, error→result
 // mapping, the streaming sender) without Electron — only the IPC transport is faked.
 
+// Every registrar registers through `guardedHandle` (#252), which checks `event.sender.id`
+// against the context's trusted set; fake contexts pass `ANY_SENDER` so the harness stays
+// permissive, and `makeEvent(senderId)` builds a sender with an id for the guard's own tests.
+export { ANY_SENDER } from '../../src/main/ipc/guarded-handle'
+
 export type IpcHandler = (event: FakeIpcEvent, ...args: unknown[]) => unknown
 export type IpcHandlers = Map<string, IpcHandler>
 
@@ -16,6 +21,8 @@ export type IpcHandlers = Map<string, IpcHandler>
  *  is EventEmitter-backed so handlers can wire the WebContents `'destroyed'` lifecycle (L3). */
 export interface FakeIpcEvent {
   sender: {
+    /** WebContents id; absent by default (the permissive harness never reads it). */
+    id?: number
     send: ReturnType<typeof vi.fn>
     isDestroyed: () => boolean
     once: (event: string, listener: (...args: unknown[]) => void) => void
@@ -27,10 +34,11 @@ export interface FakeIpcEvent {
   }
 }
 
-export function makeEvent(): FakeIpcEvent {
+export function makeEvent(senderId?: number): FakeIpcEvent {
   const emitter = new EventEmitter()
   let destroyed = false
   const sender = {
+    ...(senderId === undefined ? {} : { id: senderId }),
     send: vi.fn(),
     isDestroyed: () => destroyed,
     once: (event: string, listener: (...args: unknown[]) => void): void => {

--- a/apps/desktop/tests/integration/audit-ipc.test.ts
+++ b/apps/desktop/tests/integration/audit-ipc.test.ts
@@ -73,7 +73,7 @@ import type {
   Message,
   WorkspaceActionResult
 } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -189,6 +189,7 @@ function makeHarness(): Harness {
   const audit = createAuditRecorder(() => db)
   const runtime = echoRuntime()
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath, workspacePath, configPath },
     db,
     workspace: {
@@ -683,6 +684,7 @@ describe('workspace audit events (buffered while locked, flushed after unlock)',
     ctrl.init()
 
     const ctx = {
+      trustedSenders: ANY_SENDER,
       workspace: ctrl,
       runtime: { stop: async () => {}, active: () => null, activeModelId: () => null },
       embedder: { stop: async () => {} },
@@ -718,6 +720,7 @@ describe('workspace audit events (buffered while locked, flushed after unlock)',
     const ctrl = new WorkspaceController(vault, DEFAULT_POLICY, false)
     ctrl.init()
     const ctx = {
+      trustedSenders: ANY_SENDER,
       workspace: ctrl,
       runtime: { stop: async () => {}, active: () => null, activeModelId: () => null },
       embedder: { stop: async () => {} },

--- a/apps/desktop/tests/integration/chat-compaction-ipc.test.ts
+++ b/apps/desktop/tests/integration/chat-compaction-ipc.test.ts
@@ -25,7 +25,7 @@ import { appendMessage, createConversation } from '../../src/main/services/chat'
 import { selfSummaryPrompt } from '../../src/main/services/chat/compaction'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -49,6 +49,7 @@ function compactingRuntime(window: number): ModelRuntime {
 
 function makeCtx(db: Db, runtime: ModelRuntime): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     db,
     workspace: { isUnlocked: () => true },
     runtime: { active: () => runtime, activeModelId: () => runtime.modelId }

--- a/apps/desktop/tests/integration/chat-ipc.test.ts
+++ b/apps/desktop/tests/integration/chat-ipc.test.ts
@@ -46,7 +46,7 @@ import type { TableSpec } from '../../src/main/services/tables'
 import { createMockEmbedder } from '../../src/main/services/embeddings/mock'
 import type { ModelRuntime, RuntimeChatOptions, ChatMessage } from '../../src/main/services/runtime'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -91,6 +91,7 @@ function throwingRuntime(): ModelRuntime {
 
 function makeCtx(db: Db, runtime: ModelRuntime | null, unlocked = true): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     db,
     workspace: { isUnlocked: () => unlocked },
     runtime: { active: () => runtime, activeModelId: () => runtime?.modelId ?? null }
@@ -181,6 +182,7 @@ describe('registerChatIpc', () => {
     linkConversationDocument(db, conv.id, 'att-1')
 
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       workspace: { isUnlocked: () => true },
       embedder: createMockEmbedder(),
@@ -265,6 +267,7 @@ describe('registerChatIpc', () => {
     linkConversationDocument(db, conv.id, 'att-a')
     linkConversationDocument(db, conv.id, 'att-b')
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       workspace: { isUnlocked: () => true },
       embedder: { id: 'active-model' },
@@ -570,7 +573,10 @@ describe('locked-vault guard coverage (TEST-N8)', () => {
   })
 
   it('the benchmark handlers refuse when locked (SEC-N2 parity)', async () => {
-    registerBenchmarkIpc({ workspace: { isUnlocked: () => false } } as unknown as AppContext)
+    registerBenchmarkIpc({
+      trustedSenders: ANY_SENDER,
+      workspace: { isUnlocked: () => false }
+    } as unknown as AppContext)
     await expect(invoke(handlers, IPC.runBenchmark)).rejects.toThrow('Workspace is locked. Unlock it to run the benchmark.')
     await expect(invoke(handlers, IPC.tryGpuAgain)).rejects.toThrow('Workspace is locked. Unlock it to run the benchmark.')
     await expect(invoke(handlers, IPC.runBenchmark)).rejects.not.toThrow(/unlock it first/i)
@@ -586,6 +592,7 @@ describe('chat export handlers (T-8)', () => {
   function ctxWithAudit(db: Db): { ctx: AppContext; audit: ReturnType<typeof vi.fn> } {
     const audit = vi.fn()
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       workspace: { isUnlocked: () => true },
       runtime: { active: () => null, activeModelId: () => null },

--- a/apps/desktop/tests/integration/collections-ipc.test.ts
+++ b/apps/desktop/tests/integration/collections-ipc.test.ts
@@ -32,7 +32,7 @@ import { createMockEmbedder } from '../../src/main/services/embeddings/mock'
 import type { ModelRuntime, ChatMessage } from '../../src/main/services/runtime'
 import type { AppContext } from '../../src/main/services/context'
 import type { Collection, Conversation, DocumentInfo, ImportJob, ImportJobStatus, Message } from '../../src/shared/types'
-import { invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
 import { inFlightStreams } from '../../src/main/ipc/inflight'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
@@ -63,6 +63,7 @@ function makeHarness(): Harness {
   seedSettings(db)
   const runtime = echoRuntime()
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath, workspacePath },
     db,
     workspace: {

--- a/apps/desktop/tests/integration/conversation-search.test.ts
+++ b/apps/desktop/tests/integration/conversation-search.test.ts
@@ -32,7 +32,7 @@ import { registerChatIpc } from '../../src/main/ipc/registerChatIpc'
 import { IPC } from '../../src/shared/ipc'
 import { SEARCH_MARK_END, SEARCH_MARK_START } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -344,6 +344,7 @@ describe('chat:search IPC', () => {
     appendMessage(db, { conversationId: conv.id, role: 'user', content: 'what is the liability cap?' })
     const audit = createAuditRecorder(() => db)
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       workspace: { isUnlocked: () => true },
       runtime: { active: () => null, activeModelId: () => null },

--- a/apps/desktop/tests/integration/core-model-ipc.test.ts
+++ b/apps/desktop/tests/integration/core-model-ipc.test.ts
@@ -55,7 +55,7 @@ import { getSettings, seedSettings, updateSettings } from '../../src/main/servic
 import type { AppSettings, AppStatus, ModelInfo, WorkspaceStateInfo } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
 import { t } from '../../src/shared/i18n'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const REPO_MANIFESTS = join(process.cwd(), '..', '..', 'model-manifests')
@@ -88,6 +88,7 @@ describe('registerCoreIpc', () => {
       })
     }
     const ctx = {
+      trustedSenders: ANY_SENDER,
       paths: { configPath: bogusConfigDir() },
       workspace: lockedWorkspace
     } as unknown as AppContext
@@ -123,6 +124,7 @@ describe('registerCoreIpc', () => {
     }
     const statusWith = async (ocrEngine: unknown): Promise<AppStatus> => {
       const ctx = {
+        trustedSenders: ANY_SENDER,
         paths: { configPath: bogusConfigDir() },
         workspace: lockedWorkspace,
         ocrEngine
@@ -163,6 +165,7 @@ describe('registerCoreIpc', () => {
       })
     }
     const ctx = {
+      trustedSenders: ANY_SENDER,
       paths: { configPath: bogusConfigDir() },
       workspace: lockedWorkspace,
       // The Translator seam's OPTIONAL deviceStatus (a fake without it reads as null via `?.`).
@@ -180,7 +183,11 @@ describe('registerCoreIpc', () => {
   })
 
   it('writeClipboard writes text via the MAIN clipboard module and reports success', async () => {
-    const ctx = { paths: {}, workspace: { isUnlocked: () => false } } as unknown as AppContext
+    const ctx = {
+      trustedSenders: ANY_SENDER,
+      paths: {},
+      workspace: { isUnlocked: () => false }
+    } as unknown as AppContext
     registerCoreIpc(ctx)
 
     const { result } = await invoke(handlers, IPC.writeClipboard, 'copy me')
@@ -189,7 +196,11 @@ describe('registerCoreIpc', () => {
   })
 
   it('writeClipboard returns false (never throws) when the clipboard write fails', async () => {
-    const ctx = { paths: {}, workspace: { isUnlocked: () => false } } as unknown as AppContext
+    const ctx = {
+      trustedSenders: ANY_SENDER,
+      paths: {},
+      workspace: { isUnlocked: () => false }
+    } as unknown as AppContext
     registerCoreIpc(ctx)
     ipcState.clipboardThrows = true
 
@@ -202,6 +213,7 @@ describe('registerCoreIpc', () => {
   // shapes silently no-oped. All must reject with the friendly localized copy.
   it('updateSettings rejects a null/non-object patch with the friendly copy (BE-1)', async () => {
     const ctx = {
+      trustedSenders: ANY_SENDER,
       paths: { configPath: bogusConfigDir() },
       db: seededDb(),
       workspace: { isUnlocked: () => true }
@@ -224,7 +236,11 @@ describe('registerModelIpc', () => {
   // workspace. These fixtures predate that guard and omit `workspace`; default them to unlocked
   // (the locked-refusal behaviour is enumerated separately in ipc-lock-coverage.test.ts).
   const reg = (ctx: AppContext): void =>
-    registerModelIpc({ workspace: { isUnlocked: () => true }, ...(ctx as object) } as AppContext)
+    registerModelIpc({
+      trustedSenders: ANY_SENDER,
+      workspace: { isUnlocked: () => true },
+      ...(ctx as object)
+    } as AppContext)
 
   // Model handlers resolve the drive policy from `paths.configPath` (M10); a missing
   // config dir means "no policy file" → developer-friendly defaults.

--- a/apps/desktop/tests/integration/dictation-ipc.test.ts
+++ b/apps/desktop/tests/integration/dictation-ipc.test.ts
@@ -28,7 +28,7 @@ import {
 import { documentsDir } from '../../src/main/services/ingestion'
 import type { Transcriber, TranscribeOptions } from '../../src/main/services/transcriber'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -66,6 +66,7 @@ function ctxWith(workspacePath: string, transcriber: Transcriber | null): {
 } {
   const audit = vi.fn()
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { workspacePath },
     transcriber,
     audit,
@@ -172,6 +173,7 @@ describe('registerDictationIpc', () => {
     const workspacePath = freshWorkspacePath()
     const { transcriber, seen } = fakeTranscriber()
     const lockedCtx = {
+      trustedSenders: ANY_SENDER,
       paths: { workspacePath },
       transcriber,
       audit: vi.fn(),

--- a/apps/desktop/tests/integration/docs-ipc.test.ts
+++ b/apps/desktop/tests/integration/docs-ipc.test.ts
@@ -101,7 +101,7 @@ import {
 import type { OcrEngine } from '../../src/main/services/ocr'
 import type { RasterizePdf } from '../../src/main/services/ocr/rasterizer'
 import { makeScanOnlyPdf } from '../helpers/fixtures'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -125,6 +125,7 @@ function ctxWith(
   cipher: DocumentCipher | null = null
 ): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath },
     embedder,

--- a/apps/desktop/tests/integration/doctasks-ipc.test.ts
+++ b/apps/desktop/tests/integration/doctasks-ipc.test.ts
@@ -36,7 +36,7 @@ import { registerDocTasksIpc } from '../../src/main/ipc/registerDocTasksIpc'
 import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -82,6 +82,7 @@ async function makeHarness(opts: { unlocked?: boolean } = {}): Promise<Harness> 
 
   const unlocked = opts.unlocked ?? true
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/document-delete-derivatives.test.ts
+++ b/apps/desktop/tests/integration/document-delete-derivatives.test.ts
@@ -36,7 +36,7 @@ import { createMockEmbedder } from '../../src/main/services/embeddings/mock'
 import { IPC } from '../../src/shared/ipc'
 import type { SkillToolAudit } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -282,6 +282,7 @@ describe('deleteDocument IPC — a document WITH a tool run deletes + audits (TE
 
     const events: Array<{ type: string }> = []
     const ctx = {
+      trustedSenders: ANY_SENDER,
       paths: { rootPath, workspacePath, configPath: join(rootPath, 'config') },
       db,
       workspace: { isUnlocked: () => true, documentCipher: () => null, beginDocumentWork: () => () => {} },

--- a/apps/desktop/tests/integration/download-ipc.test.ts
+++ b/apps/desktop/tests/integration/download-ipc.test.ts
@@ -26,7 +26,7 @@ import { openDatabase, type Db } from '../../src/main/services/db'
 import { seedSettings, updateSettings } from '../../src/main/services/settings'
 import type { DownloadJob } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -94,6 +94,7 @@ function makeCtx(opts: {
   // case genuinely exercises the setting-off gate rather than inheriting the default.
   updateSettings(db, { allowNetwork: opts.allowNetwork ?? false })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: drive.rootPath, configPath: drive.configPath },
     db,
     workspace: { isUnlocked: () => opts.unlocked !== false },

--- a/apps/desktop/tests/integration/evidence-freshness.test.ts
+++ b/apps/desktop/tests/integration/evidence-freshness.test.ts
@@ -69,7 +69,7 @@ import type {
   EvidenceReviewSummary,
   EvidenceSourceContext
 } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -590,6 +590,7 @@ describe('export after drift (spec §28.6/§28.7 + §20.1 refresh step)', () => 
 describe('IPC surface (new P4 channels + real overlay)', () => {
   function makeCtx(db: Db, root: string): AppContext {
     return {
+      trustedSenders: ANY_SENDER,
       db,
       paths: { workspacePath: root, rootPath: root, configPath: join(root, 'config.json') },
       workspace: { isUnlocked: () => true },

--- a/apps/desktop/tests/integration/evidence-review-batch-ops.test.ts
+++ b/apps/desktop/tests/integration/evidence-review-batch-ops.test.ts
@@ -55,7 +55,7 @@ import {
 } from '../../src/main/services/evidence-reviews'
 import type { AppContext } from '../../src/main/services/context'
 import type { Citation, EvidenceReviewItem, EvidenceReviewSummary } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -159,6 +159,7 @@ function seedConversation(
 
 function ctxFor(db: Db): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     db,
     workspace: { isUnlocked: () => true, isLocking: () => false },
     paths: { workspacePath: '/tmp', rootPath: '/tmp', configPath: '/tmp/config.json' },

--- a/apps/desktop/tests/integration/evidence-review-open-perf.test.ts
+++ b/apps/desktop/tests/integration/evidence-review-open-perf.test.ts
@@ -43,7 +43,7 @@ import type {
   EvidenceReviewDetail,
   EvidenceReviewFreshness
 } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -79,6 +79,7 @@ function makeHarness(): { ctx: AppContext; db: Db; runtimeTouched: string[] } {
   const db = openDatabase(join(root, 'test.sqlite'))
   const runtimeTouched: string[] = []
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root, rootPath: root, configPath: join(root, 'config.json') },
     workspace: { isUnlocked: () => true },

--- a/apps/desktop/tests/integration/evidence-reviews-ipc.test.ts
+++ b/apps/desktop/tests/integration/evidence-reviews-ipc.test.ts
@@ -96,7 +96,7 @@ import type {
   EvidenceReviewItem,
   EvidenceReviewSummary
 } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -139,6 +139,7 @@ function makeHarness(opts: { root?: string; unlocked?: () => boolean } = {}): Ha
   const db = openDatabase(join(root, 'test.sqlite'))
   const runtimeTouched: string[] = []
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root, rootPath: root, configPath: join(root, 'config.json') },
     workspace: { isUnlocked: opts.unlocked ?? (() => true) },

--- a/apps/desktop/tests/integration/images-ipc.test.ts
+++ b/apps/desktop/tests/integration/images-ipc.test.ts
@@ -54,12 +54,13 @@ import type {
 import type { AppContext } from '../../src/main/services/context'
 import { openDatabase, type Db } from '../../src/main/services/db'
 import { encryptFile, decryptFile, encryptFileAsync, decryptFileAsync } from '../../src/main/services/workspace-vault'
-import { invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
 function ctxFor(rootPath: string, unlocked = true): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath },
     manifestsDir: null,
     isDev: false,
@@ -427,6 +428,7 @@ describe('registerImagesIpc — history persistence', () => {
     const db = openDatabase(join(workspacePath, 'hilbertraum.sqlite'))
     const key = randomBytes(32)
     const ctx = {
+      trustedSenders: ANY_SENDER,
       paths: { rootPath: workspacePath, workspacePath },
       db,
       manifestsDir: null,

--- a/apps/desktop/tests/integration/ipc-lock-coverage.test.ts
+++ b/apps/desktop/tests/integration/ipc-lock-coverage.test.ts
@@ -47,7 +47,7 @@ import { registerLocalApiIpc } from '../../src/main/ipc/registerLocalApiIpc'
 import { IPC } from '../../src/shared/ipc'
 import { initLogging } from '../../src/main/services/logging'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -56,6 +56,7 @@ const handlers = ipcState.handlers as unknown as IpcHandlers
  *  requireUnlocked() preamble (the first statement) before any of this matters. */
 function lockedCtx(tmp: string): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     workspace: { isUnlocked: () => false },
     paths: { workspacePath: tmp, rootPath: tmp, configPath: join(tmp, 'config.json') },
     runtime: {

--- a/apps/desktop/tests/integration/local-api-ipc.test.ts
+++ b/apps/desktop/tests/integration/local-api-ipc.test.ts
@@ -38,7 +38,7 @@ import { seedSettings, updateSettings } from '../../src/main/services/settings'
 import { readToken } from '../../src/main/services/local-api/token'
 import type { AppContext } from '../../src/main/services/context'
 import type { AppStatus, LocalApiConnectionInfo, LocalApiStatus } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -75,6 +75,7 @@ function makeHarness(opts: { unlocked?: boolean; localApi?: boolean } = {}): Har
   const status = localApiStatus()
   const unlocked = opts.unlocked ?? true
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath, workspacePath, configPath },
     db,
     isDev: true,

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -64,7 +64,7 @@ import { createQueuedDocument, documentsDir, processDocument } from '../../src/m
 import { createPlaintextOps } from '../../src/main/services/ingestion/plaintext-ops'
 import { performShutdown } from '../../src/main/shutdown'
 import { t } from '../../src/shared/i18n'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const FAST_KDF: KdfParams = { algo: 'scrypt', N: 1024, r: 8, p: 1, keyLen: 32 }
@@ -223,6 +223,7 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
   if (opts.failReEncrypt) release()
 
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, configPath: join(root, 'config'), workspacePath, dbPath: vp.dbPath },
     get db() {
       return ctrl.requireDb()
@@ -516,6 +517,7 @@ describe('admission during the lock teardown (AUD-02)', () => {
     ctrl.init()
     expect(ctrl.isUnlocked()).toBe(true)
     registerWorkspaceIpc({
+      trustedSenders: ANY_SENDER,
       workspace: ctrl,
       runtime: { stop: async () => {}, activeModelId: () => null },
       embedder: { stop: async () => {} }

--- a/apps/desktop/tests/integration/model-occupancy-ipc.test.ts
+++ b/apps/desktop/tests/integration/model-occupancy-ipc.test.ts
@@ -46,7 +46,7 @@ import { IPC } from '../../src/shared/ipc'
 import { t } from '../../src/shared/i18n'
 import type { AppContext } from '../../src/main/services/context'
 import type { SkillRunState, StartSkillRunResult } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -135,6 +135,7 @@ async function makeHarness(
   seedSettings(db)
   const runtime = await startedManager()
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root, rootPath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },

--- a/apps/desktop/tests/integration/rag-classify-offer.test.ts
+++ b/apps/desktop/tests/integration/rag-classify-offer.test.ts
@@ -42,7 +42,7 @@ import { t, type MessageKey, type MessageParams } from '../../src/shared/i18n'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
 import type { Message } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const tr = (key: MessageKey, params?: MessageParams): string => t('en', key, params)
@@ -138,6 +138,7 @@ function makeCtx(
   skillsDirs: { appSkillsDir: string; userSkillsDir: string }
 ): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: workspacePath, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/rag-regenerate-ipc.test.ts
+++ b/apps/desktop/tests/integration/rag-regenerate-ipc.test.ts
@@ -30,7 +30,7 @@ import { registerRagIpc } from '../../src/main/ipc/registerRagIpc'
 import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -79,6 +79,7 @@ function freshDb(): { db: Db; workspacePath: string } {
 
 function makeCtx(db: Db, workspacePath: string, runtime: ModelRuntime): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: workspacePath, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/rag-skill-analysis-invoice.test.ts
+++ b/apps/desktop/tests/integration/rag-skill-analysis-invoice.test.ts
@@ -33,7 +33,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import { t } from '../../src/shared/i18n'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const INVOICE_INSTALL_ID = 'app:invoice'
@@ -138,6 +138,7 @@ async function makeHarness(
 
   const audit: { type: string; meta?: Record<string, unknown> }[] = []
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/rag-skill-analysis.test.ts
+++ b/apps/desktop/tests/integration/rag-skill-analysis.test.ts
@@ -36,7 +36,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import { t } from '../../src/shared/i18n'
-import { invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const BANK_INSTALL_ID = 'app:bank-statement'
@@ -161,6 +161,7 @@ async function makeHarness(
 
   const audit: { type: string; meta?: Record<string, unknown> }[] = []
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db
@@ -641,6 +642,7 @@ async function makeMultiHarness(opts: {
 
   const audit: { type: string; meta?: Record<string, unknown> }[] = []
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/rag-whole-doc-compare.test.ts
+++ b/apps/desktop/tests/integration/rag-whole-doc-compare.test.ts
@@ -33,7 +33,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import { t } from '../../src/shared/i18n'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const WHAT_CHANGED_INSTALL_ID = 'app:what-changed'
@@ -113,6 +113,7 @@ async function makeHarness(opts: { bothFullyChunked?: boolean } = {}): Promise<H
   } as unknown as ModelRuntime & { calls: number; lastMessages: ChatMessage[] }
 
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/rag-whole-doc-skill.test.ts
+++ b/apps/desktop/tests/integration/rag-whole-doc-skill.test.ts
@@ -36,7 +36,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import { t } from '../../src/shared/i18n'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const MEETING_INSTALL_ID = 'app:meeting-protocol'
@@ -152,6 +152,7 @@ async function makeHarness(opts: { fullyChunked?: boolean; text?: string; contex
   } as unknown as ModelRuntime & { calls: number; lastMessages: ChatMessage[] }
 
   const ctx = {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: root, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/regenerate-evidence-review-guard.test.ts
+++ b/apps/desktop/tests/integration/regenerate-evidence-review-guard.test.ts
@@ -59,7 +59,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import type { Message } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -133,6 +133,7 @@ function freshDb(): { db: Db; workspacePath: string } {
 
 function makeCtx(db: Db, workspacePath: string, runtime: ModelRuntime): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: workspacePath, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/regenerate-result-table-restore.test.ts
+++ b/apps/desktop/tests/integration/regenerate-result-table-restore.test.ts
@@ -56,7 +56,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime } from '../../src/main/services/runtime'
 import type { Message } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -165,6 +165,7 @@ function freshDb(): { db: Db; workspacePath: string } {
 
 function makeCtx(db: Db, workspacePath: string, runtime: ModelRuntime): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath: workspacePath, workspacePath },
     get db() {
       return db

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -654,4 +654,17 @@ describe('repo hygiene — every ipcMain.handle under src/main/ipc goes through 
     const code = guard.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, '') // its comments name the call too
     expect((code.match(/ipcMain\.handle\(/g) ?? []).length).toBe(1)
   })
+
+  it('the permissive ANY_SENDER set is referenced nowhere under src/main except its definition', () => {
+    const mainDir = join(process.cwd(), 'src', 'main')
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+        e.isDirectory() ? walk(join(dir, e.name)) : e.name.endsWith('.ts') ? [join(dir, e.name)] : []
+      )
+    const offenders = walk(mainDir)
+      .filter((p) => !p.endsWith('guarded-handle.ts'))
+      .filter((p) => /\bANY_SENDER\b/.test(readFileSync(p, 'utf8')))
+      .map((p) => p.slice(mainDir.length + 1))
+    expect(offenders).toEqual([])
+  })
 })

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -651,6 +651,7 @@ describe('repo hygiene — every ipcMain.handle under src/main/ipc goes through 
 
   it('the guard module itself is the one place that calls ipcMain.handle', () => {
     const guard = readFileSync(join(ipcDir, 'guarded-handle.ts'), 'utf8')
-    expect((guard.match(/ipcMain\.handle\(/g) ?? []).length).toBe(1)
+    const code = guard.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, '') // its comments name the call too
+    expect((code.match(/ipcMain\.handle\(/g) ?? []).length).toBe(1)
   })
 })

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -621,3 +621,36 @@ describe('repo hygiene — CHANGELOG is release-page-shaped', () => {
     expect(changelog).not.toMatch(/No public release yet/i)
   })
 })
+
+// #252: every `ipcMain.handle` registration in the main process goes through
+// `guardedHandle` (src/main/ipc/guarded-handle.ts), which refuses an untrusted sender before
+// the handler body runs. A registrar that kept the direct `ipcMain` import would leave the
+// guard partial while every test stayed green (the harness is permissive), so the ban is
+// structural: no bare `ipcMain.handle(` and no `ipcMain` import under src/main/ipc/** except
+// in the guard module itself.
+describe('repo hygiene — every ipcMain.handle under src/main/ipc goes through the guard (#252)', () => {
+  const ipcDir = join(process.cwd(), 'src', 'main', 'ipc')
+  const sources = readdirSync(ipcDir)
+    .filter((f) => f.endsWith('.ts') && f !== 'guarded-handle.ts')
+    .map((f) => ({ file: f, src: readFileSync(join(ipcDir, f), 'utf8') }))
+
+  it('no bare ipcMain.handle( remains outside guarded-handle.ts', () => {
+    const offenders = sources
+      .map(({ file, src }) => ({ file, n: (src.match(/ipcMain\.handle\(/g) ?? []).length }))
+      .filter(({ n }) => n > 0)
+      .map(({ file, n }) => `${file}: ${n}`)
+    expect(offenders).toEqual([])
+  })
+
+  it('no registrar imports ipcMain at all (the guard is the only registration path)', () => {
+    const offenders = sources
+      .filter(({ src }) => /import\s*\{[^}]*\bipcMain\b[^}]*\}\s*from\s*'electron'/.test(src))
+      .map(({ file }) => file)
+    expect(offenders).toEqual([])
+  })
+
+  it('the guard module itself is the one place that calls ipcMain.handle', () => {
+    const guard = readFileSync(join(ipcDir, 'guarded-handle.ts'), 'utf8')
+    expect((guard.match(/ipcMain\.handle\(/g) ?? []).length).toBe(1)
+  })
+})

--- a/apps/desktop/tests/integration/result-tables.test.ts
+++ b/apps/desktop/tests/integration/result-tables.test.ts
@@ -44,7 +44,7 @@ import {
 } from '../../src/main/services/tables/store'
 import type { TableSpec } from '../../src/main/services/tables'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -54,6 +54,7 @@ function freshDb(): Db {
 
 function makeCtx(db: Db, audit?: (type: string, msg: string, meta?: Record<string, unknown>) => void): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     db,
     workspace: { isUnlocked: () => true },
     runtime: { active: () => null, activeModelId: () => null },

--- a/apps/desktop/tests/integration/skills-ipc.test.ts
+++ b/apps/desktop/tests/integration/skills-ipc.test.ts
@@ -72,7 +72,7 @@ import { createAuditRecorder, listAuditEvents } from '../../src/main/services/au
 import { createSkillRegistry } from '../../src/main/services/skills/registry'
 import type { AppContext } from '../../src/main/services/context'
 import type { SkillInfo, SkillPreview } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -124,6 +124,7 @@ function makeHarness(): Harness {
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -232,6 +233,7 @@ describe('skills IPC — round-trip lifecycle', () => {
       userSkillsDir: join(root, 'user-skills')
     })
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       paths: { workspacePath: root },
       workspace: { isUnlocked: () => false, documentCipher: () => null },

--- a/apps/desktop/tests/integration/skills-tool-run-ipc.test.ts
+++ b/apps/desktop/tests/integration/skills-tool-run-ipc.test.ts
@@ -62,7 +62,7 @@ import { createSkillRegistry, getSkill } from '../../src/main/services/skills/re
 import { createConversation } from '../../src/main/services/chat'
 import type { AppContext } from '../../src/main/services/context'
 import type { RunnableTool, RunnableToolSet, SkillRunState, StartSkillRunResult } from '../../src/shared/types'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const SENTINEL = 'XTOOLRUN_SENTINEL_secret_payee_77777'
@@ -193,6 +193,7 @@ function makeMultiDocHarness(texts: string[]): Harness & { docIds: string[] } {
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -227,6 +228,7 @@ function makeHarness(statementText: string, opts: { title?: string } = {}): Harn
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -253,6 +255,7 @@ function makeRedactionHarness(docText: string): Harness {
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -279,6 +282,7 @@ function makeInvoiceHarness(invoiceText: string): Harness {
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -308,6 +312,7 @@ function makeUserSkillHarness(statementText: string): Harness {
   const audit = createAuditRecorder(() => db)
   const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
   const ctx = {
+    trustedSenders: ANY_SENDER,
     db,
     paths: { workspacePath: root },
     workspace: { isUnlocked: () => true, documentCipher: () => null },
@@ -416,6 +421,7 @@ describe('skills tool-run IPC (S11b)', () => {
     const audit = createAuditRecorder(() => db)
     const skills = createSkillRegistry({ getDb: () => db, appSkillsDir, userSkillsDir })
     const ctx = {
+      trustedSenders: ANY_SENDER,
       db,
       paths: { workspacePath: root },
       workspace: { isUnlocked: () => true, documentCipher: () => null },

--- a/apps/desktop/tests/integration/translate-ipc.test.ts
+++ b/apps/desktop/tests/integration/translate-ipc.test.ts
@@ -24,7 +24,7 @@ import { IPC, STREAM } from '../../src/shared/ipc'
 import { TRANSLATE_MAX_TEXT_CHARS } from '../../src/shared/types'
 import type { TranslateJob, TranslateRequest } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -33,6 +33,7 @@ function ctxFor(unlocked = true, locking = false): AppContext {
   // `isUnlocked() && isLocking?.() !== true` (AUD-02), and stubbing only `isUnlocked` left a
   // regression back to a bare isUnlocked() check green across the whole suite.
   return {
+    trustedSenders: ANY_SENDER,
     workspace: { isUnlocked: () => unlocked, isLocking: () => locking }
   } as unknown as AppContext
 }

--- a/apps/desktop/tests/integration/vault-recovery-guards.test.ts
+++ b/apps/desktop/tests/integration/vault-recovery-guards.test.ts
@@ -25,7 +25,7 @@ import { getSettings, updateSettings } from '../../src/main/services/settings'
 import { DEFAULT_POLICY } from '../../src/main/services/policy'
 import { IPC } from '../../src/shared/ipc'
 import { registerWorkspaceIpc } from '../../src/main/ipc/registerWorkspaceIpc'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 import type { PrivacyPolicy } from '../../src/shared/types'
 import type { KdfParams } from '../../src/main/services/security/crypto'
 import type { AppContext } from '../../src/main/services/context'
@@ -169,6 +169,7 @@ function freshVault(): VaultPaths {
 /** The minimal AppContext the unlock handler's failure path reads. */
 function ctxWith(ctrl: WorkspaceController): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     workspace: ctrl,
     runtime: { stop: async () => {}, activeModelId: () => null },
     embedder: { stop: async () => {} }

--- a/apps/desktop/tests/integration/vision-security.test.ts
+++ b/apps/desktop/tests/integration/vision-security.test.ts
@@ -32,7 +32,7 @@ import { log } from '../../src/main/services/logging'
 import { IPC, STREAM } from '../../src/shared/ipc'
 import type { ImageAnalyzeRequest, ImageJob, VisionStatus } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -90,6 +90,7 @@ function ctxFor(
 ): AppContext {
   const key = randomBytes(32)
   return {
+    trustedSenders: ANY_SENDER,
     paths: { rootPath, workspacePath: rootPath },
     db: openDatabase(join(rootPath, 'hilbertraum.sqlite')),
     manifestsDir: null,

--- a/apps/desktop/tests/integration/workspace-ipc.test.ts
+++ b/apps/desktop/tests/integration/workspace-ipc.test.ts
@@ -47,7 +47,7 @@ import {
 } from '../../src/main/services/workspace-vault'
 import type { KdfParams } from '../../src/main/services/security/crypto'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const FAST_KDF: KdfParams = { algo: 'scrypt', N: 1024, r: 8, p: 1, keyLen: 32 }
@@ -72,6 +72,7 @@ function ctxWith(
   }
 ): AppContext {
   return {
+    trustedSenders: ANY_SENDER,
     workspace: ctrl,
     runtime: { stop: sidecars?.stopRuntime ?? (async () => {}), activeModelId: () => null },
     embedder: { stop: sidecars?.stopEmbedder ?? (async () => {}) },

--- a/apps/desktop/tests/manual/dictation-smoke.test.ts
+++ b/apps/desktop/tests/manual/dictation-smoke.test.ts
@@ -35,7 +35,7 @@ import {
   resolveWhisperCliPath
 } from '../../src/main/services/transcriber'
 import type { AppContext } from '../../src/main/services/context'
-import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
 
 const ROOT = process.env.HILBERTRAUM_DICTATION_SMOKE?.trim() ?? ''
 const AUDIO_DIR = process.env.HILBERTRAUM_WHISPER_AUDIO?.trim() ?? ''
@@ -66,6 +66,7 @@ describe.skipIf(!enabled)('Dictation smoke (manual, real whisper-cli over the di
 
       const workspacePath = mkdtempSync(join(tmpdir(), 'hilbertraum-dictation-smoke-'))
       const ctx = {
+        trustedSenders: ANY_SENDER,
         paths: { workspacePath },
         transcriber: createWhisperCliTranscriber({
           id: 'smoke-whisper',

--- a/apps/desktop/tests/unit/guarded-handle.test.ts
+++ b/apps/desktop/tests/unit/guarded-handle.test.ts
@@ -30,6 +30,7 @@ import {
   type TrustedSenders
 } from '../../src/main/ipc/guarded-handle'
 import { registerAuditIpc } from '../../src/main/ipc/registerAuditIpc'
+import { log as appLog } from '../../src/main/services/logging'
 import { openDatabase } from '../../src/main/services/db'
 import type { AppContext } from '../../src/main/services/context'
 import { IPC } from '../../src/shared/ipc'
@@ -61,6 +62,25 @@ describe('guardedHandle (#252)', () => {
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.lines.join('\n')).toContain('t:refuse')
     expect(log.lines.join('\n')).not.toContain(SECRET_ARG)
+  })
+
+  it('without an injected logger the refusal goes to the app log (production wiring), still content-free', async () => {
+    handlers.clear()
+    const warn = vi.spyOn(appLog, 'warn').mockImplementation(() => {})
+    try {
+      const trusted = createTrustedSenders()
+      trusted.add(7)
+      guardedHandle('t:applog', () => 'ran', { trustedSenders: trusted })
+      await expect(
+        Promise.resolve().then(() => handlers.get('t:applog')!(makeEvent(8), SECRET_ARG))
+      ).rejects.toBeInstanceOf(UntrustedSenderError)
+      expect(warn).toHaveBeenCalledTimes(1)
+      const said = JSON.stringify(warn.mock.calls[0])
+      expect(said).toContain('t:applog')
+      expect(said).not.toContain(SECRET_ARG)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('the trusted id passes and the handler sees the event and its arguments', async () => {

--- a/apps/desktop/tests/unit/guarded-handle.test.ts
+++ b/apps/desktop/tests/unit/guarded-handle.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { IpcMainInvokeEvent } from 'electron'
 
 // #252: every `ipcMain.handle` in the main process is registered through `guardedHandle`,
 // which runs the handler body only for a sender in the trusted set (the main window's
@@ -25,7 +26,8 @@ import {
   UntrustedSenderError,
   createTrustedSenders,
   guardedHandle,
-  guardedHandleFor
+  guardedHandleFor,
+  type TrustedSenders
 } from '../../src/main/ipc/guarded-handle'
 import { registerAuditIpc } from '../../src/main/ipc/registerAuditIpc'
 import { openDatabase } from '../../src/main/services/db'
@@ -65,8 +67,8 @@ describe('guardedHandle (#252)', () => {
     handlers.clear()
     const trusted = createTrustedSenders()
     trusted.add(7)
-    const body = vi.fn((_e: unknown, a: string) => `ok:${a}`)
-    guardedHandle('t:pass', body as never, { trustedSenders: trusted })
+    const body = vi.fn((_e: IpcMainInvokeEvent, a: string) => `ok:${a}`)
+    guardedHandle('t:pass', body, { trustedSenders: trusted })
     const event = makeEvent(7)
     expect(await handlers.get('t:pass')!(event, 'x')).toBe('ok:x')
     expect(body).toHaveBeenCalledWith(event, 'x')
@@ -102,9 +104,8 @@ describe('guardedHandle (#252)', () => {
 
   it('registration without a trusted set fails loudly instead of refusing every call later', () => {
     handlers.clear()
-    expect(() =>
-      guardedHandle('t:missing', () => 'ran', { trustedSenders: undefined as never })
-    ).toThrow(/no trustedSenders/)
+    const noSet = { trustedSenders: undefined } as unknown as { trustedSenders: TrustedSenders }
+    expect(() => guardedHandle('t:missing', () => 'ran', noSet)).toThrow(/no trustedSenders/)
     expect(handlers.has('t:missing')).toBe(false)
   })
 

--- a/apps/desktop/tests/unit/guarded-handle.test.ts
+++ b/apps/desktop/tests/unit/guarded-handle.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// #252: every `ipcMain.handle` in the main process is registered through `guardedHandle`,
+// which runs the handler body only for a sender in the trusted set (the main window's
+// WebContents id in production). The fake harness passes `ANY_SENDER`; this file drives
+// the guard itself with real sets, and one real registrar with a NON-permissive set.
+
+const handlers = vi.hoisted(() => new Map<string, (...args: unknown[]) => unknown>())
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => handlers.set(channel, fn),
+    removeHandler: (channel: string) => handlers.delete(channel)
+  },
+  app: { getVersion: () => '0.0.0-test', getPath: () => '', getLocale: () => 'en' },
+  BrowserWindow: { getFocusedWindow: () => null },
+  dialog: { showSaveDialog: async () => ({ canceled: true }) },
+  clipboard: { writeText: () => {} }
+}))
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ANY_SENDER,
+  UntrustedSenderError,
+  createTrustedSenders,
+  guardedHandle,
+  guardedHandleFor
+} from '../../src/main/ipc/guarded-handle'
+import { registerAuditIpc } from '../../src/main/ipc/registerAuditIpc'
+import { openDatabase } from '../../src/main/services/db'
+import type { AppContext } from '../../src/main/services/context'
+import { IPC } from '../../src/shared/ipc'
+import { makeEvent } from '../helpers/ipc'
+
+const SECRET_ARG = 'ARG_SENTINEL_never_logged'
+
+function quietLog(): { warn: ReturnType<typeof vi.fn>; lines: string[] } {
+  const lines: string[] = []
+  const warn = vi.fn((msg: string, meta?: unknown) => {
+    lines.push(`${msg} ${JSON.stringify(meta ?? null)}`)
+  })
+  return { warn, lines }
+}
+
+describe('guardedHandle (#252)', () => {
+  it('refuses a foreign webContents id with a content-free log, and the handler never runs', async () => {
+    handlers.clear()
+    const trusted = createTrustedSenders()
+    trusted.add(7)
+    const body = vi.fn(() => 'ran')
+    const log = quietLog()
+    guardedHandle('t:refuse', body, { trustedSenders: trusted, log })
+    const fn = handlers.get('t:refuse')!
+    await expect(Promise.resolve().then(() => fn(makeEvent(99), SECRET_ARG))).rejects.toBeInstanceOf(
+      UntrustedSenderError
+    )
+    expect(body).not.toHaveBeenCalled()
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.lines.join('\n')).toContain('t:refuse')
+    expect(log.lines.join('\n')).not.toContain(SECRET_ARG)
+  })
+
+  it('the trusted id passes and the handler sees the event and its arguments', async () => {
+    handlers.clear()
+    const trusted = createTrustedSenders()
+    trusted.add(7)
+    const body = vi.fn((_e: unknown, a: string) => `ok:${a}`)
+    guardedHandle('t:pass', body as never, { trustedSenders: trusted })
+    const event = makeEvent(7)
+    expect(await handlers.get('t:pass')!(event, 'x')).toBe('ok:x')
+    expect(body).toHaveBeenCalledWith(event, 'x')
+  })
+
+  it('a sender without an id is refused by a real set (fail closed) — and passes only ANY_SENDER', async () => {
+    handlers.clear()
+    const trusted = createTrustedSenders()
+    trusted.add(7)
+    guardedHandle('t:noid', () => 'ran', { trustedSenders: trusted })
+    await expect(Promise.resolve().then(() => handlers.get('t:noid')!(makeEvent()))).rejects.toThrow(
+      /untrusted sender/
+    )
+    await expect(Promise.resolve().then(() => handlers.get('t:noid')!(null))).rejects.toThrow(/untrusted sender/)
+
+    guardedHandle('t:any', () => 'ran', { trustedSenders: ANY_SENDER })
+    expect(await handlers.get('t:any')!(makeEvent())).toBe('ran')
+    expect(await handlers.get('t:any')!(makeEvent(12345))).toBe('ran')
+  })
+
+  it('a deleted id is refused again (the set is live, not a snapshot)', async () => {
+    handlers.clear()
+    const trusted = createTrustedSenders()
+    trusted.add(7)
+    guardedHandle('t:live', () => 'ran', { trustedSenders: trusted })
+    expect(await handlers.get('t:live')!(makeEvent(7))).toBe('ran')
+    trusted.delete(7)
+    expect(trusted.size()).toBe(0)
+    await expect(Promise.resolve().then(() => handlers.get('t:live')!(makeEvent(7)))).rejects.toThrow(
+      /untrusted sender/
+    )
+  })
+
+  it('registration without a trusted set fails loudly instead of refusing every call later', () => {
+    handlers.clear()
+    expect(() =>
+      guardedHandle('t:missing', () => 'ran', { trustedSenders: undefined as never })
+    ).toThrow(/no trustedSenders/)
+    expect(handlers.has('t:missing')).toBe(false)
+  })
+
+  it('a real registrar through a NON-permissive set: the main-window id passes, a foreign id is refused', async () => {
+    // The substitute for the live launch smoke where electron.exe cannot run: the audit
+    // registrar is wired exactly as production wires it, with a set holding one fake
+    // main-window id. The main-window path reaches the handler body (a real query on a real
+    // SQLite file); the foreign path never does.
+    handlers.clear()
+    const MAIN_WINDOW_ID = 4242
+    const trustedSenders = createTrustedSenders()
+    trustedSenders.add(MAIN_WINDOW_ID)
+    const db = openDatabase(join(mkdtempSync(join(tmpdir(), 'hilbertraum-guard-')), 'test.sqlite'))
+    const ctx = {
+      db,
+      workspace: { isUnlocked: () => true, isLocking: () => false },
+      trustedSenders
+    } as unknown as AppContext
+    registerAuditIpc(ctx)
+    const fn = handlers.get(IPC.getAuditEvents)!
+    expect(fn).toBeDefined()
+    expect(await fn(makeEvent(MAIN_WINDOW_ID), 10)).toEqual([])
+    await expect(Promise.resolve().then(() => fn(makeEvent(MAIN_WINDOW_ID + 1), 10))).rejects.toThrow(
+      /untrusted sender/
+    )
+    await expect(Promise.resolve().then(() => fn(makeEvent(), 10))).rejects.toThrow(/untrusted sender/)
+  })
+
+  it('guardedHandleFor(ctx) binds the context set for a registrar', async () => {
+    handlers.clear()
+    const trusted = createTrustedSenders()
+    trusted.add(3)
+    const ipcHandle = guardedHandleFor({ trustedSenders: trusted })
+    ipcHandle('t:bound', () => 'ran')
+    expect(await handlers.get('t:bound')!(makeEvent(3))).toBe('ran')
+    await expect(Promise.resolve().then(() => handlers.get('t:bound')!(makeEvent(4)))).rejects.toThrow(
+      /untrusted sender/
+    )
+  })
+})

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -28,6 +28,7 @@ posture (spec §3.6), how the privacy policy is loaded and enforced, and the **e
 |---|---|
 | Context isolation, no node integration, sandboxed renderer | `main/index.ts` `webPreferences` |
 | Renderer talks only to a typed `contextBridge` (`window.api`) | `preload/index.ts` |
+| **Every `ipcMain.handle` checks the sender** — the handler body runs only for the main window's `webContents.id` (#252); a bare registration under `src/main/ipc/**` is banned by `repo-hygiene.test.ts` | `main/ipc/guarded-handle.ts`, set populated in `main/index.ts` `createWindow` |
 | `will-navigate` **and `will-redirect`** block remote origins (SEC-3) | `services/navigation-guard.ts`, installed in `main/index.ts` + OCR window |
 | `setWindowOpenHandler` opens external links in the OS browser, denies in-app | `main/index.ts` |
 | **Content-Security-Policy** (response header + build-time-generated meta tag) | `main/window-security.ts` (both policies), applied in `main/index.ts` + `electron.vite.config.ts` |
@@ -1738,6 +1739,17 @@ The renderer is the **untrusted** boundary (M-S2) and threat #1 is a hostile imp
 achieving code-exec in the context-isolated renderer. Four main-side IPC seams trusted renderer
 input more than that model allows; all four are now tightened (`registerDocsIpc.ts`,
 `registerImagesIpc.ts`, `services/assets.ts`, `services/vision/limits.ts`).
+
+**Sender check on every `handle` channel (#252).** All 137 `ipcMain.handle` registrations go
+through `guardedHandle` (`main/ipc/guarded-handle.ts`): the handler body runs only when
+`event.sender.id` is in the context's trusted set, which `createWindow` fills with the main
+window's `webContents.id` — the OCR rasterizer window's preload only `send`s (its replies are
+`ipcMain.on` listeners that compare `event.sender` themselves) and the print window has no
+preload, so neither is trusted for `handle` channels. A refused invoke rejects the renderer's
+promise with a content-free error and logs the channel name only. Today no other WebContents
+can invoke; the check is load-bearing the moment a webview or a second window exists, and
+`repo-hygiene.test.ts` bans a bare `ipcMain.handle(` or an `ipcMain` import in any registrar so
+the guard cannot become partial.
 
 ### D1 — `importDocuments` is bound to a picker capability token (not raw renderer paths)
 `importDocuments(paths)` accepted arbitrary renderer-controlled absolute paths and `expandPaths`


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 8 (PR 8-b): SEC-6 — every `ipcMain.handle` checks its sender
Closes #252
Tracker: #217

### What
- New `apps/desktop/src/main/ipc/guarded-handle.ts`: `guardedHandle(channel, handler, { trustedSenders, log })` registers `ipcMain.handle(channel, …)` with the sender check in front — the handler body runs only when `event.sender.id` is in the trusted set; a refused invoke rejects the renderer's promise with a content-free `UntrustedSenderError` and logs the channel name only. `createTrustedSenders()` (production set), `ANY_SENDER` (the permissive test set), `guardedHandleFor(ctx)` (the registrar binding). Registration without a set throws at once (fail closed and loud, not a silent runtime refusal).
- `AppContext.trustedSenders` (required). `index.ts` builds the set at module scope, puts it in the context, and `createWindow` adds `mainWindow.webContents.id` right after the `BrowserWindow` constructor, before any `loadURL`/`loadFile`.
- **Trusted-set rule:** the main window only. The OCR rasterizer window's preload only `send`s (its replies are `ipcMain.on` listeners that compare `event.sender` themselves) and the print window has no preload; neither invokes a `handle` channel, so neither is trusted. The two `ipcMain.on` sites (`index.ts` perfMark, a metric; `ocr/rasterizer.ts`, which checks identity itself) are outside the finding's scope and unchanged.
- All 18 registrars converted by a codemod (kept outside the repo): `ipcMain` dropped from the `electron` import, `const ipcHandle = guardedHandleFor(ctx)` as the first line of each `register*Ipc`, every `ipcMain.handle(` → `ipcHandle(` — 137 registrations, none by hand.
- `tests/helpers/ipc.ts`: `makeEvent(senderId?)` (the sender gains an optional `id`; the default is unchanged) and a re-export of `ANY_SENDER`; the 36 test files that register handlers pass `trustedSenders: ANY_SENDER` in their fake context (58 literal sites, from a read-only inventory; four single-line literals rewritten by hand).

### Why
SEC-6 (#252): no `ipcMain.handle` validated `event.sender`. Unreachable today (no other WebContents can invoke), load-bearing the moment a webview or a second window exists; review rec 9 tied the change to the hygiene ban so a registrar cannot keep the direct import and leave the guard partial while every test stays green.

### Tests
- characterisation (red before, commit `25679e57`): `tests/unit/guarded-handle.test.ts` — a foreign `webContents.id` is refused with a content-free log (the argument sentinel never appears) and the body never runs; the trusted id passes with event and arguments intact; a sender without an id (the harness default) is refused by a real set and passes only `ANY_SENDER`; the set is live (a deleted id is refused again); registration without a set throws; `guardedHandleFor(ctx)` binds; **a real registrar (`registerAuditIpc`) through a NON-permissive set holding one fake main-window id — the main-window path reaches a real query on a real SQLite file, a foreign id and an id-less sender are refused**. `tests/integration/repo-hygiene.test.ts` — no bare `ipcMain.handle(` and no `ipcMain` import under `src/main/ipc/**` except the guard (red at 18 files / 137 registrations), and the guard module is the single caller.
- every existing IPC test green through the permissive harness (36 files).
- `npm test`: **370 files / 5,561 passed / 74 skipped** excluding `evidence-pack-pdf-smoke.test.ts` (after 8-a: 369 / 5,549 / 74 → +1 file, +12 tests, all new; the raw run says 80 skipped = 74 + the smoke file's 6). `npm run typecheck` and `npm run build` pass.
- **Launch smoke NOT run.** The plan makes it mandatory for this PR; on this machine an application-control policy blocks the unsigned dev `electron.exe` (`spawn UNKNOWN` from `npm run dev` with `ELECTRON_RUN_AS_NODE` stripped; PowerShell on the binary: "Eine Anwendungssteuerungsrichtlinie hat diese Datei blockiert"). Substitute proof, per the phase plan: (i) every existing IPC test green through the permissive harness, (ii) the real-registrar test above with a non-permissive set, (iii) the ban test green. The smoke "start the app, unlock a scratch workspace, run one IPC-backed action (Settings → Diagnostics)" joins the owner-runnable list; this PR merges without a live launch.

### Docs + BUILD_STATE
`docs/security-model.md` (baseline table row; a "Sender check on every `handle` channel (#252)" paragraph in the least-privilege section), `CHANGELOG.md` (one Changed line), `BUILD_STATE.md` (dated entry; the §5 item-19 Phase 8 line covering 8-a and 8-b — the block is at its 45-line cap).

### Owner decisions relied on (issue #, answer or default)
None needed. Review rec 9 (#217) on its default: 8-b in Phase 8 WITH the ban test. Decisions 4/11 (#221, #228) and 5 (#222) still unanswered at kickoff; 5a and 5b-b stay blocked.

### Reviewer pass
Opus tier (independent, read-only): 12 findings, none blocking. Repaired: (1) should-fix — `guardedHandleFor(ctx)` passed the context as the options and `AppContext` has no `log`, so a production refusal was silent while the security doc said the channel is logged; the guard now defaults to the app log (`services/logging`) when no logger is injected, with a test that the refusal reaches it and stays content-free; (8) nit — a hygiene assertion that `ANY_SENDER` is referenced nowhere under `src/main` except its definition, so the permissive set cannot leak into production. Recorded, not repaired: (2) the launch smoke — undischargeable on this machine (policy); the one live-only fact (that an `invoke` from the main window's renderer arrives with `event.sender.id === mainWindow.webContents.id`) rests on Electron's documented semantics and joins the owner-runnable smoke list; (9) `delete`/`size` on the mutable set are used only by the tests and no path removes a closed window's id (ids are process-unique, so a stale entry is inert); the guard test's temp dir is not cleaned (suite convention); (12) `GuardedHandler`'s `...args: never[]` is as loose as `ipcMain.handle`'s own signature, no regression. Confirmed ok: the trusted set (three windows enumerated; only the main preload invokes; the id is added before any load), fail-closed event handling, the codemod reaching all 137 sites with no module-level registration, the two `ipcMain.on` sites out of scope, the ban's coverage (aliased imports included), harness compatibility, no new audit-ID comments.

### CI note
The first `windows-latest, 22.x` run at `1907b84b` reported every test green (370 files / 5,566 passed / 75 skipped on that leg) and then failed on a vitest worker RPC timeout (`Timeout calling "onTaskUpdate"`, 595 s run) — an infrastructure flake in no file this PR touches; the job was re-run, not fixed here.

### Rollback
Revert the PR (one module, one field, 18 mechanical registrar diffs, the harness); no on-disk format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
