### PR TITLE
fix(zim): open a ZIM redirect entry — follow kiwix-serve's one /raw 302, same book only (#301 P7 T19)

### DIFF
--- a/apps/desktop/src/main/services/zim/client.ts
+++ b/apps/desktop/src/main/services/zim/client.ts
@@ -20,6 +20,11 @@ const MAX_BODY_BYTES = 8 * 1024 * 1024
 export interface KiwixResponse {
   status: number
   body: string
+  /**
+   * The `Location` response header, verbatim, when the server sent one — additive (#301 P7 T19):
+   * only `fetchArticleHtml`'s redirect leg reads it, every other caller is unchanged.
+   */
+  location?: string
 }
 
 /**
@@ -48,9 +53,14 @@ export function kiwixGet(
           }
           chunks.push(chunk)
         })
-        res.on('end', () =>
-          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') })
-        )
+        res.on('end', () => {
+          const location = res.headers.location
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+            ...(typeof location === 'string' ? { location } : {})
+          })
+        })
         res.on('error', reject)
       }
     )
@@ -312,6 +322,45 @@ export function encodeArticlePath(articlePath: string): string {
   return articlePath.split('/').map(encodeURIComponent).join('/')
 }
 
+/** The redirect statuses a `/raw/…/content/` read can answer with (kiwix-serve 3.8.1 sends 302). */
+const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 307, 308])
+
+/** The one `/raw` route builder — `encodeArticlePath` (and therefore `assertArticlePath`) owns
+ *  the entry key, `encodeURIComponent` the serving name. */
+function rawContentPath(name: string, articlePath: string): string {
+  return `/raw/${encodeURIComponent(name)}/content/${encodeArticlePath(articlePath)}`
+}
+
+/**
+ * The entry key a redirect `Location` points at within the SAME book, or null when the
+ * location is anything we refuse to follow (#301 P7 T19).
+ *
+ * Accepted: a PATH-ABSOLUTE `/content/<name>/<target>` (what kiwix-serve answers — the viewer
+ * route, not `/raw`) or `/raw/<name>/content/<target>`, where `<name>` URL-decodes to EXACTLY
+ * the `name` we asked under. Refused, as null: another book's name (the viewer must never show
+ * another book's text — finding L4), an absolute-URL or protocol-relative location, a relative
+ * reference, an unparseable one, and a target the entry-key contract refuses (finding L5;
+ * `assertArticlePath` never THROWS for a server-supplied target — that throw is for
+ * caller-supplied keys, at the first request only).
+ */
+function redirectTargetFor(name: string, location: string | undefined): string | null {
+  if (location === undefined) return null
+  if (!location.startsWith('/') || location.startsWith('//')) return null
+  const m =
+    /^\/content\/([^/]+)\/(.+)$/.exec(location) ?? /^\/raw\/([^/]+)\/content\/(.+)$/.exec(location)
+  if (!m) return null
+  if (safeDecodeURIComponent(m[1]) !== name) return null
+  // Per SEGMENT — the exact inverse of `encodeArticlePath`, so an already-encoded slash inside
+  // one segment stays inside it and the re-encode round-trips (`a%252Fb` → `a%2Fb` → `a%252Fb`).
+  const target = m[2].split('/').map(safeDecodeURIComponent).join('/')
+  try {
+    assertArticlePath(target)
+  } catch {
+    return null
+  }
+  return target
+}
+
 /**
  * Fetch one article's raw HTML. 404 → null (entry vanished between search and fetch,
  * or the pack file changed underneath us — a skip, not a failure); other non-200 → throws.
@@ -319,6 +368,13 @@ export function encodeArticlePath(articlePath: string): string {
  * `name` is the SERVING name (`identity.ts` `servingNameFor`), never the file stem: libkiwix
  * ≥ 14 slugifies case, accents, spaces and `+`, so the stem 404s or — worse — names another
  * book (finding L4).
+ *
+ * #301 P7 T19: kiwix-serve 3.8.1 answers a ZIM redirect entry under /raw with 302 →
+ * /content/<book>/<target>; followed one hop, same book only. Roughly half a Wikipedia ZIM's
+ * entries are such alias titles, so without the hop the viewer could not open them at all.
+ * A second redirect, another book, or a target the entry-key contract refuses ⇒ the honest
+ * "unavailable" null. The locator is unchanged by the hop — a citation stays
+ * `packId + articlePath` (`docs/rag-design.md` §17 D-Z11).
  */
 export async function fetchArticleHtml(
   port: number,
@@ -326,11 +382,17 @@ export async function fetchArticleHtml(
   articlePath: string,
   signal?: AbortSignal
 ): Promise<string | null> {
-  const encodedPath = encodeArticlePath(articlePath)
-  const res = await kiwixGet(port, `/raw/${encodeURIComponent(name)}/content/${encodedPath}`, {
-    signal
-  })
+  const res = await kiwixGet(port, rawContentPath(name, articlePath), { signal })
   if (res.status === 404) return null
+  if (REDIRECT_STATUSES.has(res.status)) {
+    const target = redirectTargetFor(name, res.location)
+    if (target === null) return null
+    // Exactly ONE more request, under the same signal: a chain is bounded, not followed.
+    const hop = await kiwixGet(port, rawContentPath(name, target), { signal })
+    if (hop.status === 200) return hop.body
+    if (hop.status === 404 || REDIRECT_STATUSES.has(hop.status)) return null
+    throw new Error(`kiwix-serve article fetch failed (HTTP ${hop.status})`)
+  }
   if (res.status !== 200) throw new Error(`kiwix-serve article fetch failed (HTTP ${res.status})`)
   return res.body
 }

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -168,8 +168,13 @@ interface SessionHooks {
   probe: (port: number) => Promise<boolean>
   /** Runs before the loopback server answers; park it to hold an HTTP read open. */
   beforeRespond: (url: string) => Promise<void>
-  /** Decide the whole response for this URL (T12), or null for the default fixtures. */
-  respond: (url: string) => { status: number; body: string } | null
+  /** Decide the whole response for this URL (T12), or null for the default fixtures.
+   *  `headers` carries a redirect's `Location` (#301 P7 T19); it defaults to none. */
+  respond: (url: string) => {
+    status: number
+    headers?: Record<string, string>
+    body: string
+  } | null
 }
 
 interface SessionHarness {
@@ -284,7 +289,7 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
       // "the viewer fetched the OTHER archive" cannot pass as a success.
       const custom = hooks.respond(url)
       if (custom) {
-        res.writeHead(custom.status, { 'content-type': 'text/html' })
+        res.writeHead(custom.status, { 'content-type': 'text/html', ...custom.headers })
         res.end(custom.body)
         return
       }
@@ -1197,6 +1202,61 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
           .map((p) => p.trim())
           .filter(Boolean)
       ).toEqual(['packId: string', 'articlePath: string'])
+    } finally {
+      await h.close()
+    }
+  })
+
+  // ---------------------------------------------------------------------------------------
+  // T19 (the real-tool acceptance run) — kiwix-serve 3.8.1 answers a ZIM REDIRECT ENTRY under
+  // /raw with a 302 to the VIEWER route /content/<book>/<target>. The viewer must open the
+  // target; a redirect naming ANOTHER book must stay the honest null (finding L4).
+  // (#301 P7; docs/rag-design.md §17 D-Z11)
+  // ---------------------------------------------------------------------------------------
+  it('T19 a redirect entry read over packs:getArticle opens the TARGET article, while a cross-book redirect stays null and fetches nothing from the other book', async () => {
+    const h = await sessionHarness()
+    try {
+      const packId = await h.registerPack('klima.zim', '55555555-0000-4000-8000-000000000000')
+      const library = (await h.svc.ensureServer(h.db())) as ServedLibrary
+      const name = library.names.get(packId)!
+      const alias = 'A/CO2-Äquivalent' // the redirect entry the user's citation names
+      const target = 'A/Treibhauspotential' // the article it aliases
+      const aliasUrl = `/raw/${encodeURIComponent(name)}/content/${encodeArticlePath(alias)}`
+      const targetUrl = `/raw/${encodeURIComponent(name)}/content/${encodeArticlePath(target)}`
+      const targetHtml =
+        '<html><body><h1>Treibhauspotential</h1><p>' +
+        'Das Treibhauspotential ist der Zielartikel dieser Weiterleitung. '.repeat(40) +
+        '</p></body></html>'
+      /** Where the alias redirects; flipped to another book for the second half. */
+      let location = `/content/${name}/${encodeArticlePath(target)}`
+      h.hooks.respond = (url) => {
+        if (url === aliasUrl) return { status: 302, headers: { location }, body: '' }
+        if (url === targetUrl) return { status: 200, body: targetHtml }
+        return null
+      }
+      const rawsSinceMark = (mark: number): string[] =>
+        h.requests.slice(mark).filter((u) => u.startsWith('/raw/'))
+
+      // ---- (1) THE SAME BOOK: the viewer gets the TARGET article, title and all ------------
+      let mark = h.requests.length
+      const opened = (await invoke(handlers, IPC.getPackArticle, packId, alias)).result as {
+        title: string
+        sections: Array<{ label: string | null; text: string }>
+      } | null
+      expect(opened).not.toBeNull()
+      // The title comes from the fetched HTML, so it is the TARGET's — the locator that was
+      // stored stays `packId + articlePath` (the alias), unchanged by the hop.
+      expect(opened!.title).toBe('Treibhauspotential')
+      expect(opened!.sections.map((s) => s.text).join('\n')).toContain('Zielartikel dieser Weiterleitung')
+      // Exactly one hop: the alias, then the target, and nothing else.
+      expect(rawsSinceMark(mark)).toEqual([aliasUrl, targetUrl])
+
+      // ---- (2) ANOTHER BOOK: null, and not one byte read from that book --------------------
+      location = '/content/some_other_book/A/Treibhauspotential'
+      mark = h.requests.length
+      const crossBook = await invoke(handlers, IPC.getPackArticle, packId, alias)
+      expect(crossBook.result).toBeNull()
+      expect(rawsSinceMark(mark)).toEqual([aliasUrl])
     } finally {
       await h.close()
     }

--- a/apps/desktop/tests/unit/zim-client.test.ts
+++ b/apps/desktop/tests/unit/zim-client.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { readFileSync, readdirSync } from 'node:fs'
@@ -63,10 +63,22 @@ const CEILING_BYTES = 8 * 1024 * 1024
 /** Every request the fixture server received — used to prove the L5 contract rejects a
  *  hazardous key BEFORE any HTTP request (#301 P5, finding L5). */
 let requestCount = 0
+/** Every request URL the fixture server received, in order — the redirect legs assert not just
+ *  the answer but exactly WHICH routes were asked for, and in what order (#301 P7 T19). */
+const requestLog: string[] = []
+/**
+ * What the fixture answers on a `/raw/` request (#301 P7 T19): a status, optional response
+ * headers (a redirect's `Location`) and a body; null falls through to the default article
+ * fixtures below, so every pre-existing `/raw` test is untouched.
+ */
+let rawHook:
+  | ((url: string) => { status: number; headers?: Record<string, string>; body: string } | null)
+  | null = null
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
     requestCount++
+    requestLog.push(req.url ?? '')
     if (req.url?.startsWith('/slow')) return // never responds — timeout leg
     if (req.url?.startsWith('/suggest')) {
       const answer = suggestHook?.(req.url) ?? null
@@ -113,6 +125,12 @@ beforeAll(async () => {
       return
     }
     if (req.url?.startsWith('/raw/')) {
+      const answer = rawHook?.(req.url) ?? null
+      if (answer) {
+        res.writeHead(answer.status, { 'content-type': 'text/html', ...answer.headers })
+        res.end(answer.body)
+        return
+      }
       if (req.url.includes('/raw/missing/')) {
         res.writeHead(404)
         res.end('not found')
@@ -226,6 +244,163 @@ describe('fetchArticleHtml', () => {
     const before = requestCount
     await expect(fetchArticleHtml(port, 'book', 'A/../x')).rejects.toThrow(ArticlePathError)
     expect(requestCount).toBe(before)
+  })
+})
+
+// ------------------------------------------------------------------------------------------
+// #301 P7 T19: kiwix-serve 3.8.1 answers a ZIM REDIRECT ENTRY (an alias title — roughly half a
+// Wikipedia ZIM's entries) under `/raw/<book>/content/<key>` with a 302 whose `Location` is the
+// VIEWER route `/content/<book>/<target>`. It redirects; it does not follow. One hop, same book
+// only; everything else is the honest "unavailable" null (`docs/rag-design.md` §17 D-Z11).
+// ------------------------------------------------------------------------------------------
+describe('fetchArticleHtml follows one same-book redirect (#301 P7 T19)', () => {
+  /** The real archive of the T19 acceptance run, served under its own name. */
+  const NAME = 'wikipedia_de_climate-change_nopic_2026-07'
+  const ALIAS = 'CO2-Äquivalent' // a redirect entry
+  const TARGET_HTML = '<html><body><h1>Treibhauspotential</h1><p>Zielartikel</p></body></html>'
+  type RawAnswer = { status: number; headers?: Record<string, string>; body: string }
+  const raw = (encodedKey: string): string => `/raw/${NAME}/content/${encodedKey}`
+  const ALIAS_URL = raw('CO2-%C3%84quivalent')
+  const TARGET_URL = raw('Treibhauspotential')
+  const NOT_FOUND: RawAnswer = { status: 404, body: 'not found' }
+  const redirectTo = (location: string, status = 302): RawAnswer => ({
+    status,
+    headers: { location },
+    body: ''
+  })
+  /** The fixture answers exactly the routes the leg spells out; anything else is a 404. */
+  const install = (answers: Record<string, RawAnswer>): void => {
+    rawHook = (url) => answers[url] ?? NOT_FOUND
+  }
+  /** Every `/raw` request of THIS leg, in order. */
+  const rawLog = (): string[] => requestLog.filter((u) => u.startsWith('/raw/'))
+
+  beforeEach(() => {
+    requestLog.length = 0
+  })
+  afterEach(() => {
+    rawHook = null
+  })
+
+  it('(a) 302 to /content/<same book>/<target> returns the target body after exactly two requests', async () => {
+    install({
+      [ALIAS_URL]: redirectTo(`/content/${NAME}/Treibhauspotential`),
+      [TARGET_URL]: { status: 200, body: TARGET_HTML }
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBe(TARGET_HTML)
+    // The order matters as much as the count: the alias first, then the target — and nothing else.
+    expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
+  })
+
+  it('(a2) the same one hop for 301, 307 and 308, and a /raw-shaped Location is accepted too', async () => {
+    for (const status of [301, 302, 307, 308]) {
+      requestLog.length = 0
+      install({
+        [ALIAS_URL]: redirectTo(`/content/${NAME}/Treibhauspotential`, status),
+        [TARGET_URL]: { status: 200, body: TARGET_HTML }
+      })
+      await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBe(TARGET_HTML)
+      expect(rawLog(), `status ${status}`).toEqual([ALIAS_URL, TARGET_URL])
+    }
+    // Some builds could answer with the /raw route instead; the same book is the whole test.
+    requestLog.length = 0
+    install({
+      [ALIAS_URL]: redirectTo(`/raw/${NAME}/content/Treibhauspotential`),
+      [TARGET_URL]: { status: 200, body: TARGET_HTML }
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBe(TARGET_HTML)
+    expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
+  })
+
+  it('(b) a 302 to ANOTHER book returns null and fetches nothing from it (finding L4)', async () => {
+    install({ [ALIAS_URL]: redirectTo('/content/other_book/Treibhauspotential') })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBeNull()
+    expect(rawLog()).toEqual([ALIAS_URL])
+  })
+
+  it('(c) a redirect CHAIN is not followed: null after exactly two requests', async () => {
+    install({
+      [ALIAS_URL]: redirectTo(`/content/${NAME}/Treibhauspotential`),
+      [TARGET_URL]: redirectTo(`/content/${NAME}/Klimawandel`)
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBeNull()
+    expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
+  })
+
+  it('(d) a target the L5 entry-key contract refuses returns null WITHOUT throwing, after one request', async () => {
+    // A server-supplied target is never a caller's key: it is refused as unavailable, quietly.
+    // `..%2Fx` decodes per segment to `../x`, whose `..` segment is the enumeration vector L5
+    // exists to stop; `x%00y` decodes to a C0 control character.
+    for (const hostile of ['..%2Fx', 'x%00y', '%2E%2E/x']) {
+      requestLog.length = 0
+      install({ [ALIAS_URL]: redirectTo(`/content/${NAME}/${hostile}`) })
+      await expect(fetchArticleHtml(port, NAME, ALIAS), hostile).resolves.toBeNull()
+      expect(rawLog(), hostile).toEqual([ALIAS_URL])
+    }
+  })
+
+  it('(e) an absolute-URL, protocol-relative, relative or missing Location returns null after one request', async () => {
+    const locations = [
+      `http://127.0.0.1:1/content/${NAME}/Treibhauspotential`, // an absolute URL — never followed
+      `//evil.example/content/${NAME}/Treibhauspotential`, // protocol-relative
+      'Treibhauspotential', // a relative reference
+      `/content/${NAME}`, // no target segment at all
+      '/something/else'
+    ]
+    for (const location of locations) {
+      requestLog.length = 0
+      install({ [ALIAS_URL]: redirectTo(location), [TARGET_URL]: { status: 200, body: TARGET_HTML } })
+      await expect(fetchArticleHtml(port, NAME, ALIAS), location).resolves.toBeNull()
+      expect(rawLog(), location).toEqual([ALIAS_URL])
+    }
+    // A redirect status with no `Location` header at all is the same honest null.
+    requestLog.length = 0
+    install({ [ALIAS_URL]: { status: 302, body: '' } })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBeNull()
+    expect(rawLog()).toEqual([ALIAS_URL])
+  })
+
+  it('(f) a percent-encoded non-ASCII target is decoded then re-encoded exactly once', async () => {
+    const targetUrl = raw('CO2-%C3%84quivalente')
+    install({
+      [ALIAS_URL]: redirectTo(`/content/${NAME}/CO2-%C3%84quivalente`),
+      [targetUrl]: { status: 200, body: TARGET_HTML }
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBe(TARGET_HTML)
+    // Exactly once: `%C3%84` must not come back as `%25C3%2584` (the L4 double-encode).
+    expect(rawLog()).toEqual([ALIAS_URL, targetUrl])
+    expect(rawLog()[1]).not.toContain('%25')
+    // …and an already-encoded slash inside one segment stays inside it, both ways.
+    requestLog.length = 0
+    const encodedSlash = raw('A/a%252Fb')
+    install({
+      [ALIAS_URL]: redirectTo(`/content/${NAME}/A/a%252Fb`),
+      [encodedSlash]: { status: 200, body: TARGET_HTML }
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBe(TARGET_HTML)
+    expect(rawLog()).toEqual([ALIAS_URL, encodedSlash])
+  })
+
+  it('(g) the book-name comparison is EXACT — a case-shifted name is another book', async () => {
+    install({ [ALIAS_URL]: redirectTo(`/content/${NAME.toUpperCase()}/Treibhauspotential`) })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBeNull()
+    expect(rawLog()).toEqual([ALIAS_URL])
+  })
+
+  it('the second hop maps 404 to null and any other error status to the existing throw', async () => {
+    install({ [ALIAS_URL]: redirectTo(`/content/${NAME}/Treibhauspotential`) }) // target 404s
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).resolves.toBeNull()
+    expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
+
+    requestLog.length = 0
+    install({
+      [ALIAS_URL]: redirectTo(`/content/${NAME}/Treibhauspotential`),
+      [TARGET_URL]: { status: 500, body: 'boom' }
+    })
+    await expect(fetchArticleHtml(port, NAME, ALIAS)).rejects.toThrow(
+      /article fetch failed \(HTTP 500\)/
+    )
+    expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
   })
 })
 


### PR DESCRIPTION
## Fix — a ZIM redirect entry opens the article it points to (found by P7's real-tool run, T19)

Refs #301 (Phase 7). Base `feat/zim-knowledge-packs`.

**Finding.** Against the real kiwix-tools 3.8.1 (libkiwix 14.1.1) and `wikipedia_de_climate-change_nopic_2026-07.zim`, `GET /raw/<book>/content/CO2-%C3%84quivalent` answers `302 Location: /content/<book>/Treibhauspotential`: `CO2-Äquivalent` is a ZIM **redirect entry** (an alias title — roughly half of a Wikipedia ZIM's entries), and kiwix-serve does not follow archive redirects under `/raw`, contrary to the spike-era assumption. `fetchArticleHtml` treated every non-200/404 as an error, the `packs:getArticle` handler mapped the throw to `null`, so the viewer showed "article unavailable" for every alias title (the ask arm loses at most one search hit, since Xapian hits are articles).

**Fix (`services/zim/client.ts`, no signature / IPC / shared-shape change).** `KiwixResponse` gains an optional `location`; on 301/302/307/308 `fetchArticleHtml` resolves the target through `redirectTargetFor` and issues **exactly one** more request under the same signal: accepted only for a path-absolute `/content/<name>/<target>` or `/raw/<name>/content/<target>` whose decoded name is EXACTLY the book asked (finding L4 — never another book's text); the target is decoded per segment and re-encoded through the one owner `encodeArticlePath`, so `assertArticlePath` (finding L5) still runs on it — a refused target returns `null`, never a throw. Another book, an absolute-URL / protocol-relative / relative / missing `Location`, or a second redirect ⇒ `null` with no further request; second hop 404 ⇒ `null`, 200 ⇒ body, else the existing throw. The stored locator (`packId + articlePath`) is unchanged by the hop.

**Tests.** `tests/unit/zim-client.test.ts` — describe "fetchArticleHtml follows one same-book redirect (#301 P7 T19)": legs (a) one hop returns the target body after exactly two requests (request log asserted in order), (a2) 301/307/308 and a `/raw`-shaped Location, (b) another book ⇒ null and nothing fetched from it, (c) a chain ⇒ null after two requests, (d) a contract-refused target ⇒ null without throwing, (e) absolute-URL / protocol-relative / relative / missing Location ⇒ null, (f) a percent-encoded non-ASCII target is decoded then re-encoded exactly once, (g) the name comparison is exact, plus the second-hop status mapping (31/31, 22 before). `tests/integration/zim-ipc-session.test.ts` — "T19 a redirect entry read over packs:getArticle opens the TARGET article, while a cross-book redirect stays null and fetches nothing from the other book" (9/9). Anti-test: with the client change stashed, all ten new legs go red. Re-run against the real archive with the fix: `getArticle(A, 'CO2-Äquivalent')` resolves.

**Verification.** zim-client 31/31, zim-ipc-session 9/9, zim-arm 11/11, zim-packs 14/14, zim-regressions 15/15, repo-hygiene 34/34, typecheck clean; the full suite on the P7 records tree that includes this commit: 421 files / 6,180 tests (6,100 passed / 79 skipped), exit 0.

The records (rag-design §17 D-Z11 + "Real acceptance (T19, P7)", data-contracts, known-limitations, CHANGELOG, the inventory rows T19-b / T19-c) travel in the P7 records PR, which is stacked on this branch — merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
