### PR TITLE
fix(workspace): re-arm the chat engine and the local API after a FAILED lock (#344)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -105,6 +105,12 @@ check in `maybeRunFirstBenchmark` restores a known machine's result or benchmark
 `benchmark:progress` streams the run's steps. Diagnostics keeps the raw table. Records:
 `docs/benchmark.md` "History per machine" / "Performance screen", data-contracts (settings
 storage + IPC). §5 item 22 tracks the residuals._
+_2026-09-06 — **ZIM follow-up wave, step 1 — #344 (`fix/344-failed-lock-rearm`, working paper `tmp/344-failed-lock-rearm.md`, git-ignored):** a FAILED lock left the chat
+engine stopped (and an opted-in local API down) — the teardown stops every sidecar before the re-encrypt and only the post-unlock seam restarted the two eager ones. The lock
+handler's single AUD-02 disarm point now re-runs exactly those two restarts (`maybeAutoStartActiveModel`, `maybeStartLocalApi`) after `cancelLock()`; the successful-lock, quit and
+unlock paths are untouched, no epoch moves. Test: `lock-admission-race.test.ts` "a FAILED lock re-arms the chat engine …" (real vault + handler + `RuntimeManager`, a chat-path ask after
+the failure; red with the fix reverted). Docs: troubleshooting "Could not lock the workspace", CHANGELOG, rag-design §17 owner-leg annotation. Next: #340 residuals, then #339, then #340 capabilities._
+
 _2026-09-06 — **ZIM knowledge packs (PR #294 → #301) — WAVE CLOSED: Phases 0–7 complete, #294 MERGED to master (`92e86a07`, 16:12 UTC), #301 closed by the merge.**_
 The PR's review remediation — 28 findings (H1–H4, M1–M11, L1–L9 with L10 withdrawn, DOC-1–DOC-4; three assessed High, H3 and DOC-1/DOC-2 Medium) — closed across P0–P6 on the integration branch `feat/zim-knowledge-packs`;
 master merged in at P0 (`bfdb514a`) and again at P7 (`ddd704ad`). Durable records: `rag-design.md` §17 D-Z1–D-Z14 (with a §-anchor legend),
@@ -711,7 +717,7 @@ open round's item stays the last block of §5.)
     `reconcile-start` and `-end` of one epoch (cosmetic, P9); the pack meta line shows the raw ISO 639-3 code unlabelled (copy nit, P9); `.footer-menu-btn` has no overflow rule of its own (low, P9);
     accepted deviation: the ScopePopover is non-modal (design-guidelines §11.15 decision 1, P6); T18-b — RECORDED 2026-09-06 (run by the orchestrator at the owner's request in real Electron against the real packs; rag-design §17 "Real acceptance" → "T18-b"; it surfaced T19 finding 3: kiwix-serve 3.8.1 win-x86_64 cuts ~5–20 % of large /raw reads short (the body's last part never arrives) — upstream, mitigated by the P7 fix PR 2, upstream report on #339); T19 the owner's Electron/drive legs — (vi) the relocated drive with
     persisted citations and (vii) live lock/unlock/failed lock PASSED 2026-09-06 on the real K: drive (rag-design §17 "Real acceptance" → "The owner's legs"; observations: a failed lock leaves the chat
-    engine stopped until a model is re-selected — #344; a pack added via Add packs… stays searchability-unknown until Refresh; LaTeX echoed in answers — #340), (viii) the offline ask + viewer PASSED
+    engine stopped until a model is re-selected — #344, FIXED in the follow-up wave (2026-09-06 dated entry); a pack added via Add packs… stays searchability-unknown until Refresh; LaTeX echoed in answers — #340), (viii) the offline ask + viewer PASSED
     (item (d) closed) — T19 complete; the orchestrator's machine legs are recorded in rag-design §17 "Real acceptance"; R-1 open
     until P8 (the acceptance bundle has no install marker ⇒ `skip-legacy`); R-2 multipart unsupported; R-4 Authenticode — result recorded at P7 in model-policy.md; R-6 → P9; R-9 accepted
     (2026-09-05). From P7's T19: kiwix-manage 3.8.1 refuses non-ASCII archive paths on Windows (registration-only — kiwix-serve serves such a file from UTF-8 XML; documented in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **A lock that could not finish no longer leaves the chat without a model.** When "Lock now"
+  fails (for example on a nearly-full drive) the workspace stays open, as before — but the app
+  used to stop the AI model on the way and never start it again, so the next question was met
+  with "No model is running" until you started the model by hand on the AI Model screen. The
+  model now restarts by itself after a failed lock (when "Start the selected model automatically"
+  is on, exactly as after an unlock), and the local API, if you have it switched on, comes back
+  too.
 - **The speed figure on Settings → Diagnostics is now the model's real decode speed.** The
   benchmark used to count streamed chunks over the whole request, including the time the model
   spent reading the prompt, so on the recommended Qwen3.8 models — which can produce several

--- a/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
+++ b/apps/desktop/src/main/ipc/registerWorkspaceIpc.ts
@@ -425,7 +425,22 @@ export function registerWorkspaceIpc(ctx: AppContext): void {
       // The condition is deliberate: disarm only while the workspace is genuinely still open.
       // A lock that already closed the DB must KEEP the latch (`isUnlocked()` reports locked by
       // then, and the next unlock clears it).
-      if (ctx.workspace.isUnlocked()) ctx.workspace.cancelLock()
+      if (ctx.workspace.isUnlocked()) {
+        ctx.workspace.cancelLock()
+        // #344: the teardown above stopped every sidecar BEFORE the vault re-encrypted, and a
+        // failed lock never reaches the post-unlock seam that brings the two EAGER ones back —
+        // the workspace stays open, but the chat runtime is stopped (`runtime.stop()`; Chat then
+        // shows "No model is running" until the user re-starts it on the AI Model screen) and an
+        // opted-in local API is down (`localApi.stop()`, "restarted only by the post-unlock
+        // seam"). Everything else the teardown suspended comes back lazily on its next use
+        // (embedder, reranker, transcriber, OCR, translator, vision, kiwix-serve — the #301
+        // P3b/P5 non-latching pattern), so nothing more needs re-arming. Re-run exactly the two
+        // post-unlock restarts, AFTER the disarm (both check `workspaceAdmitsWork()` first) and
+        // fire-and-forget, so the handler still rejects at once with the friendly copy below.
+        // No new session, no epoch bump, no benchmark scheduling: a failed lock is not an unlock.
+        maybeStartLocalApi(ctx)
+        void maybeAutoStartActiveModel(ctx)
+      }
       throw err
     }
   })

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -79,6 +79,17 @@ import { createPlaintextOps } from '../../src/main/services/ingestion/plaintext-
 import { performShutdown } from '../../src/main/shutdown'
 import { t } from '../../src/shared/i18n'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
+import { registerChatIpc } from '../../src/main/ipc/registerChatIpc'
+import { startModelRuntime } from '../../src/main/ipc/registerModelIpc'
+import { RuntimeManager } from '../../src/main/services/runtime'
+import { createMockRuntime } from '../../src/main/services/runtime/mock'
+import { createConversation, listMessages } from '../../src/main/services/chat'
+import { updateSettings } from '../../src/main/services/settings'
+import type { LocalApiServer } from '../../src/main/services/local-api/server'
+import type { Message } from '../../src/shared/types'
+
+/** The repo's manifest tree, so the REAL `startModelRuntime` install gate runs (#344 leg). */
+const REPO_MANIFESTS = join(__dirname, '..', '..', '..', '..', 'model-manifests')
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 const FAST_KDF: KdfParams = { algo: 'scrypt', N: 1024, r: 8, p: 1, keyLen: 32 }
@@ -163,6 +174,14 @@ interface HarnessOptions {
    * registry seam on ctx, so the sweep-bounded cases do not wait out the real constant.
    */
   settleBoundMs?: number
+  /**
+   * #344: the REAL `RuntimeManager` (its `stop()`/`start()`/`active()` lifecycle is what the
+   * failed-lock re-arm acts on) plus the repo manifests + a dev context, so the real
+   * `startModelRuntime` install gate resolves the owner's model to the mock fallback. Also
+   * registers the chat IPC so the ask goes through `assertChatStreamReady`, the guard that
+   * refused the owner's question.
+   */
+  chatEngine?: { runtime: RuntimeManager; localApi: LocalApiServer }
 }
 
 async function harness(opts: HarnessOptions = {}): Promise<Harness> {
@@ -245,13 +264,14 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     workspace: ctrl,
     // `shutdown` is the quit path's runtime latch — present so the quit teardown runs the same
     // shape it does in production (a missing method there would throw into a best-effort catch).
-    runtime: {
+    runtime: opts.chatEngine?.runtime ?? {
       stop: async () => {},
       shutdown: () => {},
       isShutdown: () => false,
       activeModelId: () => null,
       active: () => null
     },
+    ...(opts.chatEngine ? { localApi: opts.chatEngine.localApi } : {}),
     embedder: {
       ...fakeEmbedder,
       suspend: (): Promise<void> => {
@@ -268,8 +288,8 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     },
     translator,
     ocrEngine: opts.ocrEngine ?? null,
-    manifestsDir: null,
-    isDev: false
+    manifestsDir: opts.chatEngine ? REPO_MANIFESTS : null,
+    isDev: opts.chatEngine !== undefined
   } as unknown as AppContext
 
   // The plaintext-operation registry (#237), as `main/index.ts` wires it; optionally with the
@@ -308,6 +328,7 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
   registerTranslateIpc(ctx, ctx.translateJobs)
   registerImagesIpc(ctx, ctx.vision)
   registerDocsIpc(ctx)
+  if (opts.chatEngine) registerChatIpc(ctx)
 
   return {
     ctrl,
@@ -504,6 +525,74 @@ describe('admission during the lock teardown (AUD-02)', () => {
     expect(result).toMatchObject({ jobId: expect.any(String) })
     h.ctx.docTasks?.cancelAllDocTasks()
     await h.ctx.docTasks?.awaitActiveTaskSettled()
+  })
+
+  // #344 (the owner's T19 leg (vii) on the real K: drive): the teardown stops EVERY sidecar before
+  // the vault re-encrypts, and a failed lock never reaches the post-unlock seam that brings the two
+  // EAGER ones back — the chat runtime (`runtime.stop()`) and an opted-in local API
+  // (`localApi.stop()`). The latch disarmed and every content surface admitted work again (the case
+  // above), but the next question met `assertChatStreamReady`'s "No AI model is running" until the
+  // user re-started the model by hand. Everything else the teardown suspended restarts lazily on
+  // its next use (the #301 P3b/P5 non-latching pattern); these two need the restart re-run.
+  //
+  // Real vault, real handler, the real failure seam, the REAL `RuntimeManager` lifecycle and the
+  // real `startModelRuntime` install gate (the owner's model resolves to the mock fallback in a dev
+  // context, so no weights are needed); the ask goes through the real chat IPC. The oracle is the
+  // RESULT — an assistant reply after the failed lock, the local API running again — never a call
+  // count; the wait is bounded, never a fixed sleep. Reverting the two re-arm lines in the lock
+  // handler's catch turns this red at the second ask (verified by hand before the fix landed).
+  it('a FAILED lock re-arms the chat engine and the local API — an ask through the chat path answers again, in the SAME session (#344)', async () => {
+    const runtime = new RuntimeManager((opts) => createMockRuntime(opts))
+    // A state-holding local-API stand-in: `stop()` is the teardown's call, `applySettings` the
+    // post-unlock seam's — exactly the two the real server exposes to the lock lifecycle.
+    let apiRunning = false
+    const localApi = {
+      stop: async () => {
+        apiRunning = false
+      },
+      applySettings: async (next: { shouldRun: boolean }) => {
+        apiRunning = next.shouldRun
+      }
+    } as unknown as LocalApiServer
+    const h = await harness({ failReEncrypt: true, chatEngine: { runtime, localApi } })
+    const modelId = 'gemma4-e2b-it-qat-q4'
+    updateSettings(h.ctrl.requireDb(), { activeModelId: modelId, autoStartActiveModel: true, localApiEnabled: true })
+
+    // A session in use: the model up through the real start path, the API on, one answer given.
+    await startModelRuntime(h.ctx, modelId)
+    await localApi.applySettings({ shouldRun: true })
+    expect(runtime.activeModelId()).toBe(modelId)
+    const conv = createConversation(h.ctrl.requireDb(), {})
+    const first = (await invoke(handlers, IPC.sendChatMessage, conv.id, 'before the lock')).result as Message
+    expect(first.role).toBe('assistant')
+    const epochBefore = h.ctrl.unlockEpoch()
+
+    // The lock runs its whole teardown — the runtime and the API are stopped — then fails at the
+    // re-encrypt and rejects with the friendly copy; the workspace is genuinely open again.
+    await expect(invoke(handlers, IPC.lockWorkspace)).rejects.toThrow(t('en', 'main.workspace.lockFailed'))
+    expect(h.ctrl.isUnlocked()).toBe(true)
+    expect(h.ctrl.isLocking()).toBe(false)
+    expect(workspaceAdmitsWork(h.ctrl)).toBe(true)
+
+    // The re-arm is the post-unlock restart, fire-and-forget: the model comes back in the
+    // background (the mock start is quick; a real one takes the load window, which is why the
+    // Chat screen keeps polling `runtime:status` until it flips), the API at once.
+    expect(await waitUntil(() => runtime.activeModelId() === modelId, 400)).toBe(true)
+    expect(apiRunning).toBe(true)
+    // …in the SAME session: no new unlock epoch — a failed lock is not an unlock.
+    expect(h.ctrl.unlockEpoch()).toBe(epochBefore)
+
+    // The property that matters, driven through the real chat path: the next question answers.
+    const second = (await invoke(handlers, IPC.sendChatMessage, conv.id, 'after the failed lock')).result as Message
+    expect(second.role).toBe('assistant')
+    expect(second.content).toContain('after the failed lock')
+    expect(listMessages(h.ctrl.requireDb(), conv.id).map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant'
+    ])
+    await runtime.stop()
   })
 
   // A throw ANYWHERE between arming the latch and `lock()` must disarm it too. Arming a latch

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -482,8 +482,9 @@ describe('repo hygiene — bare workspace.isUnlocked() call sites stay allowlist
     // The lock latch's own disarm-on-failure path: it must disarm ONLY while the workspace is
     // genuinely still open. A lock that already closed the DB must KEEP the latch, so the bare
     // check is precisely the intended question here — `workspaceAdmitsWork` would be false
-    // mid-teardown and would skip the disarm, stranding the session.
-    'src/main/ipc/registerWorkspaceIpc.ts :: if (ctx.workspace.isUnlocked()) ctx.workspace.cancelLock()',
+    // mid-teardown and would skip the disarm, stranding the session. The block also re-runs the
+    // two eager post-unlock restarts after the disarm (#344), which DO check `workspaceAdmitsWork`.
+    'src/main/ipc/registerWorkspaceIpc.ts :: if (ctx.workspace.isUnlocked()) {',
     // Vision status: a display-only availability probe. Locked ⇒ fall back to the build's isDev
     // and a cache miss; it computes install state, it does not load a model.
     'src/main/services/vision/status.ts :: const unlocked = ctx.workspace.isUnlocked()',

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2887,9 +2887,13 @@ edition — its copied tag STILL says `_ftindex:yes`, a lying hint); **C** the m
   fail) → the "Could not lock the workspace — it stays open and your data is safe" banner, the
   pack server gone, and after re-selecting the model a third pack question answered with citations
   (pack work is admitted again — the non-latching recovery); then a normal lock and unlock with the
-  chat intact. **Observation (not a pack defect — issue #344):** the lock teardown stops the
-  chat engine (`ctx.runtime.stop()`) and only the post-unlock seam restarts it, so after a FAILED
-  lock the app asks for a model again before the next question. **(vi) the relocated drive with
+  chat intact. **Observation (not a pack defect — issue #344, FIXED in the follow-up wave):** the
+  lock teardown stops the chat engine (`ctx.runtime.stop()`) and only the post-unlock seam
+  restarted it, so after a FAILED lock the app asked for a model again before the next question;
+  the lock handler's failed-lock path now re-runs the two eager post-unlock restarts (the chat
+  runtime's auto-start and the local API) — `lock-admission-race.test.ts` "a FAILED lock re-arms
+  the chat engine …" drives the real vault, handler and `RuntimeManager` through a chat-path ask
+  after the failure. **(vi) the relocated drive with
   persisted citations — PASSED.** Quit, `Set-Partition K → M`, launched with `M:\`, unlocked: the
   `zim\` pack still Enabled (drive-relative resolution), the pack added from `K:\zim-external\…`
   honestly "File missing" (its recorded path names the old letter); "Open article" on the first

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -203,6 +203,13 @@ model off the drive via the AI Model screen), then press **Lock now** again. Qui
 retries the lock too. Even if the app closes before a lock ever succeeds, your newest data is
 kept safely on the drive and secured at the next unlock — you don't lose the session's work.
 
+The lock stops the AI model (and every other engine) before it re-encrypts, so after a failed
+lock the model comes back the same way it does after an unlock: automatically in the
+background when **Start the selected model automatically** is on (Chat shows "Starting…" for a
+moment and then the composer again), or by hand on the AI Model screen when that setting is off.
+The local API, if you have it switched on, comes back as well. Everything else — document
+search, the reranker, translation, voice input, OCR, knowledge packs — restarts on its next use.
+
 ---
 
 ## "Could not open the workspace yet: another program is holding a recovery file"


### PR DESCRIPTION
Closes #344. Refs #301.

## What

A FAILED "Lock now" (the re-encrypt fails — ENOSPC, a read-only `.enc`) leaves the workspace open, as designed (CODE-1a + AUD-02), but the lock teardown had already stopped every sidecar before the re-encrypt, and only the post-unlock seam restarted the two **eager** ones: the chat runtime (`ctx.runtime.stop()`) and an opted-in local API (`localApi.stop()`, "restarted only by the post-unlock seam"). A failed lock never reaches that seam, so Chat showed "No model is running" until the model was re-started by hand on the AI Model screen (the owner's T19 leg (vii) on the real K: drive). Knowledge packs were already non-latching (#301 P3b/P5); the chat engine was not.

## Fix (one file, the failed-lock path only)

`registerWorkspaceIpc.ts`, the lock handler's single AUD-02 disarm point: after `cancelLock()`, inside the same `isUnlocked()` branch, re-run exactly the two post-unlock restarts — `maybeStartLocalApi(ctx)` and `void maybeAutoStartActiveModel(ctx)` — fire-and-forget, so the handler still rejects at once with the friendly `lockFailed` copy. Both check `workspaceAdmitsWork()` first (hence after the disarm). Every other engine the teardown suspended (embedder, reranker, transcriber, OCR, translator, vision, kiwix-serve) restarts lazily on its next use by its own contract — nothing else to re-arm. Untouched: the successful-lock path, the quit path, the unlock seam; no new session, no epoch bump, no benchmark scheduling.

The renderer needs no change: ChatScreen polls `runtime:status` every 2.5 s while no model is up and flips back to the composer on its own ("Starting…" while `startingModelId` is set).

Blast-radius note (every teardown step, its latch semantics, what brings it back): `tmp/344-failed-lock-rearm.md` (maintainer-local, git-ignored).

## Tests

`lock-admission-race.test.ts` (the AUD-02 admission seam): NEW "a FAILED lock re-arms the chat engine and the local API — an ask through the chat path answers again, in the SAME session (#344)" — real vault, the real handler, the real `failReEncrypt` seam, the REAL `RuntimeManager` over the mock runtime, the real `startModelRuntime` install gate (the owner's model `gemma4-e2b-it-qat-q4` → the dev mock fallback), the ask through `IPC.sendChatMessage` / `assertChatStreamReady`. Oracle: an assistant reply after the failure and the local API running again; the wait is bounded, never a fixed sleep; the unlock epoch is asserted unchanged. **Anti-test:** with the two re-arm lines stashed the leg goes red at the second ask (run by hand before the fix landed). The `repo-hygiene` AUD-02 allowlist entry for the disarm line was updated to the block form.

Full suite on the branch: 437 files / 6,688 tests — 6,606 passed, 79 skipped, the OCR worker-load leg failed under load and is green alone (the listed flake); typecheck + build green.

## Docs

`docs/troubleshooting.md` "Could not lock the workspace" (how the model comes back; auto-start off → start by hand, as after an unlock), CHANGELOG `[Unreleased]` › Fixed, `docs/rag-design.md` §17 owner-leg observation annotated, BUILD_STATE dated entry + item 21(l) annotation. No new known limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
