### PR TITLE
feat(runtime): surface llama-server timings through onFinish (#290/#291 — PR 1, parser seam)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,6 +29,15 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 
+_2026-09-04 — **#290/#291 wave, PR 1 of 3 (`fix/290-291-pr1-sse-timings-seam`): the parser seam.
+`readChatSSE` now reads llama-server's top-level `timings` off any chunk and hands the last one
+up through `onFinish(reason, timings?)` at `[DONE]`/close — never on an abort, error frame or
+watchdog trip; one shared `RuntimeTimings` type in `runtime/index.ts`; every existing `onFinish`
+caller source-compatible.**_ Blast-radius re-analysis in the PR description (the app never logs the
+sidecar argv; the finish hand-up moved from the finish chunk to the sentinel). §5 item 20 tracks the
+wave; #290/#291 stay OPEN until the reporter runs the hardware legs (verification issue opened
+with PR 3). Suite on the branch: see the PR. Master `b4e0ed06` recounted: 375 / 5,633 / 74 raw.
+
 _2026-09-04 — **Phase F PR 6 (PR #293, `fix/pf-code1-rag-excerpt-framing`): #228 shipped — the excerpt
 block of `buildGroundedPrompt` / `buildCompareWholeDocPrompt` is framed as document content, not
 instructions (BEGIN/END markers + a guard line, user turn only, `rag/grounded-data.ts`). The eval
@@ -596,6 +605,22 @@ open round's item stays the last block of §5.)
       `skills-installer`, `third-party-notices`, `ocr`, `rail-labels` tests), the katex hoist
       compare, `as unknown as` private-field injection — convert to behavioural assertions when
       touched; `FullSuiteGuard` cannot see dropped individual tests.
+
+20. **#290/#291 — server `timings` → Diagnostics decode speed + per-answer speed line (opened
+    2026-09-04; three stacked PRs on one lineage).** PR 1 (`fix/290-291-pr1-sse-timings-seam`):
+    the `readChatSSE` seam — `onFinish(reason, timings?)`, `RuntimeTimings` in `runtime/index.ts`.
+    PR 2 (#291): `measureTokensPerSecond` reports `predicted_per_second` (decode tokens, prefill
+    excluded) with the chunk count as the flagged fallback; `BenchmarkResult.speedBasis`; the card
+    says "Decode speed" + the token count; MTP record §7 watch item → observed. PR 3 (#290): chat
+    only — one ephemeral `chat:speed:<id>` payload per finished answer, `tok/s · s to first
+    token · tokens`, EN/DE, nothing persisted. **Both issues stay OPEN** ("Refs", not "Closes"):
+    the "matches llama-server's `print_timing` within rounding" legs need a real runtime and the
+    execution machine cannot launch one (Smart App Control, exit `0xC0E90002`) — a verification
+    issue assigned to the reporter carries both acceptance lists, the reconstructed rung-1a argv
+    (the app does not log it) and a request for a captured final-chunk SSE transcript from the
+    b9849 pin, to be committed as a fixture. Thresholds (`VERY_LOW_TOKENS_PER_SECOND`,
+    `SLOW_PICK_TOKENS_PER_SECOND`) deliberately NOT retuned — they now compare a decode figure
+    against probe-basis calibration (recorded in `docs/benchmark.md` / `model-benchmarks.md` §6.5).
 
 ---
 

--- a/apps/desktop/src/main/services/runtime/index.ts
+++ b/apps/desktop/src/main/services/runtime/index.ts
@@ -41,6 +41,31 @@ export class ExternalGenerationBusyError extends Error {
   }
 }
 
