### PR TITLE
fix(zim): probe a pack's searchability right after Add packs… / Enable (#340, D-Z15)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -109,7 +109,11 @@ _2026-09-06 — **ZIM follow-up wave, step 1 — #344 (`fix/344-failed-lock-rear
 engine stopped (and an opted-in local API down) — the teardown stops every sidecar before the re-encrypt and only the post-unlock seam restarted the two eager ones. The lock
 handler's single AUD-02 disarm point now re-runs exactly those two restarts (`maybeAutoStartActiveModel`, `maybeStartLocalApi`) after `cancelLock()`; the successful-lock, quit and
 unlock paths are untouched, no epoch moves. Test: `lock-admission-race.test.ts` "a FAILED lock re-arms the chat engine …" (real vault + handler + `RuntimeManager`, a chat-path ask after
-the failure; red with the fix reverted). Docs: troubleshooting "Could not lock the workspace", CHANGELOG, rag-design §17 owner-leg annotation. Next: #340 residuals, then #339, then #340 capabilities._
+the failure; red with the fix reverted). Docs: troubleshooting "Could not lock the workspace", CHANGELOG, rag-design §17 owner-leg annotation. **Step 2 — #340 residual (a), the
+post-registration searchability probe (`fix/340-post-registration-probe`, stacked on step 1; paper `tmp/340-residuals.md`):** `ZimService.scheduleSearchabilityProbe` — once per completed
+`packs:add` batch and on enable, the reconcile's key pass first, the same guarded probe and conditional write, a `'mutation'` notice after a verdict; record rag-design **D-Z15**; test
+`zim-ipc-session` "#340 …" (four legs, red without the trigger). Owner questions (b) non-ASCII message vs metadata and (c) LaTeX strip / normalise / render posted on #340 — their
+code waits. Next: 21(l) `packs:status.excluded`, the UI nits, then #339, then #340 capabilities._
 
 _2026-09-06 — **ZIM knowledge packs (PR #294 → #301) — WAVE CLOSED: Phases 0–7 complete, #294 MERGED to master (`92e86a07`, 16:12 UTC), #301 closed by the merge.**_
 The PR's review remediation — 28 findings (H1–H4, M1–M11, L1–L9 with L10 withdrawn, DOC-1–DOC-4; three assessed High, H3 and DOC-1/DOC-2 Medium) — closed across P0–P6 on the integration branch `feat/zim-knowledge-packs`;
@@ -717,7 +721,7 @@ open round's item stays the last block of §5.)
     `reconcile-start` and `-end` of one epoch (cosmetic, P9); the pack meta line shows the raw ISO 639-3 code unlabelled (copy nit, P9); `.footer-menu-btn` has no overflow rule of its own (low, P9);
     accepted deviation: the ScopePopover is non-modal (design-guidelines §11.15 decision 1, P6); T18-b — RECORDED 2026-09-06 (run by the orchestrator at the owner's request in real Electron against the real packs; rag-design §17 "Real acceptance" → "T18-b"; it surfaced T19 finding 3: kiwix-serve 3.8.1 win-x86_64 cuts ~5–20 % of large /raw reads short (the body's last part never arrives) — upstream, mitigated by the P7 fix PR 2, upstream report on #339); T19 the owner's Electron/drive legs — (vi) the relocated drive with
     persisted citations and (vii) live lock/unlock/failed lock PASSED 2026-09-06 on the real K: drive (rag-design §17 "Real acceptance" → "The owner's legs"; observations: a failed lock leaves the chat
-    engine stopped until a model is re-selected — #344, FIXED in the follow-up wave (2026-09-06 dated entry); a pack added via Add packs… stays searchability-unknown until Refresh; LaTeX echoed in answers — #340), (viii) the offline ask + viewer PASSED
+    engine stopped until a model is re-selected — #344, FIXED in the follow-up wave (2026-09-06 dated entry); a pack added via Add packs… stays searchability-unknown until Refresh — FIXED, D-Z15 (follow-up wave step 2); LaTeX echoed in answers — #340, owner ruling pending), (viii) the offline ask + viewer PASSED
     (item (d) closed) — T19 complete; the orchestrator's machine legs are recorded in rag-design §17 "Real acceptance"; R-1 open
     until P8 (the acceptance bundle has no install marker ⇒ `skip-legacy`); R-2 multipart unsupported; R-4 Authenticode — result recorded at P7 in model-policy.md; R-6 → P9; R-9 accepted
     (2026-09-05). From P7's T19: kiwix-manage 3.8.1 refuses non-ASCII archive paths on Windows (registration-only — kiwix-serve serves such a file from UTF-8 XML; documented in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **A knowledge pack you just added is checked for full-text search right away.** Until now the
+  check ran only when you unlocked or pressed Refresh, so a pack added through *Add packs…* (or
+  enabled after being added) showed no "No full-text index" badge until then, and a question asked
+  in between reported such a pack as "search failed". The check now runs by itself a moment after
+  adding or enabling, and the badge and the sources picker update without a Refresh.
 - **A lock that could not finish no longer leaves the chat without a model.** When "Lock now"
   fails (for example on a nearly-full drive) the workspace stays open, as before — but the app
   used to stop the AI model on the way and never start it again, so the next question was met

--- a/apps/desktop/src/main/ipc/registerZimIpc.ts
+++ b/apps/desktop/src/main/ipc/registerZimIpc.ts
@@ -155,6 +155,9 @@ export function registerZimIpc(ctx: AppContext): void {
       }
       const outcome: KnowledgePackAddResult['outcome'] =
         added.length === 0 ? 'failure' : failed === 0 ? 'success' : 'partial'
+      // #340 (D-Z15): confirm the new packs' full-text capability in the background — ONCE per
+      // batch, after the loop, never per file. Scheduled, so the result below returns first.
+      if (added.length > 0) svc.scheduleSearchabilityProbe(() => ctx.db)
       return { outcome, added, failed, failureReason }
     } finally {
       op.release()
@@ -170,7 +173,10 @@ export function registerZimIpc(ctx: AppContext): void {
 
   ipcHandle(IPC.setKnowledgePackEnabled, (_e, id: string, enabled: boolean): void => {
     requireUnlocked()
-    zim().setPackEnabled(ctx.db, id, enabled)
+    const changed = zim().setPackEnabled(ctx.db, id, enabled)
+    // #340 (D-Z15): a pack enabled after the session's reconcile was skipped by that probe
+    // (it covers enabled ∧ available rows only), so it would stay unknown until a Refresh.
+    if (changed && enabled) zim().scheduleSearchabilityProbe(() => ctx.db)
   })
 
   ipcHandle(

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -22,6 +22,7 @@ import {
   reconcile,
   registerPack,
   removePack,
+  resetStaleSearchability,
   retrievablePacks,
   servedCandidates,
   setPackEnabled,
@@ -373,6 +374,11 @@ export class ZimService {
   private reconcileInFlight: Promise<void> | null = null
   /** A Refresh arrived while a pass was running: run exactly ONE more, however many arrived. */
   private runAgain = false
+  /** The post-registration searchability probe currently running, or null (#340, D-Z15) —
+   *  the same single-flight shape as the reconcile. */
+  private probeInFlight: Promise<void> | null = null
+  /** A probe was requested while one ran: run exactly ONE more afterwards. */
+  private probeAgain = false
 
   constructor(opts: ZimServiceOptions) {
     this.opts = opts
@@ -615,9 +621,9 @@ export class ZimService {
    * quit, a new epoch) propagates without a write. `null` (unknown) verdicts are skipped, so a
    * 404, a timeout or a malformed body simply means "ask again next time".
    */
-  private async probeUnknownSearchability(db: Db, op: ZimOp): Promise<void> {
+  private async probeUnknownSearchability(db: Db, op: ZimOp): Promise<number> {
     const pending = unknownSearchablePacks(db)
-    if (pending.length === 0) return
+    if (pending.length === 0) return 0
     let verdicts: Array<{ id: string; verdict: 'yes' | 'no'; searchableKey: string | null }> | null
     try {
       verdicts = await this.withServer(db, op, async (library) => {
@@ -643,14 +649,78 @@ export class ZimService {
         log.warn('Knowledge-pack searchability probe discarded — the pack server changed', {
           reason: err.reason
         })
-        return
+        return 0
       }
       throw err // an AbortError (lock / quit / cancelled reconcile) propagates, unwritten
     }
-    if (verdicts === null || verdicts.length === 0) return
+    if (verdicts === null || verdicts.length === 0) return 0
     // The LAST recheck before the only capability write there is.
     op.assert()
-    writeSearchableVerdicts(db, verdicts)
+    return writeSearchableVerdicts(db, verdicts)
+  }
+
+  /**
+   * Probe the searchability of whatever is still unknown, in the background — the second
+   * trigger of the capability probe (#340, rag-design D-Z15). The reconcile-end probe above
+   * covers session start and Refresh; without this, a pack the user just ADDED (or ENABLED
+   * after registering it disabled) stayed unknown — tickable, no badge — until the next Refresh,
+   * and an ask in between reported an index-less pack as "search failed" instead of "no full-text
+   * index". The IPC layer calls this once per completed `packs:add` batch (never per file: a
+   * probe started between two files of one batch would be discarded as stale by the second
+   * file's revision bump) and on `packs:setEnabled(…, true)`.
+   *
+   * Never on the caller's critical path (D3: the timer runs after the add/enable has resolved);
+   * `getDb` is read when the pass runs, not when it is scheduled, so a workspace that locked
+   * meanwhile is refused by the operation's admission check before any handle is touched.
+   * Single-flight with one coalesced rerun, like `reconcile()`; while a reconciliation is in
+   * flight nothing runs here — that pass's own end-probe sees the new row. The pass runs the
+   * reconcile's key pass FIRST so the verdict is stored under the SAME cache key the reconcile
+   * would compute, then the same guarded probe and the same conditional write, and announces
+   * `'mutation'` when a verdict landed so the panel and the picker refetch without a Refresh.
+   * Fully best-effort: an `AbortError` (lock / quit / a new session) writes nothing and is not
+   * even logged; anything else is a warn line with the error class only.
+   */
+  scheduleSearchabilityProbe(getDb: () => Db): void {
+    const timer = setTimeout(() => {
+      void this.runScheduledProbe(getDb)
+    }, 0)
+    timer.unref?.()
+  }
+
+  private async runScheduledProbe(getDb: () => Db): Promise<void> {
+    if (this.probeInFlight) {
+      this.probeAgain = true
+      return this.probeInFlight
+    }
+    const run = this.probeOnce(getDb).finally(() => {
+      this.probeInFlight = null
+    })
+    this.probeInFlight = run
+    await run
+    if (this.probeAgain) {
+      this.probeAgain = false
+      await this.runScheduledProbe(getDb)
+    }
+  }
+
+  private async probeOnce(getDb: () => Db): Promise<void> {
+    if (this.reconcileInFlight) return // its end-probe covers whatever is unknown
+    const op = this.beginOp('zim-reconcile')
+    try {
+      op.assert()
+      if (!this.toolsInstalled()) return
+      const db = getDb()
+      resetStaleSearchability(db, this.packDeps(op.signal, op), () => op.assert())
+      const written = await this.probeUnknownSearchability(db, op)
+      if (written > 0) this.emitPacksChanged(op, 'mutation', this.refreshing())
+    } catch (err) {
+      if (isAbortError(err)) return
+      log.warn('Knowledge-pack searchability probe failed (non-fatal)', {
+        error: err instanceof Error ? err.constructor.name : 'UnknownError'
+      })
+    } finally {
+      op.release()
+    }
   }
 
   /**

--- a/apps/desktop/src/main/services/zim/packs.ts
+++ b/apps/desktop/src/main/services/zim/packs.ts
@@ -607,8 +607,13 @@ function searchableKeyFor(filePath: string, toolsFingerprint: string | null): st
  * Recompute the key for every enabled ∧ available row and RESET the verdict whose key moved
  * (the reconcile is the ONE write path for capability state — plan §9.17 (d)/§9.21 (d)3).
  * A row whose key is unchanged is not touched at all, so a no-op Refresh writes nothing.
+ *
+ * Exported for the post-registration probe (#340, rag-design D-Z15): a row a registration just
+ * inserted has NO key yet, and a verdict written under a NULL key would be reset — and the pack
+ * re-probed — by the next reconcile's key pass. Running this same pass first keys the new row
+ * exactly as the reconcile would, so the two probes share one cache key.
  */
-function resetStaleSearchability(db: Db, deps: PackDeps, assert: () => void): void {
+export function resetStaleSearchability(db: Db, deps: PackDeps, assert: () => void): void {
   const fingerprint = deps.toolsFingerprint?.() ?? null
   const rows = prepareCached(
     db,

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -375,11 +375,20 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
         return
       }
       const stem = basename(zimPath).replace(/\.zim$/i, '')
-      appendFileSync(
-        libraryXmlPath,
-        `<book id="${readZimHeader(zimPath).uuid}" path="${zimPath.replace(/\\/g, '/')}" title="Title of ${stem}" ` +
-          `description="Test archive" language="deu" date="2026-07-01" articleCount="41" mediaCount="7" />\n`
-      )
+      // The real kiwix-manage exits non-zero when the archive (or the library file) is gone —
+      // e.g. a background probe's library build (D-Z15) landing after a test's temp root was
+      // removed. The fake must fail the same way, never reject out of this detached IIFE.
+      try {
+        appendFileSync(
+          libraryXmlPath,
+          `<book id="${readZimHeader(zimPath).uuid}" path="${zimPath.replace(/\\/g, '/')}" title="Title of ${stem}" ` +
+            `description="Test archive" language="deu" date="2026-07-01" articleCount="41" mediaCount="7" />\n`
+        )
+      } catch (err) {
+        child.stderr.emit('data', `Cannot add ZIM to the library: ${err instanceof Error ? err.name : 'error'}`)
+        child.emit('exit', 1, null)
+        return
+      }
       child.emit('exit', 0, null)
     })()
     return child

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -2242,3 +2242,121 @@ describe('T16 — per-ask knowledge-pack outcomes end to end (#301 P4, M6/M7)', 
     // controlled promise with an entered/release pair, and no leg waits on a fixed sleep).
   }, 120_000)
 })
+
+// ---- #340 — the searchability probe after Add packs… / Enable (rag-design §17 D-Z15) ----------
+//
+// The owner's real-drive observation (T19): a pack added through Add packs… stayed
+// `searchable: unknown` — tickable, no badge — until the next Refresh or unlock, because the
+// `/suggest` probe ran only at the END of a reconciliation, and an ask in between reported an
+// index-less pack as "search failed" (the `/search` 404) instead of "no full-text index". The
+// probe now also runs, in the background, once per completed `packs:add` batch and on
+// `packs:setEnabled(…, true)` — through the SAME request guard and under the SAME cache key as
+// the reconcile's probe, so a Refresh afterwards asks nothing again.
+//
+// Real vault, the real handlers, the real service + registry, fake kiwix children and the
+// loopback stand-in; the harness's default responder 404s `/suggest` (unknown), so this suite
+// answers it the way the pinned binary does (T19: a `path` title entry for every book, the
+// synthetic `pattern` entry only for an indexed one). Every wait is bounded, never a fixed sleep.
+describe('#340 — searchability is confirmed right after Add packs… / Enable (D-Z15)', () => {
+  /** The pinned binary's /suggest shape: a title match for every book, `pattern` iff indexed. */
+  const suggestFor =
+    (indexed: ReadonlySet<string>) =>
+    (url: string): { status: number; headers?: Record<string, string>; body: string } | null => {
+      if (!url.startsWith('/suggest')) return null
+      const name = new URL(url, 'http://127.0.0.1').searchParams.get('content') ?? ''
+      const entries: Array<Record<string, string>> = [{ value: 'the', label: 'the', kind: 'path', path: 'A/The' }]
+      if (indexed.has(name)) entries.push({ value: 'the ', label: "containing 'the'...", kind: 'pattern' })
+      return { status: 200, headers: { 'content-type': 'application/json' }, body: JSON.stringify(entries) }
+    }
+  const searchableOf = (h: SessionHarness, id: string): { searchable: string | null; searchable_key: string | null } =>
+    h.db().prepare('SELECT searchable, searchable_key FROM knowledge_packs WHERE id = ?').get(id) as unknown as {
+      searchable: string | null
+      searchable_key: string | null
+    }
+  const suggestsSince = (h: SessionHarness, mark: number): string[] =>
+    h.requests.slice(mark).filter((u) => u.startsWith('/suggest'))
+
+  it('#340 a pack added through packs:add (or enabled through packs:setEnabled) is probed in the background: the verdict lands without a Refresh, under the reconcile’s own cache key, the picker is told, an ask in between says "no full-text index", and a lock mid-probe writes nothing', async () => {
+    const h = await sessionHarness()
+    try {
+      const db = h.db()
+      // Serving names are the leaf without `.zim` (D-Z11), so the responder keys on the leaf.
+      h.hooks.respond = suggestFor(new Set(['alpha-indexed']))
+
+      // ---- (1) ONE add batch, two files: both confirmed, one sidecar start, no Refresh ------
+      dialogState.paths = [h.addPackFile('alpha-indexed.zim'), h.addPackFile('bravo-noindex.zim')]
+      const noticesBefore = h.notices.length
+      const spawnsBefore = h.serveSpawns.length
+      const { result } = await invoke(handlers, IPC.addKnowledgePacks)
+      const added = (result as KnowledgePackAddResult).added
+      expect(added).toHaveLength(2)
+      const alpha = added.find((p) => p.leaf === 'alpha-indexed.zim')!.id
+      const bravo = added.find((p) => p.leaf === 'bravo-noindex.zim')!.id
+      // The add RESOLVED before the probe ran (D3: never on the caller's critical path).
+      expect(searchableOf(h, alpha)).toEqual({ searchable: null, searchable_key: null })
+      expect(searchableOf(h, bravo)).toEqual({ searchable: null, searchable_key: null })
+      expect(
+        await waitUntil(() => searchableOf(h, alpha).searchable === 'yes' && searchableOf(h, bravo).searchable === 'no')
+      ).toBe(true)
+      // Once per batch, after the loop: ONE sidecar start, one /suggest per pack.
+      expect(h.serveSpawns.length - spawnsBefore).toBe(1)
+      expect(suggestsSince(h, 0).filter((u) => u.includes('alpha-indexed'))).toHaveLength(1)
+      expect(suggestsSince(h, 0).filter((u) => u.includes('bravo-noindex'))).toHaveLength(1)
+      // The verdict is keyed exactly as the reconcile keys it: `<size>:<mtime>:<tools fingerprint>`.
+      const keyAlpha = searchableOf(h, alpha).searchable_key
+      expect(keyAlpha).toMatch(/^\d+:[\d.]+:.+$/)
+      // …and the picker / panel were told, under THIS session's epoch, after the verdict landed.
+      const mutation = h.notices.slice(noticesBefore).filter((n) => n.reason === 'mutation')
+      expect(mutation.length).toBeGreaterThan(0)
+      expect(mutation[mutation.length - 1]!.epoch).toBe(h.ctrl.unlockEpoch())
+      // An ask in between now reports the index-less pack honestly: skipped, not failed.
+      const arm = h.svc.makeArm(db, [bravo])
+      const { outcomes } = await arm!('alpha climate', new AbortController().signal)
+      expect(outcomes).toEqual([expect.objectContaining({ packId: bravo, status: 'skipped', reason: 'not-searchable' })])
+
+      // ---- (2) the next Refresh asks NOTHING again — same key, verdict kept ---------------
+      const mark = h.requests.length
+      await h.svc.reconcile(db) // the whole pass, its end-probe included
+      expect(suggestsSince(h, mark)).toEqual([])
+      expect(searchableOf(h, alpha)).toEqual({ searchable: 'yes', searchable_key: keyAlpha })
+      expect(searchableOf(h, bravo).searchable).toBe('no')
+
+      // ---- (3) ENABLE after a registration that never probed ----------------------------
+      // The direct service API does not schedule (the IPC layer owns the trigger); the pack
+      // stays unknown through a disable, and the enable through packs:setEnabled probes it.
+      const charlie = await h.registerPack('charlie-indexed.zim')
+      h.hooks.respond = suggestFor(new Set(['alpha-indexed', 'charlie-indexed']))
+      await invoke(handlers, IPC.setKnowledgePackEnabled, charlie, false)
+      for (let i = 0; i < 10; i++) await tick() // a ceiling, not a proof: nothing probed a disable
+      expect(searchableOf(h, charlie).searchable).toBeNull()
+      await invoke(handlers, IPC.setKnowledgePackEnabled, charlie, true)
+      expect(await waitUntil(() => searchableOf(h, charlie).searchable === 'yes')).toBe(true)
+
+      // ---- (4) a LOCK landing while the probe's /suggest is parked writes nothing --------
+      h.hooks.respond = suggestFor(new Set(['alpha-indexed', 'charlie-indexed', 'delta-indexed']))
+      const probeGate = serveGate<void>()
+      h.hooks.beforeRespond = async (url) => {
+        if (url.startsWith('/suggest')) await probeGate.wait()
+      }
+      dialogState.paths = [h.addPackFile('delta-indexed.zim')]
+      const { result: r4 } = await invoke(handlers, IPC.addKnowledgePacks)
+      const delta = (r4 as KnowledgePackAddResult).added[0]!.id
+      await probeGate.entered // the probe is inside its request when the lock arms
+      const { lockP } = await parkedLock(h)
+      h.hooks.beforeRespond = async () => undefined
+      probeGate.release() // the response arrives — into an aborted operation
+      h.releaseSuspend()
+      await lockP
+      expect(h.ctrl.isUnlocked()).toBe(false)
+      expect(h.transientEntries()).toEqual([])
+      // A fresh session through the real unlock handler: the row is still unknown (no post-lock
+      // write) — and that session's reconcile-end probe then confirms it, unprompted.
+      const { result: unlocked } = await invoke(handlers, IPC.unlockWorkspace, 'right-password')
+      expect(unlocked).toMatchObject({ ok: true })
+      expect(searchableOf(h, delta).searchable).toBeNull()
+      expect(await waitUntil(() => searchableOf(h, delta).searchable === 'yes', 2_000)).toBe(true)
+    } finally {
+      await h.close()
+    }
+  }, 60_000)
+})

--- a/apps/desktop/tests/integration/zim-ipc.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc.test.ts
@@ -79,6 +79,9 @@ function fakeZimService(db: () => Db, zimDir: string): unknown {
     registerPack: (d: Db, p: string) => packs.registerPack(d, deps, p),
     removePack: (d: Db, id: string) => packs.removePack(d, id),
     setPackEnabled: (d: Db, id: string, enabled: boolean) => packs.setPackEnabled(d, id, enabled),
+    // #340 (D-Z15): the post-add / post-enable probe is a background service pass; this stand-in
+    // has no sidecar, and the behaviour is driven against the REAL service in zim-ipc-session.
+    scheduleSearchabilityProbe: () => undefined,
     getArticle: async () => null,
     makeArm: () => null,
     // #301 P3b: `packs:add` opens the native picker under a service-owned operation. This

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1833,7 +1833,9 @@ into `RetrievalScope.noDocuments` only when no file is attached to the chat (att
 stay in scope); `buildScopeFilter`, the resident-vector fast path and `retrieve`'s pre-embed
 skip all honour it. A pack's searchability is CONFIRMED only by a validated `/suggest`
 probe (`GET /suggest?content=<name>&term=the&count=1`, `'yes'` iff the body is a JSON array
-with a `kind:"pattern"` entry) run once at the end of a reconciliation, under the SAME
+with a `kind:"pattern"` entry) run at the end of a reconciliation and, in the background, once
+per completed `packs:add` batch and on `packs:setEnabled(…, true)` (`ZimService.scheduleSearchabilityProbe`,
+rag-design D-Z15, #340 — a `packs:changed` `'mutation'` follows a landed verdict), under the SAME
 request guard as an ask, and cached against `<file size>:<file mtime>:<kiwix-serve binary
 size>:<mtime>` — a 404, a timeout, a malformed body or a response observed across a server
 change never confirms "no"; a confirmed-no pack is skipped by an ask but stays readable.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2533,8 +2533,10 @@ reports and phase plans were working papers; their full text lives in git histor
   archive's own metadata tag is a hint only. The app confirms full-text search capability
   with one request to the pack server (cached against the archive file and the
   kiwix-tools build, so a replaced file or a new tools install re-checks automatically,
-  and Refresh re-runs it too); until that check completes, the pack is treated as
-  searchable. A 404, a timeout, a malformed reply, or a reply observed across a
+  and Refresh re-runs it too). The check runs when you unlock, when you press Refresh, and — a
+  moment after — when you add a pack through *Add packs…* or enable one; until it completes,
+  the pack is treated as searchable, so a question asked in that moment against an index-less
+  pack reports "search failed" rather than "no full-text index". A 404, a timeout, a malformed reply, or a reply observed across a
   pack-server restart never confirms "no" — only a clean, positive or negative reply
   does. A pack confirmed to have no full-text index is skipped for asking ("not searched:
   no full-text index") but stays fully readable in the article viewer, which never

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2561,6 +2561,8 @@ offline article viewer. Files are registered in place, never copied.
   unknown. The key (`<file size>:<file mtime>:<kiwix-serve binary size>:<mtime>`) resets a
   row to unknown whenever it changes — a replaced file, a healed path with a different
   size, or a tools-bundle swap all re-probe automatically; Refresh re-runs the same pass.
+  The reconcile is no longer the only trigger: a completed `packs:add` batch and an enable
+  schedule the same probe in the background — **D-Z15** below (#340).
   Cost, accepted: a session whose registered packs are all confirmed wakes no sidecar at
   all; a session with one unknown pack costs one background sidecar start (~0.8 s) at that
   session's reconcile. A confirmed-`'no'` pack is skipped by the ask (outcome
@@ -2624,6 +2626,31 @@ offline article viewer. Files are registered in place, never copied.
   line is scrubbed from the persisted answer; archive candidates are charged against the SAME
   context budget as document chunks, in both directions. Tests: `zim-prompt-framing.test.ts`,
   T01-a/b/c.
+- **D-Z15 — the searchability probe runs after Add packs… and Enable too (follow-up wave,
+  2026-09-06; #340, the owner's T19 observation).** D-Z11's probe ran only at the end of a
+  reconciliation, so a pack registered through `packs:add` — or enabled after being registered
+  disabled, which the reconcile's enabled ∧ available filter skipped — stayed `unknown` (tickable,
+  no badge) until the next Refresh or unlock, and an ask in between reported an index-less pack as
+  `search-failed` (the `/search` 404) instead of `not-searchable`. `ZimService.scheduleSearchabilityProbe(getDb)`
+  is the second trigger: the IPC layer calls it ONCE per completed `packs:add` batch (after the
+  loop — a probe started between two files of one batch would be discarded as stale by the second
+  file's revision bump, a wasted sidecar start) and on `packs:setEnabled(…, true)` when the flag
+  actually changed; the direct service API does not schedule (its many unit callers count
+  starts and generations). Never on the caller's critical path (a zero timer, D3; `getDb` is read
+  when the pass runs, so a workspace that locked meanwhile is refused by admission before any
+  handle is touched); single-flight with one coalesced rerun like `reconcile()`; a no-op while a
+  reconciliation is in flight (that pass's end-probe sees the new row). The pass is a registered
+  `zim-reconcile` operation (the lock's `abortAll` + bounded settle reach it) that runs the
+  reconcile's `resetStaleSearchability` key pass FIRST — a freshly registered row has no
+  `searchable_key`, and a verdict stored under a NULL key would be reset and re-probed by the next
+  reconcile — then the same `withServer`-guarded `probeUnknownSearchability` and the same
+  conditional write, and emits `packs:changed` `'mutation'` after a verdict landed so the panel and
+  the picker refetch without a Refresh. An `AbortError` writes nothing and is not logged; a
+  `StaleServerError` leaves unknown as before. Test: `zim-ipc-session.test.ts` "#340 a pack added
+  through packs:add (or enabled …) is probed in the background …" (one batch of two files →
+  yes/no with ONE sidecar start and no Refresh; the next Refresh issues no `/suggest`; enable
+  after a never-probed registration; a lock landing mid-probe writes nothing and the next
+  session's reconcile confirms). Red with the IPC trigger removed.
 
 ### Module map
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -818,6 +818,8 @@ Wikivoyage, …) at `library.kiwix.org`; download once, use forever offline.
    server restarted mid-question. In the sources picker, a greyed-out pack always says why
    it can't be ticked — file missing, a different archive at that location, disabled, or no
    full-text search index; the panel itself shows a "No full-text index" badge on such a pack.
+   The app checks that a moment after you add or enable a pack (and when you unlock or press
+   Refresh), so the badge appears on its own.
 
 Removing a pack's registration (the **Remove** button) only forgets it — the file itself is
 never deleted. An article from a pack that has no full-text search index is still readable:


### PR DESCRIPTION
Refs #340 (residual: searchability stays unknown after *Add packs…* until the next Refresh). Refs #301. **Stacked on #348** (`fix/344-failed-lock-rearm`) — the two PRs extend the same BUILD_STATE wave entry; retarget to `master` and rebase once #348 lands.

## What

The `/suggest` searchability probe (D-Z11) ran only at the END of a reconciliation, so a pack registered through `packs:add` — or enabled after being registered disabled, which the reconcile's enabled ∧ available filter skips — stayed `unknown` (tickable, no badge) until the next Refresh or unlock; an ask in between reported an index-less pack as `search-failed` (the `/search` 404) instead of `not-searchable`. The owner's T19 observation on the real K: drive.

## Fix (rag-design §17 **D-Z15**)

`ZimService.scheduleSearchabilityProbe(getDb)` — the second trigger. The IPC layer calls it ONCE per completed `packs:add` batch (after the loop: a probe started between two files would be discarded as stale by the second file's revision bump, a wasted sidecar start) and on `packs:setEnabled(…, true)` when the flag changed. The direct service API does not schedule (its unit callers count starts and generations). Never on the caller's critical path (a zero timer; `getDb` is read when the pass runs, so a workspace that locked meanwhile is refused by admission first); single-flight with one coalesced rerun like `reconcile()`; a no-op while a reconciliation is in flight. The pass is a registered `zim-reconcile` operation that runs the reconcile's `resetStaleSearchability` key pass FIRST (a fresh row has no `searchable_key`; a verdict under a NULL key would be reset and re-probed by the next reconcile), then the same `withServer`-guarded `probeUnknownSearchability` and the same conditional write, and emits `packs:changed` `'mutation'` after a verdict lands so the panel and picker refetch without a Refresh. An `AbortError` writes nothing (not logged); a `StaleServerError` leaves unknown as before. No shape, channel or preload change; the D-Z10 op/epoch contract holds (assert after every await, before the write, release in `finally`).

Blast-radius note: `tmp/340-residuals.md` PR A (maintainer-local).

## Tests

`zim-ipc-session.test.ts` — NEW "#340 a pack added through packs:add (or enabled through packs:setEnabled) is probed in the background …": real vault, real handlers, real service + registry, fake children, the loopback stand-in answering `/suggest` the way the pinned binary does. Legs: (1) one batch of two files → alpha `yes` / bravo `no` with ONE sidecar start and no Refresh, the add resolved before the probe ran, the verdict keyed `<size>:<mtime>:<fingerprint>`, a `mutation` notice under the session epoch, the arm over bravo → `skipped/not-searchable`; (2) the next Refresh issues NO `/suggest`; (3) enable after a never-probed registration; (4) a lock landing while the probe's request is parked writes nothing — still unknown after the real unlock, then confirmed by that session's reconcile. **Anti-test:** with the IPC trigger stashed the leg goes red (`expected false to be true` at leg 1). `zim-ipc.test.ts`'s fake service gained the method. Suites run: zim-ipc-session + zim-ipc (24/24), repo-hygiene + zim-packs + zim-service-lifecycle + zim-arm (87/88 — the zim-arm P1b abort leg failed under load and is green alone, the listed flake); typecheck green.

## Docs

rag-design §17 D-Z15 (+ a pointer in D-Z11), data-contracts "Retrieval outcomes and searchability", known-limitations "Whether a pack can be searched…", user-guide §7b step 6, CHANGELOG `[Unreleased]` › Fixed, BUILD_STATE (the wave entry's step 2; item 21(l) residual closed). The two owner questions for the remaining 21(l) residuals (non-ASCII add failure: message vs metadata; LaTeX: strip / normalise / render) are posted on #340 — their code waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
