### PR TITLE
fix(renderer): skill write/export confirm snapshots its target and names it (audit 2026-09-02 Phase 9a — DOC-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **The confirmation before a skill writes or exports a file now names the document.** The
+  dialog says which document the tool will run on, and the run goes to that document even if the
+  document list refreshed while the dialog was open — before, it silently used whichever document
+  was first in the list at the moment you pressed Run.
 - **A tampered engine list can no longer write outside the engine folder.** The file that
   names where to download the AI engine from lives on the drive. If it had been edited to
   carry a download address whose file name walked up the folder tree, the downloaded archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,10 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
-- **The confirmation before a skill writes or exports a file now names the document.** The
-  dialog says which document the tool will run on, and the run goes to that document even if the
-  document list refreshed while the dialog was open — before, it silently used whichever document
-  was first in the list at the moment you pressed Run.
+- **The confirmation before a skill writes or exports a file now names the document.** You can
+  see which document the tool will run on before you confirm, and the run is pinned to that
+  document — if it is no longer in the chat by the time you press Run, the app says so instead of
+  running on a different one.
 - **A tampered engine list can no longer write outside the engine folder.** The file that
   names where to download the AI engine from lives on the drive. If it had been edited to
   carry a download address whose file name walked up the folder tree, the downloaded archive

--- a/apps/desktop/src/renderer/chat/SkillRunBar.tsx
+++ b/apps/desktop/src/renderer/chat/SkillRunBar.tsx
@@ -36,6 +36,13 @@ export interface SkillRunTarget {
   name: string | null
 }
 
+// The write/export confirm, snapshotted when the dialog opens (#261).
+interface PendingConfirm {
+  tool: RunnableTool
+  documentId: string
+  documentName: string | null
+}
+
 // The tool's display label, done copy and result-shape all come from the self-describing tool
 // registry (`@shared/skill-tools`, audit §6.2) — the renderer no longer keeps parallel label/done
 // maps that drift from the wired set. A tool with no descriptor (should not happen for an offered
@@ -178,13 +185,16 @@ export function SkillRunBar({
   offerRoutedFollowups = true
 }: SkillRunBarProps): JSX.Element {
   const { t, tCount } = useT()
-  const [confirmTool, setConfirmTool] = useState<RunnableTool | null>(null)
+  // The pending write/export confirm. It SNAPSHOTS the target at open (#261): the dialog is the
+  // last checkpoint before a file is written, so it names the document it will run on and the run
+  // goes to that document even if the target list changes underneath the open dialog.
+  const [confirmTool, setConfirmTool] = useState<PendingConfirm | null>(null)
   // RD-6 (full-audit 2026-07-10): a pending confirm must not outlive its offer. `confirmTool` is
   // state, so it survives the offer row unmounting (tools emptied by a scope change / a run
   // starting elsewhere) and would silently RE-OPEN the dialog the moment the offer returns —
   // unreachable today only by accident of modality. Clear it once the tool is no longer offered.
   useEffect(() => {
-    if (confirmTool && !runnableTools.some((tool) => tool.name === confirmTool.name)) {
+    if (confirmTool && !runnableTools.some((tool) => tool.name === confirmTool.tool.name)) {
       setConfirmTool(null)
     }
   }, [confirmTool, runnableTools])
@@ -265,9 +275,9 @@ export function SkillRunBar({
   // discoverable in the save dialog / result file. An UNRESOLVED target name (null, RD-2 — e.g. the
   // document list not yet loaded) falls back to the full matrix line rather than guessing ".txt".
   const confirmFormatKey: MessageKey | null =
-    confirmTool && getToolDescriptor(confirmTool.name)?.docxDialog
+    confirmTool && getToolDescriptor(confirmTool.tool.name)?.docxDialog
       ? (() => {
-          const name = targets.find((d) => d.id === selectedId)?.name
+          const name = confirmTool.documentName
           if (!name) return 'chat.skill.confirm.outputMatrix' as const
           return name.toLowerCase().endsWith('.docx')
             ? ('chat.skill.confirm.outputDocx' as const)
@@ -279,11 +289,16 @@ export function SkillRunBar({
   // reach (pictures/scanned pages, embedded objects) — so the same-format export never implies
   // whole-file redaction. Text parts + metadata ARE covered since #129; this names the residuals.
   const confirmScopeKey: MessageKey | null =
-    confirmTool && confirmTool.name === 'redact_document' ? 'chat.skill.confirm.redactionScope' : null
+    confirmTool && confirmTool.tool.name === 'redact_document' ? 'chat.skill.confirm.redactionScope' : null
 
   const onClickTool = (tool: RunnableTool): void => {
-    if (tool.requiresConfirmation) setConfirmTool(tool)
-    else runTool(tool)
+    if (tool.requiresConfirmation) {
+      setConfirmTool({
+        tool,
+        documentId: selectedId,
+        documentName: targets.find((d) => d.id === selectedId)?.name ?? null
+      })
+    } else runTool(tool)
   }
 
   // The RUN row (running / result / state-unknown) renders INSIDE the always-mounted live region below
@@ -387,13 +402,18 @@ export function SkillRunBar({
           title={t('chat.skill.confirm.title')}
           confirmLabel={t('chat.skill.confirm.ok')}
           onConfirm={() => {
-            if (confirmTool) onRun(confirmTool.name, true, selectedId || undefined)
+            if (confirmTool) onRun(confirmTool.tool.name, true, confirmTool.documentId || undefined)
             setConfirmTool(null)
           }}
           onCancel={() => setConfirmTool(null)}
           t={t}
         >
           {t('chat.skill.confirm.body')}
+          {confirmTool?.documentName && (
+            <p className="hint skill-confirm-format">
+              {t('chat.skill.confirm.target', { document: confirmTool.documentName })}
+            </p>
+          )}
           {confirmFormatKey && <p className="hint skill-confirm-format">{t(confirmFormatKey)}</p>}
           {confirmScopeKey && <p className="hint skill-confirm-format">{t(confirmScopeKey)}</p>}
         </ConfirmDialog>

--- a/apps/desktop/src/renderer/chat/SkillRunBar.tsx
+++ b/apps/desktop/src/renderer/chat/SkillRunBar.tsx
@@ -293,11 +293,8 @@ export function SkillRunBar({
 
   const onClickTool = (tool: RunnableTool): void => {
     if (tool.requiresConfirmation) {
-      setConfirmTool({
-        tool,
-        documentId: selectedId,
-        documentName: targets.find((d) => d.id === selectedId)?.name ?? null
-      })
+      const target = targets.find((d) => d.id === selectedId)
+      setConfirmTool({ tool, documentId: selectedId, documentName: target?.name ?? null })
     } else runTool(tool)
   }
 
@@ -410,7 +407,7 @@ export function SkillRunBar({
         >
           {t('chat.skill.confirm.body')}
           {confirmTool?.documentName && (
-            <p className="hint skill-confirm-format">
+            <p className="hint skill-confirm-target">
               {t('chat.skill.confirm.target', { document: confirmTool.documentName })}
             </p>
           )}

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -381,6 +381,8 @@ export const de: Record<keyof typeof en, string> = {
   'chat.skill.run.dismiss': 'Schließen',
   'chat.skill.confirm.title': 'Dieses Tool ausführen?',
   'chat.skill.confirm.body': 'Dabei wird aus den Dokumenten auf diesem Laufwerk eine Datei erstellt oder exportiert.',
+  // #261: Die Bestätigung nennt das Dokument, für das sie ausgeführt wird.
+  'chat.skill.confirm.target': 'Dokument: {document}',
   // #45: Die Bestätigung der Dokument-Werkzeuge (Schwärzen/Bearbeiten) nennt das AUSGABE-Format
   // VOR dem Lauf — vorher war die .docx-behält-Format / alles-andere-wird-.txt-Klippe erst im
   // Speichern-Dialog sichtbar.

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -346,6 +346,8 @@ export const en = {
   'chat.skill.run.dismiss': 'Dismiss',
   'chat.skill.confirm.title': 'Run this tool?',
   'chat.skill.confirm.body': 'This creates or exports a file from the documents on this drive.',
+  // #261: the confirm names the document it will run on (snapshotted when the dialog opened).
+  'chat.skill.confirm.target': 'Document: {document}',
   // #45: the document-transform confirms (redact/edit) state the OUTPUT format BEFORE the run — the
   // .docx-keeps-format / everything-else-becomes-.txt cliff was previously only discoverable in the
   // save dialog. Derived from the selected target's extension (mirrors main's source-format probe);

--- a/apps/desktop/tests/renderer/SkillRunBar.test.tsx
+++ b/apps/desktop/tests/renderer/SkillRunBar.test.tsx
@@ -603,4 +603,57 @@ describe('SkillRunBar (S11b)', () => {
     expect(screen.queryByText(/plain text \(\.txt\)/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Word format/)).not.toBeInTheDocument()
   })
+
+  it('CONFIRM (#261): the run targets the document that was shown when the dialog opened, even if the list changes underneath', async () => {
+    // The confirm is the last checkpoint before a write/export. If the target list changes while
+    // the dialog is open (a background scope refresh), the run must still go to the document the
+    // user saw and confirmed — never to whatever is first in the NEW list.
+    const onRun = vi.fn()
+    const user = userEvent.setup()
+    const shared = { run: null, onRun, onCancel: vi.fn(), onDismiss: vi.fn(), runnableTools: [writeTool] }
+    const { rerender } = render(
+      withI18n(
+        <SkillRunBar
+          {...shared}
+          targetDocuments={[
+            { id: 'd1', name: 'first.pdf' },
+            { id: 'd2', name: 'second.pdf' }
+          ]}
+        />
+      )
+    )
+    await user.click(screen.getByRole('button', { name: 'synthetic_write' }))
+    expect(screen.getByText('Run this tool?')).toBeInTheDocument()
+
+    // The list changes under the open dialog: d1 is gone, d2 is now first.
+    rerender(withI18n(<SkillRunBar {...shared} targetDocuments={[{ id: 'd2', name: 'second.pdf' }]} />))
+    await user.click(screen.getByRole('button', { name: 'Run' }))
+    expect(onRun).toHaveBeenCalledWith('synthetic_write', true, 'd1')
+  })
+
+  it('CONFIRM (#261): the dialog names the target document', async () => {
+    const user = userEvent.setup()
+    render(
+      withI18n(
+        <SkillRunBar
+          run={null}
+          runnableTools={[writeTool]}
+          targetDocuments={[
+            { id: 'd1', name: 'first.pdf' },
+            { id: 'd2', name: 'second.pdf' }
+          ]}
+          onRun={vi.fn()}
+          onCancel={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      )
+    )
+    // Pick the second document, then open the confirm: the dialog must say which one it will run on.
+    await user.click(screen.getByRole('button', { name: /choose target document/i }))
+    await user.click(await screen.findByRole('menuitemradio', { name: /second.pdf/i }))
+    await user.click(screen.getByRole('button', { name: 'synthetic_write' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent('Document: second.pdf')
+    expect(dialog).not.toHaveTextContent('first.pdf')
+  })
 })

--- a/apps/desktop/tests/renderer/SkillRunBar.test.tsx
+++ b/apps/desktop/tests/renderer/SkillRunBar.test.tsx
@@ -650,7 +650,7 @@ describe('SkillRunBar (S11b)', () => {
     )
     // Pick the second document, then open the confirm: the dialog must say which one it will run on.
     await user.click(screen.getByRole('button', { name: /choose target document/i }))
-    await user.click(await screen.findByRole('menuitemradio', { name: /second.pdf/i }))
+    await user.click(await screen.findByRole('menuitemradio', { name: /second\.pdf/i }))
     await user.click(screen.getByRole('button', { name: 'synthetic_write' }))
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveTextContent('Document: second.pdf')

--- a/apps/desktop/tests/renderer/SkillRunBar.test.tsx
+++ b/apps/desktop/tests/renderer/SkillRunBar.test.tsx
@@ -627,6 +627,9 @@ describe('SkillRunBar (S11b)', () => {
 
     // The list changes under the open dialog: d1 is gone, d2 is now first.
     rerender(withI18n(<SkillRunBar {...shared} targetDocuments={[{ id: 'd2', name: 'second.pdf' }]} />))
+    // The dialog still names the document it opened on…
+    expect(screen.getByRole('dialog')).toHaveTextContent('Document: first.pdf')
+    // …and the run goes to it.
     await user.click(screen.getByRole('button', { name: 'Run' }))
     expect(onRun).toHaveBeenCalledWith('synthetic_write', true, 'd1')
   })


### PR DESCRIPTION
## Audit 2026-09-02 — Phase 9a: skill confirm snapshots its target and names it (DOC-16)
Closes #261
Tracker: #217

### What
- `src/renderer/chat/SkillRunBar.tsx`: the write/export confirm now stores a `PendingConfirm` snapshot `{ tool, documentId, documentName }` when it opens. `onConfirm` runs on the snapshot's id; the `#45` output-format line reads the snapshot name; the dialog body gains a "Document: <name>" line (new i18n key `chat.skill.confirm.target`, EN + DE) when the name is known (an unresolved name — RD-2 — shows no line, and the matrix fallback still applies).
- `tests/renderer/SkillRunBar.test.tsx`: two characterisation tests (committed red first): the target list changes under the open dialog → `onRun` receives the id that was shown; the dialog names the chosen document. Fixture names only (`first.pdf`, `second.pdf`).
- `CHANGELOG.md` `[Unreleased]` → Fixed: one user-facing line.

### Why — investigation outcome (#261 was a HYPOTHESIS)
- **Component level — CONFIRMED.** `selectedId` recomputed every render from the live `targetDocuments` prop; `confirmTool` stored only the tool. Rendering `[d1, d2]`, opening the confirm, re-rendering with `[d2]` and pressing Run called `onRun(…, 'd2')` — the user saw and confirmed d1 (test red at `6c3ecc15`).
- **Screen level — the stated race is only incidentally unreachable.** `scopeDocIds` has one writer effect in `ChatScreen.tsx` and every branch of it first clears `runnableTools`, which unmounts the offer row and its dialog (RD-6 then nulls the confirm). The one no-interaction trigger (the 400 ms attach-job poll) therefore closes the dialog rather than swapping the target under it; every other trigger needs clicks the modal overlay blocks. That protection is timing-based (the up-front clear must commit before the `listRunnableTools` reply lands) and nothing pins it, so the component now guarantees the invariant itself.
- **Sibling defect (confirmed, same fix):** `chosenId` is never reset and `SkillRunBar` is mounted without a `key`, so a picked document that leaves the list silently falls back to `targets[0]`; the generic dialog gave no chance to notice. Naming the target in the dialog is the user-visible check.
- No document title enters `SkillRunState`, IPC, logs or tests (the name is already rendered a few pixels away in the target menu).

### Tests
- characterisation (red before): `CONFIRM (#261): the run targets the document that was shown when the dialog opened…` — `expected "spy" to be called with [ 'synthetic_write', true, 'd1' ]` at `6c3ecc15`; `CONFIRM (#261): the dialog names the target document` — red at the same commit.
- green after the fix; `i18n.test.ts` + `skill-i18n.test.ts` parity green.
- `npm test` count: **370 files passed, 23 skipped; 5,563 passed, 74 skipped** excluding the Electron smoke (+2 tests over the Phase 8-b baseline 370 / 5,561 / 74). Raw run 371 / 5,569 / 74: the `evidence-pack-pdf-smoke` PASSED this session. `npm run typecheck` + `npm run build` green at `f51f7f7f`.
- Launch gate (`env -u ELECTRON_RUN_AS_NODE timeout 75 npm run dev` at `f51f7f7f`): **ran** this time — Electron started, workspace resolved (`desktop-dev` app-data root, `plaintext_dev` unlocked), OCR backend `none`, skill registry reconciled (9 present, 0 errors), offline posture logged, ran to the 75 s watchdog, 0 `electron.exe` left. The interactive leg (run a write tool, see the name in the dialog) is non-interactive here; the in-process proof is the two renderer tests.

### Docs + BUILD_STATE
- CHANGELOG line (above). BUILD_STATE: PR #280's Phase 9a item-19 line and dated entry are amended in #280 to name this PR and the outcome ("DOC-16 #261 confirmed at the component, fixed in PR #281"); no separate entry (one phase, two PRs).

### Owner decisions relied on (issue #, answer or default)
- Kickoff owner line "DOC-16 as its own PR [default]" left blank → default (own PR). No decision issue gates #261.

### Reviewer pass: Opus
Verdict: merge after repairs — no blocking finding. Confirmed: the red test fails on the old code for the right reason (`selectedId` → `d2`); every reader of the old `confirmTool` migrated; an out-of-scope snapshot id is REFUSED by main (`registerSkillsIpc.ts` confirm-gated branch → `main.skills.run.documentOutOfScope` banner), so the snapshot is never worse than the live binding; `{document}` interpolation + EN/DE parity pinned by `i18n.test.ts`; the new line sits inside the dialog's `aria-describedby` region; no title leaves the renderer. Repairs applied in `5c80e628`: (1) CHANGELOG line reworded — the old text asserted a screen-level bug the investigation itself calls unreachable; (2) test 1 now also asserts `Document: first.pdf` survives the list change; (3) the target line uses its own marker class `skill-confirm-target`; (4) the duplicate `targets.find` folded. Left as-is: the colon label vs a second body key (reviewer: defensible).

### Rollback
Revert the PR (one component, two i18n keys, one CHANGELOG line, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