+/**
+ * llama-server's per-request timing block, as carried on a streamed chat completion's final
+ * chunk(s) (issues #290/#291). Decode figures (`predicted_*`) cover generation only — prompt
+ * processing (prefill) is the separate `prompt_*` pair — and count TOKENS, not SSE chunks, so
+ * they stay honest under MTP speculative decoding (#182), where one chunk can carry an accepted
+ * draft run of several tokens. Every field is optional: the shape is upstream-defined and a
+ * runtime that sends none (the mock; an older server) simply reports no timings. This is the
+ * ONE shared timings type for the chat runtime boundary (spec §9.2) — the translation sidecar's
+ * `CompletionTimings` describes the native `/completion` shape and is deliberately not reused.
+ */
+export interface RuntimeTimings {
+  /** Generated (decode) tokens in this completion. */
+  predicted_n?: number
+  /** Wall milliseconds spent generating them. */
+  predicted_ms?: number
+  /** Prompt tokens processed (prefill). */
+  prompt_n?: number
+  /** Wall milliseconds spent on prefill. */
+  prompt_ms?: number
+  /** Decode throughput, tokens per second — the headline speed figure. */
+  predicted_per_second?: number
+  /** Prefill throughput, tokens per second. */
+  prompt_per_second?: number
+}
+
 export interface RuntimeChatOptions {
   /** Explicit caps/sampling; when set they WIN over anything `mode` would derive. */
   maxTokens?: number
@@ -68,8 +93,13 @@ export interface RuntimeChatOptions {
    * UI can say the reply was cut off instead of stopping mid-word silently. Never fired on a user
    * abort (an aborted request carries no final chunk). The mock runtime reports 'stop' on a clean
    * finish; a runtime that can't report one simply never calls it (callers treat that as 'stop').
+   *
+   * The optional second argument carries the server's per-request `timings` when the stream
+   * had them (#290/#291 — the last top-level `timings` object seen on any chunk, handed up once
+   * at the `[DONE]` sentinel / clean close). Undefined when the runtime sent none (the mock).
+   * Existing callers that take only the reason stay source-compatible.
    */
-  onFinish?: (finishReason: string) => void
+  onFinish?: (finishReason: string, timings?: RuntimeTimings) => void
   /**
    * Grammar-constrained decoding (D55): when set, the runtime constrains the model's output to
    * this JSON Schema via llama-server's OpenAI-compatible `response_format: { type: 'json_schema' }`,

--- a/apps/desktop/src/main/services/runtime/llama.ts
+++ b/apps/desktop/src/main/services/runtime/llama.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeChatOptions,
   RuntimeStartOptions
 } from './index'
+import type { RuntimeTimings } from './index'
 import { LlamaServer, type LlamaServerOptions } from './sidecar'
 
 // Real local inference (spec §3.2, §7.5). `LlamaRuntime` drops in behind
@@ -104,6 +105,12 @@ interface ChatCompletionChunk {
      */
     finish_reason?: string | null
   }>
+  /**
+   * llama-server's per-request timing block (#290/#291). Rides the completing chunk at the
+   * pinned b9849 as far as the repo knows — but NO captured chat transcript with `timings`
+   * exists here yet, so the reader tolerates it on ANY chunk, including one with no `choices`.
+   */
+  timings?: RuntimeTimings
 }
 
 /**
@@ -126,6 +133,8 @@ function parseSseLine(line: string): {
   finishReason?: string
   done?: boolean
   streamError?: ChatStreamError
+  /** A top-level `timings` object on this chunk (#290/#291) — read off ANY data chunk. */
+  timings?: RuntimeTimings
 } {
   const t = line.trim()
   // F-02: the bare `error: {…}` SSE field-line carrier (mirrors completion.ts's M3 handling).
@@ -162,7 +171,16 @@ function parseSseLine(line: string): {
     }
     const choice = json.choices?.[0]
     const d = choice?.delta
-    const out: { delta?: string; reasoning?: string; finishReason?: string } = {}
+    const out: {
+      delta?: string
+      reasoning?: string
+      finishReason?: string
+      timings?: RuntimeTimings
+    } = {}
+    // #290/#291: the server's timing block. Read from whichever chunk carries it — with or
+    // without `choices` — and let the reader keep the LAST one seen (llama-server's are cumulative
+    // for the request, so the last is the complete one).
+    if (json.timings != null && typeof json.timings === 'object') out.timings = json.timings
     if (typeof d?.content === 'string' && d.content.length > 0) out.delta = d.content
     if (typeof d?.reasoning_content === 'string' && d.reasoning_content.length > 0) {
       out.reasoning = d.reasoning_content
@@ -323,12 +341,21 @@ function readWithIdleTimeout<T>(
  * CB-5: each read is raced against a two-phase idle watchdog (`idle`, injectable for tests; the
  * production default keeps behaviour byte-identical on any live stream) so a HUNG sidecar rejects with
  * `RuntimeUnresponsiveError` instead of wedging the conversation forever. A user Stop still wins first.
+ *
+ * #290/#291: the server's top-level `timings` block is remembered from whichever chunk carries it
+ * (the completing chunk at the pinned b9849, as far as the repo knows — a chunk with no `choices` is
+ * tolerated too) and handed up with the finish reason ONCE, at the `[DONE]` sentinel or the clean
+ * close. Deferring the hand-up to the sentinel (instead of firing on the `finish_reason` chunk) is
+ * what lets a trailing timings-only chunk still be attached; no consumer observes the difference —
+ * every caller reads the captured value after the stream completes, and the finish chunk's delta is
+ * empty. A stream that never reaches the sentinel (abort, error frame, idle watchdog) hands up
+ * nothing, exactly as before.
  */
 export async function* readChatSSE(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
   onReasoning?: (delta: string) => void,
-  onFinish?: (finishReason: string) => void,
+  onFinish?: (finishReason: string, timings?: RuntimeTimings) => void,
   idle: IdleWatchdog = DEFAULT_IDLE
 ): AsyncGenerator<string, void, unknown> {
   const reader = body.getReader()
@@ -337,6 +364,12 @@ export async function* readChatSSE(
   // The FIRST chunk gets the generous prefill budget; once any chunk (token OR reasoning delta) has
   // landed, later reads get the tighter stream budget. Re-armed per read, so a steady stream resets it.
   let sawChunk = false
+  // The finish reason + the last timings block seen, handed up together at the sentinel/close.
+  let finishReason: string | undefined
+  let timings: RuntimeTimings | undefined
+  const finish = (): void => {
+    if (finishReason) onFinish?.(finishReason, timings)
+  }
   try {
     for (;;) {
       if (signal?.aborted) return
@@ -357,10 +390,15 @@ export async function* readChatSSE(
         // signal-aborted read never reaches this loop, and consumers treat a race via
         // `isAbortError(err, signal)` (signal-aborted ⇒ abort semantics, partial kept).
         if (r.streamError) throw r.streamError
-        // The finish reason rides the final content chunk, which arrives BEFORE `[DONE]`;
-        // surface it before honouring the sentinel so a 'length' stop is never dropped.
-        if (r.finishReason) onFinish?.(r.finishReason)
-        if (r.done) return
+        // The finish reason rides the final content chunk, which arrives BEFORE `[DONE]`; it is
+        // captured here and surfaced at the sentinel (with the timings) so a 'length' stop is
+        // never dropped and a timings block on a later chunk is never missed.
+        if (r.finishReason) finishReason = r.finishReason
+        if (r.timings) timings = r.timings
+        if (r.done) {
+          finish()
+          return
+        }
         // A reasoning delta counts as a live chunk (a long "thinking" phase must not trip the
         // watchdog); switch to the tighter inter-chunk budget once anything has streamed.
         if (r.reasoning) {
@@ -378,9 +416,13 @@ export async function* readChatSSE(
     const r = parseSseLine(buffer)
     // F-02: a server that dies mid-write can flush the error frame WITHOUT a trailing newline.
     if (r.streamError) throw r.streamError
-    if (r.finishReason) onFinish?.(r.finishReason)
+    if (r.finishReason) finishReason = r.finishReason
+    if (r.timings) timings = r.timings
     if (r.reasoning) onReasoning?.(r.reasoning)
     if (r.delta) yield r.delta
+    // A clean close without `[DONE]` still hands the captured finish up (byte-identical to the
+    // pre-#290 behaviour for a stream whose finish chunk was the last thing sent).
+    finish()
   } finally {
     try {
       await reader.cancel()

--- a/apps/desktop/tests/integration/llama-runtime.test.ts
+++ b/apps/desktop/tests/integration/llama-runtime.test.ts
@@ -142,6 +142,35 @@ describe('readChatSSE', () => {
     expect(out.join('')).toBe('done')
     expect(finishes).toEqual(['stop'])
   })
+
+  // #290/#291: the server's per-request `timings` block (b9849 shape — hand-authored, see the
+  // fixture-provenance note above; NO captured chat transcript with timings exists in the repo yet).
+  it('hands the final chunk\'s `timings` up with the finish reason (#290/#291)', async () => {
+    const timings = { prompt_n: 9, prompt_ms: 120, predicted_n: 64, predicted_ms: 1336, predicted_per_second: 47.9, prompt_per_second: 75 }
+    const stream = sseStream([
+      chatChunk('fast'),
+      `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }], timings })}\n\n`,
+      'data: [DONE]\n\n'
+    ])
+    const finishes: Array<[string, unknown]> = []
+    const out: string[] = []
+    for await (const t of readChatSSE(stream, undefined, undefined, (r, tm) => finishes.push([r, tm]))) {
+      out.push(t)
+    }
+    expect(out.join('')).toBe('fast')
+    expect(finishes).toEqual([['stop', timings]])
+  })
+
+  it('hands up undefined timings when the final chunk carries none (#290/#291)', async () => {
+    const stream = sseStream([
+      chatChunk('x'),
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n'
+    ])
+    const finishes: Array<[string, unknown]> = []
+    for await (const _t of readChatSSE(stream, undefined, undefined, (r, tm) => finishes.push([r, tm]))) void _t
+    expect(finishes).toEqual([['stop', undefined]])
+  })
 })
 
 describe('LlamaRuntime', () => {
@@ -191,6 +220,36 @@ describe('LlamaRuntime', () => {
     const h = await runtime.health()
     expect(h.healthy).toBe(true)
     expect(h.port).toBe(51000)
+    await runtime.stop()
+  })
+
+  it('forwards the server timings through RuntimeChatOptions.onFinish end-to-end (#290/#291)', async () => {
+    const { spawn } = fakeSpawn()
+    const timings = { prompt_n: 5, prompt_ms: 40, predicted_n: 2, predicted_ms: 50, predicted_per_second: 40, prompt_per_second: 125 }
+    const runtime = new LlamaRuntime(startOpts, {
+      binPath: '/bin/llama-server',
+      spawn,
+      fetchImpl: chatFetch({
+        frames: [
+          chatChunk('Privacy'),
+          chatChunk(' first'),
+          `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }], timings })}\n\n`,
+          'data: [DONE]\n\n'
+        ]
+      }),
+      findPort: async () => 51001,
+      healthIntervalMs: 1
+    })
+    await runtime.start()
+    const finishes: Array<[string, unknown]> = []
+    const out: string[] = []
+    for await (const t of runtime.chatStream([{ role: 'user', content: 'hi' }], {
+      onFinish: (reason, tm) => finishes.push([reason, tm])
+    })) {
+      out.push(t)
+    }
+    expect(out.join('')).toBe('Privacy first')
+    expect(finishes).toEqual([['stop', timings]])
     await runtime.stop()
   })
 

--- a/apps/desktop/tests/unit/read-chat-sse.test.ts
+++ b/apps/desktop/tests/unit/read-chat-sse.test.ts
@@ -212,3 +212,136 @@ describe('readChatSSE — in-band error frames reject the stream (F-02)', () => 
     expect(finish).toBe('stop')
   })
 })
+
+// #290/#291 — llama-server's per-request `timings` block rides the streamed completion (at the
+// pinned b9849, on the completing chunk as far as the repo knows; NO captured chat transcript with
+// `timings` exists here yet, hence the tolerant shapes below). The reader remembers the last one
+// seen on ANY chunk and hands it up with the finish reason, once, at `[DONE]` / the clean close —
+// and never on an abort, an error frame or a watchdog trip.
+describe('readChatSSE — server timings ride the finish hand-up (#290/#291)', () => {
+  const TIMINGS = {
+    prompt_n: 12,
+    prompt_ms: 180.5,
+    predicted_n: 64,
+    predicted_ms: 1336.1,
+    predicted_per_second: 47.9,
+    prompt_per_second: 66.5
+  }
+  const finishWithTimings = (): string =>
+    `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }], timings: TIMINGS })}\n\n`
+  type Finish = { reason: string; timings: unknown }
+  const collect = async (frames: string[], signal?: AbortSignal): Promise<{ out: string; finishes: Finish[] }> => {
+    const finishes: Finish[] = []
+    const out: string[] = []
+    for await (const t of readChatSSE(pacedStream(frames, 1), signal, undefined, (reason, timings) =>
+      finishes.push({ reason, timings })
+    )) {
+      out.push(t)
+    }
+    return { out: out.join(''), finishes }
+  }
+
+  it('surfaces a timings object carried on the final (finish_reason) chunk', async () => {
+    const { out, finishes } = await collect([chatChunk('a'), chatChunk('b'), finishWithTimings(), 'data: [DONE]\n\n'])
+    expect(out).toBe('ab')
+    expect(finishes).toEqual([{ reason: 'stop', timings: TIMINGS }])
+  })
+
+  it('hands up undefined timings when no chunk carried them (the mock / an older server)', async () => {
+    const finishChunk = `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })}\n\n`
+    const { finishes } = await collect([chatChunk('a'), finishChunk, 'data: [DONE]\n\n'])
+    expect(finishes).toEqual([{ reason: 'stop', timings: undefined }])
+  })
+
+  it('still surfaces timings sent on a separate TRAILING chunk with empty choices', async () => {
+    const finishChunk = `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'length' }] })}\n\n`
+    const trailing = `data: ${JSON.stringify({ choices: [], timings: TIMINGS })}\n\n`
+    const { out, finishes } = await collect([chatChunk('x'), finishChunk, trailing, 'data: [DONE]\n\n'])
+    expect(out).toBe('x')
+    expect(finishes).toEqual([{ reason: 'length', timings: TIMINGS }])
+  })
+
+  it('keeps the LAST timings seen when several chunks carry one (cumulative per request)', async () => {
+    const early = `data: ${JSON.stringify({ choices: [{ delta: { content: 'a' } }], timings: { predicted_n: 1 } })}\n\n`
+    const { finishes } = await collect([early, finishWithTimings(), 'data: [DONE]\n\n'])
+    expect(finishes[0].timings).toEqual(TIMINGS)
+  })
+
+  it('hands the timings up on a clean close WITHOUT [DONE] (the flush path)', async () => {
+    const enc2 = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc2.encode(chatChunk('a')))
+        // No trailing newline, no sentinel — the server closed right after the finish chunk.
+        controller.enqueue(enc2.encode(finishWithTimings().trimEnd()))
+        controller.close()
+      }
+    })
+    const finishes: Finish[] = []
+    for await (const _t of readChatSSE(stream, undefined, undefined, (reason, timings) =>
+      finishes.push({ reason, timings })
+    )) {
+      void _t
+    }
+    expect(finishes).toEqual([{ reason: 'stop', timings: TIMINGS }])
+  })
+
+  it('never reports timings (or a finish) on an aborted stream', async () => {
+    const controller = new AbortController()
+    const finishes: Finish[] = []
+    const out: string[] = []
+    for await (const t of readChatSSE(
+      pacedStream([chatChunk('a'), chatChunk('b'), finishWithTimings(), 'data: [DONE]\n\n'], 1),
+      controller.signal,
+      undefined,
+      (reason, timings) => finishes.push({ reason, timings })
+    )) {
+      out.push(t)
+      controller.abort()
+    }
+    expect(out).toEqual(['a'])
+    expect(finishes).toEqual([])
+  })
+
+  it('never reports timings when an in-band error frame ends the stream (F-02 unchanged)', async () => {
+    const finishes: Finish[] = []
+    const errorFrame = `data: ${JSON.stringify({ error: { message: 'slot failed', type: 'server_error' } })}\n\n`
+    await expect(async () => {
+      for await (const _t of readChatSSE(pacedStream([chatChunk('a'), errorFrame], 1), undefined, undefined, (reason, timings) =>
+        finishes.push({ reason, timings })
+      )) {
+        void _t
+      }
+    }).rejects.toBeInstanceOf(ChatStreamError)
+    expect(finishes).toEqual([])
+  })
+
+  it('never reports timings when the idle watchdog trips (CB-5 unchanged)', async () => {
+    const finishes: Finish[] = []
+    const idle = { prefillMs: 500, streamMs: 40 }
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(enc.encode(chatChunk('a')))
+        // Then silence beyond the stream budget; the watchdog fires before anything else arrives.
+        await delay(400)
+        controller.close()
+      }
+    })
+    await expect(async () => {
+      for await (const _t of readChatSSE(stream, undefined, undefined, (reason, timings) =>
+        finishes.push({ reason, timings }), idle)) {
+        void _t
+      }
+    }).rejects.toBeInstanceOf(RuntimeUnresponsiveError)
+    expect(finishes).toEqual([])
+  })
+
+  it('ignores a non-object timings value and a timings block on an ignored post-[DONE] chunk', async () => {
+    const junk = `data: ${JSON.stringify({ choices: [{ delta: { content: 'a' } }], timings: 'nope' })}\n\n`
+    const finishChunk = `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })}\n\n`
+    const late = `data: ${JSON.stringify({ choices: [], timings: TIMINGS })}\n\n`
+    const { out, finishes } = await collect([junk, finishChunk, 'data: [DONE]\n\n', late])
+    expect(out).toBe('a')
+    expect(finishes).toEqual([{ reason: 'stop', timings: undefined }])
+  })
+})


### PR DESCRIPTION
## PR 1 of 3 — the parser seam shared by #290 and #291

Refs #290, #291 (the originals stay open until the reporter runs the hardware legs — see the verification issue linked from PR 3).

llama-server's streamed chat completion carries a top-level `timings` object (`prompt_n`, `prompt_ms`, `predicted_n`, `predicted_ms`, `predicted_per_second`, `prompt_per_second`) that `readChatSSE` used to drop. This PR surfaces it once per completed stream, through the existing `onFinish` hand-up, so PR 2 (the Diagnostics probe, #291) and PR 3 (the per-answer speed line, #290) read one parser.

### What changed

- `services/runtime/index.ts` — ONE shared `RuntimeTimings` type (all fields optional). `onFinish` gains an optional second argument: `(finishReason, timings?)`.
- `services/runtime/llama.ts` — `parseSseLine` reads top-level `timings` from ANY `data:` chunk (including one with no `choices`); `readChatSSE` remembers the last one seen and hands it up with the finish reason. The finish hand-up now fires at `[DONE]` (or the clean close/flush) instead of on the `finish_reason` chunk itself, so a `timings` object on a trailing chunk is still attached; a stream that never reached `[DONE]` (abort, error frame, idle watchdog) fires nothing — exactly as before. Positional parameters of `readChatSSE` unchanged.
- Tests: `tests/unit/read-chat-sse.test.ts`, `tests/integration/llama-runtime.test.ts`.

### Why extend `onFinish` rather than add a new option

Timings can only exist when a finish reason exists (llama-server sends both on the completing chunk); a separate `onTimings` would be a second callback that can never fire without the first, and every consumer would have to reason about their ordering. A trailing optional parameter keeps every existing caller source-compatible: `chat.ts`, `rag/index.ts` (2×), `rag/whole-doc-tree.ts` (2×), `local-api/server.ts` (`(reason: string) => void` is assignable to the widened type) and `mock.ts` (`onFinish?.('stop')`, no timings — the fallback path) are untouched.

### Blast-radius re-analysis (Step 1 of the task — every claim re-checked against the code)

| Claim from the prior analysis | Verdict |
|---|---|
| The probe (`benchmark.ts` `measureTokensPerSecond`) counts streamed chunks over wall time that starts BEFORE the request, so prefill + first-token latency are inside the window | **Confirmed.** `t0 = performance.now()` precedes `runtime.chatStream(...)`; `count / seconds` over that window. |
| `readChatSSE` parses one `data:` line per chunk, so MTP under-counting needs llama-server to pack an accepted draft run into one SSE event | **Confirmed** (`parseSseLine` per line; one `delta.content` per line). #291's measurement (25 vs 47.9) is the first observation of the packing the MTP record §7 listed as "not observed". Record updated in PR 2. |
| `ChatCompletionChunk` reads `choices` only; top-level `timings` is dropped; `docs/local-api.md` §6.5 records `usage` absent | **Confirmed.** `usage` stays absent (separate wire-contract decision; PR 3 adds the one-line note). |
| `CompletionTimings` exists in `services/translation/completion.ts`; do not import across the boundary | **Confirmed.** The new type lives in `runtime/index.ts`; `completion.ts` is untouched (it reads the native `/completion` shape, not the OpenAI chat shape). |
| The manager gate (`gatedChatStream`) and the ladder runtime (`factory.ts` `chatStream`) forward `RuntimeChatOptions` unchanged | **Confirmed.** `gatedChatStream` passes `options` through; the ladder spreads `...options` (it only wraps `onReasoning`). The mock sends no timings. |
| Other `readChatSSE` consumers must stay byte-identical | **Confirmed and re-checked:** `vision/runtime.ts` (positional `(body, signal)` — no `onFinish`), `tests/unit/vision-sse.test.ts`, the chat-stream / compaction / RAG tests (they use fake runtimes, not the parser). All green. |
| Consumers whose MEANING changes, code unchanged: `classifyProfile`/`VERY_LOW_TOKENS_PER_SECOND`, the §6.5 picker step-down (`SLOW_PICK_TOKENS_PER_SECOND`, doc comment "chunk-rate"), the local-API Retry-After heuristic (`lifecycle.ts`, 768 / tps), `listModels` reading the persisted pairing | **Confirmed** — handled in PR 2 (comments + docs record the basis shift; thresholds NOT retuned). |
| The app does NOT pass `-fa`; sidecar args are `CHAT_SERVER_ARGS` + the rung's `extraArgs` | **Confirmed.** `sidecar.ts` `buildArgs` + `CHAT_SERVER_ARGS = ['--jinja','--reasoning-format','deepseek']` + rung 1a `MTP_SERVER_ARGS = ['--spec-type','draft-mtp','--spec-draft-n-max','2']`; no `-fa` anywhere. |

Three traps:

1. **The early `break` discards the final chunk** — confirmed (`if (count >= BENCHMARK_TOKEN_TARGET) break` cancels the reader before the finish chunk). Removed in PR 2; `max_tokens` bounds the server; the mid-probe busy discard (#185) is kept.
2. **`timings` may not share the `finish_reason` chunk** — no captured OpenAI-compatible transcript with `timings` exists in the repo (only the `/completion` fixture). The parser is tolerant: last `timings` seen on ANY chunk, handed up at `[DONE]`/close, never on an abort.
3. **Short answers** — handled in PR 2 (token count shown; `BENCHMARK_PROMPT` changed so the 64-token cap fills reliably).

Things the list missed, found during the re-analysis:

- **The app never logs the sidecar argv.** `sidecar.ts` spawns `buildArgs(port)` without logging it, and `index.ts` logs only "Speculative decoding enabled (MTP draft head)". The verification issue therefore quotes the argv reconstructed from `buildArgs` + `CHAT_SERVER_ARGS` + `MTP_SERVER_ARGS` (with the runtime-derived `--threads` / batch values marked as such) rather than a log line.
- **The finish hand-up timing moved** (finish chunk → `[DONE]`/close) to make trap 2 tolerable. No consumer observes the difference: every `onFinish` caller reads the captured value after the `for await` completes, and the finish chunk carries an empty delta.
- **RAG / document answers** also stream through `withChatStream` but pass their own `onFinish`; they are outside #290's scope (chat answers only) and will not show the line.

### Checks

- `npm test`, `npm run typecheck`, `npm run build` — see the PR checklist in the last comment.
- No cloud, no telemetry, no new dependency, no new i18n keys in this PR, no paths.

### Checks on this machine

- `npm test`: 375 files / 5,645 tests passed / 74 skipped (master `b4e0ed06` recounted: 375 / 5,633 / 74 — +12 tests).
- `npm run typecheck` and `npm run build`: green.
- Not verifiable here: a real llama-server run (Smart App Control blocks the sidecar, exit `0xC0E90002`) — the wire shape of a real `timings` chunk is covered by hand-authored fixtures only; the verification issue (PR 3) asks for a captured transcript.
