### PR TITLE
fix(zim): retry a /raw article read the pinned kiwix-serve cuts short (#301 P7 T19 finding 3)

### DIFF
--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -71,6 +71,12 @@ export interface CollectPackCandidatesOptions {
    * `AbortError`, never an outcome). Absent ⇒ every abort is treated as a cancellation.
    */
   askSignal?: AbortSignal
+  /**
+   * The per-ATTEMPT `/raw` timeout of the stall retry (`ARTICLE_READ_TIMEOUT_MS`, #301 P7 T19).
+   * Test seam only, so the "one article's first read stalls" leg does not sit out the real 4 s.
+   * Production never sets it.
+   */
+  articleTimeoutMs?: number
 }
 
 /** One pack's produced candidates, in the pack's own rank order (search hit order). */
@@ -207,7 +213,9 @@ export async function collectPackCandidates(
       attempted++
       let html: string | null
       try {
-        html = await fetchArticleHtml(port, expected ?? hit.urlId, hit.articlePath, signal)
+        html = await fetchArticleHtml(port, expected ?? hit.urlId, hit.articlePath, signal, {
+          timeoutMs: opts.articleTimeoutMs
+        })
       } catch (err) {
         if (aborted()) return noteAbort(err)
         continue

--- a/apps/desktop/src/main/services/zim/client.ts
+++ b/apps/desktop/src/main/services/zim/client.ts
@@ -1,4 +1,5 @@
 import http from 'node:http'
+import { log } from '../logging'
 import { combineSignals } from '../runtime/sidecar'
 import { attrValue, decodeEntities } from './html'
 
@@ -28,20 +29,62 @@ export interface KiwixResponse {
 }
 
 /**
+ * The rejection of a `kiwixGet` whose OWN per-request timeout fired (#301 P7 T19) — NEVER a
+ * caller abort, which keeps rejecting with the caller's own reason so the #159 `AbortError`
+ * convention, the ask deadline and the lock are unchanged.
+ *
+ * Purely additive: every existing caller still just sees "the request rejected" on a timeout
+ * (`probeSearchable` → unknown, the `serve.ts` health probe → not healthy, `searchPack` → the
+ * arm's `search-failed`). Only `fetchArticleHtml` reads the shape, and only to tell the stall
+ * signature — timed out with NOTHING received — from a timeout mid-body, which stays an error.
+ */
+export class KiwixTimeoutError extends Error {
+  /** The per-request budget that elapsed. */
+  readonly timeoutMs: number
+  /** True when the server had already sent response headers when the budget elapsed. */
+  readonly headersReceived: boolean
+  constructor(timeoutMs: number, headersReceived: boolean) {
+    super(
+      `kiwix-serve did not answer within ${timeoutMs} ms` +
+        (headersReceived ? ' (headers received, body incomplete)' : ' (no response headers)')
+    )
+    this.name = 'KiwixTimeoutError'
+    this.timeoutMs = timeoutMs
+    this.headersReceived = headersReceived
+  }
+}
+
+/**
  * GET one path from the sidecar. Resolves with status + UTF-8 body (non-2xx included —
  * the caller maps statuses); rejects on network error, timeout, caller abort, or an
- * over-ceiling body.
+ * over-ceiling body. A timeout rejects with `KiwixTimeoutError`; a caller abort rejects
+ * with whatever the caller's signal aborted with.
  */
 export function kiwixGet(
   port: number,
   path: string,
   opts: { timeoutMs?: number; signal?: AbortSignal } = {}
 ): Promise<KiwixResponse> {
-  const combined = combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const combined = combineSignals(opts.signal, timeoutMs)
   return new Promise<KiwixResponse>((resolve, reject) => {
+    let headersReceived = false
+    /**
+     * Classify a transport failure. `combineSignals` aborts the combined signal for exactly two
+     * reasons — the caller's signal, or its own timer — so "the combined signal fired while the
+     * CALLER's did not" is the timeout, and the caller's abort keeps precedence in the race.
+     */
+    const fail = (err: unknown): void => {
+      if (combined.signal.aborted && opts.signal?.aborted !== true) {
+        reject(new KiwixTimeoutError(timeoutMs, headersReceived))
+        return
+      }
+      reject(err)
+    }
     const req = http.get(
       { host: '127.0.0.1', port, path, agent, signal: combined.signal },
       (res) => {
+        headersReceived = true
         const chunks: Buffer[] = []
         let size = 0
         res.on('data', (chunk: Buffer) => {
@@ -61,10 +104,10 @@ export function kiwixGet(
             ...(typeof location === 'string' ? { location } : {})
           })
         })
-        res.on('error', reject)
+        res.on('error', fail)
       }
     )
-    req.on('error', reject)
+    req.on('error', fail)
   }).finally(() => combined.clear())
 }
 
@@ -362,6 +405,60 @@ function redirectTargetFor(name: string, location: string | undefined): string |
 }
 
 /**
+ * The per-ATTEMPT budget of one `/raw` article read, and how many attempts it gets.
+ *
+ * #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) never answers ~5–20 % of `/raw` reads above
+ * ~80 KB (client- and thread-count-independent); each stall is detected by a short per-attempt
+ * timeout and retried on a fresh connection. Measurement: `docs/rag-design.md` §17 "Real
+ * acceptance (T19, P7)".
+ *
+ * 4 s is a STALL DETECTOR, not a throughput bound: a healthy loopback read of a 700 KB entry
+ * takes ~10–80 ms on the measurement machine, and a 1 MiB article off a USB drive on the
+ * i7-8550U reference is still far under a second. Three attempts × 4 s = 12 s worst case —
+ * under the client's old 15 s default and under the 20 s per-ask deadline — while three
+ * consecutive stalls have probability ≈ 0.1–0.8 %.
+ */
+export const ARTICLE_READ_TIMEOUT_MS = 4_000
+/** Total `/raw` attempts per request, the first one included (see `ARTICLE_READ_TIMEOUT_MS`). */
+export const ARTICLE_READ_ATTEMPTS = 3
+
+/**
+ * One `/raw` read with the stall retry (#301 P7 T19). Retried ONLY on the stall signature:
+ * this attempt's own timeout elapsed with NO response headers received. Never retried when the
+ * caller's signal aborted (its reason propagates at once — the ask deadline, a cancellation, a
+ * lock: the H4 contract), when any HTTP status arrived (200/404/redirect/other — existing
+ * semantics stand), when the body had begun to arrive (a mid-body timeout, an over-ceiling body
+ * or a socket error stays an error), or on any non-timeout failure. Each attempt opens a fresh
+ * connection — the module agent is `keepAlive: false`.
+ *
+ * This lives INSIDE one request-guard window (`ZimService.withServer`, index.ts): the server
+ * tuple cannot change across a stall that never reached the server's lifecycle, so the guard's
+ * single admitted lifecycle retry is untouched and no double-retry semantics arise.
+ */
+async function readRawArticle(
+  port: number,
+  path: string,
+  signal: AbortSignal | undefined,
+  timeoutMs: number
+): Promise<KiwixResponse> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await kiwixGet(port, path, { signal, timeoutMs })
+    } catch (err) {
+      if (signal?.aborted === true) throw err
+      if (!(err instanceof KiwixTimeoutError) || err.headersReceived) throw err
+      if (attempt >= ARTICLE_READ_ATTEMPTS) throw err
+      // No path and no serving name (finding L1): the route class is all a log line may carry.
+      log.warn('kiwix-serve did not answer a knowledge-pack article read — retrying', {
+        route: 'raw',
+        attempt,
+        timeoutMs
+      })
+    }
+  }
+}
+
+/**
  * Fetch one article's raw HTML. 404 → null (entry vanished between search and fetch,
  * or the pack file changed underneath us — a skip, not a failure); other non-200 → throws.
  *
@@ -375,20 +472,27 @@ function redirectTargetFor(name: string, location: string | undefined): string |
  * A second redirect, another book, or a target the entry-key contract refuses ⇒ the honest
  * "unavailable" null. The locator is unchanged by the hop — a citation stays
  * `packId + articlePath` (`docs/rag-design.md` §17 D-Z11).
+ *
+ * Both requests — the first AND the redirect hop's — go through `readRawArticle`, so either
+ * one may be retried on the T19 stall signature (see `ARTICLE_READ_TIMEOUT_MS`).
  */
 export async function fetchArticleHtml(
   port: number,
   name: string,
   articlePath: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  /** Test seam only: the per-ATTEMPT timeout, so the stall legs need not sit out the real 4 s
+   *  (mirrors `probeSearchable`'s `opts.timeoutMs`). Production never passes it. */
+  opts: { timeoutMs?: number } = {}
 ): Promise<string | null> {
-  const res = await kiwixGet(port, rawContentPath(name, articlePath), { signal })
+  const timeoutMs = opts.timeoutMs ?? ARTICLE_READ_TIMEOUT_MS
+  const res = await readRawArticle(port, rawContentPath(name, articlePath), signal, timeoutMs)
   if (res.status === 404) return null
   if (REDIRECT_STATUSES.has(res.status)) {
     const target = redirectTargetFor(name, res.location)
     if (target === null) return null
     // Exactly ONE more request, under the same signal: a chain is bounded, not followed.
-    const hop = await kiwixGet(port, rawContentPath(name, target), { signal })
+    const hop = await readRawArticle(port, rawContentPath(name, target), signal, timeoutMs)
     if (hop.status === 200) return hop.body
     if (hop.status === 404 || REDIRECT_STATUSES.has(hop.status)) return null
     throw new Error(`kiwix-serve article fetch failed (HTTP ${hop.status})`)

--- a/apps/desktop/src/main/services/zim/client.ts
+++ b/apps/desktop/src/main/services/zim/client.ts
@@ -35,22 +35,29 @@ export interface KiwixResponse {
  *
  * Purely additive: every existing caller still just sees "the request rejected" on a timeout
  * (`probeSearchable` → unknown, the `serve.ts` health probe → not healthy, `searchPack` → the
- * arm's `search-failed`). Only `fetchArticleHtml` reads the shape, and only to tell the stall
- * signature — timed out with NOTHING received — from a timeout mid-body, which stays an error.
+ * arm's `search-failed`). Only `fetchArticleHtml` reads the class — to separate "this attempt's
+ * own timer elapsed before the body completed" (retryable) from a socket error, an over-ceiling
+ * body or a completed HTTP status (not retryable). `headersReceived` / `bytesReceived` are
+ * DIAGNOSTIC ONLY: the measured kiwix-serve fault arrives with both of them set.
  */
 export class KiwixTimeoutError extends Error {
   /** The per-request budget that elapsed. */
   readonly timeoutMs: number
   /** True when the server had already sent response headers when the budget elapsed. */
   readonly headersReceived: boolean
-  constructor(timeoutMs: number, headersReceived: boolean) {
+  /** Body bytes received before the budget elapsed (the truncation point of a T19 stall). */
+  readonly bytesReceived: number
+  constructor(timeoutMs: number, headersReceived: boolean, bytesReceived: number) {
     super(
       `kiwix-serve did not answer within ${timeoutMs} ms` +
-        (headersReceived ? ' (headers received, body incomplete)' : ' (no response headers)')
+        (headersReceived
+          ? ` (headers received, ${bytesReceived} body bytes, incomplete)`
+          : ' (no response headers)')
     )
     this.name = 'KiwixTimeoutError'
     this.timeoutMs = timeoutMs
     this.headersReceived = headersReceived
+    this.bytesReceived = bytesReceived
   }
 }
 
@@ -69,6 +76,7 @@ export function kiwixGet(
   const combined = combineSignals(opts.signal, timeoutMs)
   return new Promise<KiwixResponse>((resolve, reject) => {
     let headersReceived = false
+    let size = 0
     /**
      * Classify a transport failure. `combineSignals` aborts the combined signal for exactly two
      * reasons — the caller's signal, or its own timer — so "the combined signal fired while the
@@ -76,7 +84,7 @@ export function kiwixGet(
      */
     const fail = (err: unknown): void => {
       if (combined.signal.aborted && opts.signal?.aborted !== true) {
-        reject(new KiwixTimeoutError(timeoutMs, headersReceived))
+        reject(new KiwixTimeoutError(timeoutMs, headersReceived, size))
         return
       }
       reject(err)
@@ -86,7 +94,6 @@ export function kiwixGet(
       (res) => {
         headersReceived = true
         const chunks: Buffer[] = []
-        let size = 0
         res.on('data', (chunk: Buffer) => {
           size += chunk.length
           if (size > MAX_BODY_BYTES) {
@@ -407,29 +414,35 @@ function redirectTargetFor(name: string, location: string | undefined): string |
 /**
  * The per-ATTEMPT budget of one `/raw` article read, and how many attempts it gets.
  *
- * #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) never answers ~5–20 % of `/raw` reads above
- * ~80 KB (client- and thread-count-independent); each stall is detected by a short per-attempt
- * timeout and retried on a fresh connection. Measurement: `docs/rag-design.md` §17 "Real
- * acceptance (T19, P7)".
+ * #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) cuts ~5–20 % of `/raw` reads above ~80 KB short —
+ * the status line and most of the body arrive, the last part never does; the per-attempt timeout
+ * detects it and the read is retried on a fresh connection. Client- and thread-count-independent,
+ * and the truncation point is the same for a given entry every time (Treibhauseffekt stops at
+ * 195,590 of 234,141 bytes). Measurement: `docs/rag-design.md` §17 "Real acceptance (T19, P7)".
  *
  * 4 s is a STALL DETECTOR, not a throughput bound: a healthy loopback read of a 700 KB entry
- * takes ~10–80 ms on the measurement machine, and a 1 MiB article off a USB drive on the
- * i7-8550U reference is still far under a second. Three attempts × 4 s = 12 s worst case —
- * under the client's old 15 s default and under the 20 s per-ask deadline — while three
- * consecutive stalls have probability ≈ 0.1–0.8 %.
+ * takes ~10–80 ms on the measurement machine (a stalling one delivers its truncated body in
+ * 3–6 ms and then hangs), and a 1 MiB article off a USB drive on the i7-8550U reference is
+ * still far under a second. Three attempts × 4 s = 12 s worst case — under the client's old
+ * 15 s default and under the 20 s per-ask deadline — while three consecutive stalls have
+ * probability ≈ 0.1–0.8 %.
  */
 export const ARTICLE_READ_TIMEOUT_MS = 4_000
 /** Total `/raw` attempts per request, the first one included (see `ARTICLE_READ_TIMEOUT_MS`). */
 export const ARTICLE_READ_ATTEMPTS = 3
 
 /**
- * One `/raw` read with the stall retry (#301 P7 T19). Retried ONLY on the stall signature:
- * this attempt's own timeout elapsed with NO response headers received. Never retried when the
- * caller's signal aborted (its reason propagates at once — the ask deadline, a cancellation, a
- * lock: the H4 contract), when any HTTP status arrived (200/404/redirect/other — existing
- * semantics stand), when the body had begun to arrive (a mid-body timeout, an over-ceiling body
- * or a socket error stays an error), or on any non-timeout failure. Each attempt opens a fresh
- * connection — the module agent is `keepAlive: false`.
+ * One `/raw` read with the stall retry (#301 P7 T19). The retryable signature is exactly one
+ * thing: THIS ATTEMPT'S OWN TIMER elapsed before the body completed — whether or not headers and
+ * part of the body had already arrived. The measured fault arrives WITH both (200, a
+ * `Content-Length`, and ~85 % of the bytes in 3–6 ms, then silence), so a partial body is the
+ * normal case, not the exception; the partial body is discarded and the whole entry is read
+ * again on a fresh connection (the module agent is `keepAlive: false`).
+ *
+ * NEVER retried when: the caller's signal aborted — checked first, its reason propagates at once
+ * (the ask deadline, a cancellation, a lock: the H4 contract); a non-timeout socket error ended
+ * the attempt; the body went over `MAX_BODY_BYTES`; or any HTTP status completed
+ * (200/404/redirect/other — existing semantics stand).
  *
  * This lives INSIDE one request-guard window (`ZimService.withServer`, index.ts): the server
  * tuple cannot change across a stall that never reached the server's lifecycle, so the guard's
@@ -446,13 +459,16 @@ async function readRawArticle(
       return await kiwixGet(port, path, { signal, timeoutMs })
     } catch (err) {
       if (signal?.aborted === true) throw err
-      if (!(err instanceof KiwixTimeoutError) || err.headersReceived) throw err
+      if (!(err instanceof KiwixTimeoutError)) throw err
       if (attempt >= ARTICLE_READ_ATTEMPTS) throw err
-      // No path and no serving name (finding L1): the route class is all a log line may carry.
-      log.warn('kiwix-serve did not answer a knowledge-pack article read — retrying', {
+      // No path and no serving name (finding L1): the route class plus the truncation shape is
+      // all a log line may carry — enough to recognise the T19 fault in a diagnostics tail.
+      log.warn('kiwix-serve cut a knowledge-pack article read short — retrying', {
         route: 'raw',
         attempt,
-        timeoutMs
+        timeoutMs,
+        headersReceived: err.headersReceived,
+        bytesReceived: err.bytesReceived
       })
     }
   }

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -201,6 +201,12 @@ export interface ZimServiceDeps {
    * timeout leaves the pack unknown" leg does not sit out the client's real 15 s default.
    */
   probeTimeoutMs?: number
+  /**
+   * The per-ATTEMPT timeout of a `/raw` article read (`ARTICLE_READ_TIMEOUT_MS`, #301 P7 T19 —
+   * the stall retry). Test seam only, so a "the first read stalled" leg costs milliseconds
+   * instead of the real 4 s. Production never sets it.
+   */
+  articleTimeoutMs?: number
 }
 
 /**
@@ -1335,7 +1341,7 @@ export class ZimService {
           question,
           deadline.signal,
           library.names,
-          { askSignal: op.signal }
+          { askSignal: op.signal, articleTimeoutMs: this.deps.articleTimeoutMs }
         )
         return { candidates: produced.candidates, outcomes: [...outcomes, ...produced.outcomes] }
       })
@@ -1425,7 +1431,9 @@ export class ZimService {
         // a collision loser returns the honest "unavailable" null, not another book's text.
         const name = library.names.get(packId)
         if (name === undefined) return null
-        return fetchArticleHtml(library.port, name, articlePath, op.signal)
+        return fetchArticleHtml(library.port, name, articlePath, op.signal, {
+          timeoutMs: this.deps.articleTimeoutMs
+        })
       })
       op.assert()
       // Null covers all three honest "unavailable" cases: nothing to serve, an unmapped pack,

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -58,9 +58,10 @@ function bigArticleHtml(): string {
 /** Set by the fake sidecar once the big article's body has been written. */
 let bigArticleServed = false
 /**
- * Article titles whose NEXT `/raw` read the fake sidecar accepts and never answers — the
- * measured kiwix-serve 3.8.1 stall (#301 P7 T19). The title is removed as it fires, so the
- * retry finds the article served normally, exactly as the real server behaves.
+ * Article titles whose NEXT `/raw` read the fake sidecar CUTS SHORT — the measured kiwix-serve
+ * 3.8.1 stall (#301 P7 T19): the 200, an honest `Content-Length` and most of the body arrive,
+ * then the connection hangs and the last part never does. The title is removed as it fires, so
+ * the retry finds the article served whole, exactly as the real server behaves.
  */
 const stallOnce = new Set<string>()
 /** Every article title the fake sidecar was asked for over `/raw`, in order. */
@@ -101,9 +102,6 @@ beforeAll(async () => {
     if (url.pathname.startsWith('/raw/')) {
       const article = decodeURIComponent(url.pathname.split('/content/')[1] ?? '').replace(/_/g, ' ')
       rawReads.push(article)
-      // #301 P7 T19: accepted, then nothing at all — no headers, no bytes. The client's
-      // per-attempt timeout is what ends it, and the retry gets the article below.
-      if (stallOnce.delete(article)) return
       // One article whose fetch fails: the arm must skip THAT HIT and keep the others.
       if (article === 'Kaputt') {
         res.writeHead(500)
@@ -118,14 +116,24 @@ beforeAll(async () => {
         bigArticleServed = true
         return
       }
+      const body = articleHtml(article, [
+        ['Landwirtschaft', `${article} entsteht durch Methan aus der Landwirtschaft.`],
+        ['Industrie', `${article} in der Industrie stammt aus Verbrennung.`],
+        ['Trivia', 'Ein Abschnitt ohne die gesuchten Begriffe.']
+      ])
+      // #301 P7 T19: the 200 and an honest `Content-Length`, then only ~85 % of the body —
+      // the connection hangs and the last part never arrives. The client's per-attempt timeout
+      // ends it, and the retry (the title is already consumed) reads the article whole.
+      if (stallOnce.delete(article)) {
+        res.writeHead(200, {
+          'content-type': 'text/html',
+          'content-length': String(Buffer.byteLength(body))
+        })
+        res.write(body.slice(0, Math.floor(body.length * 0.85)))
+        return
+      }
       res.writeHead(200, { 'content-type': 'text/html' })
-      res.end(
-        articleHtml(article, [
-          ['Landwirtschaft', `${article} entsteht durch Methan aus der Landwirtschaft.`],
-          ['Industrie', `${article} in der Industrie stammt aus Verbrennung.`],
-          ['Trivia', 'Ein Abschnitt ohne die gesuchten Begriffe.']
-        ])
-      )
+      res.end(body)
       return
     }
     res.writeHead(404)
@@ -171,11 +179,12 @@ describe('collectPackCandidates', () => {
     expect(first.text).toContain('Landwirtschaft')
   })
 
-  it('#301 P7 T19 an article whose first read is never answered keeps its chunks', async () => {
-    // Before the stall retry, kiwix-serve 3.8.1 (win-x86_64) leaving a `/raw` read unanswered
-    // cost the ask that article ENTIRELY and silently: `fetchArticleHtml` rejected on the 15 s
-    // timeout and the arm's per-hit `continue` swallowed it (a measured ask returned 16 of 20
-    // passages after 40 s). The retry makes the stall invisible to the ask.
+  it('#301 P7 T19 an article whose first read is cut short keeps its chunks', async () => {
+    // Before the stall retry, kiwix-serve 3.8.1 (win-x86_64) cutting a `/raw` read short cost
+    // the ask that article ENTIRELY and silently: `fetchArticleHtml` rejected on the timeout and
+    // the arm's per-hit `continue` swallowed it (a measured ask returned 16 of 20 passages after
+    // 40 s). The retry makes the stall invisible to the ask — and the truncated body is
+    // discarded, so no half-article's chunks reach the answer either.
     const packs = [{ id: 'pack-climate', title: 'Klimawandel von Wikipedia' }]
     const question = 'Wie entsteht Treibhausgas in der Landwirtschaft?'
     const { candidates: unstalled } = await collectPackCandidates(port, packs, question)

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -57,6 +57,14 @@ function bigArticleHtml(): string {
 }
 /** Set by the fake sidecar once the big article's body has been written. */
 let bigArticleServed = false
+/**
+ * Article titles whose NEXT `/raw` read the fake sidecar accepts and never answers — the
+ * measured kiwix-serve 3.8.1 stall (#301 P7 T19). The title is removed as it fires, so the
+ * retry finds the article served normally, exactly as the real server behaves.
+ */
+const stallOnce = new Set<string>()
+/** Every article title the fake sidecar was asked for over `/raw`, in order. */
+const rawReads: string[] = []
 
 function searchXml(bookUrlId: string, titles: string[]): string {
   const items = titles
@@ -92,6 +100,10 @@ beforeAll(async () => {
     }
     if (url.pathname.startsWith('/raw/')) {
       const article = decodeURIComponent(url.pathname.split('/content/')[1] ?? '').replace(/_/g, ' ')
+      rawReads.push(article)
+      // #301 P7 T19: accepted, then nothing at all — no headers, no bytes. The client's
+      // per-attempt timeout is what ends it, and the retry gets the article below.
+      if (stallOnce.delete(article)) return
       // One article whose fetch fails: the arm must skip THAT HIT and keep the others.
       if (article === 'Kaputt') {
         res.writeHead(500)
@@ -157,6 +169,41 @@ describe('collectPackCandidates', () => {
     expect(first.articlePath).toBe('Treibhausgas')
     // The overlap picker prefers the section naming the query terms.
     expect(first.text).toContain('Landwirtschaft')
+  })
+
+  it('#301 P7 T19 an article whose first read is never answered keeps its chunks', async () => {
+    // Before the stall retry, kiwix-serve 3.8.1 (win-x86_64) leaving a `/raw` read unanswered
+    // cost the ask that article ENTIRELY and silently: `fetchArticleHtml` rejected on the 15 s
+    // timeout and the arm's per-hit `continue` swallowed it (a measured ask returned 16 of 20
+    // passages after 40 s). The retry makes the stall invisible to the ask.
+    const packs = [{ id: 'pack-climate', title: 'Klimawandel von Wikipedia' }]
+    const question = 'Wie entsteht Treibhausgas in der Landwirtschaft?'
+    const { candidates: unstalled } = await collectPackCandidates(port, packs, question)
+
+    rawReads.length = 0
+    stallOnce.add('Treibhausgas') // the top hit — the one that used to disappear
+    const { candidates, outcomes } = await collectPackCandidates(
+      port,
+      packs,
+      question,
+      undefined,
+      undefined,
+      // Shrunk for this leg only; the shipped per-attempt budget is 4 s.
+      { articleTimeoutMs: 300 }
+    )
+
+    expect(stallOnce.size).toBe(0) // the stall really fired
+    // Same candidates, in the same order, as the run where nothing stalled.
+    expect(candidates.map((c) => c.chunkId)).toEqual(unstalled.map((c) => c.chunkId))
+    expect(candidates.some((c) => c.sourceTitle === 'Treibhausgas')).toBe(true)
+    expect(outcomes[0]).toMatchObject({
+      packId: 'pack-climate',
+      status: 'searched',
+      reason: null,
+      found: candidates.length
+    })
+    // Exactly ONE extra read, of the stalled article alone — the other hit is fetched once.
+    expect(rawReads).toEqual(['Treibhausgas', 'Treibhausgas', 'Treibhauspotential'])
   })
 
   it('P1b an aborted ask signal propagates out of collectPackCandidates instead of an empty list', async () => {

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -175,6 +175,12 @@ interface SessionHooks {
     headers?: Record<string, string>
     body: string
   } | null
+  /**
+   * The per-ATTEMPT `/raw` timeout of the stall retry (`ARTICLE_READ_TIMEOUT_MS`, #301 P7 T19).
+   * A hook rather than a fixed dep so ONE leg can shrink it: every other article read in this
+   * file keeps the shipped 4 s, T07's parked-read-under-lock leg included.
+   */
+  articleTimeoutMs?: number
 }
 
 interface SessionHarness {
@@ -394,7 +400,12 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
         healthTimeoutMs: 1_000,
         healthIntervalMs: 1,
         killGraceMs: 5,
-        forceKillWaitMs: 5
+        forceKillWaitMs: 5,
+        // Read at CALL time (#301 P7 T19), so the stall-retry leg shrinks the per-attempt
+        // budget for itself and leaves every other read on the shipped default.
+        get articleTimeoutMs(): number | undefined {
+          return hooks.articleTimeoutMs
+        }
       }
     })
   const svc = makeService()
@@ -1257,6 +1268,57 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
       const crossBook = await invoke(handlers, IPC.getPackArticle, packId, alias)
       expect(crossBook.result).toBeNull()
       expect(rawsSinceMark(mark)).toEqual([aliasUrl])
+    } finally {
+      await h.close()
+    }
+  })
+
+  it('T19 an article whose first /raw read is never answered still opens: the stall is retried inside the same guard window', async () => {
+    // The measured kiwix-serve 3.8.1 (win-x86_64) fault: ~5–20 % of `/raw` reads of an entry
+    // above ~80 KB receive nothing at all — no headers, no bytes — while the server stays
+    // alive and answers the next request normally. Before the retry the viewer showed
+    // "This article is not available right now" after the client's 15 s timeout.
+    const h = await sessionHarness()
+    try {
+      const packId = await h.registerPack('klima.zim', '66666666-0000-4000-8000-000000000000')
+      const library = (await h.svc.ensureServer(h.db())) as ServedLibrary
+      const name = library.names.get(packId)!
+      const entry = 'A/Treibhauseffekt' // one of the measured stallers (234 KB in the archive)
+      const entryUrl = `/raw/${encodeURIComponent(name)}/content/${encodeArticlePath(entry)}`
+      const html =
+        '<html><body><h1>Treibhauseffekt</h1><p>' +
+        'Der Treibhauseffekt beschreibt die Erwärmung der Atmosphäre. '.repeat(40) +
+        '</p></body></html>'
+      h.hooks.respond = (url) => (url === entryUrl ? { status: 200, body: html } : null)
+      // Shrunk for this leg only: the shipped budget is 4 s per attempt.
+      h.hooks.articleTimeoutMs = 300
+      let stalls = 0
+      h.hooks.beforeRespond = (url) => {
+        // The FIRST read of this entry is accepted and never answered — the promise is left
+        // pending on purpose, exactly like a socket kiwix-serve never writes to.
+        if (url === entryUrl && stalls === 0) {
+          stalls++
+          return new Promise<void>(() => undefined)
+        }
+        return Promise.resolve()
+      }
+
+      const mark = h.requests.length
+      const opened = (await invoke(handlers, IPC.getPackArticle, packId, entry)).result as {
+        title: string
+        sections: Array<{ label: string | null; text: string }>
+      } | null
+
+      // The viewer gets the article, not the honest-but-wrong "unavailable" null.
+      expect(opened).not.toBeNull()
+      expect(opened!.title).toBe('Treibhauseffekt')
+      expect(opened!.sections.map((s) => s.text).join('\n')).toContain('Erwärmung der Atmosphäre')
+      // Two reads of the SAME route and nothing else: the retry is a fresh request inside the
+      // one request-guard window, so the guard's own lifecycle retry is untouched.
+      expect(h.requests.slice(mark).filter((u) => u.startsWith('/raw/'))).toEqual([entryUrl, entryUrl])
+      expect(stalls).toBe(1)
+      // No child was restarted for it — the server tuple never changed across the stall.
+      expect(h.svc.serverState()).toMatchObject({ port: h.httpPort, alive: true })
     } finally {
       await h.close()
     }

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -176,6 +176,12 @@ interface SessionHooks {
     body: string
   } | null
   /**
+   * Cut ONE response short (#301 P7 T19), the measured kiwix-serve 3.8.1 fault: a 200 with an
+   * HONEST `Content-Length`, then `partial` bytes and a connection that simply hangs — the rest
+   * never arrives. Null answers normally. Runs after `beforeRespond`, before `respond`.
+   */
+  truncate: (url: string) => { partial: string; total: number } | null
+  /**
    * The per-ATTEMPT `/raw` timeout of the stall retry (`ARTICLE_READ_TIMEOUT_MS`, #301 P7 T19).
    * A hook rather than a fixed dep so ONE leg can shrink it: every other article read in this
    * file keeps the shipped 4 s, T07's parked-read-under-lock leg included.
@@ -279,6 +285,7 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
     findPort: async () => httpPort,
     probe: async () => true,
     beforeRespond: async () => undefined,
+    truncate: () => null,
     respond: () => null
   }
   const requests: string[] = []
@@ -290,6 +297,17 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
         await hooks.beforeRespond(url)
       } catch {
         /* a parked response released by teardown still answers */
+      }
+      // #301 P7 T19: the measured stall — headers, an honest length, most of the body, then
+      // silence. Left hanging on purpose; the client's per-attempt timeout is what ends it.
+      const cut = hooks.truncate(url)
+      if (cut) {
+        res.writeHead(200, {
+          'content-type': 'text/html',
+          'content-length': String(cut.total)
+        })
+        res.write(cut.partial) // …and the rest never arrives
+        return
       }
       // The T12 seam: a test that needs per-book / per-entry bytes answers here, so
       // "the viewer fetched the OTHER archive" cannot pass as a success.
@@ -1273,11 +1291,12 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
     }
   })
 
-  it('T19 an article whose first /raw read is never answered still opens: the stall is retried inside the same guard window', async () => {
+  it('T19 an article whose first /raw read is cut short still opens whole: the stall is retried inside the same guard window', async () => {
     // The measured kiwix-serve 3.8.1 (win-x86_64) fault: ~5–20 % of `/raw` reads of an entry
-    // above ~80 KB receive nothing at all — no headers, no bytes — while the server stays
-    // alive and answers the next request normally. Before the retry the viewer showed
-    // "This article is not available right now" after the client's 15 s timeout.
+    // above ~80 KB deliver the 200, a `Content-Length` and most of the body in 3–6 ms and then
+    // hang, the last part never arriving, while the server stays alive and answers the next
+    // request normally. Before the retry the viewer showed "This article is not available
+    // right now"; the truncated body must never be shown as the article either.
     const h = await sessionHarness()
     try {
       const packId = await h.registerPack('klima.zim', '66666666-0000-4000-8000-000000000000')
@@ -1288,19 +1307,17 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
       const html =
         '<html><body><h1>Treibhauseffekt</h1><p>' +
         'Der Treibhauseffekt beschreibt die Erwärmung der Atmosphäre. '.repeat(40) +
-        '</p></body></html>'
+        '</p><p>Schlussabsatz: der letzte Teil des Artikels.</p></body></html>'
       h.hooks.respond = (url) => (url === entryUrl ? { status: 200, body: html } : null)
       // Shrunk for this leg only: the shipped budget is 4 s per attempt.
       h.hooks.articleTimeoutMs = 300
       let stalls = 0
-      h.hooks.beforeRespond = (url) => {
-        // The FIRST read of this entry is accepted and never answered — the promise is left
-        // pending on purpose, exactly like a socket kiwix-serve never writes to.
-        if (url === entryUrl && stalls === 0) {
-          stalls++
-          return new Promise<void>(() => undefined)
-        }
-        return Promise.resolve()
+      h.hooks.truncate = (url) => {
+        // The FIRST read of this entry is cut at ~85 %: the closing paragraph — the only place
+        // "Schlussabsatz" appears — is in the part that never arrives.
+        if (url !== entryUrl || stalls > 0) return null
+        stalls++
+        return { partial: html.slice(0, Math.floor(html.length * 0.85)), total: Buffer.byteLength(html) }
       }
 
       const mark = h.requests.length
@@ -1309,10 +1326,13 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
         sections: Array<{ label: string | null; text: string }>
       } | null
 
-      // The viewer gets the article, not the honest-but-wrong "unavailable" null.
+      // The viewer gets the WHOLE article, not the honest-but-wrong "unavailable" null and not
+      // the truncated body either.
       expect(opened).not.toBeNull()
       expect(opened!.title).toBe('Treibhauseffekt')
-      expect(opened!.sections.map((s) => s.text).join('\n')).toContain('Erwärmung der Atmosphäre')
+      const text = opened!.sections.map((s) => s.text).join('\n')
+      expect(text).toContain('Erwärmung der Atmosphäre')
+      expect(text).toContain('Schlussabsatz')
       // Two reads of the SAME route and nothing else: the retry is a fresh request inside the
       // one request-guard window, so the guard's own lifecycle retry is untouched.
       expect(h.requests.slice(mark).filter((u) => u.startsWith('/raw/'))).toEqual([entryUrl, entryUrl])

--- a/apps/desktop/tests/unit/zim-client.test.ts
+++ b/apps/desktop/tests/unit/zim-client.test.ts
@@ -4,7 +4,10 @@ import type { AddressInfo } from 'node:net'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import {
+  ARTICLE_READ_ATTEMPTS,
+  ARTICLE_READ_TIMEOUT_MS,
   ArticlePathError,
+  KiwixTimeoutError,
   MAX_ARTICLE_PATH_CHARS,
   SUGGEST_PROBE_TERM,
   assertArticlePath,
@@ -70,10 +73,23 @@ const requestLog: string[] = []
  * What the fixture answers on a `/raw/` request (#301 P7 T19): a status, optional response
  * headers (a redirect's `Location`) and a body; null falls through to the default article
  * fixtures below, so every pre-existing `/raw` test is untouched.
+ *
+ * The two string variants reproduce the T19 stall and its near-miss:
+ *   `'park'`          — the request is accepted and NOTHING is ever sent, not even headers.
+ *                       That is the measured kiwix-serve behaviour the retry exists for.
+ *   `'park-mid-body'` — headers plus the first bytes of the body, then the response hangs.
+ *                       Deliberately NOT the stall signature: a half-read body stays an error.
+ * Both are released only by the client giving up (the per-attempt timeout destroys the socket).
  */
-let rawHook:
-  | ((url: string) => { status: number; headers?: Record<string, string>; body: string } | null)
-  | null = null
+type RawFixtureAnswer =
+  | { status: number; headers?: Record<string, string>; body: string }
+  | 'park'
+  | 'park-mid-body'
+let rawHook: ((url: string) => RawFixtureAnswer | null) | null = null
+/** The bytes `'park-mid-body'` sends before hanging — enough to prove headers arrived. */
+const PARK_MID_BODY_PREFIX = '<html><body><p>Anfang'
+/** Every parked `/raw` URL whose connection the CLIENT closed (it gave up), in order. */
+const parkedClosedByClient: string[] = []
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
@@ -126,6 +142,19 @@ beforeAll(async () => {
     }
     if (req.url?.startsWith('/raw/')) {
       const answer = rawHook?.(req.url) ?? null
+      if (answer === 'park' || answer === 'park-mid-body') {
+        const url = req.url
+        // `writableFinished` is false exactly when the client tore the connection down first —
+        // the proof that the retry opened a FRESH socket rather than reusing a stuck one.
+        res.on('close', () => {
+          if (!res.writableFinished) parkedClosedByClient.push(url)
+        })
+        if (answer === 'park-mid-body') {
+          res.writeHead(200, { 'content-type': 'text/html' })
+          res.write(PARK_MID_BODY_PREFIX) // headers + a partial body, then nothing more
+        }
+        return // never answered
+      }
       if (answer) {
         res.writeHead(answer.status, { 'content-type': 'text/html', ...answer.headers })
         res.end(answer.body)
@@ -181,6 +210,35 @@ describe('kiwixGet', () => {
 
   it('times out on a server that never responds', async () => {
     await expect(kiwixGet(port, '/slow', { timeoutMs: 100 })).rejects.toThrow()
+  })
+
+  // #301 P7 T19: the timeout rejection now CARRIES its classification, so `fetchArticleHtml`
+  // can tell the kiwix-serve stall (nothing received at all) from a timeout mid-body. Every
+  // other caller still just sees a rejection — kiwixGet itself never retries anything.
+  it('rejects a timeout as a KiwixTimeoutError that records no headers were received', async () => {
+    const before = requestCount
+    let caught: unknown
+    await kiwixGet(port, '/slow', { timeoutMs: 100 }).catch((err: unknown) => {
+      caught = err
+    })
+    expect(caught).toBeInstanceOf(KiwixTimeoutError)
+    expect((caught as KiwixTimeoutError).name).toBe('KiwixTimeoutError')
+    expect((caught as KiwixTimeoutError).headersReceived).toBe(false)
+    expect((caught as KiwixTimeoutError).timeoutMs).toBe(100)
+    // The retry is the /raw route's alone: a non-article request is tried exactly once.
+    expect(requestCount - before).toBe(1)
+  })
+
+  it('a caller abort still rejects with the abort, never with the timeout error', async () => {
+    const ac = new AbortController()
+    const pending = kiwixGet(port, '/slow', { signal: ac.signal, timeoutMs: 60_000 })
+    ac.abort()
+    let caught: unknown
+    await pending.catch((err: unknown) => {
+      caught = err
+    })
+    expect(caught).not.toBeInstanceOf(KiwixTimeoutError)
+    expect((caught as Error).name).toBe('AbortError')
   })
 
   it('aborts on the caller signal', async () => {
@@ -401,6 +459,156 @@ describe('fetchArticleHtml follows one same-book redirect (#301 P7 T19)', () => 
       /article fetch failed \(HTTP 500\)/
     )
     expect(rawLog()).toEqual([ALIAS_URL, TARGET_URL])
+  })
+})
+
+// ------------------------------------------------------------------------------------------
+// #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) NEVER ANSWERS ~5–20 % of `/raw` reads of entries
+// above ~80 KB — zero bytes, no headers — while the server stays alive and answers the next
+// request normally. Client-, thread-count- and pause-independent, so it is the sidecar's
+// behaviour, not ours. Each stall is detected by the short per-attempt timeout and retried on a
+// fresh connection; nothing else is retried (`docs/rag-design.md` §17 "Real acceptance").
+// ------------------------------------------------------------------------------------------
+describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
+  const NAME = 'wikipedia_de_climate-change_nopic_2026-07'
+  const ENTRY = 'Treibhauseffekt' // one of the measured stallers (234 KB)
+  const ALIAS = 'CO2-Äquivalent'
+  const HTML = '<html><body><p>Treibhauseffekt</p></body></html>'
+  const raw = (encodedKey: string): string => `/raw/${NAME}/content/${encodedKey}`
+  const ENTRY_URL = raw('Treibhauseffekt')
+  const ALIAS_URL = raw('CO2-%C3%84quivalent')
+  /** The shrunk per-attempt budget (the production one is `ARTICLE_READ_TIMEOUT_MS` = 4 s).
+   *  Long enough that a healthy loopback answer lands inside it even under fork load. */
+  const STALL_TIMEOUT_MS = 300
+  /** A generous ceiling that still proves the read did NOT sit out a 15 s default. */
+  const ALL_ATTEMPTS_BUDGET_MS = 5_000
+
+  /** Answers `url` with `queue.shift()` on each request, so "stalls once, then answers" is
+   *  expressed as a list rather than as a counter each leg has to re-invent. */
+  const installQueues = (queues: Record<string, RawFixtureAnswer[]>): void => {
+    rawHook = (url) => queues[url]?.shift() ?? { status: 404, body: 'not found' }
+  }
+  const rawLog = (): string[] => requestLog.filter((u) => u.startsWith('/raw/'))
+  const read = (signal?: AbortSignal): Promise<string | null> =>
+    fetchArticleHtml(port, NAME, ENTRY, signal, { timeoutMs: STALL_TIMEOUT_MS })
+
+  beforeEach(() => {
+    requestLog.length = 0
+    parkedClosedByClient.length = 0
+  })
+  afterEach(() => {
+    rawHook = null
+  })
+
+  it('the shipped constants are a stall detector, not a throughput bound', () => {
+    expect(ARTICLE_READ_TIMEOUT_MS).toBe(4_000)
+    expect(ARTICLE_READ_ATTEMPTS).toBe(3)
+    // The whole ladder must fit inside the 20 s per-ask deadline with room to spare.
+    expect(ARTICLE_READ_TIMEOUT_MS * ARTICLE_READ_ATTEMPTS).toBeLessThan(15_000)
+  })
+
+  it('(a) a first attempt that is never answered is retried on a fresh connection', async () => {
+    installQueues({ [ENTRY_URL]: ['park', { status: 200, body: HTML }] })
+    await expect(read()).resolves.toBe(HTML)
+    expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL])
+    // The stalled socket was torn down by the CLIENT, so attempt 2 really is a new connection.
+    expect(parkedClosedByClient).toEqual([ENTRY_URL])
+  })
+
+  it('(b) three unanswered attempts reject as the timeout, and stop at three', async () => {
+    installQueues({ [ENTRY_URL]: ['park', 'park', 'park', { status: 200, body: HTML }] })
+    const started = Date.now()
+    let caught: unknown
+    await read().catch((err: unknown) => {
+      caught = err
+    })
+    expect(caught).toBeInstanceOf(KiwixTimeoutError)
+    expect((caught as KiwixTimeoutError).name).toBe('KiwixTimeoutError')
+    expect((caught as KiwixTimeoutError).headersReceived).toBe(false)
+    // A fourth answering entry sits in the queue: the bound is the code's, not the fixture's.
+    expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL, ENTRY_URL])
+    expect(rawLog()).toHaveLength(ARTICLE_READ_ATTEMPTS)
+    expect(Date.now() - started).toBeLessThan(ALL_ATTEMPTS_BUDGET_MS)
+  })
+
+  it('(c) the caller aborting during attempt 2 rejects at once, with no attempt 3', async () => {
+    const ac = new AbortController()
+    const reason = new Error('the ask was cancelled')
+    let seen = 0
+    rawHook = (url) => {
+      if (url !== ENTRY_URL) return { status: 404, body: 'not found' }
+      // Abort as the SECOND attempt arrives: the request is in flight and parked, which is
+      // exactly the window the retry would otherwise cover.
+      if (++seen === 2) ac.abort(reason)
+      return 'park'
+    }
+    let caught: unknown
+    await read(ac.signal).catch((err: unknown) => {
+      caught = err
+    })
+    expect(caught).not.toBeInstanceOf(KiwixTimeoutError)
+    expect((caught as Error).name).toBe('AbortError')
+    expect((caught as Error).cause).toBe(reason)
+    expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL])
+  })
+
+  it('(d) headers plus a partial body then a hang is NOT retried — that is a mid-body error', async () => {
+    installQueues({ [ENTRY_URL]: ['park-mid-body', { status: 200, body: HTML }] })
+    let caught: unknown
+    await read().catch((err: unknown) => {
+      caught = err
+    })
+    expect(caught).toBeInstanceOf(KiwixTimeoutError)
+    // The signature the retry keys on is "NOTHING arrived"; a half-read body is a real failure.
+    expect((caught as KiwixTimeoutError).headersReceived).toBe(true)
+    expect(rawLog()).toEqual([ENTRY_URL])
+  })
+
+  it('(e) an answered attempt keeps its existing semantics and is never retried', async () => {
+    for (const answer of [
+      { status: 404, body: 'not found' },
+      { status: 500, body: 'boom' },
+      { status: 302, headers: { location: '/content/other_book/x' }, body: '' }
+    ] as const) {
+      requestLog.length = 0
+      installQueues({ [ENTRY_URL]: [answer, { status: 200, body: HTML }] })
+      const pending = read()
+      if (answer.status === 500) {
+        await expect(pending).rejects.toThrow(/article fetch failed \(HTTP 500\)/)
+      } else {
+        await expect(pending, String(answer.status)).resolves.toBeNull()
+      }
+      expect(rawLog(), String(answer.status)).toEqual([ENTRY_URL])
+    }
+  })
+
+  it('(f) the redirect hop is retried the same way', async () => {
+    installQueues({
+      [ALIAS_URL]: [{ status: 302, headers: { location: `/content/${NAME}/Treibhauseffekt` }, body: '' }],
+      [ENTRY_URL]: ['park', { status: 200, body: HTML }]
+    })
+    await expect(
+      fetchArticleHtml(port, NAME, ALIAS, undefined, { timeoutMs: STALL_TIMEOUT_MS })
+    ).resolves.toBe(HTML)
+    expect(rawLog()).toEqual([ALIAS_URL, ENTRY_URL, ENTRY_URL])
+    expect(parkedClosedByClient).toEqual([ENTRY_URL])
+  })
+
+  it('(g) the other routes are untouched: /suggest and /search are tried exactly once', async () => {
+    // The stall retry is scoped to `/raw`; a probe timeout is still one request and an unknown.
+    suggestHook = () => 'park'
+    requestLog.length = 0
+    await expect(
+      probeSearchable(port, 'parked', undefined, { timeoutMs: STALL_TIMEOUT_MS })
+    ).resolves.toBeNull()
+    expect(requestLog.filter((u) => u.startsWith('/suggest'))).toHaveLength(1)
+    suggestHook = null
+
+    // …and a search still makes exactly one request per call (it answers here; the point is
+    // that nothing in the search path grew a retry).
+    requestLog.length = 0
+    await expect(searchPack(port, 'uuid-1', 'Treibhausgas', 5)).resolves.toHaveLength(2)
+    expect(requestLog.filter((u) => u.startsWith('/search'))).toHaveLength(1)
   })
 })
 

--- a/apps/desktop/tests/unit/zim-client.test.ts
+++ b/apps/desktop/tests/unit/zim-client.test.ts
@@ -74,21 +74,29 @@ const requestLog: string[] = []
  * headers (a redirect's `Location`) and a body; null falls through to the default article
  * fixtures below, so every pre-existing `/raw` test is untouched.
  *
- * The two string variants reproduce the T19 stall and its near-miss:
- *   `'park'`          — the request is accepted and NOTHING is ever sent, not even headers.
- *                       That is the measured kiwix-serve behaviour the retry exists for.
- *   `'park-mid-body'` — headers plus the first bytes of the body, then the response hangs.
- *                       Deliberately NOT the stall signature: a half-read body stays an error.
- * Both are released only by the client giving up (the per-attempt timeout destroys the socket).
+ * The `stall` variants reproduce the T19 fault and the failure it must NOT be confused with:
+ *   `'truncated'` — 200 + `Content-Length` + MOST of the body within a few ms, then the
+ *                   connection hangs and the last part never arrives. This is the MEASURED
+ *                   kiwix-serve 3.8.1 (win-x86_64) shape: every stall of the 120-read capture
+ *                   looked like this, cutting a given entry at the same byte every time.
+ *   `'silent'`    — accepted, and nothing sent at all — not even headers. The same class of
+ *                   failure (the attempt's own timer elapses before the body completes), kept
+ *                   as its own leg so the retry cannot come to depend on headers arriving.
+ *   `'reset'`     — 200 + part of the body, then the SOCKET IS DESTROYED. A real network
+ *                   error, not a stall: it must NOT be retried.
+ * The two hanging variants end only when the client gives up (its per-attempt timeout).
  */
-type RawFixtureAnswer =
-  | { status: number; headers?: Record<string, string>; body: string }
-  | 'park'
-  | 'park-mid-body'
+type RawStall =
+  | { stall: 'silent' }
+  | { stall: 'truncated'; partial: string; total: number }
+  | { stall: 'reset'; partial: string }
+type RawFixtureAnswer = { status: number; headers?: Record<string, string>; body: string } | RawStall
 let rawHook: ((url: string) => RawFixtureAnswer | null) | null = null
-/** The bytes `'park-mid-body'` sends before hanging — enough to prove headers arrived. */
-const PARK_MID_BODY_PREFIX = '<html><body><p>Anfang'
-/** Every parked `/raw` URL whose connection the CLIENT closed (it gave up), in order. */
+/**
+ * Every hanging `/raw` URL whose connection the CLIENT tore down (it gave up). A leg asserts
+ * `toContain`, never an exact list: the server sees a socket close on its own schedule, so a
+ * previous leg's teardown can still land here.
+ */
 const parkedClosedByClient: string[] = []
 
 beforeAll(async () => {
@@ -142,18 +150,28 @@ beforeAll(async () => {
     }
     if (req.url?.startsWith('/raw/')) {
       const answer = rawHook?.(req.url) ?? null
-      if (answer === 'park' || answer === 'park-mid-body') {
+      if (answer && 'stall' in answer) {
         const url = req.url
-        // `writableFinished` is false exactly when the client tore the connection down first —
-        // the proof that the retry opened a FRESH socket rather than reusing a stuck one.
+        if (answer.stall === 'silent') {
+          // `writableFinished` is false exactly when the client tore the connection down first —
+          // the proof that the retry opened a FRESH socket rather than reusing a stuck one.
+          res.on('close', () => {
+            if (!res.writableFinished) parkedClosedByClient.push(url)
+          })
+          return // nothing is ever sent
+        }
+        if (answer.stall === 'reset') {
+          res.writeHead(200, { 'content-type': 'text/html' })
+          res.write(answer.partial, () => res.destroy()) // a real socket error mid-body
+          return
+        }
         res.on('close', () => {
           if (!res.writableFinished) parkedClosedByClient.push(url)
         })
-        if (answer === 'park-mid-body') {
-          res.writeHead(200, { 'content-type': 'text/html' })
-          res.write(PARK_MID_BODY_PREFIX) // headers + a partial body, then nothing more
-        }
-        return // never answered
+        // The measured shape: a complete, HONEST `Content-Length`, then only part of the body.
+        res.writeHead(200, { 'content-type': 'text/html', 'content-length': String(answer.total) })
+        res.write(answer.partial) // …and the rest never comes
+        return
       }
       if (answer) {
         res.writeHead(answer.status, { 'content-type': 'text/html', ...answer.headers })
@@ -463,17 +481,26 @@ describe('fetchArticleHtml follows one same-book redirect (#301 P7 T19)', () => 
 })
 
 // ------------------------------------------------------------------------------------------
-// #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) NEVER ANSWERS ~5–20 % of `/raw` reads of entries
-// above ~80 KB — zero bytes, no headers — while the server stays alive and answers the next
-// request normally. Client-, thread-count- and pause-independent, so it is the sidecar's
-// behaviour, not ours. Each stall is detected by the short per-attempt timeout and retried on a
-// fresh connection; nothing else is retried (`docs/rag-design.md` §17 "Real acceptance").
+// #301 P7 T19: kiwix-serve 3.8.1 (win-x86_64) CUTS ~5–20 % of `/raw` reads of entries above
+// ~80 KB SHORT — the status line, a `Content-Length` and most of the body arrive within 3–6 ms,
+// then the connection hangs and the last part never comes (Treibhauseffekt always stops at
+// 195,590 of 234,141 bytes) — while the server stays alive and answers the next request
+// normally. Client-, thread-count- and pause-independent, so it is the sidecar's behaviour, not
+// ours. The per-attempt timeout detects it and the read is retried on a fresh connection;
+// nothing else is retried (`docs/rag-design.md` §17 "Real acceptance").
 // ------------------------------------------------------------------------------------------
 describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
   const NAME = 'wikipedia_de_climate-change_nopic_2026-07'
   const ENTRY = 'Treibhauseffekt' // one of the measured stallers (234 KB)
   const ALIAS = 'CO2-Äquivalent'
   const HTML = '<html><body><p>Treibhauseffekt</p></body></html>'
+  /** The measured fault, to scale: the last ~15 % of the entry never arrives. */
+  const TRUNCATED_PARTIAL = HTML.slice(0, Math.floor(HTML.length * 0.85))
+  const TRUNCATED: RawStall = {
+    stall: 'truncated',
+    partial: TRUNCATED_PARTIAL,
+    total: Buffer.byteLength(HTML)
+  }
   const raw = (encodedKey: string): string => `/raw/${NAME}/content/${encodedKey}`
   const ENTRY_URL = raw('Treibhauseffekt')
   const ALIAS_URL = raw('CO2-%C3%84quivalent')
@@ -507,16 +534,16 @@ describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
     expect(ARTICLE_READ_TIMEOUT_MS * ARTICLE_READ_ATTEMPTS).toBeLessThan(15_000)
   })
 
-  it('(a) a first attempt that is never answered is retried on a fresh connection', async () => {
-    installQueues({ [ENTRY_URL]: ['park', { status: 200, body: HTML }] })
+  it('(a) a first attempt that is never answered at all is retried on a fresh connection', async () => {
+    installQueues({ [ENTRY_URL]: [{ stall: 'silent' }, { status: 200, body: HTML }] })
     await expect(read()).resolves.toBe(HTML)
     expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL])
     // The stalled socket was torn down by the CLIENT, so attempt 2 really is a new connection.
-    expect(parkedClosedByClient).toEqual([ENTRY_URL])
+    expect(parkedClosedByClient).toContain(ENTRY_URL)
   })
 
-  it('(b) three unanswered attempts reject as the timeout, and stop at three', async () => {
-    installQueues({ [ENTRY_URL]: ['park', 'park', 'park', { status: 200, body: HTML }] })
+  it('(b) three cut-short attempts reject as the timeout, and stop at three', async () => {
+    installQueues({ [ENTRY_URL]: [TRUNCATED, TRUNCATED, TRUNCATED, { status: 200, body: HTML }] })
     const started = Date.now()
     let caught: unknown
     await read().catch((err: unknown) => {
@@ -524,7 +551,9 @@ describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
     })
     expect(caught).toBeInstanceOf(KiwixTimeoutError)
     expect((caught as KiwixTimeoutError).name).toBe('KiwixTimeoutError')
-    expect((caught as KiwixTimeoutError).headersReceived).toBe(false)
+    // The partial body is on the error as diagnosis, never as a result.
+    expect((caught as KiwixTimeoutError).headersReceived).toBe(true)
+    expect((caught as KiwixTimeoutError).bytesReceived).toBe(Buffer.byteLength(TRUNCATED_PARTIAL))
     // A fourth answering entry sits in the queue: the bound is the code's, not the fixture's.
     expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL, ENTRY_URL])
     expect(rawLog()).toHaveLength(ARTICLE_READ_ATTEMPTS)
@@ -537,10 +566,10 @@ describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
     let seen = 0
     rawHook = (url) => {
       if (url !== ENTRY_URL) return { status: 404, body: 'not found' }
-      // Abort as the SECOND attempt arrives: the request is in flight and parked, which is
+      // Abort as the SECOND attempt arrives: the request is in flight and stalled, which is
       // exactly the window the retry would otherwise cover.
       if (++seen === 2) ac.abort(reason)
-      return 'park'
+      return TRUNCATED
     }
     let caught: unknown
     await read(ac.signal).catch((err: unknown) => {
@@ -552,15 +581,30 @@ describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
     expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL])
   })
 
-  it('(d) headers plus a partial body then a hang is NOT retried — that is a mid-body error', async () => {
-    installQueues({ [ENTRY_URL]: ['park-mid-body', { status: 200, body: HTML }] })
+  it('(d) headers plus a partial body then a hang IS retried, and the partial body is discarded', async () => {
+    // THE measured signature (`tmp/zim-wave/p7/t19-raw-stall4-headers.log`, 120 reads): every
+    // stall carried the 200 and most of the entry, then the last part never arrived. The whole
+    // read starts over on a fresh connection — a truncated article is never handed to the app.
+    installQueues({ [ENTRY_URL]: [TRUNCATED, { status: 200, body: HTML }] })
+    const html = await read()
+    expect(html).toBe(HTML)
+    expect(html).not.toBe(TRUNCATED_PARTIAL)
+    expect(rawLog()).toEqual([ENTRY_URL, ENTRY_URL])
+    expect(parkedClosedByClient).toContain(ENTRY_URL)
+  })
+
+  it('(d2) a mid-body SOCKET ERROR is not a stall: it is not retried', async () => {
+    // The retryable signature is "this attempt's own timer elapsed", nothing wider. A connection
+    // the server tears down mid-body is a real network failure and keeps its existing semantics.
+    installQueues({
+      [ENTRY_URL]: [{ stall: 'reset', partial: TRUNCATED_PARTIAL }, { status: 200, body: HTML }]
+    })
     let caught: unknown
     await read().catch((err: unknown) => {
       caught = err
     })
-    expect(caught).toBeInstanceOf(KiwixTimeoutError)
-    // The signature the retry keys on is "NOTHING arrived"; a half-read body is a real failure.
-    expect((caught as KiwixTimeoutError).headersReceived).toBe(true)
+    expect(caught).toBeInstanceOf(Error)
+    expect(caught).not.toBeInstanceOf(KiwixTimeoutError)
     expect(rawLog()).toEqual([ENTRY_URL])
   })
 
@@ -585,13 +629,13 @@ describe('fetchArticleHtml retries a stalled /raw read (#301 P7 T19)', () => {
   it('(f) the redirect hop is retried the same way', async () => {
     installQueues({
       [ALIAS_URL]: [{ status: 302, headers: { location: `/content/${NAME}/Treibhauseffekt` }, body: '' }],
-      [ENTRY_URL]: ['park', { status: 200, body: HTML }]
+      [ENTRY_URL]: [TRUNCATED, { status: 200, body: HTML }]
     })
     await expect(
       fetchArticleHtml(port, NAME, ALIAS, undefined, { timeoutMs: STALL_TIMEOUT_MS })
     ).resolves.toBe(HTML)
     expect(rawLog()).toEqual([ALIAS_URL, ENTRY_URL, ENTRY_URL])
-    expect(parkedClosedByClient).toEqual([ENTRY_URL])
+    expect(parkedClosedByClient).toContain(ENTRY_URL)
   })
 
   it('(g) the other routes are untouched: /suggest and /search are tried exactly once', async () => {


### PR DESCRIPTION
## Fix — retry a `/raw` article read that the pinned kiwix-serve never answers (P7 real acceptance, T19 finding 3)

Refs #301 (Phase 7). Base `feat/zim-knowledge-packs`. Code + tests only; the records PR stacked on this one carries the docs.

**Finding (2026-09-06, i9-14900K, Windows 11, kiwix-tools 3.8.1 win-x86_64 / libkiwix 14.1.1).** During the real-Electron visual review, 3 of 27 article opens hung for exactly 15 s (the client's `DEFAULT_TIMEOUT_MS`), logged `Pack article read failed {"error":"AbortError"}`, and showed the viewer's unavailable state while kiwix-serve stayed alive. Isolated against a raw kiwix-serve with no app code: a `GET /raw/<book>/content/<entry>` of any entry above ~80 KB **stops short** on ~5–20 % of attempts — the `200` status line, `Content-Length` and most of the body arrive within milliseconds, then the last part never does (always the same cut per entry: 195,590 of 234,141 B for `Treibhauseffekt`, 456,710 of 508,338 B for `Klimawandel`, 260,870 of 294,238 B for `Treibhausgas`) and the connection hangs (84 KB 2/40 · 211 KB 4/40 · 234 KB 2–8 per 40–60 · 294 KB 6/40 · 508 KB 8/40 · 707 KB 4/40), while a 24 KB entry never stalled in 180 reads; the same with `curl.exe`, with keep-alive on or off, with `--threads 1 / 4 / 16`, with 0 / 400 / 2500 ms between reads; the next request is answered normally. An upstream defect of that build (reporting it rides the provisioning issue #339). App impact before this fix: the viewer showed "unavailable" after 15 s, and the ask arm silently dropped the stalled article after 15 s (a real ask took 40 s and returned 16 instead of 20 passages).

**Fix (`services/zim/client.ts`, commits 0eb79f1f + 14cf363f).** `kiwixGet` now classifies its own timer separately from the caller's abort (`KiwixTimeoutError { timeoutMs, headersReceived, bytesReceived }`; a caller abort still rejects with the `AbortError` exactly as before). `fetchArticleHtml` reads through `readRawArticle`: `ARTICLE_READ_TIMEOUT_MS = 4_000` per attempt, `ARTICLE_READ_ATTEMPTS = 3`, a retry **only** when an attempt's own timer elapsed before the body completed (the measured shape: the status line and most of the body arrive, the tail never does — the partial body is discarded), on a fresh connection; rethrown at once when the caller's signal is aborted (the ask deadline, a cancellation, a lock — checked first), on any non-timeout socket error, on an over-ceiling body, or when attempts are exhausted. Any HTTP status keeps its existing semantics; the redirect hop's request (#337) is retried the same way; `/suggest`, `/search` and the health probe are unchanged (the stall was measured on `/raw` bodies only); the request guard's lifecycle retry is untouched (a stall never reaches the server's lifecycle). Worst case 12 s, under the 20 s per-ask deadline. Test seams: `fetchArticleHtml`'s `opts.timeoutMs`, `CollectPackCandidatesOptions.articleTimeoutMs`, `ZimServiceDeps.articleTimeoutMs`. One `warn` per retried stall (`{ route: 'raw', attempt, timeoutMs }` — no path, no name).

**Tests.** `zim-client.test.ts`: two `kiwixGet` classification legs and the describe "fetchArticleHtml retries a stalled /raw read (#301 P7 T19)" — (a) a first attempt never answered at all is retried on a fresh connection (the stalled socket torn down by the client), (b) three cut-short attempts reject as the timeout and stop at three (`headersReceived` / `bytesReceived` asserted), (c) a caller abort during attempt 2 rejects at once with no attempt 3, (d) headers plus a partial body then a hang IS retried and the partial body is discarded, (d2) a mid-body socket error is not a stall and is not retried, (e) a completed status keeps its semantics, (f) the redirect hop is retried the same way, (g) `/suggest` and `/search` are tried exactly once, plus the constants leg. `zim-ipc-session.test.ts`: "T19 an article whose first /raw read is cut short still opens whole …" (a paragraph past the 85 % cut reaches the viewer; request log exactly `[entry, entry]`, `serverState()` unchanged). `zim-arm.test.ts`: "#301 P7 T19 an article whose first read is cut short keeps its chunks". Anti-test with `ARTICLE_READ_ATTEMPTS = 1`: eight legs red ((a), (b), (c), (d), (f), the constants leg, the ipc leg, the arm leg); (d2), (e), (g) stay green by design.

**Verification.** zim-client 41, zim-ipc-session 10, zim-arm 12, zim-regressions 15, zim-packs 14, repo-hygiene 34 — 126/126; typecheck clean. Real app rebuilt with the fix: 12 consecutive article opens ready in 42–476 ms (a longer sample is in the records PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
