### PR TITLE
feat(chat): tokens/s, time to first token and token count under a finished answer (#290 — PR 3)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -35,8 +35,8 @@ up through `onFinish(reason, timings?)` at `[DONE]`/close — never on an abort,
 watchdog trip; one shared `RuntimeTimings` type in `runtime/index.ts`; every existing `onFinish`
 caller source-compatible.**_ Blast-radius re-analysis in the PR description (the app never logs the
 sidecar argv; the finish hand-up moved from the finish chunk to the sentinel). §5 item 20 tracks the
-wave; #290/#291 stay OPEN until the reporter runs the hardware legs (verification issue opened
-with PR 3). PR 1 = #295 (375 / 5,645 / 74). Master `b4e0ed06` recounted: 375 / 5,633 / 74 raw.
+wave; #290/#291 stay OPEN until the reporter runs the hardware legs (verification issue **#298**,
+assigned to the #291 reporter). PR 1 = #295 (375 / 5,645 / 74). Master `b4e0ed06` recounted: 375 / 5,633 / 74 raw.
 **PR 2 (`fix/290-291-pr2-decode-speed`, #291):** `measureTokensPerSecond` → `SpeedReading`
 (`predicted_per_second` when timings are present, chunk fallback flagged), the early `break`
 removed, `BENCHMARK_PROMPT` now a paragraph so the 64-token cap fills, `BenchmarkResult.speedBasis`,
@@ -47,7 +47,9 @@ only — `GenerateOptions.onTimings` (completed streams only) → `withChatStrea
 ONE ephemeral `chat:speed:<id>` `AnswerSpeed` payload (tok/s + tokens from the server timings,
 TTFT on the `first_token` clock) keyed to the persisted message id; `ChatScreen` session map →
 `Transcript` line `42 tok/s · 1.8 s to first token · 615 tokens` (EN/DE); nothing persisted;
-design record: `architecture.md` "Chat & streaming" → "Per-answer speed line" §1–§3.
+design record: `architecture.md` "Chat & streaming" → "Per-answer speed line" §1–§3. PR 3 = #297
+(376 / 5,670 / 74; +37 tests over master across the stack). Dev launch not possible on this
+machine (Smart App Control blocks `electron.exe` and the sidecar) — build + suite only.
 
 _2026-09-04 — **Phase F PR 6 (PR #293, `fix/pf-code1-rag-excerpt-framing`): #228 shipped — the excerpt
 block of `buildGroundedPrompt` / `buildCompareWholeDocPrompt` is framed as document content, not
@@ -626,10 +628,11 @@ open round's item stays the last block of §5.)
     only — one ephemeral `chat:speed:<id>` payload per finished answer, `tok/s · s to first
     token · tokens`, EN/DE, nothing persisted. **Both issues stay OPEN** ("Refs", not "Closes"):
     the "matches llama-server's `print_timing` within rounding" legs need a real runtime and the
-    execution machine cannot launch one (Smart App Control, exit `0xC0E90002`) — a verification
-    issue assigned to the reporter carries both acceptance lists, the reconstructed rung-1a argv
-    (the app does not log it) and a request for a captured final-chunk SSE transcript from the
-    b9849 pin, to be committed as a fixture. Thresholds (`VERY_LOW_TOKENS_PER_SECOND`,
+    execution machine cannot launch one (Smart App Control, exit `0xC0E90002`) — verification
+    issue **#298** (assigned to the #291 reporter) carries both acceptance lists, the
+    reconstructed rung-1a argv (the app does not log it) and a request for a captured final-chunk
+    SSE transcript from the b9849 pin, to be committed as a fixture. PRs: #295 → #296 → #297
+    (stacked; merge in order, re-basing each onto master as the one below lands). Thresholds (`VERY_LOW_TOKENS_PER_SECOND`,
     `SLOW_PICK_TOKENS_PER_SECOND`) deliberately NOT retuned — they now compare a decode figure
     against probe-basis calibration (recorded in `docs/benchmark.md` / `model-benchmarks.md` §6.5).
 

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -42,6 +42,12 @@ with PR 3). PR 1 = #295 (375 / 5,645 / 74). Master `b4e0ed06` recounted: 375 / 5
 removed, `BENCHMARK_PROMPT` now a paragraph so the 64-token cap fills, `BenchmarkResult.speedBasis`,
 the card says "Decode speed" + token window / "≈ approximate"; thresholds NOT retuned (basis
 recorded in `benchmark.md`, `model-benchmarks.md` §6.5); MTP record §7 watch item → observed.
+PR 2 = #296 (375 / 5,654 / 74). **PR 3 (`fix/290-291-pr3-answer-speed-line`, #290):** chat
+only — `GenerateOptions.onTimings` (completed streams only) → `withChatStream` `sendTimings` →
+ONE ephemeral `chat:speed:<id>` `AnswerSpeed` payload (tok/s + tokens from the server timings,
+TTFT on the `first_token` clock) keyed to the persisted message id; `ChatScreen` session map →
+`Transcript` line `42 tok/s · 1.8 s to first token · 615 tokens` (EN/DE); nothing persisted;
+design record: `architecture.md` "Chat & streaming" → "Per-answer speed line" §1–§3.
 
 _2026-09-04 — **Phase F PR 6 (PR #293, `fix/pf-code1-rag-excerpt-framing`): #228 shipped — the excerpt
 block of `buildGroundedPrompt` / `buildCompareWholeDocPrompt` is framed as document content, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ from its first public `1.0.0` release onward.
 
 ## [Unreleased]
 
+### Added
+
+- **Each finished chat answer now shows how fast it was generated.** A small line under the
+  answer reads, for example, "42 tok/s · 1.8 s to first token · 615 tokens": the model's decode
+  speed as reported by the AI engine, how long you waited for the first word, and how many
+  tokens the answer took. It appears for answers generated in the current session only — nothing
+  is saved, so older answers show no line after a restart — and only for plain chat answers with
+  the real AI engine (not for document answers, and not for a stopped answer). English and German.
+
 ### Fixed
 
 - **The speed figure on Settings → Diagnostics is now the model's real decode speed.** The

--- a/apps/desktop/src/main/ipc/chat-stream.ts
+++ b/apps/desktop/src/main/ipc/chat-stream.ts
@@ -1,5 +1,6 @@
 import type { IpcMainInvokeEvent } from 'electron'
-import { STREAM, type CompactionNotice } from '../../shared/ipc'
+import { STREAM, type AnswerSpeed, type CompactionNotice } from '../../shared/ipc'
+import type { RuntimeTimings } from '../services/runtime'
 import type { AppContext } from '../services/context'
 import {
   DOC_TASK_BUSY_MESSAGE,
@@ -103,6 +104,15 @@ export type SendCompaction = (kind?: CompactionNotice['kind']) => void
  * never buffered; a remount misses it and the meter falls back to the resting estimate.
  */
 export type SendUsage = (usage: ContextUsage) => void
+/**
+ * #290: a one-shot sink for the runtime's per-request `timings` of a COMPLETED answer. The
+ * stream lifecycle turns them into ONE ephemeral `chat:speed:<id>` payload (tokens/sec, the
+ * user-felt time to first token measured on its own clock, the token count) keyed to the
+ * persisted message id, fired right before `done`. EPHEMERAL like `SendUsage` (R14): never
+ * buffered, nothing persisted. Only the plain-chat channel wires it; a runFn that never calls it
+ * (document answers, the mock runtime, an aborted answer) emits no speed payload at all.
+ */
+export type SendTimings = (timings: RuntimeTimings) => void
 
 /** The generation body run under the locked streaming contract — handed the turn's abort signal
  *  and the guarded senders, resolving with the persisted assistant Message. */
@@ -111,7 +121,9 @@ export type ChatStreamRunFn = (
   sendToken: SendToken,
   sendReasoning: SendReasoning,
   sendCompaction: SendCompaction,
-  sendUsage: SendUsage
+  sendUsage: SendUsage,
+  /** Optional so existing five-argument callers (the regenerate tests) stay source-compatible. */
+  sendTimings?: SendTimings
 ) => Promise<Message>
 
 /**
@@ -143,7 +155,7 @@ export function withRegenerateGuard(
   runFn: ChatStreamRunFn
 ): ChatStreamRunFn {
   if (!regenerate) return runFn
-  return async (signal, sendToken, sendReasoning, sendCompaction, sendUsage) => {
+  return async (signal, sendToken, sendReasoning, sendCompaction, sendUsage, sendTimings) => {
     // AUD-01 (data loss): `evidence_reviews.message_id` is a foreign key with ON DELETE CASCADE
     // and the workspace runs with `PRAGMA foreign_keys = ON`, so the `DELETE FROM messages` below
     // does not just drop an answer — it takes the reply's ENTIRE review chain with it: the review
@@ -162,7 +174,7 @@ export function withRegenerateGuard(
     }
     const deleted = deleteLastAssistantMessage(db, conversationId)
     try {
-      const result = await runFn(signal, sendToken, sendReasoning, sendCompaction, sendUsage)
+      const result = await runFn(signal, sendToken, sendReasoning, sendCompaction, sendUsage, sendTimings)
       // CB-2: a Stop BEFORE the first token RESOLVES (it does not throw) with an unpersisted empty
       // message (`content === ''`, the sole empty-return path of `generateAssistantMessage`). Without
       // this the destructive regenerate delete would stand with NOTHING in its place — two clicks
@@ -181,6 +193,26 @@ export function withRegenerateGuard(
       throw err
     }
   }
+}
+
+/**
+ * #290: build the per-answer speed payload, or null when any input is unusable. Pure and
+ * exported for the IPC test. Requires a persisted non-empty reply, a first token on the stream
+ * clock, and finite positive `predicted_per_second` + `predicted_n` from the runtime — a
+ * runtime without timings (the mock), an aborted answer (no timings) or an empty reply yields
+ * null, so the line is absent rather than wrong.
+ */
+export function answerSpeedFrom(
+  assistant: Message,
+  timings: RuntimeTimings | null,
+  ttftMs: number | null
+): AnswerSpeed | null {
+  if (!timings || ttftMs == null || assistant.content === '' || !assistant.id) return null
+  const tps = timings.predicted_per_second
+  const tokens = timings.predicted_n
+  if (typeof tps !== 'number' || !Number.isFinite(tps) || tps <= 0) return null
+  if (typeof tokens !== 'number' || !Number.isFinite(tokens) || tokens <= 0) return null
+  return { messageId: assistant.id, tokensPerSecond: tps, ttftMs, tokens: Math.round(tokens) }
 }
 
 /**
@@ -229,8 +261,13 @@ export async function withChatStream(
   // chunk approximates a token for llama-server; the mock streams words.
   const streamT0 = performance.now()
   let chunkCount = 0
+  // #290: the user-felt time to first token, on the SAME clock as the `first_token` perf mark.
+  let ttftMs: number | null = null
   const sendToken: SendToken = (token) => {
-    if (chunkCount === 0) perfMark('first_token', { ttftMs: perfMs(streamT0) })
+    if (chunkCount === 0) {
+      ttftMs = perfMs(streamT0)
+      perfMark('first_token', { ttftMs })
+    }
     chunkCount += 1
     const buf = streamBuffers.get(conversationId)
     if (buf) buf.content += token
@@ -262,17 +299,32 @@ export async function withChatStream(
       event.sender.send(STREAM.usage(conversationId), usage)
     }
   }
+  // #290: the runtime's timings for a COMPLETED answer are parked here and turned into the one
+  // `chat:speed` payload once the persisted message id is known (after runFn resolves). The
+  // message id has to come from the persisted row, which is why this is not sent immediately.
+  let pendingTimings: RuntimeTimings | null = null
+  const sendTimings: SendTimings = (timings) => {
+    pendingTimings = timings
+  }
   try {
     // Hand the model slot off from a yielding build before any model call (no-op when none).
     // The abort signal is threaded in (REL-3) so a Stop while parked waiting for the build's
     // handoff rejects this acquire instead of blocking for up to one tree-node summarization.
     if (acquireSlot) releaseSlot = await acquireSlot(controller.signal)
-    const assistant = await runFn(controller.signal, sendToken, sendReasoning, sendCompaction, sendUsage)
+    const assistant = await runFn(controller.signal, sendToken, sendReasoning, sendCompaction, sendUsage, sendTimings)
     perfMark('stream_done', {
       chunks: chunkCount,
       chars: streamBuffers.get(conversationId)?.content.length ?? 0,
       elapsedMs: perfMs(streamT0)
     })
+    // #290: ONE ephemeral speed payload per finished answer, before `done`. Requires a persisted
+    // (non-empty) reply, a first token on this clock, and usable server figures — anything less
+    // (an abort carries no timings; a stripped-to-empty reply persists nothing) emits nothing,
+    // never a wrong speed. Not buffered (R14): a remount or reload shows no line.
+    const speed = answerSpeedFrom(assistant, pendingTimings, ttftMs)
+    if (speed && !event.sender.isDestroyed()) {
+      event.sender.send(STREAM.speed(conversationId), speed)
+    }
     if (!event.sender.isDestroyed()) {
       event.sender.send(STREAM.done(conversationId), assistant)
     }

--- a/apps/desktop/src/main/ipc/registerChatIpc.ts
+++ b/apps/desktop/src/main/ipc/registerChatIpc.ts
@@ -295,7 +295,7 @@ export function registerChatIpc(ctx: AppContext): void {
         'Chat generation failed',
         // F2: on regenerate the destructive delete runs INSIDE this runFn (slot held) and is
         // restored on a non-abort failure, so a failed regenerate never leaves the turn answer-less.
-        withRegenerateGuard(ctx.db, conversationId, regenerate, (signal, sendToken, sendReasoning, sendCompaction, sendUsage) =>
+        withRegenerateGuard(ctx.db, conversationId, regenerate, (signal, sendToken, sendReasoning, sendCompaction, sendUsage, sendTimings) =>
           generateAssistantMessage(ctx.db, runtime, conversationId, {
             signal,
             mode,
@@ -307,7 +307,10 @@ export function registerChatIpc(ctx: AppContext): void {
             // starts (§5.2); isDestroyed-guarded inside withChatStream, never buffered (R14).
             onCompactionStart: sendCompaction,
             // The real assembled-prompt usage for the live composer meter (ephemeral, R14).
-            onPromptUsage: sendUsage
+            onPromptUsage: sendUsage,
+            // #290: the runtime's timings of a COMPLETED answer → the one ephemeral speed line.
+            // Plain chat only — the document channels never wire this.
+            onTimings: sendTimings
           })),
         (signal) => ctx.docTasks?.acquireChatSlot(signal) ?? Promise.resolve(() => {})
       )

--- a/apps/desktop/src/main/services/chat.ts
+++ b/apps/desktop/src/main/services/chat.ts
@@ -27,7 +27,7 @@ import {
   skillFenceBudgetTokens,
   stripSkillFenceEcho
 } from './skills/prompt'
-import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from './runtime'
+import type { ChatMessage, ModelRuntime, RuntimeChatOptions, RuntimeTimings } from './runtime'
 import { requestParamsForMode } from './runtime/llama'
 import { ensureCompacted } from './chat/compaction'
 import { log } from './logging'
@@ -1473,6 +1473,13 @@ export interface GenerateOptions {
    * excerpt/document block.
    */
   onPromptUsage?: (usage: ContextUsage) => void
+  /**
+   * #290: fired at most once, after the stream COMPLETED (never on a user Stop — an aborted
+   * request carries no final chunk), with the runtime's per-request `timings` when it sent any.
+   * The mock runtime sends none, so this never fires there. Numbers only; the IPC layer turns
+   * them into the ephemeral per-answer speed line. Nothing is persisted.
+   */
+  onTimings?: (timings: RuntimeTimings) => void
 }
 
 /**
@@ -1530,12 +1537,16 @@ export async function generateAssistantMessage(
   // (§L0 honest-signal). A user Stop aborts before any final chunk, so this stays null → not
   // truncated (the abort partial is intentional and user-known).
   let finishReason: string | null = null
+  // #290: the runtime's per-request timings ride the same final chunk as the finish reason, so
+  // a user Stop (no final chunk) leaves this null and the speed line is simply never emitted.
+  let timings: RuntimeTimings | null = null
   const stream = runtime.chatStream(messages, {
     signal: opts.signal,
     mode: opts.mode,
     onReasoning: opts.onReasoning,
-    onFinish: (reason) => {
+    onFinish: (reason, tm) => {
       finishReason = reason
+      timings = tm ?? null
     },
     ...opts.runtimeOptions
   })
@@ -1551,6 +1562,8 @@ export async function generateAssistantMessage(
     if (!isAbortError(err, opts.signal)) throw err
     caughtAbort = true
   }
+  // #290: hand the timings up only for a COMPLETED stream — never a wrong speed on a partial.
+  if (timings && !caughtAbort && opts.signal?.aborted !== true) opts.onTimings?.(timings)
   // CB-4: capture whether the model actually emitted anything BEFORE the strip passes below. A
   // reply that arrived and then stripped to empty (all-`<think>`/fence-echo) is a benign silent-empty
   // — distinct from a completed stream that produced no token at all.

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,12 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import { EVENTS, IPC, STREAM, type CompactionNotice, type ScopeNotice } from '../shared/ipc'
+import {
+  EVENTS,
+  IPC,
+  STREAM,
+  type AnswerSpeed,
+  type CompactionNotice,
+  type ScopeNotice
+} from '../shared/ipc'
 import type {
   ActiveStreamSnapshot,
   AppSettings,
@@ -747,6 +754,15 @@ const api = {
   onContextUsage: (requestId: string, cb: (usage: ContextUsage) => void): (() => void) => {
     const ch = STREAM.usage(requestId)
     const handler = (_e: unknown, usage: ContextUsage) => cb(usage)
+    ipcRenderer.on(ch, handler)
+    return () => ipcRenderer.removeListener(ch, handler)
+  },
+  /** Subscribe to the one-shot per-answer speed payload of a FINISHED chat answer (#290):
+   *  decode tokens/sec, time to first token and token count, keyed to the persisted message id.
+   *  Fired right before `done`; ephemeral, never persisted — a reload shows nothing. */
+  onAnswerSpeed: (requestId: string, cb: (speed: AnswerSpeed) => void): (() => void) => {
+    const ch = STREAM.speed(requestId)
+    const handler = (_e: unknown, speed: AnswerSpeed) => cb(speed)
     ipcRenderer.on(ch, handler)
     return () => ipcRenderer.removeListener(ch, handler)
   },

--- a/apps/desktop/src/renderer/chat/Transcript.tsx
+++ b/apps/desktop/src/renderer/chat/Transcript.tsx
@@ -1,7 +1,10 @@
 import { Fragment, memo, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import { AssistantMarkdown } from './AssistantMarkdownLazy'
 import type { ConversationSummaryMarker, EvidenceReviewSummary, Message } from '@shared/types'
+import type { AnswerSpeed } from '@shared/ipc'
+import type { UiLanguage } from '@shared/i18n'
 import { isReviewEligible } from '@shared/evidence-review'
+import { formatAnswerSpeed } from './answerSpeed'
 import { MessageActions } from './MessageActions'
 import { SourcesDisclosure } from './SourcesDisclosure'
 import { CoverageMeter, Icon, Spinner } from '../components'
@@ -60,6 +63,12 @@ interface TranscriptProps {
    * available (older callers keep their behavior; main still refuses the stale id).
    */
   isSkillOfferAvailable?: (installId: string) => boolean
+  /**
+   * #290: per-answer speed figures for answers generated in THIS session, keyed by message id.
+   * A message without an entry (older turns after a reload, the mock runtime, an aborted answer)
+   * renders no line. Absent ⇒ no lines at all.
+   */
+  answerSpeeds?: ReadonlyMap<string, AnswerSpeed>
   onCopy: (content: string) => void
   onSave: () => void
   /**
@@ -130,9 +139,10 @@ export const Transcript = memo(function Transcript({
   actionsDisabled,
   resolveSkillTitle,
   progressNotice,
-  summaryMarker
+  summaryMarker,
+  answerSpeeds
 }: TranscriptProps): JSX.Element {
-  const { t } = useT()
+  const { t, lang } = useT()
   // Stable ids wiring the live "Thinking…" toggle to its region (FE-D aria-controls).
   const thinkingId = useId()
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -209,6 +219,8 @@ export const Transcript = memo(function Transcript({
               reviewConversation={reviewConversation}
               actionsDisabled={actionsDisabled}
               resolveSkillTitle={resolveSkillTitle}
+              answerSpeed={answerSpeeds?.get(m.id) ?? null}
+              lang={lang}
             />
           </Fragment>
         ))}
@@ -316,10 +328,15 @@ const MessageBlock = memo(function MessageBlock({
   reviewSummary,
   reviewConversation,
   actionsDisabled,
-  resolveSkillTitle
+  resolveSkillTitle,
+  answerSpeed,
+  lang
 }: {
   m: Message
   t: I18n['t']
+  /** #290: this session's speed figures for the answer, or null (no line). */
+  answerSpeed: AnswerSpeed | null
+  lang: UiLanguage
   /** True on the last assistant turn — gates the regenerate + "answer without it" affordances. */
   isLast: boolean
   onTryAgain?: () => void
@@ -494,6 +511,15 @@ const MessageBlock = memo(function MessageBlock({
               ⚠
             </span>
             <span>{t('chat.truncated.label')}</span>
+          </div>
+        )}
+        {/* #290: the per-answer speed line — decode tokens/sec, time to first token, token count —
+            in the same quiet metadata style as the skill glyph and the truncation note. Session-only:
+            rendered only for an answer whose `chat:speed` payload arrived in this session, so older
+            turns after a reload, a mock-runtime answer and an aborted answer show nothing. */}
+        {m.role === 'assistant' && answerSpeed && (
+          <div className="msg-speed" role="note" title={t('chat.speed.hint')}>
+            {formatAnswerSpeed(answerSpeed, t, lang)}
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/chat/answerSpeed.ts
+++ b/apps/desktop/src/renderer/chat/answerSpeed.ts
@@ -1,0 +1,26 @@
+import type { AnswerSpeed } from '@shared/ipc'
+import type { UiLanguage } from '@shared/i18n'
+import type { I18n } from '../i18n'
+
+/**
+ * Format the per-answer speed line (#290): `42 tok/s · 1.8 s to first token · 615 tokens`.
+ * Rounding rule from the issue: no decimals at or above 10 tok/s, one decimal below; time to
+ * first token in seconds with one decimal; the token count as a whole number. Every number goes
+ * through the UI language so German reads "1,8 s" and "1.024 Token" (M-U5). Pure — one
+ * definition shared by the transcript and its render test.
+ */
+export function formatAnswerSpeed(speed: AnswerSpeed, t: I18n['t'], lang: UiLanguage): string {
+  const tps =
+    speed.tokensPerSecond >= 10
+      ? Math.round(speed.tokensPerSecond).toLocaleString(lang, { maximumFractionDigits: 0 })
+      : speed.tokensPerSecond.toLocaleString(lang, {
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1
+        })
+  const ttft = (speed.ttftMs / 1000).toLocaleString(lang, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  })
+  const tokens = Math.round(speed.tokens).toLocaleString(lang, { maximumFractionDigits: 0 })
+  return t('chat.speed.line', { tps, ttft, tokens })
+}

--- a/apps/desktop/src/renderer/screens/ChatScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ChatScreen.tsx
@@ -16,6 +16,7 @@ import {
   type SkillInfo,
   type SkillSuggestion
 } from '@shared/types'
+import type { AnswerSpeed } from '@shared/ipc'
 import { isReviewEligible } from '@shared/evidence-review'
 import type { ReviewHandoffTarget } from '../lib/reviewSession'
 import { cancelActiveDocTask } from '../lib/doctasks'
@@ -235,6 +236,10 @@ export function ChatScreen({
    *  base while streaming; cleared when the turn settles (the excerpt block is per-turn, so the
    *  meter honestly drops back to the resting read). */
   const [streamUsage, setStreamUsage] = useState<ContextUsage | null>(null)
+  /** #290: per-answer speed figures for answers generated in THIS session, keyed by message id
+   *  (the one-shot `chat:speed` payload). Session state only — never persisted, so a reload or a
+   *  message the mock runtime answered (no timings) shows no line. */
+  const [answerSpeeds, setAnswerSpeeds] = useState<ReadonlyMap<string, AnswerSpeed>>(() => new Map())
   /** The latest compaction summary + its transcript marker position (§5.3, D-b); null hides it. */
   const [summaryMarker, setSummaryMarker] = useState<ConversationSummaryMarker | null>(null)
   // True while RECOVERING an in-flight generation that this component instance did not
@@ -1524,6 +1529,7 @@ export function ChatScreen({
     let unsubscribe: () => void = () => {}
     let unsubscribeCompaction: (() => void) | undefined
     let unsubscribeUsage: (() => void) | undefined
+    let unsubscribeSpeed: (() => void) | undefined
     let unsubscribeReasoning: () => void = () => {}
     let unsubscribeScope: () => void = () => {}
     // Only update the visible transcript if the user is still looking at THIS
@@ -1580,6 +1586,11 @@ export function ChatScreen({
       // base while streaming — the only way a document turn's injected excerpt block reaches the
       // meter. Optional-chained like onCompaction (tolerates an older bridge); ephemeral (R14).
       unsubscribeUsage = window.api.onContextUsage?.(convId, (usage) => setStreamUsage(usage))
+      // #290: the one-shot per-answer speed payload (fired right before `done`, keyed to the
+      // persisted message id). Kept in session state only; optional-chained like the others.
+      unsubscribeSpeed = window.api.onAnswerSpeed?.(convId, (speed) =>
+        setAnswerSpeeds((prev) => new Map(prev).set(speed.messageId, speed))
+      )
       // Deep-mode reasoning deltas feed the live "Thinking…" line. They are
       // a separate channel from answer tokens and are never part of the persisted reply.
       unsubscribeReasoning = window.api.onReasoning(convId, (delta) => {
@@ -1648,6 +1659,7 @@ export function ChatScreen({
       unsubscribeScope()
       unsubscribeCompaction?.()
       unsubscribeUsage?.()
+      unsubscribeSpeed?.()
       // #39: retire the warm-up hint with the turn — clear the pending timer, invalidate any
       // in-flight status check (turn identity), and drop the visible line.
       clearTimeout(warmupTimer)
@@ -2314,6 +2326,8 @@ export function ChatScreen({
           warmupHint={warmupHint}
           thinkingOpen={thinkingOpen}
           onThinkingOpenChange={setThinkingOpen}
+          // #290: session-only per-answer speed figures; a message without an entry shows no line.
+          answerSpeeds={answerSpeeds}
           emptyState={emptyState}
           onTryAgain={canTryAgain ? handleTryAgain : undefined}
           // The undo's own placement gate (last skill-stamped turn — auto-fired OR picked, U3 §4.3)

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -889,6 +889,18 @@ code, pre, kbd { font-family: var(--font-mono); }
   cursor: default;
 }
 .msg-truncated-glyph { flex-shrink: 0; font-size: 12px; }
+/* #290: the per-answer speed line (decode tok/s · time to first token · tokens) — the same quiet
+   muted metadata vocabulary as .msg-skill; numbers in tabular figures so lines align. */
+.msg-speed {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 8px;
+  font-size: var(--text-xs);
+  line-height: var(--line-xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  cursor: default;
+}
 /* S13c (D3): the per-turn "answer without it" undo on an auto-fired turn — a quiet inline link, not a
    loud button, so an auto-applied skill is reversible without shouting. */
 .msg-skill-undo {

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -420,6 +420,10 @@ export const de: Record<keyof typeof en, string> = {
   'chat.context.usageTooltip': 'Speicher für dieses Gespräch: {pct} % belegt (etwa {used} von {window} Token).',
   'chat.context.willSummarize': 'Bei vollem Speicher werden ältere Nachrichten automatisch zusammengefasst, um Platz zu schaffen.',
   // Ehrliches Signal (§L0): erscheint bei einer Antwort, die das Modell am Kontextlimit abgeschnitten hat.
+  // #290: Geschwindigkeitszeile unter einer fertigen Antwort (nur diese Sitzung, nie gespeichert).
+  'chat.speed.line': '{tps} Token/s · {ttft} s bis zum ersten Token · {tokens} Token',
+  'chat.speed.hint':
+    'Wie schnell diese Antwort entstanden ist: Decodier-Geschwindigkeit der KI-Engine, Wartezeit bis zum ersten Wort und Anzahl der erzeugten Token. Nur für Antworten aus dieser Sitzung.',
   'chat.truncated.label': 'Antwort abgeschnitten – Kontextlimit des Modells erreicht',
   'chat.truncated.hint':
     'Dem Modell ging der Platz aus, um diese Antwort zu beenden. Bitte es fortzufahren, beginne einen neuen Chat oder erhöhe die Kontextgröße im Bereich „KI-Modell“.',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -397,6 +397,11 @@ export const en = {
   'chat.truncated.label': 'Reply cut off — reached the model’s context limit',
   'chat.truncated.hint':
     'The model ran out of room to finish this answer. Ask it to continue, start a new chat, or raise the context size on the AI Model screen.',
+  // #290: the per-answer speed line under a finished chat answer (this session only, never saved).
+  // {tps} / {ttft} / {tokens} arrive pre-formatted for the UI language.
+  'chat.speed.line': '{tps} tok/s · {ttft} s to first token · {tokens} tokens',
+  'chat.speed.hint':
+    'How fast this answer was generated: decode speed from the AI engine, the wait until the first word, and the number of tokens produced. Shown for answers from this session only.',
 
   // ---- Chat: document scope (ScopePopover.tsx) ----
   // Truthful, calm scope copy: never "Using all 0 documents". Zero documents routes to

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -414,6 +414,13 @@ export const STREAM = {
   // ("meter says 7% while the window is full"). Ephemeral like `compaction` (R14): never
   // buffered, fine to miss on remount — the meter then falls back to the resting estimate.
   usage: (requestId: string) => `chat:usage:${requestId}`,
+  // ADDITIVE (#290): ONE ephemeral `AnswerSpeed` payload per FINISHED chat answer — the runtime's
+  // decode tokens/sec + token count (llama-server `timings`) and the user-felt time to first
+  // token — fired right before `done`, keyed to the persisted message id. Never persisted, never
+  // buffered (R14): a reload shows nothing on old messages, and the mock runtime (no timings)
+  // never fires it. Plain chat answers only — not the hidden warm-up, document tasks, skill runs
+  // or compaction. An aborted answer carries no timings and fires nothing.
+  speed: (requestId: string) => `chat:speed:${requestId}`,
   // Image understanding (vision) per-job streaming (image-understanding plan §9.1). Mirrors the
   // chat token/done/error contract, keyed by analyze jobId: the vision sidecar emits SSE
   // byte-identical to chat (V1-confirmed), so `readChatSSE` forwards the deltas as imgToken.
@@ -449,6 +456,23 @@ export interface ScopeNotice {
 export interface CompactionNotice {
   phase: 'start'
   kind?: 'compaction' | 'analysis'
+}
+
+/**
+ * Payload of the `speed` channel (#290): how fast a FINISHED chat answer was generated. Session-
+ * only — never persisted, never on the local API (`usage` there stays absent by decision,
+ * local-api.md §6.5). Numbers only, never content.
+ */
+export interface AnswerSpeed {
+  /** The persisted assistant message the figures belong to. */
+  messageId: string
+  /** Decode throughput from llama-server `timings.predicted_per_second` (tokens, not chunks). */
+  tokensPerSecond: number
+  /** User-felt wait from the send to the first answer token (prompt assembly, any compaction
+   *  pre-pass and prefill included), in milliseconds. */
+  ttftMs: number
+  /** Generated tokens (`timings.predicted_n`). */
+  tokens: number
 }
 
 /**

--- a/apps/desktop/tests/integration/chat.test.ts
+++ b/apps/desktop/tests/integration/chat.test.ts
@@ -473,6 +473,94 @@ describe('generateAssistantMessage (streaming)', () => {
     expect(listMessages(db, conv.id).at(-1)?.truncated).toBe(true)
   })
 
+  // #290: the runtime's per-request timings reach the caller through `onTimings` — only for a
+  // COMPLETED stream, and only when the runtime actually sent them.
+  describe('onTimings (#290)', () => {
+    const timings = { prompt_n: 12, predicted_n: 615, predicted_ms: 14_640, predicted_per_second: 42 }
+    function timedRuntime(finish: (options?: RuntimeChatOptions) => void): ModelRuntime {
+      return {
+        modelId: 'timed',
+        start: async () => {},
+        stop: async () => {},
+        health: async () => ({ healthy: true, message: 'ok', port: null }),
+        contextWindow: () => 2048,
+        async *chatStream(_messages: ChatMessage[], options?: RuntimeChatOptions) {
+          yield 'a full'
+          yield ' answer'
+          finish(options)
+        }
+      }
+    }
+
+    it('hands the runtime timings up once for a completed answer', async () => {
+      const db = freshDb()
+      const conv = createConversation(db, {})
+      appendMessage(db, { conversationId: conv.id, role: 'user', content: 'how fast?' })
+      const seen: unknown[] = []
+      const msg = await generateAssistantMessage(
+        db,
+        timedRuntime((o) => o?.onFinish?.('stop', timings)),
+        conv.id,
+        { onTimings: (tm) => seen.push(tm) }
+      )
+      expect(msg.content).toBe('a full answer')
+      expect(seen).toEqual([timings])
+      // Nothing about the speed is persisted — the row carries no such column/field.
+      expect(Object.keys(listMessages(db, conv.id).at(-1) ?? {})).not.toContain('timings')
+    })
+
+    it('never fires when the runtime sent no timings (the mock runtime)', async () => {
+      const db = freshDb()
+      const conv = createConversation(db, {})
+      appendMessage(db, { conversationId: conv.id, role: 'user', content: 'ping' })
+      const seen: unknown[] = []
+      await generateAssistantMessage(db, runtime(), conv.id, { onTimings: (tm) => seen.push(tm) })
+      expect(seen).toEqual([])
+    })
+
+    it('never fires on a user Stop — an aborted stream carries no final chunk', async () => {
+      const db = freshDb()
+      const conv = createConversation(db, {})
+      appendMessage(db, { conversationId: conv.id, role: 'user', content: 'ping' })
+      const controller = new AbortController()
+      const seen: unknown[] = []
+      const aborting: ModelRuntime = {
+        ...timedRuntime(() => {}),
+        async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+          yield 'partial'
+          controller.abort()
+          // A real runtime's reader returns on the aborted signal before any finish chunk; a
+          // timings hand-up here would be a bug in the runtime — the service must still refuse it.
+          if (options?.signal?.aborted) return
+          options?.onFinish?.('stop', timings)
+        }
+      }
+      const msg = await generateAssistantMessage(db, aborting, conv.id, {
+        signal: controller.signal,
+        onTimings: (tm) => seen.push(tm)
+      })
+      expect(msg.content).toBe('partial')
+      expect(seen).toEqual([])
+    })
+
+    it('refuses timings that arrive on an aborted signal even if the runtime reported them', async () => {
+      const db = freshDb()
+      const conv = createConversation(db, {})
+      appendMessage(db, { conversationId: conv.id, role: 'user', content: 'ping' })
+      const controller = new AbortController()
+      const seen: unknown[] = []
+      const misbehaving = timedRuntime((o) => {
+        controller.abort()
+        o?.onFinish?.('stop', timings)
+      })
+      await generateAssistantMessage(db, misbehaving, conv.id, {
+        signal: controller.signal,
+        onTimings: (tm) => seen.push(tm)
+      })
+      expect(seen).toEqual([])
+    })
+  })
+
   // 2026-07-04 user report: a Fast-mode reply that hit the FAST_MAX_TOKENS cap also finishes with
   // 'length', and the badge then claimed "reached the model's context limit" while the meter
   // (truthfully) sat at single-digit percent. A capped run must NOT wear the context-limit badge.

--- a/apps/desktop/tests/renderer/AnswerSpeedLine.test.tsx
+++ b/apps/desktop/tests/renderer/AnswerSpeedLine.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { Transcript } from '../../src/renderer/chat/Transcript'
+import { formatAnswerSpeed } from '../../src/renderer/chat/answerSpeed'
+import { I18nProvider, UI_LANGUAGE_STORAGE_KEY } from '../../src/renderer/i18n'
+import { t, type UiLanguage } from '../../src/shared/i18n'
+import type { Message } from '../../src/shared/types'
+import type { AnswerSpeed } from '../../src/shared/ipc'
+
+// #290: the per-answer speed line under a FINISHED chat answer — `42 tok/s · 1.8 s to first
+// token · 615 tokens` — rendered only for messages whose speed payload arrived in this session.
+
+vi.mock('streamdown', () => ({
+  Streamdown: vi.fn(({ children }) => <div data-testid="sd">{children}</div>),
+  defaultRehypePlugins: { raw: () => undefined, sanitize: () => undefined }
+}))
+
+function assistantMsg(id: string, content = 'An answer.'): Message {
+  return { id, conversationId: 'c1', role: 'assistant', content, createdAt: '2026-01-01T00:00:00Z' }
+}
+const noop = (): void => {}
+const onCopy = (_c: string): void => {}
+const tFor = (lang: UiLanguage) => (key: Parameters<typeof t>[1], params?: Parameters<typeof t>[2]) =>
+  t(lang, key, params)
+
+function renderTranscript(lang: UiLanguage, messages: Message[], answerSpeeds?: ReadonlyMap<string, AnswerSpeed>) {
+  window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, lang)
+  return render(
+    <I18nProvider>
+      <Transcript
+        messages={messages}
+        streamingHere={false}
+        streamText=""
+        streamThinking=""
+        thinkingOpen={false}
+        onThinkingOpenChange={noop}
+        emptyState={null}
+        onCopy={onCopy}
+        onSave={noop}
+        actionsDisabled={false}
+        answerSpeeds={answerSpeeds}
+      />
+    </I18nProvider>
+  )
+}
+
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollTo', {
+    configurable: true,
+    writable: true,
+    value: () => {}
+  })
+})
+beforeEach(() => window.localStorage.clear())
+afterEach(() => cleanup())
+
+describe('formatAnswerSpeed (#290) — rounding + locale', () => {
+  it('drops decimals at or above 10 tok/s, keeps one below; TTFT one decimal; whole tokens', () => {
+    expect(formatAnswerSpeed({ messageId: 'a', tokensPerSecond: 42.4, ttftMs: 1_840, tokens: 615 }, tFor('en'), 'en')).toBe(
+      '42 tok/s · 1.8 s to first token · 615 tokens'
+    )
+    expect(formatAnswerSpeed({ messageId: 'a', tokensPerSecond: 9.96, ttftMs: 12_349, tokens: 1024 }, tFor('en'), 'en')).toBe(
+      '10.0 tok/s · 12.3 s to first token · 1,024 tokens'
+    )
+    expect(formatAnswerSpeed({ messageId: 'a', tokensPerSecond: 2.25, ttftMs: 400, tokens: 3 }, tFor('en'), 'en')).toBe(
+      '2.3 tok/s · 0.4 s to first token · 3 tokens'
+    )
+  })
+
+  it('renders German separators and copy', () => {
+    expect(formatAnswerSpeed({ messageId: 'a', tokensPerSecond: 42.4, ttftMs: 1_840, tokens: 1615 }, tFor('de'), 'de')).toBe(
+      '42 Token/s · 1,8 s bis zum ersten Token · 1.615 Token'
+    )
+    expect(formatAnswerSpeed({ messageId: 'a', tokensPerSecond: 4.75, ttftMs: 950, tokens: 12 }, tFor('de'), 'de')).toBe(
+      '4,8 Token/s · 1,0 s bis zum ersten Token · 12 Token'
+    )
+  })
+})
+
+describe('Transcript speed line (#290)', () => {
+  const speed: AnswerSpeed = { messageId: 'a2', tokensPerSecond: 42, ttftMs: 1_800, tokens: 615 }
+
+  it('shows the line under the answer that has a speed payload, in English', () => {
+    renderTranscript('en', [assistantMsg('a1'), assistantMsg('a2')], new Map([['a2', speed]]))
+    const line = screen.getByText('42 tok/s · 1.8 s to first token · 615 tokens')
+    expect(line).toHaveAttribute('role', 'note')
+    expect(line).toHaveAttribute('title', t('en', 'chat.speed.hint'))
+    // Exactly one line: the other answer (no payload this session) shows nothing.
+    expect(screen.getAllByRole('note').filter((n) => n.className === 'msg-speed')).toHaveLength(1)
+  })
+
+  it('shows the line in German', () => {
+    renderTranscript('de', [assistantMsg('a2')], new Map([['a2', speed]]))
+    expect(screen.getByText('42 Token/s · 1,8 s bis zum ersten Token · 615 Token')).toBeInTheDocument()
+  })
+
+  it('renders cleanly with no line when there is no payload (mock runtime / aborted answer)', () => {
+    renderTranscript('en', [assistantMsg('a1'), assistantMsg('a2')], new Map())
+    expect(screen.queryByText(/to first token/)).not.toBeInTheDocument()
+    expect(document.querySelector('.msg-speed')).toBeNull()
+  })
+
+  it('shows nothing on reloaded history — a fresh session map carries no entries for old messages', () => {
+    // The payload is never persisted, so a reload re-renders the same messages with an empty map.
+    const { unmount } = renderTranscript('en', [assistantMsg('a2')], new Map([['a2', speed]]))
+    expect(screen.getByText(/to first token/)).toBeInTheDocument()
+    unmount()
+    renderTranscript('en', [assistantMsg('a2')], new Map())
+    expect(screen.queryByText(/to first token/)).not.toBeInTheDocument()
+  })
+
+  it('never renders a line on a user turn even if an id collides', () => {
+    const user: Message = { id: 'a2', conversationId: 'c1', role: 'user', content: 'hi', createdAt: '2026-01-01T00:00:00Z' }
+    renderTranscript('en', [user], new Map([['a2', speed]]))
+    expect(document.querySelector('.msg-speed')).toBeNull()
+  })
+})

