### PR TITLE
docs: Phase 9a early docs sweep — loss sentence, outside-the-drive, residual egress list, counts (audit 2026-09-02)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,17 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-03 — **Audit 2026-09-02 Phase 9a — early docs sweep (PR #280): the user guide §13 now says
+what an unclean stop loses (a hard pull, a crash, shutdown or logoff with the app open — every
+change since the last lock; the encrypted snapshot survives); `security-model.md` gained "What
+lives or passes outside the drive" (host Chromium profile — four `localStorage` keys, caches, no
+`Dictionaries/`, not cleared on lock; the OS clipboard — 8 Copy sites, only the local-API key copy
+self-clears) and "Residual egress channels" (i)–(iv) with the pending markers #236/#221 and
+#240/#222; OS session end documented as a hard kill (#248); `data-contracts.md` 138 IPC channels +
+`npm ci`; §8 L-8 closed; `renderer-storage-keys.test.ts` pins the key set. Decisions 9/10/14
+(#226/#227/#231) unanswered → the plan defaults (document). DOC-16 #261 investigated in its own PR.**_
+Docs-only, no launch smoke needed. Suite: 371 / 5,568 / 74 excluding the Electron smoke (which passed this run; raw 372 / 5,574 / 74).
+
 _2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-b) — SEC-6 #252: every `ipcMain.handle` in the
 main process goes through `guardedHandle(channel, handler, { trustedSenders, log })`
 (`src/main/ipc/guarded-handle.ts`): the body runs only when `event.sender.id` is in
