### PR TITLE
test(runtime): pin the captured b9849 timings transcript as a fixture; records corrected (#298 — PR 4)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -50,6 +50,13 @@ TTFT on the `first_token` clock) keyed to the persisted message id; `ChatScreen`
 design record: `architecture.md` "Chat & streaming" → "Per-answer speed line" §1–§3. PR 3 = #297
 (376 / 5,670 / 74; +37 tests over master across the stack). Dev launch not possible on this
 machine (Smart App Control blocks `electron.exe` and the sidecar) — build + suite only.
+**#298 VERIFIED on hardware the same day** (the #291 reporter, i9-9900X / RTX 3090, pinned b9849,
+every box ticked: Diagnostics 28.2 / 25.9 MTP and 21.8 no-MTP vs `print_timing` 28.20 / 25.87 /
+21.84; prefill-independent; speed line 32 / 28 tok/s + token counts exact, abort / reload / mock /
+German / document-answer legs clean; the app's argv confirmed from `/proc` — no `-fa`). **PR 4
+(`fix/290-291-pr4-timings-fixture`):** the captured b9849 transcript committed as
+`tests/fixtures/chat-sse-timings-b9849.txt` (+ `chat-sse-timings-fixture.test.ts`), the records
+corrected (the issue's 47.9 was a `-fa` build; b9849 does 26–32 t/s there); closes #290/#291/#298.
 
 _2026-09-04 — **Phase F PR 6 (PR #293, `fix/pf-code1-rag-excerpt-framing`): #228 shipped — the excerpt
 block of `buildGroundedPrompt` / `buildCompareWholeDocPrompt` is framed as document content, not
@@ -626,13 +633,14 @@ open round's item stays the last block of §5.)
     excluded) with the chunk count as the flagged fallback; `BenchmarkResult.speedBasis`; the card
     says "Decode speed" + the token count; MTP record §7 watch item → observed. PR 3 (#290): chat
     only — one ephemeral `chat:speed:<id>` payload per finished answer, `tok/s · s to first
-    token · tokens`, EN/DE, nothing persisted. **Both issues stay OPEN** ("Refs", not "Closes"):
-    the "matches llama-server's `print_timing` within rounding" legs need a real runtime and the
-    execution machine cannot launch one (Smart App Control, exit `0xC0E90002`) — verification
-    issue **#298** (assigned to the #291 reporter) carries both acceptance lists, the
-    reconstructed rung-1a argv (the app does not log it) and a request for a captured final-chunk
-    SSE transcript from the b9849 pin, to be committed as a fixture. PRs: #295 → #296 → #297
-    (stacked; merge in order, re-basing each onto master as the one below lands). Thresholds (`VERY_LOW_TOKENS_PER_SECOND`,
+    token · tokens`, EN/DE, nothing persisted. The PRs used "Refs", not "Closes": the "matches
+    llama-server's `print_timing` within rounding" legs need a real runtime and the execution
+    machine cannot launch one (Smart App Control, exit `0xC0E90002`) — verification issue
+    **#298** (the #291 reporter) carried both acceptance lists and the reconstructed rung-1a argv.
+    **#298 VERIFIED 2026-09-04, every box ticked** (figures in the dated entry); the captured b9849
+    transcript is committed by PR 4 (`fix/290-291-pr4-timings-fixture`, which closes
+    #290/#291/#298). PRs: #295 → #296 → #297 → PR 4 (stacked; merge in order, re-basing each onto
+    master as the one below lands). Remaining after merge: nothing — collapse this item. Thresholds (`VERY_LOW_TOKENS_PER_SECOND`,
     `SLOW_PICK_TOKENS_PER_SECOND`) deliberately NOT retuned — they now compare a decode figure
     against probe-basis calibration (recorded in `docs/benchmark.md` / `model-benchmarks.md` §6.5).
 

--- a/apps/desktop/src/main/services/runtime/llama.ts
+++ b/apps/desktop/src/main/services/runtime/llama.ts
@@ -106,9 +106,10 @@ interface ChatCompletionChunk {
     finish_reason?: string | null
   }>
   /**
-   * llama-server's per-request timing block (#290/#291). Rides the completing chunk at the
-   * pinned b9849 as far as the repo knows — but NO captured chat transcript with `timings`
-   * exists here yet, so the reader tolerates it on ANY chunk, including one with no `choices`.
+   * llama-server's per-request timing block (#290/#291). At the pinned b9849 it rides the
+   * `finish_reason` chunk itself — pinned by the captured transcript
+   * `tests/fixtures/chat-sse-timings-b9849.txt` (#298). The reader still tolerates it on ANY
+   * chunk, including one with no `choices`, so a future server that moves it keeps working.
    */
   timings?: RuntimeTimings
 }
@@ -343,8 +344,8 @@ function readWithIdleTimeout<T>(
  * `RuntimeUnresponsiveError` instead of wedging the conversation forever. A user Stop still wins first.
  *
  * #290/#291: the server's top-level `timings` block is remembered from whichever chunk carries it
- * (the completing chunk at the pinned b9849, as far as the repo knows — a chunk with no `choices` is
- * tolerated too) and handed up with the finish reason ONCE, at the `[DONE]` sentinel or the clean
+ * (the `finish_reason` chunk at the pinned b9849 — captured in `tests/fixtures/chat-sse-timings-b9849.txt`,
+ * #298; a chunk with no `choices` is tolerated too) and handed up with the finish reason ONCE, at the `[DONE]` sentinel or the clean
  * close. Deferring the hand-up to the sentinel (instead of firing on the `finish_reason` chunk) is
  * what lets a trailing timings-only chunk still be attached; no consumer observes the difference —
  * every caller reads the captured value after the stream completes, and the finish chunk's delta is

--- a/apps/desktop/tests/fixtures/chat-sse-timings-b9849.txt
+++ b/apps/desktop/tests/fixtures/chat-sse-timings-b9849.txt
@@ -1,0 +1,13 @@
+: Captured llama-server SSE tail — pinned b9849 (system_fingerprint b9849-799fcc04a), Linux Vulkan release,
+: /v1/chat/completions with stream:true, prompt "Write one sentence about privacy.", max_tokens 64, thinking off,
+: rung-1a argv (--jinja --reasoning-format deepseek --spec-type draft-mtp --spec-draft-n-max 2), qwen3.8-27b-q4.
+: Source: issue #298 (2026-09-04, the #291 reporter). Frames: the last content chunk, the finish chunk carrying
+: `timings` (there is NO trailing choices-less chunk), then [DONE]. The model path was scrubbed to <drive>/…;
+: nothing else was edited. Matching server line: eval time = 848.62 ms / 25 tokens (29.46 tokens per second),
+: draft acceptance 15 / 20. These leading colon lines are SSE comments — readChatSSE ignores them.
+
+data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1788533198,"id":"chatcmpl-bq6BCmbXyd2Fl2ydgKvNUvjKLUEkoeBM","model":"<drive>/models/chat/qwen3.8-27b-q4.gguf","system_fingerprint":"b9849-799fcc04a","object":"chat.completion.chunk"}
+
+data: {"choices":[{"finish_reason":"stop","index":0,"delta":{}}],"created":1788533198,"id":"chatcmpl-bq6BCmbXyd2Fl2ydgKvNUvjKLUEkoeBM","model":"<drive>/models/chat/qwen3.8-27b-q4.gguf","system_fingerprint":"b9849-799fcc04a","object":"chat.completion.chunk","timings":{"cache_n":0,"prompt_n":18,"prompt_ms":442.473,"prompt_per_token_ms":24.581833333333336,"prompt_per_second":40.68044829854025,"predicted_n":25,"predicted_ms":848.618,"predicted_per_token_ms":33.944720000000004,"predicted_per_second":29.459662651511042,"draft_n":20,"draft_n_accepted":15}}
+
+data: [DONE]

--- a/apps/desktop/tests/integration/llama-runtime.test.ts
+++ b/apps/desktop/tests/integration/llama-runtime.test.ts
@@ -143,8 +143,9 @@ describe('readChatSSE', () => {
     expect(finishes).toEqual(['stop'])
   })
 
-  // #290/#291: the server's per-request `timings` block (b9849 shape — hand-authored, see the
-  // fixture-provenance note above; NO captured chat transcript with timings exists in the repo yet).
+  // #290/#291: the server's per-request `timings` block. Hand-authored to the b9849 shape pinned by
+  // the captured transcript in `tests/fixtures/chat-sse-timings-b9849.txt` (#298) — the timings ride
+  // the finish chunk itself; `tests/unit/chat-sse-timings-fixture.test.ts` reads the real bytes.
   it('hands the final chunk\'s `timings` up with the finish reason (#290/#291)', async () => {
     const timings = { prompt_n: 9, prompt_ms: 120, predicted_n: 64, predicted_ms: 1336, predicted_per_second: 47.9, prompt_per_second: 75 }
     const stream = sseStream([

--- a/apps/desktop/tests/unit/chat-sse-timings-fixture.test.ts
+++ b/apps/desktop/tests/unit/chat-sse-timings-fixture.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { readChatSSE } from '../../src/main/services/runtime/llama'
+import type { RuntimeTimings } from '../../src/main/services/runtime'
+
+// #290/#291 — the REAL wire shape of llama-server's `timings` on a streamed chat completion,
+// captured from the pinned b9849 on the #291 reporter's rig (issue #298, 2026-09-04). This
+// replaces the hand-authored guess the reader was built against: at b9849 the timings block
+// rides the `finish_reason: "stop"` chunk itself, and there is no trailing choices-less chunk.
+// The tolerant shapes in read-chat-sse.test.ts stay as robustness cases; THIS file is the pin.
+// Re-capture on every runtime pin bump (TS-3(a)).
+
+const FIXTURE = readFileSync(join(__dirname, '../fixtures/chat-sse-timings-b9849.txt'), 'utf8')
+
+/** A `ReadableStream` over `text`, optionally chopped into `chunkSize`-byte frames. */
+function streamOf(text: string, chunkSize?: number): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text)
+  let pos = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pos >= bytes.length) {
+        controller.close()
+        return
+      }
+      const end = chunkSize ? Math.min(pos + chunkSize, bytes.length) : bytes.length
+      controller.enqueue(bytes.slice(pos, end))
+      pos = end
+    }
+  })
+}
+
+async function run(stream: ReadableStream<Uint8Array>): Promise<{
+  answer: string
+  finishes: Array<{ reason: string; timings?: RuntimeTimings }>
+}> {
+  const finishes: Array<{ reason: string; timings?: RuntimeTimings }> = []
+  let answer = ''
+  for await (const delta of readChatSSE(stream, undefined, undefined, (reason, timings) =>
+    finishes.push({ reason, timings })
+  )) {
+    answer += delta
+  }
+  return { answer, finishes }
+}
+
+describe('readChatSSE on the captured b9849 timings transcript (#298)', () => {
+  it('the capture has the documented shape: content chunk, finish chunk WITH timings, [DONE]', () => {
+    const frames = FIXTURE.split('\n').filter((l) => l.startsWith('data:'))
+    expect(frames).toHaveLength(3)
+    expect(frames[0]).toContain('"finish_reason":null')
+    expect(frames[1]).toContain('"finish_reason":"stop"')
+    expect(frames[1]).toContain('"timings":{')
+    expect(frames[2]).toBe('data: [DONE]')
+  })
+
+  it('yields the last delta and hands the finish reason + the server timings up once', async () => {
+    const { answer, finishes } = await run(streamOf(FIXTURE))
+    expect(answer).toBe('.')
+    expect(finishes).toHaveLength(1)
+    expect(finishes[0].reason).toBe('stop')
+    const tm = finishes[0].timings
+    expect(tm).toBeDefined()
+    // The figures the app displays — matched against the server's own print_timing line on #298:
+    // `eval time = 848.62 ms / 25 tokens (29.46 tokens per second)`.
+    expect(tm!.predicted_n).toBe(25)
+    expect(tm!.predicted_per_second).toBeCloseTo(29.46, 2)
+    expect(tm!.predicted_ms).toBeCloseTo(848.618, 3)
+    expect(tm!.prompt_n).toBe(18)
+    expect(tm!.prompt_ms).toBeCloseTo(442.473, 3)
+    expect(tm!.prompt_per_second).toBeCloseTo(40.68, 2)
+  })
+
+  it('parses identically when the transcript arrives in small frames split mid-JSON', async () => {
+    for (const size of [7, 64, 333]) {
+      const { answer, finishes } = await run(streamOf(FIXTURE, size))
+      expect(answer).toBe('.')
+      expect(finishes).toHaveLength(1)
+      expect(finishes[0].timings?.predicted_per_second).toBeCloseTo(29.46, 2)
+    }
+  })
+
+  it('reports the decode figure the Diagnostics probe and the speed line would show', async () => {
+    const { finishes } = await run(streamOf(FIXTURE))
+    const tm = finishes[0].timings!
+    // Rounded to one decimal for the card, integer above 10 tok/s for the chat line.
+    expect(Math.round(tm.predicted_per_second! * 10) / 10).toBe(29.5)
+    expect(Math.round(tm.predicted_per_second!)).toBe(29)
+    // MTP evidence in the capture: 20 drafted, 15 accepted — the server counts TOKENS
+    // (predicted_n 25), which is exactly why the old chunk count under-read (#291).
+    const raw = JSON.parse(FIXTURE.split('\n').find((l) => l.includes('"timings"'))!.slice('data: '.length)) as {
+      timings: { draft_n: number; draft_n_accepted: number }
+    }
+    expect(raw.timings.draft_n).toBe(20)
+    expect(raw.timings.draft_n_accepted).toBe(15)
+  })
+})

--- a/apps/desktop/tests/unit/read-chat-sse.test.ts
+++ b/apps/desktop/tests/unit/read-chat-sse.test.ts
@@ -213,11 +213,12 @@ describe('readChatSSE — in-band error frames reject the stream (F-02)', () => 
   })
 })
 
-// #290/#291 — llama-server's per-request `timings` block rides the streamed completion (at the
-// pinned b9849, on the completing chunk as far as the repo knows; NO captured chat transcript with
-// `timings` exists here yet, hence the tolerant shapes below). The reader remembers the last one
-// seen on ANY chunk and hands it up with the finish reason, once, at `[DONE]` / the clean close —
-// and never on an abort, an error frame or a watchdog trip.
+// #290/#291 — llama-server's per-request `timings` block rides the streamed completion. The REAL
+// b9849 shape is pinned by `chat-sse-timings-fixture.test.ts` on the transcript captured for #298
+// (the timings ride the `finish_reason: "stop"` chunk itself; no trailing choices-less chunk). The
+// shapes below are ROBUSTNESS cases beyond that pin. The reader remembers the last block seen on
+// ANY chunk and hands it up with the finish reason, once, at `[DONE]` / the clean close — and
+// never on an abort, an error frame or a watchdog trip.
 describe('readChatSSE — server timings ride the finish hand-up (#290/#291)', () => {
   const TIMINGS = {
     prompt_n: 12,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12077,12 +12077,17 @@ the lesson of #42 applied up front rather than after a bug report.
   documented; the concern recorded here was that a llama-server batching an accepted draft run
   into one SSE delta would make the probe under-read on an MTP model. #291 was the first
   observation: on the reporter's i9-9900X / RTX 3090 with `qwen3.8-27b-q4` (rung 1a) the card
-  showed 25 tok/s against the server's own 47.9 (draft acceptance 106/186) — the pinned b9849
-  DOES pack the accepted run into one chunk, and the wall-clock window paid the prefill on top.
-  Resolved by reading the server's `timings` off the final chunk (`readChatSSE` → `onFinish`,
+  showed 25 tok/s against the server's own figure (the issue's 47.9 came from a newer `-fa` build;
+  the pinned b9849 with the app's exact argv does 26–32 t/s on that card, #298) — the server DOES
+  pack an accepted draft run into one chunk (the #298 capture: `draft_n` 20, `draft_n_accepted` 15,
+  `predicted_n` 25 in far fewer chunks), and the wall-clock window paid the prefill on top.
+  Resolved by reading the server's `timings` off the finish chunk (`readChatSSE` → `onFinish`,
   `RuntimeTimings`) and reporting `predicted_per_second` — decode tokens over decode time — with
-  the chunk count kept only as a flagged fallback (`BenchmarkResult.speedBasis`). Record:
-  `docs/benchmark.md` step 4.
+  the chunk count kept only as a flagged fallback (`BenchmarkResult.speedBasis`). **Verified on
+  hardware 2026-09-04 (#298):** Diagnostics 28.2 / 25.9 (MTP) and 21.8 / 21.8 (no MTP) against
+  `print_timing` 28.20 / 25.87 and 21.84 / 21.85; a 207-token prompt gave 25.7 / 25.5 — prefill no
+  longer moves the value. The real wire shape is pinned by `tests/fixtures/chat-sse-timings-b9849.txt`.
+  Record: `docs/benchmark.md` step 4.
 - **Two owed hardware gates — both RAN AND PASSED 2026-08-19** (issue #182, on the i9-9900X +
   RTX 3090 rig): the §2 grounded-QA harness re-run for both quants with MTP on held score parity
   within cross-run tolerance (which was the gate, NOT byte identity), and the §9.1 smoke legs on

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -106,7 +106,9 @@ Adjustments, in order:
 - **Very low** throughput (`tokensPerSecond < VERY_LOW_TOKENS_PER_SECOND = 3`) downgrades one
   step (never below `TINY`). **Basis shift (issue #291, 2026-09-04):** the threshold was
   calibrated when the figure was a prefill-inclusive chunk rate; it now compares the runtime's
-  decode-only tokens/sec, which reads higher (the #291 rig: 25 → 47.9 with MTP). It is an
+  decode-only tokens/sec, which reads higher (the #291 rig on the pinned b9849: the old probe's
+  25 vs 28.2 / 25.9 measured with MTP, 21.8 without — verified against `print_timing` on #298;
+  the issue's 47.9 came from a newer `-fa` build). It is an
   order-of-magnitude gate far below any figure the change moves, so it was deliberately **not
   retuned** — the same applies to the §6.5 picker step-down (`SLOW_PICK_TOKENS_PER_SECOND = 5`)
   and the local API's Retry-After heuristic. Since issue #52 this is **no longer silent**: when the reading

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -466,7 +466,8 @@ model; the new sibling warning names the consequence for the pick.
 prefill-inclusive and, on an MTP model, chunk-not-token. Since #291 the persisted
 `tokensPerSecond` is llama-server's own decode-only `predicted_per_second` whenever the runtime
 sends `timings` (`BenchmarkResult.speedBasis`), which reads HIGHER than the old figure (the #291
-rig: 25 → 47.9 with MTP, 38.4 without). The threshold was deliberately not retuned: it is an
+rig on the pinned b9849, verified on #298: the old probe's 25 vs 28.2 / 25.9 with MTP and 21.8
+without; the issue's 47.9 / 38.4 came from a newer `-fa` build). The threshold was deliberately not retuned: it is an
 order-of-magnitude crawl gate, no benchmarked machine sits within a factor of two of it, and a
 decode-only figure only moves readings further above it. Re-measure the #153 class on the new
 basis before any future retune.


### PR DESCRIPTION
## PR 4 of the #290/#291 stack — the captured b9849 timings transcript as a fixture; records corrected

Closes #290, closes #291, closes #298. Stacked on #297 → #296 → #295.

The #291 reporter ran every leg of #298 on the i9-9900X / RTX 3090 rig against the pinned b9849 and ticked all boxes (Diagnostics 28.2 / 25.9 with MTP and 21.8 / 21.8 without vs `print_timing` 28.20 / 25.87 / 21.84 / 21.85; a 207-token prompt gave 25.7 / 25.5 so prefill no longer moves the value; the speed line's tok/s and token counts match the server exactly with and without MTP; abort, reload, mock, German and document-answer legs clean; the app's argv confirmed from `/proc` — no `-fa`). This PR banks the evidence:

- **`tests/fixtures/chat-sse-timings-b9849.txt`** — the captured tail of a streamed `/v1/chat/completions` from the pinned b9849 (last content chunk, the `finish_reason: "stop"` chunk carrying `timings`, `[DONE]`). Leading `:` lines carry the provenance (SSE comments, ignored by the reader); the reporter's home directory in the `model` field was scrubbed to `<drive>/…`, nothing else edited.
- **`tests/unit/chat-sse-timings-fixture.test.ts`** — the pin on the real bytes: shape (timings ride the finish chunk; no trailing choices-less chunk), the exact figures the app displays (`predicted_n` 25, `predicted_per_second` 29.46 — the server's own `eval time = 848.62 ms / 25 tokens (29.46 tokens per second)`), split-frame parsing, and the MTP evidence (`draft_n` 20 / `draft_n_accepted` 15 — tokens, not chunks, which is what #291 was about).
- The hand-authored frames in `read-chat-sse.test.ts` / `llama-runtime.test.ts` stay as robustness cases; their provenance comments (and the `llama.ts` comments) now point at the fixture instead of saying no capture exists.
- **Records corrected:** the 47.9 t/s in #291 came from a newer `-fa` build, not b9849 (which does 26–32 t/s on that card with the app's argv). `architecture.md` MTP record §7, `benchmark.md` and `model-benchmarks.md` §6.5 now cite the b9849 figures and the #298 verification. `BUILD_STATE.md` wave entry + §5 item 20 updated; the item is ready to collapse after merge.

No code behaviour changes. Re-capture the fixture on every runtime pin bump (TS-3(a)).

### Checks on this machine

- `npm test`: 377 files / 5,674 tests passed / 74 skipped (PR 3: 5,670; master `b4e0ed06`: 5,633).
- `npm run typecheck` and `npm run build`: green.
