### PR TITLE
Qwen3.8-Flash-Next catalog manifest (dev-only) + HILBERTRAUM_LLAMA_EXTRA_ARGS

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,17 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-04 — **Qwen3.8-Flash-Next catalog entry (dev-only) + `HILBERTRAUM_LLAMA_EXTRA_ARGS`:
+`model-manifests/chat/qwen3.8-flash-next-ud-q4kxl.yaml` (rank 0, 120/128 GB RAM, `license_review`
+PENDING — Qwen Community License 1.0 clause 2 "AI Work Assistant" is an open legal question, no
+`download` block because the weight is four shards and the downloader fetches one file) and the
+dev-only env override that appends llama-server flags to the GPU rungs (`devExtraServerArgs`,
+`factory.ts`; packaged builds ignore it), so the 125B MoE can be measured through the real app
+with `-ncmoe 40 -ot ple_ngram_embd=CPU -fa on` on a PR #27742 build via `HILBERTRAUM_LLAMA_BIN`.**_
+Open: multi-file download + per-shard checksum (the app checks shard 1 only), runtime pin bump
+once the PR merges, legal review before any drive. Docs: `model-policy.md` (the dev-only bullet),
+CHANGELOG Added, DRIVE-NOTICES regenerated.
+
 _2026-09-04 — **Phase F PR 3 (#285, closes #248 / #226): OS session end locks the workspace —
 `emergencyLock` (the crash path's synchronous best-effort lock, extracted to `main/shutdown.ts`)
 runs from `onSessionEnd` on the lifecycle factory, once, over the same closure as `will-quit`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ from its first public `1.0.0` release onward.
 
 ## [Unreleased]
 
+### Added
+
+- **Qwen3.8-Flash-Next (125B MoE, UD-Q4_K_XL) is in the model catalog as a selectable, never
+  auto-recommended entry.** It needs about 128 GB of RAM, a llama.cpp newer than the one the
+  app ships today, and the four weight files placed by hand, so for now it is a developer
+  entry: the AI Model screen lists it, but a normal install cannot download or start it yet.
+  Its license is the Qwen Community License, not Apache-2.0, and it is not bundled on any drive.
+
 ### Fixed
 
 - **Shutting down or logging off Windows with the app open no longer loses the session.** The

--- a/DRIVE-NOTICES.md
+++ b/DRIVE-NOTICES.md
@@ -59,6 +59,7 @@ model: qwen3.8-27b-q6 apache-2.0
 model: qwen3.8-27b-ud-q4km apache-2.0
 model: qwen3.8-27b-ud-q5km apache-2.0
 model: qwen3.8-27b-ud-q6k apache-2.0
+model: qwen3.8-flash-next-ud-q4kxl qwen-community-1.0
 model: translategemma-12b-it-q4 gemma
 model: whisper-small-multilingual mit
 ```
@@ -228,6 +229,14 @@ review time (as published upstream — the `licenses/README.md` convention).
 
 - Multilingual E5 Small (F16) (`multilingual-e5-small-q8`) — upstream: https://huggingface.co/keisuke-miyako/multilingual-e5-small-gguf-f16 — license: mit (https://huggingface.co/intfloat/multilingual-e5-small) — Copyright (c) Microsoft Corporation (github.com/microsoft/unilm, the multilingual-e5 upstream)
 - Whisper Small (multilingual transcriber) (`whisper-small-multilingual`) — upstream: https://huggingface.co/ggerganov/whisper.cpp — license: mit (https://github.com/openai/whisper/blob/main/LICENSE) — Copyright (c) 2022 OpenAI (github.com/openai/whisper)
+
+### qwen-community-1.0 (1 model)
+
+Not covered by a permissive text reproduced in this file — see each line's
+license URL for the governing terms and the manifest's `license_review` block
+for the review record.
+
+- Qwen3.8-Flash-Next 125B-A6B (UD-Q4_K_XL) (`qwen3.8-flash-next-ud-q4kxl`) — upstream: (no download block — see the manifest) — license: qwen-community-1.0 — license_review.status: pending
 
 ## Apache License 2.0
 

--- a/apps/desktop/src/main/services/runtime/factory.ts
+++ b/apps/desktop/src/main/services/runtime/factory.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { log } from '../logging'
 import { t } from '../../../shared/i18n'
 import { tMain } from '../i18n'
 import type { GpuDevice } from '../../../shared/types'
@@ -173,6 +174,8 @@ export interface RuntimeSelectionDeps {
   rootPath: string
   /** Dev build — gates the dev-only `HILBERTRAUM_LLAMA_BIN` override (M-5). Default false. */
   isDev?: boolean
+  /** Environment consulted for the dev-only overrides (defaults to `process.env`). */
+  env?: NodeJS.ProcessEnv
   /** Resolve the sidecar binary (defaults to `resolveLlamaServerPath`). */
   resolveBin?: (rootPath: string) => string | null
   /** Check whether the model weight file exists (defaults to `existsSync`). */
@@ -640,14 +643,38 @@ class LadderRuntime implements ModelRuntime {
 }
 
 /**
+ * Dev-only extra llama-server flags for the GPU rungs, from `HILBERTRAUM_LLAMA_EXTRA_ARGS`
+ * (whitespace-separated, e.g. `-ncmoe 40 -ot ple_ngram_embd=CPU -fa on`). Exists for weights
+ * the shipped ladder cannot place well on its own yet (a 125B MoE whose experts must stay in
+ * RAM), so a maintainer can measure them through the real app before any product decision.
+ * Same posture as `HILBERTRAUM_LLAMA_BIN`: honoured ONLY in a dev build. A packaged build
+ * ignores the variable, because manifests and drives must never be able to append server
+ * flags (extras go last and a later `--host` would win — see `speculative_decoding` in
+ * docs/model-policy.md). Applied to the GPU rungs only; the forced-CPU rungs stay untouched.
+ */
+export function devExtraServerArgs(isDev: boolean | undefined, env: NodeJS.ProcessEnv): string[] {
+  const raw = env.HILBERTRAUM_LLAMA_EXTRA_ARGS?.trim()
+  if (!raw) return []
+  if (!isDev) {
+    log.warn('Ignoring HILBERTRAUM_LLAMA_EXTRA_ARGS in a packaged build (dev-only override)')
+    return []
+  }
+  const args = raw.split(/\s+/)
+  log.warn(`Dev override: appending llama-server args from HILBERTRAUM_LLAMA_EXTRA_ARGS: ${args.join(' ')}`)
+  return args
+}
+
+/**
  * Build a `RuntimeFactory` that returns the GPU-ladder runtime when the sidecar binary
  * + the model weights are present, else `MockRuntime`. Pure + dependency-injected so
  * the selection + ladder logic is unit-testable without spawning anything.
  */
 export function createSelectingRuntimeFactory(deps: RuntimeSelectionDeps): RuntimeFactory {
+  const env = deps.env ?? process.env
   const resolveBin =
     deps.resolveBin ??
-    ((root: string) => resolveLlamaServerPath(root, process.platform, process.env, { isDev: deps.isDev }))
+    ((root: string) => resolveLlamaServerPath(root, process.platform, env, { isDev: deps.isDev }))
+  const devExtra = devExtraServerArgs(deps.isDev, env)
   const modelExists = deps.modelExists ?? existsSync
   const makeLlama =
     deps.makeLlama ??
@@ -684,13 +711,19 @@ export function createSelectingRuntimeFactory(deps: RuntimeSelectionDeps): Runti
         rungs.push({
           label: 'rung 1a (GPU auto-offload + MTP speculative decoding)',
           binPath,
-          extraArgs: [...MTP_SERVER_ARGS],
+          extraArgs: [...MTP_SERVER_ARGS, ...devExtra],
           gpuAttempt: true,
           speculative: true
         })
       }
-      // Rung 1: NO -ngl / --device args — b9585 defaults to ngl=auto + fit=on.
-      rungs.push({ label: 'rung 1 (default args, GPU auto-offload)', binPath, extraArgs: [], gpuAttempt: true })
+      // Rung 1: NO -ngl / --device args — b9585 defaults to ngl=auto + fit=on. `devExtra` is
+      // empty outside a dev build with HILBERTRAUM_LLAMA_EXTRA_ARGS set.
+      rungs.push({
+        label: 'rung 1 (default args, GPU auto-offload)',
+        binPath,
+        extraArgs: [...devExtra],
+        gpuAttempt: true
+      })
     }
     // Rung 2: same binary, forced CPU. `--device none` is the ONLY way we force CPU.
     rungs.push({

--- a/apps/desktop/tests/unit/runtime-ladder.test.ts
+++ b/apps/desktop/tests/unit/runtime-ladder.test.ts
@@ -40,6 +40,9 @@ interface LadderCall {
 
 /** Build a factory whose first `failFirst` llama attempts throw at start(). */
 function ladderHarness(config: {
+  /** Dev build flag + environment for the dev-only HILBERTRAUM_LLAMA_EXTRA_ARGS override. */
+  isDev?: boolean
+  env?: NodeJS.ProcessEnv
   failFirst?: number
   /** Message thrown by the failing rungs (default `rung N failed to start`). */
   failMessage?: string
@@ -145,6 +148,8 @@ function ladderHarness(config: {
 
   const factory = createSelectingRuntimeFactory({
     rootPath: '/root',
+    isDev: config.isDev,
+    env: config.env ?? {},
     resolveBin: () => (config.resolveBin === undefined ? '/bin/llama-server' : config.resolveBin),
     modelExists: () => true,
     makeLlama,
@@ -199,6 +204,26 @@ async function until(cond: () => boolean): Promise<void> {
 }
 
 describe('the GPU start ladder', () => {
+  it('dev build: HILBERTRAUM_LLAMA_EXTRA_ARGS is appended to the GPU rung only', async () => {
+    const env = { HILBERTRAUM_LLAMA_EXTRA_ARGS: ' -ncmoe 40  -ot ple_ngram_embd=CPU -fa on ' }
+    const h = ladderHarness({ probe: [RTX], isDev: true, env, failFirst: 1 })
+    const runtime = h.factory(opts)
+    await runtime.start()
+    expect(h.calls).toHaveLength(2)
+    expect(h.calls[0].extraArgs).toEqual(['-ncmoe', '40', '-ot', 'ple_ngram_embd=CPU', '-fa', 'on'])
+    // The forced-CPU rung is untouched: the override is for GPU placement experiments only.
+    expect(h.calls[1].extraArgs).toEqual(['--device', 'none'])
+  })
+
+  it('packaged build: HILBERTRAUM_LLAMA_EXTRA_ARGS is ignored', async () => {
+    const env = { HILBERTRAUM_LLAMA_EXTRA_ARGS: '-ncmoe 40' }
+    const h = ladderHarness({ probe: [RTX], isDev: false, env })
+    const runtime = h.factory(opts)
+    await runtime.start()
+    expect(h.calls).toHaveLength(1)
+    expect(h.calls[0].extraArgs).toEqual([])
+  })
+
   it('rung 1 passes NO -ngl and NO --device args; backend = gpu per a non-empty probe', async () => {
     const h = ladderHarness({ probe: [RTX] })
     const runtime = h.factory(opts)

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -278,6 +278,17 @@ vision role + mmproj projector" below). Unknown extra keys (e.g. `supports_tools
   successors on 2026-08-20 (acceptance 0.79 / 0.67, head PRESENT; §9.5), which is why they keep
   the field and why nothing keeps it unverified.
 
+- **Dev-only `HILBERTRAUM_LLAMA_EXTRA_ARGS`** (2026-09-04) is the one place extra llama-server
+  flags can come from, and it is not a manifest: a whitespace-separated list in the environment,
+  honoured **only in a dev build** (`!app.isPackaged`, the `HILBERTRAUM_LLAMA_BIN` posture) and
+  appended to the GPU rungs (1 and 1a) only. It exists so a maintainer can measure a weight the
+  shipped ladder cannot place well yet — `qwen3.8-flash-next-ud-q4kxl` needs
+  `-ncmoe 40 -ot ple_ngram_embd=CPU -fa on` (and a llama.cpp with PR #27742 via
+  `HILBERTRAUM_LLAMA_BIN`) to keep its experts in RAM — through the real app before any product
+  decision. A packaged build logs and ignores the variable; the security argument above is
+  unchanged: nothing on a drive can append a flag. `devExtraServerArgs` in
+  `services/runtime/factory.ts`; pinned by `runtime-ladder.test.ts`.
+
 ## Model states (spec §7.4)
 Computed by `services/models.ts` with this precedence:
 `unsupported` → `missing` (file absent) → `checksum_failed` (hash mismatch, or placeholder hash

--- a/model-manifests/chat/qwen3.8-flash-next-ud-q4kxl.yaml
+++ b/model-manifests/chat/qwen3.8-flash-next-ud-q4kxl.yaml
@@ -1,0 +1,65 @@
+id: qwen3.8-flash-next-ud-q4kxl
+display_name: Qwen3.8-Flash-Next 125B-A6B (UD-Q4_K_XL)
+family: qwen3.8
+role: chat
+format: gguf
+runtime: llama_cpp
+# NOT apache-2.0: Qwen/Qwen3.8-Flash-Next ships under the "Qwen Community License 1.0" (HF card
+# tag `license: other`, LICENSE blob at the URL in license_review.notes). Permissive for use and
+# redistribution, but clause 2 requires a separate Qwen license for any commercial "AI Work
+# Assistant" business (a product "primarily designed for AI-assisted coding or office
+# productivity"). Whether HilbertRaum's document skills fall under that definition is an open
+# legal question, hence `license_review.status: pending` and no bundling. See
+# offline-intelligence-private/legal/ for the review once it exists.
+license: qwen-community-1.0
+# Four shards, 111,334,654,784 bytes total (HF LFS sizes, matched on disk 2026-09-04).
+size_on_disk_gb: 111.3
+# MoE: 125B total / ~6B active, plus a ~51 GB N-gram/PLE embedding table (`ple_ngram_embd`).
+# The weight lives in RAM, not VRAM: the measured setup on the i9-9900X / RTX 3090 / 125 GB rig
+# (2026-08-28) keeps 40 expert layers on the CPU (`-ncmoe 40`) and the N-gram table in RAM
+# (`-ot ple_ngram_embd=CPU`) for 21.6 GiB VRAM, pp512 83.9 t/s, tg128 12.7 t/s. With 125 GB the
+# Q4 shards no longer fit the page cache completely (light NVMe paging on long sessions); 64 GB
+# machines cannot run it at all. Memory `qwen38-flash-next-first-bench` has the full sweep.
+recommended_min_ram_gb: 120
+recommended_ram_gb: 128
+# Rank 0 = selectable, never auto-recommended: the RAM tier is out of reach for the target
+# machines and the runtime story below is not shippable yet.
+recommendation_rank: 0
+# Native context is far larger; 8192 is the runtime budget the catalog uses everywhere. The
+# 2026-09-03 one-shot series ran it at 32768 without a Vulkan OOM (`-ncmoe 40`).
+recommended_context_tokens: 8192
+# The chat template honours `enable_thinking` (smoke 2026-09-03: thinking off is respected, no
+# <think> leak), so Deep / Balanced apply.
+supports_thinking_mode: true
+supports_tools: true
+# NO `speculative_decoding`: the PR build's MTP path is still work-in-progress and untested.
+# RUNTIME PIN: the catalog's pinned llama.cpp release (runtime-sources.yaml) cannot load this
+# architecture. It needs llama.cpp PR #27742 (unmerged at the time of writing; measured at
+# commit 250b614, Vulkan build). In a dev build point `HILBERTRAUM_LLAMA_BIN` at that
+# llama-server (and set the LunarG loader `LD_LIBRARY_PATH`); a packaged build ignores the
+# override by design and will report the model as failing to start until the pin is bumped
+# to a release that includes the merge.
+# SHARDED WEIGHT: llama.cpp opens the first shard and finds the siblings by the
+# `-0000N-of-00004` naming convention, so all four files must sit next to each other under
+# models/chat/ with this exact prefix. The manifest schema knows one file: `local_path` and
+# `sha256` are shard 1; shards 2 to 4 are listed below for the operator and are NOT checked
+# by the app's checksum gate (a known gap, tracked with the multi-file download work).
+local_path: models/chat/qwen3.8-flash-next-ud-q4kxl-00001-of-00004.gguf
+# Shard 1 hash: HF LFS OID AND on-disk sha256sum on the i9 rig, 2026-09-04.
+sha256: 4448186216b3af4cc558bbce2c3213f01608f8f8b2e5267a9767971dd3ec8082
+# Shards 2 to 4 (HF LFS OIDs from unsloth/Qwen3.8-Flash-Next-GGUF, folder UD-Q4_K_XL):
+#   qwen3.8-flash-next-ud-q4kxl-00002-of-00004.gguf  49,859,583,136 B  3f342f1c1580473f1ee94ddd5b28206e8c07a70fa1a366f59d1d6c922919a6c9
+#   qwen3.8-flash-next-ud-q4kxl-00003-of-00004.gguf  49,376,141,504 B  56758f40269cad5cd9b0d3d6fbae0f40f6d5be6de49e4ab392dbe83157d9cbd3
+#   qwen3.8-flash-next-ud-q4kxl-00004-of-00004.gguf  12,087,983,520 B  753bda48b98ba4f1636134a90a967de1b2d3908a236c026e464777342e53510a
+# Upstream files: https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/tree/main/UD-Q4_K_XL
+# NO `download` block on purpose: the in-app downloader fetches exactly one file per manifest,
+# and a shard-1-only download would leave a model that can never start. Until the downloader
+# understands multi-file weights this stays a manually placed model (curl -C - against the
+# resolve URLs with a HF token was the only reliable route on the rig; hf/xet stalled).
+bundled_on_preconfigured_drive: false
+recommended_profiles: []
+license_review:
+  status: pending
+  reviewed_by: null
+  reviewed_at: null
+  notes: "PENDING 2026-09-04: base model Qwen/Qwen3.8-Flash-Next is NOT apache-2.0 but 'Qwen Community License 1.0' (https://huggingface.co/Qwen/Qwen3.8-Flash-Next/blob/main/LICENSE; HF card tag license:other). Grants use, copy, modify, distribute, sell; conditions: (1) keep the copyright + permission notice, model-name attribution only above 100M MAU / US$20M monthly revenue; (2) a licensee running a 'Model as a Service' or an 'AI Work Assistant' business (a product primarily designed for AI-assisted coding or office productivity) needs a separate Qwen license for commercial use. Whether a prepared HilbertRaum drive with document/office skills is an 'AI Work Assistant' under clause 2 is unresolved; do not bundle or sell until legal has reviewed. Quantization provenance: unsloth Dynamic UD-Q4_K_XL GGUF (unsloth/Qwen3.8-Flash-Next-GGUF, card license:other, base_model Qwen/Qwen3.8-Flash-Next). Runtime: unmerged llama.cpp PR #27742 required; dev-only until the runtime pin catches up."


### PR DESCRIPTION
## What

- **New manifest** `model-manifests/chat/qwen3.8-flash-next-ud-q4kxl.yaml`: Qwen3.8-Flash-Next, 125B total / ~6B active MoE, unsloth UD-Q4_K_XL, four shards (111.3 GB). Rank 0 (selectable, never auto-recommended), 120 / 128 GB RAM, `supports_thinking_mode: true`, no `speculative_decoding`.
- **`license_review: pending`**, deliberately. The base model ships under the **Qwen Community License 1.0**, not Apache-2.0. Clause 2 requires a separate Qwen license for a commercial "AI Work Assistant" (a product primarily for AI-assisted coding or office productivity). Whether a prepared HilbertRaum drive with document skills falls under that is unresolved. Not bundled, not on any drive until legal has reviewed.
- **No `download` block**, deliberately: the in-app downloader fetches one file per manifest, and a shard-1-only download could never start. `local_path` / `sha256` are shard 1 (HF LFS OID, confirmed on disk); shards 2 to 4 are listed in the manifest with sizes and hashes for the operator. The app's checksum gate covers shard 1 only, a known gap.
- **Dev-only `HILBERTRAUM_LLAMA_EXTRA_ARGS`** (`devExtraServerArgs` in `runtime/factory.ts`): whitespace-separated llama-server flags appended to the GPU rungs 1 and 1a, honoured only when `isDev`. Packaged builds log and ignore it, the same posture as `HILBERTRAUM_LLAMA_BIN`. Manifests and drives still cannot supply flags. Needed because the pinned llama.cpp cannot load this architecture (llama.cpp PR #27742, unmerged) and the ladder has no MoE placement; the measured setup is `-ncmoe 40 -ot ple_ngram_embd=CPU -fa on` on the PR build.
- Docs: `model-policy.md` (the dev-only bullet under `speculative_decoding`), CHANGELOG Added, BUILD_STATE dated entry, DRIVE-NOTICES regenerated.

## Why

To measure the model through the real app on the i9 / RTX 3090 rig before any product decision, and to have the catalog entry ready for the day the runtime pin catches up.

## Open follow-ups (not in this PR)

- Multi-file weights in the downloader and per-shard checksums.
- Runtime pin bump once PR #27742 is in a llama.cpp release, then re-measure and decide on a rank.
- Legal review of the Qwen Community License clause 2 before any drive carries it.

## Verification

- `npm test`: 371 files / 5,609 tests passed, 63 skipped. The two `csp-build-output` failures on the first run were a stale `out/` from 2026-08-20; after `npm run build` the file passes (6 passed, 1 skipped).
- `npm run typecheck` clean, eslint clean on the two changed TS files.
- New ladder tests: dev build appends the flags to rung 1 only (rung 2 stays `--device none`); packaged build ignores the variable.
- Manual: a PR-build llama-server pointed at the renamed shard 1 under `models/chat/` got through metadata + tensor loading of all four shards (the run then failed on a Vulkan allocation because another model held 20 GB of the card at the time), so the `-0000N-of-00004` renaming is discovered by llama.cpp. A full through-the-app start with a free GPU is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Aw5SLVfULHN3zwVjuew6q