@@ -691,6 +702,9 @@ open round's item stays the last block of §5.)
       unlock reason `vault_recovery_blocked`) + REL-9/DOC-15 exFAT durability docs — dated entry above.
     - **8** (2026-09-03, PRs #278 + #279): SEC-2, SEC-5, SEC-7, REL-1, REL-2, SEC-14 fixed, GAP-3 a
       confirmed residual (8-a); SEC-6 `guardedHandle` over all 137 registrations + the hygiene ban (8-b) — dated entries above.
+    - **9a** (2026-09-03, PR #280): DOC-6, DOC-9, DOC-10, SEC-3 closed by the docs; GAP-1 + SEC-4 documented on
+      defaults (#248, #250 open on #226/#227); residual-egress list (i)–(iv) pending #236/#221 and #240/#222;
+      5a (#236) and 5b-b (#240) stay blocked on #221/#228 and #222 — dated entry above. DOC-16 #261: own PR.
 
 
 ---

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -37,7 +37,8 @@ lives or passes outside the drive" (host Chromium profile — four `localStorage
 self-clears) and "Residual egress channels" (i)–(iv) with the pending markers #236/#221 and
 #240/#222; OS session end documented as a hard kill (#248); `data-contracts.md` 138 IPC channels +
 `npm ci`; §8 L-8 closed; `renderer-storage-keys.test.ts` pins the key set. Decisions 9/10/14
-(#226/#227/#231) unanswered → the plan defaults (document). DOC-16 #261 investigated in its own PR.**_
+(#226/#227/#231) unanswered → the plan defaults (document). DOC-16 #261: confirmed at the
+component (the confirm bound to the live target list), fixed in PR #281 (snapshot + named target).**_
 Docs-only, no launch smoke needed. Suite: 371 / 5,568 / 74 excluding the Electron smoke (which passed this run; raw 372 / 5,574 / 74).
 
 _2026-09-03 — **Audit 2026-09-02 Phase 8 (PR 8-b) — SEC-6 #252: every `ipcMain.handle` in the
@@ -704,7 +705,7 @@ open round's item stays the last block of §5.)
       confirmed residual (8-a); SEC-6 `guardedHandle` over all 137 registrations + the hygiene ban (8-b) — dated entries above.
     - **9a** (2026-09-03, PR #280): DOC-6, DOC-9, DOC-10, SEC-3 closed by the docs; GAP-1 + SEC-4 documented on
       defaults (#248, #250 open on #226/#227); residual-egress list (i)–(iv) pending #236/#221 and #240/#222;
-      5a (#236) and 5b-b (#240) stay blocked on #221/#228 and #222 — dated entry above. DOC-16 #261: own PR.
+      5a (#236) and 5b-b (#240) stay blocked on #221/#228 and #222; DOC-16 #261 fixed in PR #281 — dated entry above.
 
 
 ---

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -655,13 +655,10 @@ open round's item stays the last block of §5.)
 
 19. **Full-audit 2026-09-02 (security/reliability) — REMEDIATION IN PROGRESS** (tracker #217;
     labels `audit-2026-09-02`, `severity:*`, `phase:0`..`phase:9`, `owner-decision`, `follow-up`).
-    Working paper, plan and STATE ledger live under the git-ignored `tmp/` for the round; the
-    durable ledger is written once, at close-out, as `docs/architecture.md` "§52 Full audit
-    (2026-09-02) — remediation ledger + close-out" (after §51). Fourteen owner decisions are open
-    as #218–#231; until answered, each phase runs on the plan's default and says so in its PR body
-    (a default is never upgraded to a ruling). Phases 0–4 as listed below, then 5a external-open
-    consent, 5b raw-path hardening, 6 rekey, 7 recovery + durability docs, 8 small code items,
-    9a docs sweep, 9b close-out. One line per merged phase (outcome + PR + pointer):
+    Working paper, plan and STATE ledger live under the git-ignored `tmp/`; the durable ledger is
+    written once, at close-out, as `docs/architecture.md` "§52 Full audit (2026-09-02) —
+    remediation ledger + close-out" (after §51). Owner decisions #218–#231: each phase runs on the
+    plan's default until answered and says so in its PR body. One line per merged phase:
     - **0-a** (2026-09-02, docs-only, PR #265): the eight closed 2026-08-20…08-22 dated entries
       drained to `docs/build-log.md`; this item opened.
     - **0** (2026-09-02, PR #267): SEC-12 + GAP-2 (quit re-entry prevented, 30 s overall deadline,
@@ -803,9 +800,9 @@ the offline/privacy guarantees:
   labeled hypothesis, likely moot (libarchive/bsdtar checks linknames; hardlinks need an
   existing same-volume target; the archive hash is owner-pinned). Owner ratified 2026-07-12:
   skip the one-time fixture probe; re-open only if the extraction path or tar binary changes.
-- **L-8 — Lockfile / `npm ci` discipline.** Confirm `package-lock.json` is committed and the
-  provisioning/build scripts use `npm ci` (not `npm install`) so a build can't float a caret range
-  to a newer minor. Integrity anchor = the committed lockfile.
+- **L-8 — Lockfile / `npm ci` discipline — CLOSED 2026-09-03 (#260).** `package-lock.json` is
+  committed; `setup-dev.{ps1,sh}`, CI and the release workflow run `npm ci` (issue #49); the one
+  stale `npm install` instruction (`data-contracts.md`) was corrected. Anchor = the lockfile.
 
 ---
 ## 9. First real Windows `D:\` drive bring-up — durable lessons (2026-06-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ from its first public `1.0.0` release onward.
   could destroy the workspace (the 0.1.59 fix for issue #208 only protects when both copies are
   0.1.59 or newer). Each launcher also accepts `--check` (`/check` on Windows) to show which app
   it would start without starting it.
+- **The user guide now says what an unclean stop costs.** Pulling the drive without quitting, a
+  crash, or shutting down or logging off the computer with the app open loses the changes made
+  since the workspace last locked or quit; the workspace itself reopens fine from that point. The
+  privacy notice and the security documentation now also say which small things live outside the
+  drive: display preferences in the computer's browser profile, and anything you copy on its
+  clipboard.
 
 ## [0.1.59] — 2026-08-21
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -54,6 +54,11 @@ folder):
 - Local debug/audit logs
 - App settings
 
+Two small things live outside the workspace: the app remembers display preferences (such as your
+chosen language) in the app-data folder that the built-in browser engine keeps on this computer,
+and anything you copy with a **Copy** button is placed on this computer's clipboard, just like
+copying text anywhere else.
+
 ## Offline mode
 
 The app's **core path — chat, documents, indexing, search — always stays local** and makes no

--- a/apps/desktop/tests/unit/renderer-storage-keys.test.ts
+++ b/apps/desktop/tests/unit/renderer-storage-keys.test.ts
@@ -43,15 +43,17 @@ describe('renderer localStorage keys are the documented set (#249)', () => {
 
   // Every read/write/remove call: `localStorage.getItem(X)` with X a literal or an identifier.
   const uses: Array<{ file: string; key: string }> = []
+  const unresolved: string[] = []
   for (const [file, src] of sources) {
     for (const m of src.matchAll(/localStorage\.(?:getItem|setItem|removeItem)\(\s*(?:'([^']+)'|([A-Za-z_][A-Za-z0-9_]*))/g)) {
       const key = m[1] ?? constants.get(m[2])
-      expect(key, `${rel(file)}: unresolvable localStorage key argument \`${m[2]}\``).toBeDefined()
-      uses.push({ file: rel(file), key: key as string })
+      if (key === undefined) unresolved.push(`${rel(file)}: ${m[2]}`)
+      else uses.push({ file: rel(file), key })
     }
   }
 
-  it('finds the calls at all (the scan is not vacuous)', () => {
+  it('finds the calls at all, and every key argument resolves to a string constant', () => {
+    expect(unresolved).toEqual([])
     expect(uses.length).toBeGreaterThanOrEqual(Object.keys(PRODUCT_KEYS).length + DEV_HARNESS_KEYS.length)
   })
 

--- a/apps/desktop/tests/unit/renderer-storage-keys.test.ts
+++ b/apps/desktop/tests/unit/renderer-storage-keys.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// The host Chromium profile (Electron `userData`) is the one place the app keeps state OUTSIDE
+// the drive, and lock does not clear it (owner decision #231). `docs/security-model.md`
+// "What lives or passes outside the drive" lists every `localStorage` key the renderer touches
+// (#249); this pin keeps that list honest. A new key means: add it here AND in the doc.
+const PRODUCT_KEYS: Record<string, string> = {
+  'hilbertraum.uiLanguage': 'i18n.tsx',
+  'hilbertraum.chat.listCollapsed': 'screens/ChatScreen.tsx',
+  'hilbertraum.docs.railCollapsed': 'screens/documents/types.ts',
+  'hilbertraum.docs.viewsMoreOpen': 'screens/documents/types.ts'
+}
+// Written only by the dev preview harness (never read by the app).
+const DEV_HARNESS_KEYS = ['hilbertraum.chat.listView']
+const DEV_HARNESS_FILE = 'preview/preview.tsx'
+
+const RENDERER = join(__dirname, '../../src/renderer')
+const MAIN = join(__dirname, '../../src/main')
+
+const walk = (dir: string): string[] => {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...walk(p))
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(p)
+  }
+  return out
+}
+
+const rel = (p: string): string => relative(RENDERER, p).replace(/\\/g, '/')
+
+describe('renderer localStorage keys are the documented set (#249)', () => {
+  const files = walk(RENDERER)
+  const sources = new Map(files.map((f) => [f, readFileSync(f, 'utf8')]))
+
+  // `const NAME = 'literal'` anywhere under src/renderer resolves an identifier argument.
+  const constants = new Map<string, string>()
+  for (const src of sources.values()) {
+    for (const m of src.matchAll(/\bconst\s+([A-Z][A-Z0-9_]*)\s*=\s*'([^']+)'/g)) constants.set(m[1], m[2])
+  }
+
+  // Every read/write/remove call: `localStorage.getItem(X)` with X a literal or an identifier.
+  const uses: Array<{ file: string; key: string }> = []
+  for (const [file, src] of sources) {
+    for (const m of src.matchAll(/localStorage\.(?:getItem|setItem|removeItem)\(\s*(?:'([^']+)'|([A-Za-z_][A-Za-z0-9_]*))/g)) {
+      const key = m[1] ?? constants.get(m[2])
+      expect(key, `${rel(file)}: unresolvable localStorage key argument \`${m[2]}\``).toBeDefined()
+      uses.push({ file: rel(file), key: key as string })
+    }
+  }
+
+  it('finds the calls at all (the scan is not vacuous)', () => {
+    expect(uses.length).toBeGreaterThanOrEqual(Object.keys(PRODUCT_KEYS).length + DEV_HARNESS_KEYS.length)
+  })
+
+  it('touches exactly the documented product keys plus the dev-harness key', () => {
+    const seen = new Set(uses.map((u) => u.key))
+    expect([...seen].sort()).toEqual([...Object.keys(PRODUCT_KEYS), ...DEV_HARNESS_KEYS].sort())
+  })
+
+  it('each product key is defined where the doc says', () => {
+    for (const [key, file] of Object.entries(PRODUCT_KEYS)) {
+      const definers = [...sources].filter(([, src]) => src.includes(`'${key}'`)).map(([f]) => rel(f))
+      expect(definers, key).toEqual([file])
+    }
+  })
+
+  it('the dev-harness key is written only by the preview harness', () => {
+    for (const key of DEV_HARNESS_KEYS) {
+      const where = uses.filter((u) => u.key === key).map((u) => u.file)
+      expect(where, key).toEqual([DEV_HARNESS_FILE])
+    }
+  })
+
+  it('no other web storage is used, and no key argument is computed', () => {
+    for (const [file, src] of sources) {
+      expect(src, rel(file)).not.toMatch(/\bsessionStorage\b|\bindexedDB\b|\bopenDatabase\(/)
+      expect(src, rel(file)).not.toMatch(/localStorage\.(?:getItem|setItem|removeItem)\(\s*[`(]/)
+    }
+  })
+})
+
+describe('the host profile is the default session and is never cleared (#249, #231)', () => {
+  const src = walk(MAIN).map((f) => readFileSync(f, 'utf8')).join('\n')
+
+  it('no window uses a `partition`', () => {
+    expect(src).not.toMatch(/\bpartition\s*:/)
+  })
+
+  it('nothing calls clearStorageData / clearCache (owner decision #231: document only)', () => {
+    expect(src).not.toMatch(/clearStorageData\(|clearCache\(/)
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -666,7 +666,7 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
 - `verify-models.{ps1,sh}` — `-Target`/`--target`, `-Generate`/`--generate`. Flat-YAML line-parses the
   manifests, SHA-256s present weights, prints `VERIFIED/UNVERIFIED/MISMATCH/MISSING/UNSUPPORTED`,
   **exit 1 on a real-hash mismatch**; `--generate` writes `config/checksums.json`.
-- `setup-dev.{ps1,sh}` — `NODE_OPTIONS=--use-system-ca npm install` (R6) + build + test smoke.
+- `setup-dev.{ps1,sh}` — `NODE_OPTIONS=--use-system-ca npm ci` (R6; lockfile-exact, issue #49) + build + test smoke.
 ✅ **Packaging** — `apps/desktop/electron-builder.yml` (portable Windows + mac/linux parity;
   `model-manifests/` as `extraResources`; asar; Electron ≥37). `npm run package` / `package:win`
   (root + workspace). New dev dep **`electron-builder ^26.15.2`**. Output → `apps/desktop/release/`
@@ -1395,10 +1395,11 @@ whole renderer-visible surface.
 ### Channel-surface completion sweep (2026-08-20, docs/code audit E-1)
 
 The #138 backfill above closed the *feature* gaps. A mechanical pass over every key in
-`shared/ipc.ts` (140 channels) against this file then found **16** that appeared under neither
-their method name nor their channel string — mostly siblings of documented calls that arrived one
-at a time. Listed here so the declared source of truth is complete; each one's behaviour stays
-owned by the design record named beside it.
+`shared/ipc.ts` (138 channels — the keys of its `IPC` constant; the `STREAM` builders,
+`OCR_RASTER` and `EVENTS` are separate constants, #259) against this file then found **16** that
+appeared under neither their method name nor their channel string — mostly siblings of documented
+calls that arrived one at a time. Listed here so the declared source of truth is complete; each
+one's behaviour stays owned by the design record named beside it.
 
 - **`useModel(modelId): Promise<RuntimeStatus>`** (`runtime:use`) — the MERGED select-and-start
   action, and the one a UI caller should reach for. It persists the active chat slot, emits

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -28,10 +28,11 @@ password recovery — are documented in
   it returned), so a compromised renderer can't forge a picker-origin read of an arbitrary file
   (`security-model.md` D1). A native OS drag-drop is delivered to the
   *renderer*, so main can't tokenize it — that seam still accepts raw paths but rejects symlinks and
-  canonicalizes them; the read *content* has no network sink (offline), but the *path* is one on
-  Windows — a UNC path reaches `lstat` before any lexical check, opening an SMB connection and an
-  NTLM/Kerberos credential exchange to the named host (pending #240 / owner decision #222; see
-  `security-model.md` "Residual egress channels").
+  canonicalizes them; the read *content* has no network sink (offline), but the *path* can be one
+  on Windows — a UNC path reaches `lstat` before any lexical check, which makes Windows attempt an
+  SMB connection to the named host and, where that host is reachable and outgoing NTLM is not
+  restricted, a credential exchange (documented behaviour, not probed; pending #240 / owner
+  decision #222; see `security-model.md` "Residual egress channels").
 - **Some things live or pass outside the drive by design.** Display preferences (the language, a
   few collapsed-panel states) sit in the host browser profile under the app's OS app-data folder,
   not in the workspace; text copied with a Copy button goes to the OS clipboard like any copied

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -28,7 +28,16 @@ password recovery — are documented in
   it returned), so a compromised renderer can't forge a picker-origin read of an arbitrary file
   (`security-model.md` D1). A native OS drag-drop is delivered to the
   *renderer*, so main can't tokenize it — that seam still accepts raw paths but rejects symlinks and
-  canonicalizes them, and there is no network sink to exfiltrate read content (offline).
+  canonicalizes them; the read *content* has no network sink (offline), but the *path* is one on
+  Windows — a UNC path reaches `lstat` before any lexical check, opening an SMB connection and an
+  NTLM/Kerberos credential exchange to the named host (pending #240 / owner decision #222; see
+  `security-model.md` "Residual egress channels").
+- **Some things live or pass outside the drive by design.** Display preferences (the language, a
+  few collapsed-panel states) sit in the host browser profile under the app's OS app-data folder,
+  not in the workspace; text copied with a Copy button goes to the OS clipboard like any copied
+  text; a link opened from an answer or a model manifest opens in the OS browser. See
+  `security-model.md` "What lives or passes outside the drive" and "Residual egress channels"
+  (#249, #250).
 - **Archive extraction trusts verified archives.** `fetch-runtime` rejects `extract_to` escapes,
   and archives are SHA-256-verified before extraction — but member paths inside an archive are only
   as trustworthy as the pinned hash in `runtime-sources.yaml`.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1068,12 +1068,12 @@ re-encrypts (the bullet below).
   `src/main` handles Windows `session-end` or macOS `shutdown` — the awaited teardown above
   (`will-quit`: sidecar stops, settle, then lock = re-encrypt + shred) never runs on logoff or
   shutdown, so the process is killed with the working DB still plaintext on the drive. The only
-  lock outside that awaited teardown is the synchronous `uncaughtException` crash path in
+  unattended lock outside that awaited teardown is the synchronous `uncaughtException` crash path in
   `main/index.ts` (`detachVaultKey()` + `workspace.shutdown()`), and it is not wired to session
   end either. On the next start the crash-recovery sweep finds the live working copy, shreds it
   and restores the last locked encrypted snapshot — the session delta since that lock is lost.
-  `docs/user-guide.md` §13 names this loss for users; a best-effort synchronous lock on those two
-  events is the alternative recorded on #226.
+  `docs/user-guide.md` §13 names this loss for users; a best-effort synchronous lock on Windows
+  `session-end` (and the macOS equivalent, unverified) is the alternative recorded on #226.
 - **Doc-task pipeline is flushed on lock/quit (TA-1).** The lock/quit handlers call
   `ctx.docTasks.cancelAllDocTasks()` — cancelling the running task **and every queued task** —
   not just the active one. The DB stays *open* while the handler awaits the sidecar suspends, so
@@ -1720,8 +1720,9 @@ are tracked under "Open hardening items" in `BUILD_STATE.md`.)
   and drops non-string path elements exactly like `importDocuments`, so a compromised renderer
   can neither drive a recursive directory walk of arbitrary paths while the workspace is locked
   nor crash `expandPaths` with junk elements. It is still a token-less probe, though: after the
-  path cap (PR #275) it `lstat`s the raw paths it is given, so a UNC or device path reaches the
-  filesystem before any lexical check — residual egress channel (ii) below, pending #222.
+  path cap (PR #275) it `stat`s the raw paths it is given (following symlinks — unlike the drop
+  seam, it rejects none), so a UNC or device path reaches the filesystem before any lexical
+  check — residual egress channel (ii) below, pending #240 (owner decision #222).
 
 ## Parsing-DoS hardening — the content tools' regexes are now linear (vuln-scan 2026-06-21)
 
@@ -1810,7 +1811,7 @@ read any supported-type file anywhere on disk (the text is then reachable via
   canonicalized (a `.pdf`-named symlink can't reach a sensitive target through the importer). A
   compromised renderer can still drive this seam with on-disk paths, but the offline guarantee
   means there is **no network sink to exfiltrate** read content (the *path* itself is one on
-  Windows — "Residual egress channels" (ii) below, pending #222), and the dominant picker surface
+  Windows — "Residual egress channels" (ii) below, pending #240 / #222), and the dominant picker surface
   is now non-forgeable. `importPreflight` still takes raw paths (counts/sizes only — lower impact).
 - **Skills use the same token mechanism (#240, PR #275):** `pickSkillPackage` is unlock-gated and
   returns `{ token, path }`; `previewSkillPackage` reads through the token without spending it and
@@ -2054,12 +2055,14 @@ it.
   link, goes straight from `window.open` to `shell.openExternal` with no confirmation or throttle:
   the OS browser opens it, and the link's host learns the machine's IP address and user agent.
   Pending #236 (owner decision #221).
-- **(ii) A UNC or device path on the raw path seams.** A native drag-drop and a token-less import
-  preflight `lstat` each path before any lexical rejection, so a `\\host\share\...` path opens an
-  SMB connection — on Windows with an NTLM/Kerberos credential exchange — to the named host before
-  any file is read. The machine's credentials, not document content, are what can leave. Mapped
-  network drives cannot be told apart lexically at all. Rejecting such paths changes the drop
-  contract for network-share users: pending #240 (owner decision #222).
+- **(ii) A UNC or device path on the raw path seams.** A native drag-drop `lstat`s and a token-less
+  import preflight `stat`s each path before any lexical rejection, so a `\\host\share\...` path
+  makes Windows attempt an SMB connection to the named host before any file is read — and, where
+  outbound 445/WebDAV is reachable and outgoing NTLM is not restricted, an NTLM/Kerberos
+  credential exchange (documented Windows behaviour, not probed here). What can leave is the
+  machine's credentials, not document content. Mapped network drives cannot be told apart
+  lexically at all. Rejecting such paths changes the drop contract for network-share users:
+  pending #240 (owner decision #222).
 - **(iii) Chromium's own background fetches and form submits — landed.** The spell-check
   dictionary download is closed by construction (`spellcheck: false`, #239), the CSP carries
   `form-action 'none'` with header/meta parity (#266), and every `ipcMain.handle` channel checks

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1064,6 +1064,16 @@ re-encrypts (the bullet below).
   reaper). A `quit: locking workspace` log line precedes the lock — with no window left, it is the
   only visible state of a quit. Pinned by `tests/unit/shutdown.test.ts` (B1 inverted, the
   activate guard, the deadline with the lock outside it).
+- **OS session end is a hard kill (#248; owner decision #226, default = document).** Nothing in
+  `src/main` handles Windows `session-end` or macOS `shutdown` — the awaited teardown above
+  (`will-quit`: sidecar stops, settle, then lock = re-encrypt + shred) never runs on logoff or
+  shutdown, so the process is killed with the working DB still plaintext on the drive. The only
+  lock outside that awaited teardown is the synchronous `uncaughtException` crash path in
+  `main/index.ts` (`detachVaultKey()` + `workspace.shutdown()`), and it is not wired to session
+  end either. On the next start the crash-recovery sweep finds the live working copy, shreds it
+  and restores the last locked encrypted snapshot — the session delta since that lock is lost.
+  `docs/user-guide.md` §13 names this loss for users; a best-effort synchronous lock on those two
+  events is the alternative recorded on #226.
 - **Doc-task pipeline is flushed on lock/quit (TA-1).** The lock/quit handlers call
   `ctx.docTasks.cancelAllDocTasks()` — cancelling the running task **and every queued task** —
   not just the active one. The DB stays *open* while the handler awaits the sidecar suspends, so
@@ -1207,6 +1217,37 @@ sidecar's KV cache dies with the child, and the CPU replacement starts empty.
   leave original blocks recoverable. We do not over-promise this.
 - **No password recovery.** The password is never stored and the key is unrecoverable without it —
   losing the password means losing the workspace. Onboarding copy says so.
+
+### What lives or passes outside the drive
+
+A few things live on the host computer rather than in the workspace by design, or leave the app
+through the OS once the user acts on them. None of it is document or chat content, but it is
+worth naming so "everything stays on the drive" is not read as "nothing touches the host" (#249).
+
+- **The host Chromium profile.** The app never sets a session `partition` and never calls
+  `session.clearStorageData()`, so Electron's default session — its web storage and Chromium's
+  own cache directories (GPU shader cache, code cache, and the like) — persists under
+  `app.getPath('userData')` on the host computer, not on the drive (dev builds add a `-dev`
+  suffix). The renderer writes only UI-preference `localStorage` keys there — the active language
+  and a few collapsed/expanded panel states (`hilbertraum.uiLanguage`,
+  `hilbertraum.chat.listCollapsed`, `hilbertraum.docs.railCollapsed`,
+  `hilbertraum.docs.viewsMoreOpen`; the set is pinned by `tests/unit/renderer-storage-keys.test.ts`)
+  — never document or chat content. When no prepared drive is found, the workspace itself falls
+  back to this same folder (`PRIVACY.md` says so). Nothing here is cleared on lock: owner decision
+  #231 keeps "document only" as the default and records clearing the profile on lock as the
+  alternative.
+- **The spell-check dictionary — none.** Chromium's spellchecker is off (`spellcheck: false` on
+  every window, #239 / owner decision #218), so there is no Hunspell `.bdic` download and no
+  `Dictionaries/` folder under `userData`. See "Chromium background fetches" above.
+- **The OS clipboard.** Eight Copy sites in seven renderer files — chat answers, document
+  summaries, translations, image answers, evidence-review hashes, the two diagnostics copies and
+  the local-API address — write straight to the OS clipboard through the `writeClipboard` IPC,
+  with no wipe and no timer. The one exception is the local-API *key* copy, which clears itself
+  after 60 s if the clipboard still holds the key. Once text is on the OS clipboard it is outside
+  the drive: Windows clipboard history (Win+V) keeps it, and cross-device clipboard sync (Windows
+  "cloud clipboard", macOS Universal Clipboard) forwards it to other devices if the user has that
+  turned on. Owner decision #227 keeps "document only" as the default and records a timed clear
+  (generalising the key-copy timer) as the alternative (#250).
 
 ## Malicious-document resource caps (audit M-1/M-2/M-3, 2026-06-13)
 
@@ -1678,7 +1719,9 @@ are tracked under "Open hardening items" in `BUILD_STATE.md`.)
   (`registerDocsIpc.ts`) was an unauthenticated filesystem probe; it now calls `requireUnlocked()`
   and drops non-string path elements exactly like `importDocuments`, so a compromised renderer
   can neither drive a recursive directory walk of arbitrary paths while the workspace is locked
-  nor crash `expandPaths` with junk elements.
+  nor crash `expandPaths` with junk elements. It is still a token-less probe, though: after the
+  path cap (PR #275) it `lstat`s the raw paths it is given, so a UNC or device path reaches the
+  filesystem before any lexical check — residual egress channel (ii) below, pending #222.
 
 ## Parsing-DoS hardening — the content tools' regexes are now linear (vuln-scan 2026-06-21)
 
@@ -1766,8 +1809,9 @@ read any supported-type file anywhere on disk (the text is then reachable via
   each top-level path is `lstat`-checked and a **symlink is rejected**, then `realpathSync`-
   canonicalized (a `.pdf`-named symlink can't reach a sensitive target through the importer). A
   compromised renderer can still drive this seam with on-disk paths, but the offline guarantee
-  means there is **no network sink to exfiltrate** read content, and the dominant picker surface is
-  now non-forgeable. `importPreflight` still takes raw paths (counts/sizes only — lower impact).
+  means there is **no network sink to exfiltrate** read content (the *path* itself is one on
+  Windows — "Residual egress channels" (ii) below, pending #222), and the dominant picker surface
+  is now non-forgeable. `importPreflight` still takes raw paths (counts/sizes only — lower impact).
 - **Skills use the same token mechanism (#240, PR #275):** `pickSkillPackage` is unlock-gated and
   returns `{ token, path }`; `previewSkillPackage` reads through the token without spending it and
   `importSkill` spends it, so a renderer string that is not a live token is refused before the
@@ -1999,6 +2043,32 @@ content, so the tail carries nothing content-bearing. This is **accepted as an I
 500-char cap bounds size and a one-line `INVARIANT (SEC-N3)` comment at the cap pins the expectation and
 asks for a re-verify on every llama.cpp pin bump; if a future server ever echoed request content into an
 error body, the fallback should be sanitized to a fixed structural string + numeric status.
+
+## Residual egress channels
+
+The offline guarantee above covers the app's own network use. These are the ways bytes can still
+leave the machine despite it, each with its current status and the issue that closes or records
+it.
+
+- **(i) An OS browser open of a link.** A link in a model answer, or a model manifest's license
+  link, goes straight from `window.open` to `shell.openExternal` with no confirmation or throttle:
+  the OS browser opens it, and the link's host learns the machine's IP address and user agent.
+  Pending #236 (owner decision #221).
+- **(ii) A UNC or device path on the raw path seams.** A native drag-drop and a token-less import
+  preflight `lstat` each path before any lexical rejection, so a `\\host\share\...` path opens an
+  SMB connection — on Windows with an NTLM/Kerberos credential exchange — to the named host before
+  any file is read. The machine's credentials, not document content, are what can leave. Mapped
+  network drives cannot be told apart lexically at all. Rejecting such paths changes the drop
+  contract for network-share users: pending #240 (owner decision #222).
+- **(iii) Chromium's own background fetches and form submits — landed.** The spell-check
+  dictionary download is closed by construction (`spellcheck: false`, #239), the CSP carries
+  `form-action 'none'` with header/meta parity (#266), and every `ipcMain.handle` channel checks
+  its sender (#252). Two channels — WebRTC and `dns-prefetch`/`preconnect` hints — sit outside
+  the CSP but need a compromised renderer first; confirmed and documented, not closed (#254). See
+  "Chromium background fetches" above.
+- **(iv) The OS clipboard.** Text copied from the app reaches the OS clipboard, and from there
+  clipboard history or cross-device sync. See "What lives or passes outside the drive" above
+  (#250; owner decision #227).
 
 ## Out of scope (MVP)
 - OS-level firewall enforcement (offline is by design + policy/UX, not a hard network block).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1020,11 +1020,11 @@ cleanly, and the safe eject flushes everything else. Skipping the eject is what 
 show the *"scan and fix this drive?"* prompt on the next plug-in (harmless, but see
 [`troubleshooting.md`](troubleshooting.md) if it appears).
 
-**If the app is not quit cleanly:** pulling the drive while the app is running, a crash, or
-shutting down or logging off the computer with the app still open loses any changes made since
-the workspace last locked (the last **Lock now** or a normal quit). The workspace itself is not
-damaged — it reopens from that last locked point — but everything after it is gone, so quit the
-app first.
+**If the app is not quit cleanly:** pulling the drive while the app is running, a power cut or a
+forced kill of the app, or shutting down or logging off the computer with the app still open
+loses any changes made since the workspace last locked (the last **Lock now** or a normal quit).
+The workspace itself is not damaged — it reopens from that last locked point — but everything
+after it is gone, so quit the app first.
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1020,6 +1020,12 @@ cleanly, and the safe eject flushes everything else. Skipping the eject is what 
 show the *"scan and fix this drive?"* prompt on the next plug-in (harmless, but see
 [`troubleshooting.md`](troubleshooting.md) if it appears).
 
+**If the app is not quit cleanly:** pulling the drive while the app is running, a crash, or
+shutting down or logging off the computer with the app still open loses any changes made since
+the workspace last locked (the last **Lock now** or a normal quit). The workspace itself is not
+damaged — it reopens from that last locked point — but everything after it is gone, so quit the
+app first.
+
 ---
 
 Stuck? See [`troubleshooting.md`](troubleshooting.md).


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 9a: early docs sweep
Closes #246, closes #259, closes #260, closes #249
Refs #250, refs #248 (both stay open on their owner decisions #227 / #226 — see below), refs #231
Tracker: #217

### What
- `docs/user-guide.md` §13: the loss statement after the quit-and-eject passage (DOC-6 #246; the GAP-1 clause per decision 9's default; **no** preview/re-index/import clause — Phase 4 #273 landed).
- `docs/security-model.md`:
  - "App-shell gate & lifecycle": one bullet — OS session end is a hard kill, no `session-end`/`shutdown` handler, the crash path is not wired to it (GAP-1 #248 wording).
  - NEW `### What lives or passes outside the drive` under "Threat notes / known limitations" (chosen over "after Vault-overwrite guards": it is a limitation list, and it sits beside the other host/at-rest caveats): the host Chromium profile (four `localStorage` keys + caches, no `Dictionaries/`, not cleared on lock — rider 14 default), the spell-check dictionary (none — pointer to the Phase 0 subsection), the OS clipboard (8 Copy sites in 7 files, the one 60 s exception, clipboard history / cloud sync — decision 10 default) (SEC-3 #249, SEC-4 #250).
  - NEW `## Residual egress channels` before "Out of scope": items (i)–(iv) — (i) OS browser opens **pending #236 / #221**; (ii) UNC/device paths on the raw seams **pending #240 / #222**; (iii) Chromium fetches / form submits — landed (#239, #266, #252; GAP-3 #254 confirmed residual); (iv) the clipboard (#250 / #227).
  - The D1 drag-drop bullet and the L-3 bullet now qualify their "no network sink" wording with a pointer to item (ii).
- `docs/known-limitations.md`: the drag-drop bullet's "no network sink" sentence qualified (path = credential sink on Windows, pending #240/#222); one new bullet "Some things live or pass outside the drive by design".
- `PRIVACY.md`: one plain-language paragraph (display preferences in the app-data folder; Copy → the computer's clipboard).
- `docs/data-contracts.md`: IPC channel count 140 → **138** with how it is counted (DOC-9 #259); `npm install` → `npm ci` in the `setup-dev` line (DOC-10 #260).
- `BUILD_STATE.md`: §8 L-8 closed with a pointer; item 19's intro tightened by 3 lines (the block was 45/45) + the 9a line; the dated entry.
- `CHANGELOG.md` `[Unreleased]` → Changed: one user-facing line.
- NEW `tests/unit/renderer-storage-keys.test.ts` (plan §2 SEC-3 "tests first"): pins the renderer `localStorage` key set the doc lists (4 product keys + the dev-harness key), and that `src/main` sets no `partition` and never calls `clearStorageData`/`clearCache`. A source scan, no product code — the PR stays docs + one test.

### Why (finding IDs + the promise line each restores)
- DOC-6 #246 — the guide now names what an unclean stop loses (the public statement of REL-11; carrier of containment item 7).
- GAP-1 #248 — the security model says logoff/shutdown is a hard kill (decision 9 default = document).
- SEC-3 #249 — the host profile is documented; rider 14 default = no `clearStorageData()` on lock.
- SEC-4 #250 — the clipboard note + residual item (iv); decision 10 default = document only.
- DOC-9 #259 / DOC-10 #260 — counts and commands match the code.

### Verified against HEAD (differences from the plan's "right after Phase 0" assumptions)
- Phase 4 landed → no SEC-10 interim clause in §13. Phase 8 landed → `local-api.md` already carries the "Body total" row; nothing to do. 5b-a landed → BUILD_STATE §8 L-4/L-5 and `architecture.md`'s `pickSkillPackage` token statement are already restated; nothing to do. Phase 0 added the spellcheck sentence to `PRIVACY.md`; the "outside the workspace" sentence was missing and is added here.
- `shared/ipc.ts` at HEAD: `IPC` = 138 keys (137 `ipcHandle(` sites + 1 unregistered); `OCR_RASTER` 5, `EVENTS` 2 — counted separately.
- `copyToClipboard` call sites at HEAD: 8 in 7 files (as the plan counted).
- Phase 0 code comments still carrying audit IDs: exactly ONE left (`tests/unit/window-security.test.ts` "SEC-1"); registered for Phase F (default: not in this PR).

### Tests
- `tests/unit/renderer-storage-keys.test.ts` — 7 tests, green (a pin, not a red-then-green characterisation: it pins the documented state).
- `repo-hygiene.test.ts` green (BUILD_STATE budgets: see below).
- `npm test` count: **371 files passed, 23 skipped; 5,568 passed, 74 skipped** excluding the Electron smoke (+1 file / +7 tests over the Phase 8-b baseline 370 / 5,561 / 74 — the new pin). Raw run 372 / 5,574 / 74: the `evidence-pack-pdf-smoke` PASSED on this machine this session (the application-control block did not fire). `npm run typecheck` + `npm run build` green at `ea62b412`.

### Docs + BUILD_STATE
Listed under "What". BUILD_STATE after this PR: preamble 181/200 · §5 471/500 · **item 19 block 45/45** (intro −3, +3-line 9a bullet) · §8 65/80 · file 827 lines; `repo-hygiene.test.ts` green; byte checks 0/0 on every touched `.md`. Docs-only: no launch smoke needed.

### Owner decisions relied on (issue #, answer or default)
- Decision 9 (#226, GAP-1): `**DECISION:**` query empty at kickoff → **default, document as a hard kill — #226 unanswered, re-open on request.** #248 stays open (Refs).
- Decision 10 (#227, SEC-4): empty → **default, document only — re-open on request.** #250 stays open (Refs) until #227 is answered or 9b records "default stands".
- Rider 14 (#231, SEC-3): empty → **default, document only (no `clearStorageData()` on lock) — re-open on request.** #249 is closed by the docs (the finding was "undocumented"); the rider stays on #231.
- Every owner line of the 9a kickoff prompt was blank → defaults stand: DOC-16 as its own PR; the Phase 0 audit-ID comment sweep → Phase F.

### Owner review — Q26 (the §13 loss sentence; merged on the drafted wording, reword after if wanted)
The user guide has no German twin, so EN only:

> **If the app is not quit cleanly:** pulling the drive while the app is running, a power cut or a forced kill of the app, or shutting down or logging off the computer with the app still open loses any changes made since the workspace last locked (the last **Lock now** or a normal quit). The workspace itself is not damaged — it reopens from that last locked point — but everything after it is gone, so quit the app first.

("a crash" was dropped after review: an in-process JS crash runs the synchronous lock and usually preserves the session — only a kill the app cannot see loses it.)

### Reviewer pass: Opus
Verdict: merge after repairs — 1 blocking, 5 should-fix, 6 nits; every factual claim of the new text re-verified against HEAD (keys, spellcheck, the 8 clipboard sites, no session-end handler, the crash path, the 138/137 counts, `npm ci`, issue states, budgets, hygiene). Repairs (commit after `fd412c1b`): **B1** the token-less preflight `stat`s (follows symlinks), it does not `lstat` — L-3 bullet + item (ii) corrected; **S1** the SMB/NTLM leg is documented Windows behaviour, not probed — hedged in item (ii) and `known-limitations.md` (reachable 445/WebDAV + outgoing NTLM not restricted); **S2** "the only *unattended* lock outside the teardown" (Lock now is a lock too); **S3** §13 no longer lists "a crash" (see Q26); **S4** the two in-body pointers now say "pending #240 (owner decision #222)"; **N1** the key-resolution assertion moved into a named test; **N4** the dated entry names PR #281 and the outcome; **N6** "Windows `session-end` (and the macOS equivalent, unverified)". Recorded, not changed: N2 (single constant map, no duplicates today), N3 (`session.fromPartition` not scanned; `src/main` only), N5 (item 19 lost "a default is never upgraded to a ruling" — 9b restores it in the ROUND COMPLETE rewrite). Handoff: item 19 is 45/45 again.

### Rollback
Revert the PR (docs + one test file; no product code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