--- a/apps/desktop/tests/unit/chat-stream.test.ts
+++ b/apps/desktop/tests/unit/chat-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { IpcMainInvokeEvent } from 'electron'
-import { withChatStream } from '../../src/main/ipc/chat-stream'
+import { answerSpeedFrom, withChatStream } from '../../src/main/ipc/chat-stream'
 import {
   ChatRequestError,
   ChatStreamError,
@@ -74,6 +74,74 @@ describe('withChatStream (M-A2)', () => {
     expect(sent[2].args[0]).toMatchObject({ content: 'hello world' })
     // The registry entry is cleared on completion.
     expect(inFlightStreams.has('c1')).toBe(false)
+  })
+
+  // #290: ONE ephemeral `chat:speed:<id>` payload per FINISHED answer, keyed to the persisted
+  // message id, before `done` — and nothing at all when the runtime sent no timings, the reply
+  // is empty, or the stream never produced a first token.
+  describe('per-answer speed payload (#290)', () => {
+    const timings = { prompt_n: 20, predicted_n: 615, predicted_ms: 14_640, predicted_per_second: 42 }
+
+    it('emits chat:speed with the message id, tok/s, TTFT and token count right before done', async () => {
+      const { event, sent } = fakeEvent()
+      await withChatStream(event, 'c1', 'label', async (_s, sendToken, _r, _c, _u, sendTimings) => {
+        sendToken('hello')
+        sendTimings?.(timings)
+        return msg('hello')
+      })
+      expect(sent.map((s) => s.channel)).toEqual(['chat:token:c1', 'chat:speed:c1', 'chat:done:c1'])
+      const speed = sent[1].args[0] as { messageId: string; tokensPerSecond: number; ttftMs: number; tokens: number }
+      expect(speed.messageId).toBe('a1')
+      expect(speed.tokensPerSecond).toBe(42)
+      expect(speed.tokens).toBe(615)
+      // TTFT is measured on the stream clock (registration → first token): non-negative, finite.
+      expect(Number.isFinite(speed.ttftMs)).toBe(true)
+      expect(speed.ttftMs).toBeGreaterThanOrEqual(0)
+      // Ephemeral (R14): nothing of it in the recovery buffers or the message.
+      expect(sent[2].args[0]).not.toHaveProperty('tokensPerSecond')
+    })
+
+    it('emits nothing when the run never hands timings up (the mock runtime, document answers)', async () => {
+      const { event, sent } = fakeEvent()
+      await withChatStream(event, 'c1', 'label', async (_s, sendToken) => {
+        sendToken('hello')
+        return msg('hello')
+      })
+      expect(sent.map((s) => s.channel)).toEqual(['chat:token:c1', 'chat:done:c1'])
+    })
+
+    it('emits nothing for an empty (unpersisted) reply even if timings arrived', async () => {
+      const { event, sent } = fakeEvent()
+      await withChatStream(event, 'c1', 'label', async (_s, _t, _r, _c, _u, sendTimings) => {
+        sendTimings?.(timings)
+        return msg('')
+      })
+      expect(sent.map((s) => s.channel)).toEqual(['chat:done:c1'])
+    })
+
+    it('emits nothing when the timings carry no usable rate or count', async () => {
+      const { event, sent } = fakeEvent()
+      await withChatStream(event, 'c1', 'label', async (_s, sendToken, _r, _c, _u, sendTimings) => {
+        sendToken('x')
+        sendTimings?.({ prompt_n: 3 })
+        return msg('x')
+      })
+      expect(sent.map((s) => s.channel)).toEqual(['chat:token:c1', 'chat:done:c1'])
+    })
+
+    it('answerSpeedFrom is the single rule: null without timings, TTFT, content or positive figures', () => {
+      expect(answerSpeedFrom(msg('x'), null, 5)).toBeNull()
+      expect(answerSpeedFrom(msg('x'), timings, null)).toBeNull()
+      expect(answerSpeedFrom(msg(''), timings, 5)).toBeNull()
+      expect(answerSpeedFrom(msg('x'), { predicted_per_second: 0, predicted_n: 5 }, 5)).toBeNull()
+      expect(answerSpeedFrom(msg('x'), { predicted_per_second: 12, predicted_n: 0 }, 5)).toBeNull()
+      expect(answerSpeedFrom(msg('x'), { predicted_per_second: 12.4, predicted_n: 7.6 }, 1800)).toEqual({
+        messageId: 'a1',
+        tokensPerSecond: 12.4,
+        ttftMs: 1800,
+        tokens: 8
+      })
+    })
   })
 
   it('emits error and clears the entry when the run throws, then rethrows', async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1186,6 +1186,25 @@ FE-4/FE-5) are unchanged — see Wave P4/P5 above.
   `chat:scope:<id>` (`STREAM.scope`) carries a one-shot `ScopeNotice` — the filenames retrieval
   was auto-restricted to — before the first token of a document answer when filename auto-scope
   fires; informational only, never persisted.
+- **Per-answer speed line (issue #290, 2026-09-04) — design record §1–§3.** **§1 What it shows.**
+  Under a FINISHED plain-chat answer, one quiet metadata line in the skill-glyph / truncation-note
+  style: `42 tok/s · 1.8 s to first token · 615 tokens` (no decimals at or above 10 tok/s, one
+  below; EN + DE via `chat.speed.line`, formatted by `renderer/chat/answerSpeed.ts`). **§2 Where
+  the numbers come from.** Tokens/sec and the token count are llama-server's own `timings`
+  (`predicted_per_second`, `predicted_n`) handed up by `readChatSSE` → `onFinish(reason, timings)`
+  (the #291 seam) → `generateAssistantMessage`'s `onTimings` (fired only for a COMPLETED stream)
+  → `withChatStream`'s `sendTimings`; time to first token is `withChatStream`'s own clock (stream
+  registration → first `sendToken`, the same figure as the `first_token` perf mark — prompt
+  assembly, any compaction pre-pass and prefill included, i.e. the user-felt wait). One ADDITIVE
+  ephemeral channel `chat:speed:<id>` (`STREAM.speed`, payload `AnswerSpeed` keyed to the persisted
+  message id) fires right before `done`; `answerSpeedFrom` is the single rule and yields nothing
+  without timings, without a first token, for an empty reply or for non-positive figures — so an
+  aborted answer (no final chunk) and the mock runtime (no timings) show no line, never a wrong
+  one. **§3 Scope + persistence.** Nothing is persisted, no schema change, not in `streamBuffers`
+  (R14): the renderer keeps a session map by message id (`ChatScreen` `answerSpeeds` → `Transcript`),
+  so a reload shows nothing on old messages. Plain chat only — the document channels, the hidden
+  warm-up (#109), Fast-mode warm-up, doc tasks, skill runs and compaction never wire `sendTimings`.
+  The local API deliberately still omits `usage` (local-api.md §6.5).
 - **Answer-depth modes (Phase 20, spec §10.3).** `ChatOptions.mode` (`fast|balanced|deep`,
   per message, sticky per conversation in the renderer) threads through
   `generateAssistantMessage` → `RuntimeChatOptions.mode`. The mapping to request parameters

--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -340,9 +340,11 @@ no chat history — the endpoint sends exactly the messages you passed.
 (`delta: {"role":"assistant"}`), content chunks (`delta: {"content":"…"}`), a final chunk carrying
 `finish_reason`, then `data: [DONE]`.
 
-> **`usage` is deliberately absent in v1.** The runtime's streaming reader discards token counts,
-> and fabricating numbers would be worse than omitting them. Do not read `usage.total_tokens` — it
-> is not there. (A post-v1 candidate.)
+> **`usage` is deliberately absent in v1.** Fabricating numbers would be worse than omitting them.
+> Do not read `usage.total_tokens` — it is not there. Since #290/#291 the runtime's streaming
+> reader does keep llama-server's `timings` (the in-app Diagnostics figure and the per-answer
+> speed line use them), but exposing them here as `usage` is a separate wire-contract decision
+> that has not been taken. (A post-v1 candidate.)
 
 > **A truncated stream never ends with `[DONE]`.** If a generation is interrupted you get an
 > in-band error frame and the stream closes *without* the terminator. Treat "no `[DONE]`" as "not


### PR DESCRIPTION
## PR 3 of 3 — #290: tokens per second, time to first token and token count under a finished chat answer

Refs #290 (stays open until the reporter runs the real-runtime, abort and reload legs — see the verification issue). Stacked on PR 2 (#296) → PR 1 (#295).

### What changed

- **`services/chat.ts`** — `GenerateOptions.onTimings`: fired at most once, after the stream COMPLETED, with the runtime's `timings` from the PR-1 hand-up. Never on a user Stop (an aborted request carries no final chunk; the service additionally refuses timings that arrive on an aborted signal). The mock runtime sends none, so it never fires there.
- **`ipc/chat-stream.ts`** — `ChatStreamRunFn` gains an optional sixth sender `sendTimings`; `withRegenerateGuard` threads it through. `withChatStream` measures the time to first token on the SAME clock as the existing `first_token` perf mark (stream registration → first `sendToken`: prompt assembly, any compaction pre-pass and prefill included — the user-felt wait) and, once `runFn` resolved with the persisted message, emits ONE ephemeral `chat:speed:<conversationId>` payload (`AnswerSpeed { messageId, tokensPerSecond, ttftMs, tokens }`) right before `done`. `answerSpeedFrom` is the single rule: nothing without timings, without a first token, for an empty (unpersisted) reply or for non-positive figures — the line is absent rather than wrong. Not buffered (R14): a remount or reload shows nothing.
- **`ipc/registerChatIpc.ts`** — the plain-chat channel wires `onTimings: sendTimings`. The document channels (`registerRagIpc`), the hidden warm-up (`factory.ts`), Fast-mode warm-up, document tasks, skill runs and compaction never do — no line there.
- **`shared/ipc.ts`** — `STREAM.speed` + `AnswerSpeed`; **`preload/index.ts`** — `onAnswerSpeed`.
- **Renderer** — `ChatScreen` keeps a session map by message id (`answerSpeeds`, fed by the subscription, cleared with the component); `Transcript` → `MessageBlock` renders `42 tok/s · 1.8 s to first token · 615 tokens` under an assistant turn that has an entry, in the existing quiet metadata style (`.msg-speed`, next to the skill glyph / truncation note), with a tooltip. `renderer/chat/answerSpeed.ts` is the one formatter: no decimals at or above 10 tok/s, one decimal below; TTFT one decimal in seconds; whole tokens; all through the UI language (German "1,8 s", "1.024 Token"). EN + DE keys `chat.speed.line` / `chat.speed.hint`.
- **Nothing persisted, no schema change** — old messages after a reload show no line; the local API still omits `usage` (one-line note in `docs/local-api.md` §6.5).

### Tests

- `tests/integration/chat.test.ts` — `onTimings` fires once for a completed answer with the runtime's timings and nothing is persisted; never for the mock (no timings); never on a user Stop; refused even if a misbehaving runtime reports timings on an aborted signal.
- `tests/unit/chat-stream.test.ts` — `chat:speed` carries message id, tok/s, TTFT and token count and precedes `done`; nothing without timings, for an empty reply, or without usable figures; `answerSpeedFrom` table.
- `tests/renderer/AnswerSpeedLine.test.tsx` — formatter rounding/locale in EN and DE; the line renders only for the answer with a payload (role="note", tooltip); no payload ⇒ clean render without the line (mock / aborted); reload case (same messages, fresh session map ⇒ nothing); never on a user turn.
- The three regenerate tests that call the guarded run function with five arguments are unchanged (the sixth parameter is optional).

### Docs

`docs/architecture.md` "Chat & streaming" → new "Per-answer speed line (issue #290)" record §1–§3; `docs/local-api.md` §6.5; `CHANGELOG.md` Unreleased → Added; `BUILD_STATE.md` wave entry + §5 item 20.

### Checks on this machine

- `npm test`: 376 files / 5,670 tests passed / 74 skipped (PR 2: 5,654; PR 1: 5,645; master `b4e0ed06`: 5,633 — +37 over master across the stack).
- `npm run typecheck` and `npm run build`: green.
- No cloud, no telemetry, no new dependency, EN/DE parity (i18n hygiene test), no paths; Windows first-class (nothing platform-specific).
- Not verifiable here: the real-runtime, abort and reload legs on a real llama-server (Smart App Control blocks the sidecar, exit `0xC0E90002`) — tracked on the verification issue.
