### PR TITLE
fix(benchmark): Diagnostics reports the runtime's decode speed, not a chunk rate (#291 — PR 2)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -36,7 +36,12 @@ watchdog trip; one shared `RuntimeTimings` type in `runtime/index.ts`; every exi
 caller source-compatible.**_ Blast-radius re-analysis in the PR description (the app never logs the
 sidecar argv; the finish hand-up moved from the finish chunk to the sentinel). §5 item 20 tracks the
 wave; #290/#291 stay OPEN until the reporter runs the hardware legs (verification issue opened
-with PR 3). Suite on the branch: see the PR. Master `b4e0ed06` recounted: 375 / 5,633 / 74 raw.
+with PR 3). PR 1 = #295 (375 / 5,645 / 74). Master `b4e0ed06` recounted: 375 / 5,633 / 74 raw.
+**PR 2 (`fix/290-291-pr2-decode-speed`, #291):** `measureTokensPerSecond` → `SpeedReading`
+(`predicted_per_second` when timings are present, chunk fallback flagged), the early `break`
+removed, `BENCHMARK_PROMPT` now a paragraph so the 64-token cap fills, `BenchmarkResult.speedBasis`,
+the card says "Decode speed" + token window / "≈ approximate"; thresholds NOT retuned (basis
+recorded in `benchmark.md`, `model-benchmarks.md` §6.5); MTP record §7 watch item → observed.
 
 _2026-09-04 — **Phase F PR 6 (PR #293, `fix/pf-code1-rag-excerpt-framing`): #228 shipped — the excerpt
 block of `buildGroundedPrompt` / `buildCompareWholeDocPrompt` is framed as document content, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **The speed figure on Settings → Diagnostics is now the model's real decode speed.** The
+  benchmark used to count streamed chunks over the whole request, including the time the model
+  spent reading the prompt, so on the recommended Qwen3.8 models — which can produce several
+  tokens per chunk — it showed roughly half the true speed. The row is now labelled "Decode
+  speed", takes the number from the AI engine's own timing (generation only, counted in tokens)
+  and shows how many tokens it was measured over. A result that could not use the engine's timing
+  is marked approximate; results saved by earlier versions show as approximate too, since they
+  were all measured the old way. Re-run the benchmark to get the new figure.
 - **Answers from your documents now tell the model more firmly that document text is not
   instructions.** The excerpts an answer is built from are marked as document content, so a
   passage that reads like a command ("ignore the rules above …") is something to quote, not to

--- a/apps/desktop/src/main/services/benchmark.ts
+++ b/apps/desktop/src/main/services/benchmark.ts
@@ -15,7 +15,7 @@ import { perfMark } from './perf'
 import { throughputMbps } from './read-speed'
 import type { ModelManifest } from '../../shared/manifest'
 import type { BenchmarkResult, EffectiveReadSample, HardwareProfile } from '../../shared/types'
-import type { ModelRuntime } from './runtime'
+import type { ModelRuntime, RuntimeTimings } from './runtime'
 import { recommendModelId, recommendModelIdByRam } from './models'
 
 // Hardware benchmarker (spec §7.3, §11). Detects RAM/CPU/OS, measures drive
@@ -201,25 +201,49 @@ export async function measureDriveSpeed(workspacePath: string): Promise<DriveSpe
 // means. (The import direction matters: read-speed.ts is a leaf; importing this module
 // from there would cycle through models.ts.)
 
-/** Prompt used for the short tokens/sec probe (spec §11.2 step 7). */
-export const BENCHMARK_PROMPT = 'Write one sentence about privacy.'
-/** How many tokens to time before stopping the probe. */
+/**
+ * Prompt used for the short decode-speed probe (spec §11.2 step 7). Asks for a PARAGRAPH so the
+ * `BENCHMARK_TOKEN_TARGET` cap fills reliably (#291): the earlier one-sentence prompt finished in
+ * ~20 tokens, and a 20-token decode window is dominated by per-request overhead. Thinking is off
+ * (balanced default), so no reasoning tokens inflate the window.
+ */
+export const BENCHMARK_PROMPT = 'Write a short paragraph about privacy.'
+/** The `max_tokens` cap the probe sends — the decode window the figure is measured over. */
 export const BENCHMARK_TOKEN_TARGET = 64
 
+/** What the speed probe measured and how (#291). */
+export interface SpeedReading {
+  /** Tokens per second, one decimal. */
+  tokensPerSecond: number
+  /**
+   * 'timings': llama-server's own `predicted_per_second` — decode only (prefill excluded),
+   * TOKENS not chunks. 'chunks': the wall-clock chunk-count fallback for a runtime that sent no
+   * `timings` (the mock) — approximate, includes prefill, and under-reads on an MTP model whose
+   * chunks carry several tokens each.
+   */
+  basis: 'timings' | 'chunks'
+  /** Tokens (basis 'timings') or chunks (basis 'chunks') the figure was measured over. */
+  tokens: number
+}
+
 /**
- * Estimate tokens/sec by running a short prompt through the active runtime
- * (spec §11.2 step 7). Returns null when no runtime is running, so it is fully
- * optional in the mock era. Never throws.
+ * Measure decode speed by running a short prompt through the active runtime (spec §11.2
+ * step 7). Returns null when no runtime is running, so it is fully optional in the mock era.
+ * Never throws.
  *
- * APPROXIMATION: this counts **stream chunks**, not true tokens — one `chatStream`
- * yield is one mock word-fragment or one real SSE delta (which may be sub- or
- * multi-token), so the number is a coarse "throughput", not an exact token rate. It feeds
- * the `VERY_LOW_TOKENS_PER_SECOND` downgrade, which only needs an order-of-magnitude signal.
+ * Since #291 the figure is the runtime's own `timings.predicted_per_second` whenever the
+ * stream carries it (see `RuntimeTimings`): decode tokens over decode time — prefill and the
+ * first-token latency are NOT in the window, and an MTP-accepted draft run counts as its
+ * tokens, not as one chunk. Without `timings` the reading falls back to the old APPROXIMATION
+ * — **stream chunks** over wall time from before the request — and says so (`basis: 'chunks'`).
+ * The `VERY_LOW_TOKENS_PER_SECOND` downgrade and the §6.5 picker step-down were calibrated on
+ * that chunk basis (the #153 figures); they now compare a decode-only figure, which reads
+ * higher — both are order-of-magnitude gates and were deliberately NOT retuned.
  */
 export async function measureTokensPerSecond(
   runtime: ModelRuntime | null | undefined,
   opts?: { signal?: AbortSignal; modelBusy?: () => boolean; onBusySkip?: () => void }
-): Promise<number | null> {
+): Promise<SpeedReading | null> {
   if (!runtime) return null
   // #185: refuse to measure a CONTENDED model. The benchmark's own admission guard already
   // refused to start beside a chat answer or a document task, but the admission is followed by
@@ -236,14 +260,23 @@ export async function measureTokensPerSecond(
   try {
     const t0 = performance.now()
     let count = 0
+    let timings: RuntimeTimings | undefined
+    // No early exit at the cap (#291): the server bounds the reply via `max_tokens`, and the
+    // chunk that carries `timings` is the FINAL one — breaking out on the 64th chunk cancelled
+    // the reader before it arrived, so the timings never reached the probe.
     for await (const _token of runtime.chatStream(
       [{ role: 'user', content: BENCHMARK_PROMPT }],
-      { maxTokens: BENCHMARK_TOKEN_TARGET, signal: opts?.signal }
+      {
+        maxTokens: BENCHMARK_TOKEN_TARGET,
+        signal: opts?.signal,
+        onFinish: (_reason, tm) => {
+          timings = tm
+        }
+      }
     )) {
       count++
-      if (count >= BENCHMARK_TOKEN_TARGET) break
       // …and DISCARD a reading that became contended mid-probe (a message sent while the 64
-      // tokens stream). Breaking runs the generator's `return()`, so the runtime manager's
+      // tokens stream). Returning runs the generator's `return()`, so the runtime manager's
       // generation gate decrements normally — an abandoned count is exactly what its epoch
       // guard exists to catch, and this path never creates one.
       if (opts?.modelBusy?.()) {
@@ -252,8 +285,17 @@ export async function measureTokensPerSecond(
       }
     }
     const seconds = (performance.now() - t0) / 1000
+    const tps = timings?.predicted_per_second
+    if (typeof tps === 'number' && Number.isFinite(tps) && tps > 0) {
+      const n = timings?.predicted_n
+      return {
+        tokensPerSecond: Math.round(tps * 10) / 10,
+        basis: 'timings',
+        tokens: typeof n === 'number' && Number.isFinite(n) && n > 0 ? Math.round(n) : count
+      }
+    }
     if (count === 0 || seconds <= 0) return null
-    return Math.round((count / seconds) * 10) / 10
+    return { tokensPerSecond: Math.round((count / seconds) * 10) / 10, basis: 'chunks', tokens: count }
   } catch {
     return null
   }
@@ -449,12 +491,16 @@ export async function runBenchmark(deps: RunBenchmarkDeps): Promise<BenchmarkRes
   // #185: `speedSkipped` distinguishes "no runtime was up, nothing to measure" (silent, the
   // long-standing behavior) from "a runtime WAS up but something else was using it" (warned).
   let speedSkipped = false
-  const tokensPerSecond = await measureTokensPerSecond(deps.runtime ?? null, {
+  const reading = await measureTokensPerSecond(deps.runtime ?? null, {
     modelBusy: deps.modelBusy,
     onBusySkip: () => {
       speedSkipped = true
     }
   })
+  const tokensPerSecond = reading?.tokensPerSecond ?? null
+  // #291: HOW the figure was measured — the runtime's decode timings, or the chunk fallback —
+  // plus the token/chunk count it covers, so the card can mark a fallback as approximate.
+  const speedBasis = reading ? { basis: reading.basis, tokens: reading.tokens } : null
   // Issue #52: record WHICH model produced the tok/s number — the currently loaded one,
   // which is often not the recommended one. null whenever nothing was measured.
   const measuredModelId = tokensPerSecond != null ? (deps.runtime?.modelId ?? null) : null
@@ -501,6 +547,7 @@ export async function runBenchmark(deps: RunBenchmarkDeps): Promise<BenchmarkRes
     driveReadMbps: drive.readMbps,
     driveWriteMbps: drive.writeMbps,
     tokensPerSecond,
+    speedBasis,
     measuredModelId,
     effectiveRead: deps.effectiveRead ?? null,
     profile,

--- a/apps/desktop/src/main/services/local-api/lifecycle.ts
+++ b/apps/desktop/src/main/services/local-api/lifecycle.ts
@@ -57,7 +57,10 @@ export function createLocalApiServer(ctx: AppContext, appVersion: string): Local
 
 /** Retry-After heuristic from the persisted measured throughput. #52 rule: a measured
  *  rate applies only when it was measured ON the currently active model
- *  (`measuredModelId` — the registerModelIpc `speedSignal` guard); anything else → 30 s. */
+ *  (`measuredModelId` — the registerModelIpc `speedSignal` guard); anything else → 30 s.
+ *  Basis (#291): the persisted figure is now the runtime's decode-only tokens/sec when the
+ *  runtime sent `timings` (higher than the old prefill-inclusive chunk rate), so this estimate
+ *  reads a little shorter for the same machine — an advisory hint, deliberately not retuned. */
 function estimateBusySeconds(ctx: AppContext): number {
   const bench = readSettingRow<{ tokensPerSecond?: number | null; measuredModelId?: string | null } | null>(
     ctx,

--- a/apps/desktop/src/main/services/models.ts
+++ b/apps/desktop/src/main/services/models.ts
@@ -782,8 +782,14 @@ export function machineRamGb(): number {
 
 /**
  * Measured-speed signal fed into the picker (model-benchmarks.md §6.5, issue #95): the
- * Diagnostics probe's honest pairing (issue #52) — the chunk-rate tok/s AND the model that
+ * Diagnostics probe's honest pairing (issue #52) — the measured tok/s AND the model that
  * produced it. Absent/null anywhere → the pure RAM-best-fit path, byte-identical.
+ *
+ * Basis (#291): since 2026-09-04 the figure is the runtime's decode-only `predicted_per_second`
+ * (tokens, prefill excluded) whenever the runtime sent `timings`, else the old prefill-inclusive
+ * chunk rate. `SLOW_PICK_TOKENS_PER_SECOND` was calibrated on the chunk basis and deliberately
+ * NOT retuned — a decode-only figure reads higher, and the gate is an order-of-magnitude crawl
+ * test (model-benchmarks.md §6.5 "Basis note").
  */
 export interface PickerSpeedSignal {
   /** Measured tok/s from the loaded-model probe; null when the probe did not run. */

--- a/apps/desktop/src/renderer/preview/preview.tsx
+++ b/apps/desktop/src/renderer/preview/preview.tsx
@@ -192,6 +192,7 @@ const overrides: Record<string, unknown> = {
       driveReadMbps: 2412, // the retired page-cache figure — must appear NOWHERE
       driveWriteMbps: 11.2,
       tokensPerSecond: 6,
+      speedBasis: { basis: 'timings', tokens: 64 },
       measuredModelId: 'qwen3-9b',
       effectiveRead:
         c === 'diagnostics-read'

--- a/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
+++ b/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
@@ -165,18 +165,26 @@ function buildAppRuntimeReport(
 }
 
 /**
- * The "Tokens / sec" value, naming the model the probe actually streamed through (issue #52:
+ * The "Decode speed" value, naming the model the probe actually streamed through (issue #52:
  * the number is measured on the CURRENTLY LOADED model, not the recommended one the card lists
  * above — without the name, the layout invites the wrong reading). Shared by the card row and
  * the Copy text so the two can never disagree. Results persisted before the field existed
- * have no measuredModelId and render as the bare number, exactly as before.
+ * have no measuredModelId and render without the model name, exactly as before.
+ *
+ * #291: a figure from the runtime's own decode timings shows the token count it covers; the
+ * chunk-count fallback — and every result persisted before `speedBasis` existed, which were all
+ * chunk-based — is marked approximate (it counts SSE chunks over wall time including prefill).
  */
 function tokensPerSecondValue(bench: BenchmarkResult, t: I18n['t'], lang: UiLanguage): string {
   if (bench.tokensPerSecond == null) return t('diag.bench.tokensNotMeasured')
-  const value = fmtNum(bench.tokensPerSecond, lang)
-  return bench.measuredModelId
-    ? `${value} (${t('diag.bench.tokensModel', { model: bench.measuredModelId })})`
-    : value
+  const basis = bench.speedBasis
+  const exact = basis?.basis === 'timings'
+  const value = exact ? fmtNum(bench.tokensPerSecond, lang) : `≈ ${fmtNum(bench.tokensPerSecond, lang)}`
+  const notes: string[] = []
+  if (exact) notes.push(t('diag.bench.tokensOver', { tokens: fmtNum(basis.tokens, lang) }))
+  else notes.push(t('diag.bench.tokensApprox'))
+  if (bench.measuredModelId) notes.push(t('diag.bench.tokensModel', { model: bench.measuredModelId }))
+  return `${value} (${notes.join('; ')})`
 }
 
 /**

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1794,9 +1794,13 @@ export const de: Record<keyof typeof en, string> = {
   'diag.bench.notMeasured': 'nicht gemessen',
   // RD-3-Glossar: „Token", nicht „Tokens" — steht auf Diagnose direkt neben
   // models.tech.contextValue („{count} Token") (CODE-43).
-  'diag.bench.tokens': 'Token / Sek.',
+  'diag.bench.tokens': 'Decodier-Geschwindigkeit (Token / Sek.)',
   'diag.bench.tokensNotMeasured': 'nicht gemessen (starte zuerst ein Modell)',
   'diag.bench.tokensModel': 'gemessen mit dem geladenen Modell {model}',
+  // #291: das Decodier-Fenster, über das die Laufzeit-Messung gilt.
+  'diag.bench.tokensOver': 'über {tokens} Token',
+  // #291: der Chunk-Zähl-Notweg (und jedes Ergebnis, das vor der Basis-Angabe gespeichert wurde).
+  'diag.bench.tokensApprox': 'ungefähr – gezählte Chunks, nicht die Laufzeit-Messung',
   'diag.bench.lastRun': 'Letzter Lauf',
   'diag.system.title': 'System',
   'diag.system.osPlatform': 'OS / Plattform',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1747,11 +1747,17 @@ export const en = {
   'diag.bench.effectiveReadHash': 'from a file check on {when}, {gb} GB read',
   'diag.bench.driveWrite': 'Drive write',
   'diag.bench.notMeasured': 'not measured',
-  'diag.bench.tokens': 'Tokens / sec',
+  // #291: the figure is the runtime's own decode speed (generation only, prefill excluded,
+  // tokens not chunks); the label says so.
+  'diag.bench.tokens': 'Decode speed (tokens / sec)',
   'diag.bench.tokensNotMeasured': 'not measured (start a model first)',
   // Issue #52: names the model the tok/s probe actually streamed through — the loaded one,
   // which is often not the recommended one the card lists above.
   'diag.bench.tokensModel': 'measured with the loaded model {model}',
+  // #291: the decode window the runtime-timings figure covers.
+  'diag.bench.tokensOver': 'over {tokens} tokens',
+  // #291: the chunk-count fallback (and every result saved before the basis was recorded).
+  'diag.bench.tokensApprox': 'approximate — counted chunks, not runtime timings',
   'diag.bench.lastRun': 'Last run',
   'diag.system.title': 'System',
   'diag.system.osPlatform': 'OS / platform',

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1916,7 +1916,21 @@ export interface BenchmarkResult {
    */
   driveReadMbps: number | null
   driveWriteMbps: number | null
+  /**
+   * Decode speed in tokens/sec. Since #291 the runtime's own `timings.predicted_per_second`
+   * (decode only, prefill excluded, tokens not chunks) whenever the stream carried it; see
+   * `speedBasis` for which it was. null when nothing was measured.
+   */
   tokensPerSecond: number | null
+  /**
+   * HOW `tokensPerSecond` was measured (#291): `basis: 'timings'` = the runtime's decode timings
+   * over `tokens` generated tokens; `basis: 'chunks'` = the wall-clock chunk-count fallback (a
+   * runtime that sent no timings — the mock) over `tokens` streamed chunks, approximate and
+   * prefill-inclusive. Optional: ABSENT on results persisted before the field existed, which
+   * were all chunk-based — readers render an absent basis as approximate. null when nothing
+   * was measured. No migration.
+   */
+  speedBasis?: { basis: 'timings' | 'chunks'; tokens: number } | null
   /**
    * Id of the model the tokens/sec probe streamed through — the CURRENTLY LOADED model at
    * benchmark time, which is often NOT `recommendedModelId` (issue #52). null when nothing

--- a/apps/desktop/tests/integration/benchmark.test.ts
+++ b/apps/desktop/tests/integration/benchmark.test.ts
@@ -26,11 +26,18 @@ import {
   upsertSlowReadWarning,
   VERY_LOW_TOKENS_PER_SECOND,
   SLOW_DRIVE_MBPS,
-  SLOW_EFFECTIVE_READ_MBPS
+  SLOW_EFFECTIVE_READ_MBPS,
+  BENCHMARK_PROMPT,
+  BENCHMARK_TOKEN_TARGET
 } from '../../src/main/services/benchmark'
 import { t } from '../../src/shared/i18n'
 import { gpuUsefulForProfile } from '../../src/main/services/runtime/gpu'
-import type { ModelRuntime } from '../../src/main/services/runtime'
+import type {
+  ChatMessage,
+  ModelRuntime,
+  RuntimeChatOptions,
+  RuntimeTimings
+} from '../../src/main/services/runtime'
 import type { GpuDevice } from '../../src/shared/types'
 
 function freshDb(): Db {
@@ -281,10 +288,104 @@ describe('measureTokensPerSecond', () => {
     expect(await measureTokensPerSecond(undefined)).toBeNull()
   })
 
-  it('returns a positive estimate from a running (mock) runtime', async () => {
-    const tps = await measureTokensPerSecond(runtime())
-    expect(tps).not.toBeNull()
-    expect(tps!).toBeGreaterThan(0)
+  it('returns a positive estimate from a running (mock) runtime — the chunk fallback, flagged', async () => {
+    const reading = await measureTokensPerSecond(runtime())
+    expect(reading).not.toBeNull()
+    expect(reading!.tokensPerSecond).toBeGreaterThan(0)
+    // The mock sends no `timings`, so the reading is the approximate chunk count over wall time.
+    expect(reading!.basis).toBe('chunks')
+    expect(reading!.tokens).toBeGreaterThan(0)
+  })
+
+  // #291 — the runtime's own decode timings win over the chunk count. A fake runtime whose
+  // stream reports `timings` on its final chunk (the llama-server shape via PR 1's onFinish
+  // hand-up); the wall clock plays no part in the timings-based figure.
+  function timedRuntime(
+    chunks: string[],
+    timings: RuntimeTimings | undefined,
+    perChunkDelayMs = 0
+  ): ModelRuntime {
+    return {
+      modelId: 'timed',
+      async start() {},
+      async stop() {},
+      async health() {
+        return { healthy: true, message: '', port: null }
+      },
+      async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+        for (const c of chunks) {
+          if (perChunkDelayMs > 0) await new Promise((r) => setTimeout(r, perChunkDelayMs))
+          yield c
+        }
+        options?.onFinish?.('length', timings)
+      }
+    }
+  }
+
+  it('reports the runtime timings’ predicted_per_second (decode only) when the final chunk carries them', async () => {
+    const reading = await measureTokensPerSecond(
+      timedRuntime(['a', 'b', 'c'], {
+        prompt_n: 12,
+        prompt_ms: 900, // a long prefill that a wall-clock window would have paid for
+        predicted_n: 64,
+        predicted_ms: 1336,
+        predicted_per_second: 47.9,
+        prompt_per_second: 13.3
+      })
+    )
+    expect(reading).toEqual({ tokensPerSecond: 47.9, basis: 'timings', tokens: 64 })
+  })
+
+  it('does NOT undercount MTP-style multi-token chunks when timings are present', async () => {
+    // Three SSE chunks carrying eight tokens (an accepted draft run rides one chunk each);
+    // 25 ms per chunk ⇒ a chunk-rate reading would be ~40 chunks/s, the server says 106 tok/s.
+    const reading = await measureTokensPerSecond(
+      timedRuntime(['one two three', 'four five', 'six seven eight'], {
+        predicted_n: 8,
+        predicted_ms: 75.5,
+        predicted_per_second: 106
+      }, 25)
+    )
+    expect(reading).toEqual({ tokensPerSecond: 106, basis: 'timings', tokens: 8 })
+  })
+
+  it('falls back to the chunk count over wall time when the stream carries no timings', async () => {
+    const reading = await measureTokensPerSecond(timedRuntime(['a', 'b', 'c', 'd'], undefined, 5))
+    expect(reading).not.toBeNull()
+    expect(reading!.basis).toBe('chunks')
+    expect(reading!.tokens).toBe(4)
+    expect(reading!.tokensPerSecond).toBeGreaterThan(0)
+  })
+
+  it('ignores a timings block without a usable predicted_per_second (falls back, flagged)', async () => {
+    const reading = await measureTokensPerSecond(timedRuntime(['a', 'b'], { prompt_n: 3 }, 5))
+    expect(reading!.basis).toBe('chunks')
+    expect(reading!.tokens).toBe(2)
+  })
+
+  it('consumes the whole capped stream so the final (timings) chunk is never cancelled away', async () => {
+    // Trap 1 (#291): the old probe broke out on the 64th chunk, cancelling the reader before the
+    // finish chunk arrived. Exactly BENCHMARK_TOKEN_TARGET chunks then the finish → timings land.
+    const chunks = Array.from({ length: BENCHMARK_TOKEN_TARGET }, (_, i) => `t${i} `)
+    const reading = await measureTokensPerSecond(
+      timedRuntime(chunks, { predicted_n: BENCHMARK_TOKEN_TARGET, predicted_per_second: 38.4 })
+    )
+    expect(reading).toEqual({ tokensPerSecond: 38.4, basis: 'timings', tokens: BENCHMARK_TOKEN_TARGET })
+  })
+
+  it('sends the paragraph prompt under the 64-token cap', async () => {
+    let seen: { prompt: string; maxTokens?: number } | null = null
+    const spy: ModelRuntime = {
+      ...timedRuntime(['x'], undefined),
+      async *chatStream(messages: ChatMessage[], options?: RuntimeChatOptions) {
+        seen = { prompt: messages[0].content, maxTokens: options?.maxTokens }
+        yield 'x'
+        options?.onFinish?.('stop')
+      }
+    }
+    await measureTokensPerSecond(spy)
+    expect(seen).toEqual({ prompt: BENCHMARK_PROMPT, maxTokens: BENCHMARK_TOKEN_TARGET })
+    expect(BENCHMARK_PROMPT).toMatch(/paragraph/)
   })
 })
 
@@ -456,6 +557,30 @@ describe('buildWarnings', () => {
 // ---- runBenchmark + persistence + downstream reads ------------------------------
 
 describe('runBenchmark', () => {
+  it('persists HOW the speed was measured next to the figure (#291 speedBasis)', async () => {
+    const timed: ModelRuntime = {
+      modelId: 'qwen3-9b',
+      async start() {},
+      async stop() {},
+      async health() {
+        return { healthy: true, message: '', port: null }
+      },
+      async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+        yield 'a'
+        options?.onFinish?.('length', { predicted_n: 64, predicted_per_second: 47.9 })
+      }
+    }
+    const result = await runBenchmark({ workspacePath: workspace(), manifests: [], runtime: timed })
+    expect(result.tokensPerSecond).toBe(47.9)
+    expect(result.speedBasis).toEqual({ basis: 'timings', tokens: 64 })
+    expect(result.measuredModelId).toBe('qwen3-9b')
+    // The mock (no timings) records the chunk fallback; no runtime records null.
+    const mock = await runBenchmark({ workspacePath: workspace(), manifests: [], runtime: runtime() })
+    expect(mock.speedBasis?.basis).toBe('chunks')
+    const none = await runBenchmark({ workspacePath: workspace(), manifests: [] })
+    expect(none.speedBasis).toBeNull()
+  })
+
   it('assembles a complete BenchmarkResult', async () => {
     const result = await runBenchmark({
       workspacePath: workspace(),

--- a/apps/desktop/tests/renderer/DiagnosticsCopySave.test.tsx
+++ b/apps/desktop/tests/renderer/DiagnosticsCopySave.test.tsx
@@ -35,6 +35,8 @@ const benchmark: BenchmarkResult = {
   // Issue #52: the loaded model at measure time — deliberately DIFFERENT from
   // recommendedModelId above, since disambiguating the two is the point of the label.
   measuredModelId: 'mock-chat-8b',
+  // #291: measured from the runtime's own decode timings over the 64-token probe window.
+  speedBasis: { basis: 'timings', tokens: 64 },
   // #108: the honest read figure from a real load window (6.0 GB in 85.2 s ≈ 70.4 MB/s
   // — the USB-stick class the field exists to expose).
   effectiveRead: {
@@ -195,7 +197,33 @@ describe('Settings → Diagnostics (advanced) — copy & save logs', () => {
     expect(lastCopied).not.toContain('120 MB/s')
     // Issue #52: the tok/s line names the model that produced the number (the loaded one,
     // not the recommended one) in the card AND the copied report.
-    expect(lastCopied).toContain('Tokens / sec: 30 (measured with the loaded model mock-chat-8b)')
+    // #291: the label says decode speed, the value names its token window.
+    expect(lastCopied).toContain(
+      'Decode speed (tokens / sec): 30 (over 64 tokens; measured with the loaded model mock-chat-8b)'
+    )
+    expect(lastCopied).not.toContain('approximate')
+  })
+
+  it('marks a chunk-count fallback reading approximate in the card and the copy (#291)', async () => {
+    const user = userEvent.setup()
+    stubDiagnostics({}, { ...benchmark, speedBasis: { basis: 'chunks', tokens: 41 } })
+    renderDiagnostics()
+    await screen.findByText('Test CPU', { exact: false })
+    expect(screen.getByText(/≈ 30 \(approximate — counted chunks, not runtime timings; measured with the loaded model mock-chat-8b\)/)).toBeInTheDocument()
+    await user.click(screen.getAllByRole('button', { name: 'Copy' })[1])
+    expect(lastCopied).toContain(
+      'Decode speed (tokens / sec): ≈ 30 (approximate — counted chunks, not runtime timings; measured with the loaded model mock-chat-8b)'
+    )
+  })
+
+  it('renders a result persisted before speedBasis existed as approximate (#291 — they were all chunk-based)', async () => {
+    const legacy = { ...benchmark }
+    delete (legacy as Partial<BenchmarkResult>).speedBasis
+    stubDiagnostics({}, legacy)
+    renderDiagnostics()
+    await screen.findByText('Test CPU', { exact: false })
+    expect(screen.getByText(/≈ 30 \(approximate/)).toBeInTheDocument()
+    expect(screen.queryByText(/over 64 tokens/)).not.toBeInTheDocument()
   })
 
   it('renders "not measured yet" for a result persisted before the effective-read field existed', async () => {
@@ -218,9 +246,10 @@ describe('Settings → Diagnostics (advanced) — copy & save logs', () => {
     stubDiagnostics({}, legacy)
     renderDiagnostics()
 
-    // The card row shows the bare number, exactly as before the field existed.
+    // The card row shows the number without a model name, exactly as before the field existed
+    // (the #291 token-window note still renders — the fixture carries a timings basis).
     await screen.findByText('Test CPU', { exact: false })
-    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('30 (over 64 tokens)')).toBeInTheDocument()
     expect(screen.queryByText(/measured with the loaded model/)).not.toBeInTheDocument()
   })
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2619,8 +2619,12 @@ files**.
   or a bare `error: {…}` field line, then a close without `[DONE]`) **rejects** with a typed
   `ChatStreamError` instead of ending cleanly — a failed generation can never persist as a clean
   answer (audit 2026-07-16 F-02; frame shapes pinned to b9849, re-verify on pin bumps per TS-3(a)). This feeds the **locked Phase-3 streaming contract**
-  unchanged, so `measureTokensPerSecond` (Phase 7) now reports **real tokens/sec** the moment a real
-  runtime streams.
+  unchanged. The reader also keeps the server's top-level **`timings`** block (last one seen on any
+  chunk) and hands it up through `onFinish(reason, timings?)` at `[DONE]`/close, never on an abort
+  (#290/#291; `RuntimeTimings` in `runtime/index.ts`), so `measureTokensPerSecond` (Phase 7) reports
+  the runtime's **decode tokens/sec** (`predicted_per_second`, prefill excluded, tokens not chunks)
+  the moment a real runtime streams, and only falls back to a chunk count for a runtime without
+  timings.
 - **`services/runtime/factory.ts`** — `createSelectingRuntimeFactory({ rootPath, … })` returns a
   `RuntimeFactory` that picks `LlamaRuntime` vs `MockRuntime` per `start()` (when the concrete model
   path is known), behind the unchanged `RuntimeManager`. `main/index.ts` uses it in place of the bare
@@ -12049,11 +12053,17 @@ the lesson of #42 applied up front rather than after a bug report.
   pre-MTP figures and stay that way until re-measured with the flag on. The repo rule is that
   manifest numbers are measured, never estimated.
 - **No UI.** Nothing to decide, nothing to show.
-- **Watch item — the tokens/sec probe.** `measureTokensPerSecond` counts stream **chunks**, an
-  approximation it already documents. If a future llama-server batches an accepted draft run into
-  one SSE delta, the probe would under-read on an MTP model and could feed the very-low-tps
-  downgrade. Not observed; recorded so the next person who sees a nonsense figure on a fast
-  machine has the thread.
+- **Watch item — the tokens/sec probe — OBSERVED and RESOLVED (issue #291, 2026-09-04).**
+  `measureTokensPerSecond` counted stream **chunks** over wall time, an approximation it
+  documented; the concern recorded here was that a llama-server batching an accepted draft run
+  into one SSE delta would make the probe under-read on an MTP model. #291 was the first
+  observation: on the reporter's i9-9900X / RTX 3090 with `qwen3.8-27b-q4` (rung 1a) the card
+  showed 25 tok/s against the server's own 47.9 (draft acceptance 106/186) — the pinned b9849
+  DOES pack the accepted run into one chunk, and the wall-clock window paid the prefill on top.
+  Resolved by reading the server's `timings` off the final chunk (`readChatSSE` → `onFinish`,
+  `RuntimeTimings`) and reporting `predicted_per_second` — decode tokens over decode time — with
+  the chunk count kept only as a flagged fallback (`BenchmarkResult.speedBasis`). Record:
+  `docs/benchmark.md` step 4.
 - **Two owed hardware gates — both RAN AND PASSED 2026-08-19** (issue #182, on the i9-9900X +
   RTX 3090 rig): the §2 grounded-QA harness re-run for both quants with MTP on held score parity
   within cross-run tolerance (which was the gate, NOT byte identity), and the §9.1 smoke legs on

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -58,17 +58,30 @@ IPC: `runBenchmark()` (`benchmark:run`) in
    own `drive_benchmark` perf mark) but never displayed and never gates anything. Old persisted
    `lastBenchmark` values (no `effectiveRead` field) render the "not measured" state — no
    migration.
-4. **Tokens/sec** (`measureTokensPerSecond`): **optional**. Only runs when a runtime is
-   active — it streams the prompt *"Write one sentence about privacy."* and times up to 64
-   tokens. It is `null` when no runtime is running. Because `measureTokensPerSecond`
-   drives off `runtime.chatStream`, this is now a **real** figure whenever the real `LlamaRuntime`
-   is streaming (it remains a simulated figure under the mock runtime). The low-tokens/sec profile
-   **downgrade** and the GPU **bump** therefore become live with real local inference.
+4. **Decode speed** (`measureTokensPerSecond`): **optional**. Only runs when a runtime is
+   active — it streams the prompt *"Write a short paragraph about privacy."* under a 64-token
+   `max_tokens` cap (the paragraph wording fills the cap reliably; a one-sentence prompt finished in
+   ~20 tokens, a window dominated by per-request overhead — issue #291). It is `null` when no
+   runtime is running. **What the number is (since #291):** llama-server's own
+   `timings.predicted_per_second` from the stream's final chunk — **decode tokens over decode
+   time**, prefill and the first-token latency excluded, and TOKENS rather than SSE chunks (under
+   MTP speculative decoding, #182, one chunk carries an accepted draft run of several tokens, which
+   halved the old chunk-count reading on the recommended Qwen3.8 entries). The result records the
+   basis and the token window (`BenchmarkResult.speedBasis = { basis: 'timings', tokens }`), and
+   the card shows the count ("48 (over 64 tokens, …)"). A runtime that sends no `timings` (the mock;
+   an older server) falls back to the old **approximation** — streamed chunks over wall time
+   measured from before the request, so prefill-inclusive — flagged `basis: 'chunks'` and rendered
+   "≈ 30 (approximate — counted chunks, not runtime timings; …)". Results persisted before the
+   field existed were all chunk-based and render as approximate too; no migration. The probe
+   consumes the whole capped stream (no early exit at 64 chunks — that used to cancel the reader
+   before the timings chunk arrived) and still DISCARDS a reading that became contended mid-probe
+   (#185). The low-tokens/sec profile **downgrade** and the GPU **bump** are live with real local
+   inference.
    **The number measures the CURRENTLY LOADED model, not the recommended one** (issue #52):
    `runBenchmark` records the loaded model's id as `BenchmarkResult.measuredModelId` (null when
    nothing was measured; absent on results persisted before the field existed), and the
-   Diagnostics card + its Copy text render the value as *"30 (measured with the loaded model
-   \<id\>)"* so the tok/s can't be misread as a property of the recommended model.
+   Diagnostics card + its Copy text render the value as *"48 (over 64 tokens; measured with the
+   loaded model \<id\>)"* so the tok/s can't be misread as a property of the recommended model.
 
 ## Profile classification (spec §11.3)
 
@@ -91,7 +104,12 @@ Adjustments, in order:
   14B recommendation — a false negative only costs a too-small recommendation, never a
   too-big one.
 - **Very low** throughput (`tokensPerSecond < VERY_LOW_TOKENS_PER_SECOND = 3`) downgrades one
-  step (never below `TINY`). Since issue #52 this is **no longer silent**: when the reading
+  step (never below `TINY`). **Basis shift (issue #291, 2026-09-04):** the threshold was
+  calibrated when the figure was a prefill-inclusive chunk rate; it now compares the runtime's
+  decode-only tokens/sec, which reads higher (the #291 rig: 25 → 47.9 with MTP). It is an
+  order-of-magnitude gate far below any figure the change moves, so it was deliberately **not
+  retuned** — the same applies to the §6.5 picker step-down (`SLOW_PICK_TOKENS_PER_SECOND = 5`)
+  and the local API's Retry-After heuristic. Since issue #52 this is **no longer silent**: when the reading
   actually moved the profile (computed as "profile with the tps hint ≠ profile without it", so
   an already-TINY machine never over-claims), the result carries a warning that **names the
   measured model** — a crawl measured on an oversized loaded model is evidence about that
@@ -202,8 +220,8 @@ falling back to **`UNKNOWN`** until the user runs the benchmark for the first ti
 
 The Diagnostics screen surfaces a **Run benchmark** button and renders RAM / CPU / OS-arch /
 measured read speed (`effectiveRead`, with its source + GB context, or "not measured yet") /
-drive write / tokens-sec / assigned profile / recommended model + the warnings, and re-loads the
-last result from settings on mount. The `effectiveRead` field is additionally **updated in
+drive write / decode speed (with its basis and token window, #291) / assigned profile /
+recommended model + the warnings, and re-loads the last result from settings on mount. The `effectiveRead` field is additionally **updated in
 place** on the persisted result outside benchmark runs (`persistEffectiveRead` in
 `registerModelIpc`) as model starts / Models-screen visits / forced re-verifies observe fresh
 samples, and `runBenchmark` receives the latest sample **injected**

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -503,8 +503,14 @@ override `--host`). The ladder gates the rung on a probed GPU with the weight's 
   `runBenchmark` via `RunBenchmarkDeps.effectiveRead` (ranking-aware carry-forward). Feeds the
   Diagnostics "Measured read speed" row (which carries the sample's own date — the card's "Last
   run" describes the benchmark, not this row), the #110 gate, and the #107 estimate.
-- **`measureTokensPerSecond(runtime)`** → number | `null` (only when a runtime is active;
-  prompt + ≤64 tokens). Mock now, real in Phase 10.
+- **`measureTokensPerSecond(runtime)`** → `SpeedReading | null` (only when a runtime is
+  active; the paragraph prompt under a 64-token cap). Since #291: `{ tokensPerSecond, basis,
+  tokens }` — `basis: 'timings'` is llama-server's own `predicted_per_second` (decode only,
+  prefill excluded, tokens not chunks) over `tokens = predicted_n`; `basis: 'chunks'` is the
+  wall-clock chunk-count fallback for a runtime without `timings` (the mock), over `tokens`
+  streamed chunks. Persisted as **`BenchmarkResult.speedBasis?: { basis, tokens } | null`** —
+  optional (absent on results persisted before the field existed, which were all chunk-based and
+  render as approximate; `null` = nothing measured). No migration.
 - **`buildWarnings(...)`** — spec §11.4 friendly copy. Since #110 the PRIMARY drive warning is
   the interpolated slow-read note (`effectiveReadMbps < SLOW_EFFECTIVE_READ_MBPS = 100`; no
   sample → no warning); the write-keyed slow-drive note (`< SLOW_DRIVE_MBPS = 30`) stays as the

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -460,6 +460,17 @@ RECOMMENDATION applies the predicate above instead: an oversized crawl never mov
 a right-sized crawl moves it exactly one tier. The #52 warning keeps naming the measured
 model; the new sibling warning names the consequence for the pick.
 
+**Basis note (issue #291, 2026-09-04).** Every tok/s figure in this section — the
+`SLOW_PICK_TOKENS_PER_SECOND = 5` calibration and the #153 legs below (17.0 / 9.0 / 14.6) — is
+**probe-basis**: streamed SSE chunks over a wall-clock window that started before the request, so
+prefill-inclusive and, on an MTP model, chunk-not-token. Since #291 the persisted
+`tokensPerSecond` is llama-server's own decode-only `predicted_per_second` whenever the runtime
+sends `timings` (`BenchmarkResult.speedBasis`), which reads HIGHER than the old figure (the #291
+rig: 25 → 47.9 with MTP, 38.4 without). The threshold was deliberately not retuned: it is an
+order-of-magnitude crawl gate, no benchmarked machine sits within a factor of two of it, and a
+decode-only figure only moves readings further above it. Re-measure the #153 class on the new
+basis before any future retune.
+
 **#153 amendment (2026-08-09, owner-ratified): the E2B promotion gives the step-down its
 sub-16 landing tier.** The weak-16 GB-box in-app Diagnostics leg (issue #153, successor to
 #95 item 2) ran on the designated class (15.8 GB, i7-1185G7, Iris Xe iGPU, Vulkan b9849, AC +


### PR DESCRIPTION
## PR 2 of 3 — #291: Diagnostics reports the runtime's decode speed, not a chunk rate over wall time

Refs #291 (stays open until the reporter runs the hardware legs — verification issue linked from PR 3). Stacked on PR 1 (the parser seam).

### What changed

- **`measureTokensPerSecond`** (`services/benchmark.ts`) now returns a `SpeedReading`: when the stream's final chunk carried llama-server `timings`, the value is `predicted_per_second` (decode only — prefill excluded — and TOKENS, not SSE chunks, so MTP's multi-token chunks no longer halve it) with `basis: 'timings'` and `tokens: predicted_n`; otherwise the old chunk count over wall time, `basis: 'chunks'`, `tokens: <chunk count>`. Null when no runtime / busy (#185), as before.
- **Trap 1 fixed:** the early `break` at 64 chunks cancelled the reader BEFORE the finish chunk (the one carrying `timings`) arrived. Removed; `max_tokens` bounds the server, the mock reply is shorter than 64 tokens. The mid-probe `modelBusy` discard (#185) is kept — it now checks after every chunk without the early exit.
- **Trap 3 (short answers):** `BENCHMARK_PROMPT` changed from *"Write one sentence about privacy."* to *"Write a short paragraph about privacy."* so a 64-token cap fills reliably — with the one-sentence prompt `predicted_n` was ~20, and a 20-token decode window is dominated by per-request overhead. The card shows the token count the figure was measured over either way. Thinking stays off (balanced default), so no reasoning tokens inflate the window.
- **`BenchmarkResult.speedBasis?`** (`shared/types.ts`): one new OPTIONAL field `{ basis: 'timings' | 'chunks'; tokens }`. Absent on old persisted results ⇒ the card renders them as approximate (the honest reading of chunk-based values). No migration.
- **Diagnostics card + Copy text** (`DiagnosticsTab.tsx`): row label "Decode speed (tokens / sec)"; a timings-based value reads `48 (over 64 tokens, measured with the loaded model X)`; a chunk-based or legacy value reads `≈ 30 (approximate — chunk count, not runtime timings; measured with the loaded model X)`. New keys in EN and DE; the persist-canonical `warnRecommendationLowered` / `warnVeryLowTokens` copy is unchanged.
- **Semantics recorded, thresholds NOT retuned:** `VERY_LOW_TOKENS_PER_SECOND` (3) and `SLOW_PICK_TOKENS_PER_SECOND` (5) were calibrated against probe readings that included prefill (the #153 figures in `model-benchmarks.md` §6.5 are probe-basis); they now compare a decode-only figure, which reads higher. Both thresholds are order-of-magnitude gates far below any figure the change moves, so nothing crosses; the basis shift is written into `benchmark.ts`, `models.ts` (`PickerSpeedSignal`), `lifecycle.ts` (Retry-After), `docs/benchmark.md` and `docs/model-benchmarks.md` §6.5.
- **Docs:** `docs/benchmark.md` step 4 + "Profile classification"; `docs/data-contracts.md` (the new field); `docs/architecture.md` MTP record §7 (watch item → observed and resolved by #291) and the runtime section's "reports real tokens/sec" line; `docs/model-benchmarks.md` §6.5 basis note; `CHANGELOG.md` Unreleased → Fixed.

### Tests (`tests/integration/benchmark.test.ts`, per #291's acceptance list)

- a fake stream whose final chunk carries `timings` yields `predicted_per_second` (basis `timings`, tokens = `predicted_n`), and the wall clock plays no part;
- no `timings` ⇒ chunk fallback, flagged `chunks`;
- MTP-style multi-token chunks (3 chunks carrying 8 tokens) do not undercount when `timings` are present;
- the mock runtime still yields a number (fallback path);
- the reader is NOT cancelled early: a 64-chunk stream's finish chunk is consumed;
- the mid-probe busy discard still returns null (`model-occupancy.test.ts` passes unchanged);
- `runBenchmark` persists `speedBasis`; Diagnostics render/Copy tests cover the timings, fallback and legacy (no field) readings.

### Not in scope (per #291 / the task)

No `usage` on the local API, no threshold retuning, no RAM-line retuning, no persistence of per-message speed.

### Checks on this machine

- `npm test`: 375 files / 5,654 tests passed / 74 skipped (PR 1: 5,645; master `b4e0ed06`: 5,633 — +21 over master).
- `npm run typecheck` and `npm run build`: green. `model-occupancy.test.ts` passes unchanged.
- Not verifiable here: the "matches llama-server print_timing within rounding" legs (with/without MTP, long vs short prompt) need a real runtime, which Smart App Control blocks on this machine (exit `0xC0E90002`). They are on the verification issue opened with PR 3.

> Supersedes #296, which GitHub closed when PR 1's branch was deleted after merging #295. Same head commit `5527f58a`, same content; CI was green there (the Windows/Node 22 leg passed on re-run after an unrelated vision-security timing flake).
