### PR TITLE
feat(zim): surface serving-name collisions in the panel via packs:status.excluded (#340, D-Z16)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -113,7 +113,9 @@ the failure; red with the fix reverted). Docs: troubleshooting "Could not lock t
 post-registration searchability probe (`fix/340-post-registration-probe`, stacked on step 1; paper `tmp/340-residuals.md`):** `ZimService.scheduleSearchabilityProbe` — once per completed
 `packs:add` batch and on enable, the reconcile's key pass first, the same guarded probe and conditional write, a `'mutation'` notice after a verdict; record rag-design **D-Z15**; test
 `zim-ipc-session` "#340 …" (four legs, red without the trigger). Owner questions (b) non-ASCII message vs metadata and (c) LaTeX strip / normalise / render posted on #340 — their
-code waits. Next: 21(l) `packs:status.excluded`, the UI nits, then #339, then #340 capabilities._
+code waits. **Step 3 — 21(l) the collision surface (`feat/340-packs-status-excluded`, stacked on step 2):** `KnowledgePackStatus.excluded?` from the service's memory (registry
+recompute at reconcile end + every mutation, the build authoritative, reset on suspend; the exempt channel never reads the DB), a "Not served" badge naming the winner on the
+loser's row; record rag-design **D-Z16**; tests `zim-ipc-session` "#340 packs:status.excluded …", `KnowledgePacks.test.tsx`. Next: the UI nits, then #339, then #340 capabilities._
 
 _2026-09-06 — **ZIM knowledge packs (PR #294 → #301) — WAVE CLOSED: Phases 0–7 complete, #294 MERGED to master (`92e86a07`, 16:12 UTC), #301 closed by the merge.**_
 The PR's review remediation — 28 findings (H1–H4, M1–M11, L1–L9 with L10 withdrawn, DOC-1–DOC-4; three assessed High, H3 and DOC-1/DOC-2 Medium) — closed across P0–P6 on the integration branch `feat/zim-knowledge-packs`;
@@ -716,8 +718,7 @@ open round's item stays the last block of §5.)
     (j) **P4 — CLOSED (2026-09-06):** M3/M6/M7/M8/M10 — effective documents-off scope, reranker-failure interleave, fair pack allocation under a per-ask deadline, refreshable searchability, per-ask
     pack outcomes. Record: rag-design D-Z4/D-Z11/D-Z12.
     (k) **P6 — CLOSED (2026-09-06):** T18-a implemented (design/frontend review); the (c) "Open article from a review" residual closed. Record: design-guidelines §11.15.
-    (l) **P7 residual register (2026-09-06):** the collision surface (`packs:status.excluded` addition — P9 issue; served-library fact, not a pack-row fact — the per-answer "not-served" row covers it
-    today); PacksPanel: an unavailable pack can only be removed, not disabled (low, P9); every row's action buttons disable while one row is busy (low, P9); ChatScreen refetches on both
+    (l) **P7 residual register (2026-09-06):** the collision surface — CLOSED, follow-up wave step 3 (`packs:status.excluded`, rag-design D-Z16; the per-answer "not-served" row stays); PacksPanel: an unavailable pack can only be removed, not disabled (low, P9); every row's action buttons disable while one row is busy (low, P9); ChatScreen refetches on both
     `reconcile-start` and `-end` of one epoch (cosmetic, P9); the pack meta line shows the raw ISO 639-3 code unlabelled (copy nit, P9); `.footer-menu-btn` has no overflow rule of its own (low, P9);
     accepted deviation: the ScopePopover is non-modal (design-guidelines §11.15 decision 1, P6); T18-b — RECORDED 2026-09-06 (run by the orchestrator at the owner's request in real Electron against the real packs; rag-design §17 "Real acceptance" → "T18-b"; it surfaced T19 finding 3: kiwix-serve 3.8.1 win-x86_64 cuts ~5–20 % of large /raw reads short (the body's last part never arrives) — upstream, mitigated by the P7 fix PR 2, upstream report on #339); T19 the owner's Electron/drive legs — (vi) the relocated drive with
     persisted citations and (vii) live lock/unlock/failed lock PASSED 2026-09-06 on the real K: drive (rag-design §17 "Real acceptance" → "The owner's legs"; observations: a failed lock leaves the chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **The knowledge-packs panel now says when two packs clash on a file name.** Two archives with
+  the same file name in different folders cannot both be served — only the earlier one is — and
+  the panel used to show both as simply "Enabled", with the reason visible only in the note under
+  an answer. The later pack now carries a "Not served" badge and a line naming the pack that keeps
+  the name, with the fix (rename one file).
 - **A knowledge pack you just added is checked for full-text search right away.** Until now the
   check ran only when you unlocked or pressed Refresh, so a pack added through *Add packs…* (or
   enabled after being added) showed no "No full-text index" badge until then, and a question asked

--- a/apps/desktop/src/main/ipc/registerZimIpc.ts
+++ b/apps/desktop/src/main/ipc/registerZimIpc.ts
@@ -58,8 +58,16 @@ export function registerZimIpc(ctx: AppContext): void {
 
   ipcHandle(IPC.getKnowledgePackStatus, (): KnowledgePackStatus => {
     const svc = ctx.zim
-    if (!svc) return { toolsInstalled: false, refreshing: false, revision: 0 }
-    return { toolsInstalled: svc.toolsInstalled(), refreshing: svc.refreshing(), revision: svc.revision() }
+    if (!svc) return { toolsInstalled: false, refreshing: false, revision: 0, excluded: null }
+    // In-memory reads only — this is the ONE lock-exempt `packs:*` channel. `excluded` (#340,
+    // D-Z16) is the service's last computed collision list, copied for the wire.
+    const excluded = svc.excluded()
+    return {
+      toolsInstalled: svc.toolsInstalled(),
+      refreshing: svc.refreshing(),
+      revision: svc.revision(),
+      excluded: excluded === null ? null : excluded.map((e) => ({ packId: e.packId, collidesWith: e.collidesWith }))
+    }
   })
 
   // Kick off a background reconciliation pass (#301 P3b, finding L7, plan §9.17 (e)2). Never

--- a/apps/desktop/src/main/services/zim/identity.ts
+++ b/apps/desktop/src/main/services/zim/identity.ts
@@ -1,4 +1,5 @@
 import { closeSync, openSync, readSync } from 'node:fs'
+import type { KnowledgePackCollision } from '../../../shared/types'
 
 // ZIM ARCHIVE IDENTITY and the SERVING-NAME MAP (#301 P3b, findings M5 and L4; plan §9.17 (d)).
 //
@@ -130,12 +131,10 @@ export function servingNameFor(path: string, platform: NodeJS.Platform = process
   return name
 }
 
-/** One pack excluded from the served library because an earlier book already owns its name. */
-export interface ServingNameCollision {
-  packId: string
-  /** The pack id that KEEPS the name (the smaller UUID — libkiwix's own first-wins rule). */
-  collidesWith: string
-}
+/** One pack excluded from the served library because an earlier book already owns its name
+ *  (`collidesWith` KEEPS it — the smaller UUID, libkiwix's own first-wins rule). The shared
+ *  shape since #340 (D-Z16): `packs:status.excluded` carries it to the panel. */
+export type ServingNameCollision = KnowledgePackCollision
 
 export interface ServedNameSet {
   /** pack id → the name kiwix-serve will answer to. Winners only. */

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -25,6 +25,7 @@ import {
   resetStaleSearchability,
   retrievablePacks,
   servedCandidates,
+  servedRegistryRows,
   setPackEnabled,
   unknownSearchablePacks,
   writeLibraryXml,
@@ -379,6 +380,11 @@ export class ZimService {
   private probeInFlight: Promise<void> | null = null
   /** A probe was requested while one ran: run exactly ONE more afterwards. */
   private probeAgain = false
+  /** The collision losers of the served set (#340, D-Z16) — `packs:status.excluded`. Null until
+   *  this session computed one (a reconciliation, a mutation or a library build); reset on
+   *  suspend, so a locked workspace's list never outlives it. In memory only: `packs:status` is
+   *  the lock-exempt channel and must not read the database. */
+  private lastExcluded: ServingNameCollision[] | null = null
 
   constructor(opts: ZimServiceOptions) {
     this.opts = opts
@@ -538,6 +544,7 @@ export class ZimService {
       )
       own.assert()
       this.invalidateLibrary()
+      this.refreshExcludedFromRegistry(db)
       // Mutation producer (plan §9.17 (e)3): AFTER the assert, so a registration that finished
       // under an old epoch (the op above would have thrown) never announces itself.
       this.emitPacksChanged(own, 'mutation', this.refreshing())
@@ -581,6 +588,27 @@ export class ZimService {
     return this.reconcileInFlight !== null
   }
 
+  /** The served set's collision losers as last computed this session, or null before any
+   *  reconciliation / mutation / build computed one (#340, D-Z16) — `packs:status.excluded`. */
+  excluded(): ReadonlyArray<ServingNameCollision> | null {
+    return this.lastExcluded
+  }
+
+  /**
+   * Recompute the collision surface from the REGISTRY (no disk probe, D-Z16): the reconcile
+   * writes the resolved winner into `recorded_path`, and the serving name depends only on the
+   * leaf, so this matches the build's own computation up to files that vanished since the last
+   * pass. Called under the producing operation, before its `packs:changed` notice, so the panel's
+   * refetch already sees it. Best-effort: a read failure keeps the previous list.
+   */
+  private refreshExcludedFromRegistry(db: Db): void {
+    try {
+      this.lastExcluded = computeServedSet(servedRegistryRows(db), this.opts.platform ?? process.platform).excluded
+    } catch {
+      /* the next reconciliation or build recomputes it */
+    }
+  }
+
   private async reconcileOnce(db: Db): Promise<void> {
     const op = this.beginOp('zim-reconcile')
     try {
@@ -592,6 +620,7 @@ export class ZimService {
       )
       op.assert()
       if (report.changed) this.invalidateLibrary()
+      this.refreshExcludedFromRegistry(db)
       // The capability probe runs at the END of the pass (#301 P4, finding M7; plan §9.21
       // (d)5) — after the reconcile has settled availability and the served set, and BEFORE
       // `reconcile-end`, so the panel refetches ONCE and already sees the verdicts.
@@ -752,6 +781,7 @@ export class ZimService {
       const removed = removePack(db, id)
       if (removed) {
         this.invalidateLibrary()
+        this.refreshExcludedFromRegistry(db)
         // Mutation producer (plan §9.17 (e)3) — only on a REAL change, like reconcile's own
         // `report.changed` gate; a no-op remove (unknown id) announces nothing.
         this.emitPacksChanged(op, 'mutation', this.refreshing())
@@ -769,6 +799,7 @@ export class ZimService {
       const changed = setPackEnabled(db, id, enabled)
       if (changed) {
         this.invalidateLibrary()
+        this.refreshExcludedFromRegistry(db)
         this.emitPacksChanged(op, 'mutation', this.refreshing())
       }
       return changed
@@ -1097,6 +1128,7 @@ export class ZimService {
       const served = computeServedSet(resolved, this.opts.platform ?? process.platform)
       names = served.names
       excluded = served.excluded
+      this.lastExcluded = [...excluded] // the authoritative (disk-resolved) list, D-Z16
       if (excluded.length > 0) {
         // Ids only — a title or a path names what the user reads (the sentinel rule).
         log.warn('Knowledge packs excluded from the served library: serving-name collision', {
@@ -1256,6 +1288,8 @@ export class ZimService {
     inFlight?.abort.abort()
     const stale = this.published
     this.published = null
+    // D-Z16: a locked workspace's collision list must not outlive it on the exempt channel.
+    this.lastExcluded = null
     await this.enqueue(() => this.teardownPublished(stale))
   }
 

--- a/apps/desktop/src/main/services/zim/packs.ts
+++ b/apps/desktop/src/main/services/zim/packs.ts
@@ -700,6 +700,17 @@ function servedSignature(db: Db): Map<string, string> {
   return new Map(rows.map((r) => [r.id, r.recorded_path]))
 }
 
+/**
+ * The registry's own view of the served set — every enabled ∧ available ∧ non-tombstoned row
+ * with its recorded path — for the collision surface BETWEEN library builds (#340, D-Z16). No
+ * disk probe: the serving name depends only on the file's leaf (D-Z11), which the
+ * `<drive>/zim/<leaf>` and recorded-path candidates share, so this equals the build's own
+ * `computeServedSet` input up to files that vanished since the last reconciliation.
+ */
+export function servedRegistryRows(db: Db): Array<{ id: string; path: string }> {
+  return [...servedSignature(db)].map(([id, path]) => ({ id, path }))
+}
+
 function sameSignature(a: Map<string, string>, b: Map<string, string>): boolean {
   if (a.size !== b.size) return false
   for (const [id, path] of a) if (b.get(id) !== path) return false

--- a/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
+++ b/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
@@ -4,6 +4,7 @@ import type {
   KnowledgePackAddFailureReason,
   KnowledgePacksChangedEvent
 } from '@shared/types'
+import type { KnowledgePackCollision } from '@shared/types'
 import type { MessageKey } from '@shared/i18n'
 import { Badge, Button, ConfirmDialog, EmptyState, ErrorBanner, Spinner, useToast } from '../../components'
 import { friendlyIpcError } from '../../lib/errors'
@@ -53,6 +54,9 @@ export function PacksPanel(): JSX.Element {
   const showToast = useToast()
   const [packs, setPacks] = useState<KnowledgePack[] | null>(null)
   const [toolsInstalled, setToolsInstalled] = useState(true)
+  // #340 (rag-design D-Z16): the served library's collision losers from `packs:status` — a
+  // served-library fact, not a row field. Null until the session computed one (or an older main).
+  const [excluded, setExcluded] = useState<KnowledgePackCollision[] | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<'add' | 'refresh' | string | null>(null)
@@ -78,6 +82,7 @@ export function PacksPanel(): JSX.Element {
       if (!mountedRef.current) return
       setToolsInstalled(status.toolsInstalled)
       setRefreshing(status.refreshing)
+      setExcluded(status.excluded ?? null)
       setPacks(list)
     } catch (e) {
       if (!mountedRef.current) return
@@ -248,6 +253,16 @@ export function PacksPanel(): JSX.Element {
               : notSearchable
                 ? t('packs.state.notSearchableTitle')
                 : null
+            // #340 (D-Z16): a collision loser is enabled and available yet NOT served — its own
+            // badge beside the state badge, and a visible line that names the winner when the
+            // list knows it (the winner is another registered pack; a stale list may not).
+            const collision = p.available && p.enabled ? (excluded?.find((e) => e.packId === p.id) ?? null) : null
+            const winner = collision ? (packs.find((k) => k.id === collision.collidesWith) ?? null) : null
+            const collisionText = collision
+              ? winner
+                ? t('packs.state.notServedTitle', { title: winner.title })
+                : t('packs.state.notServedTitleUnknown')
+              : null
             return (
               <li key={p.id} className={`card packs-card ${p.available ? '' : 'packs-card-missing'}`}>
                 <div className="packs-card-head">
@@ -276,8 +291,14 @@ export function PacksPanel(): JSX.Element {
                       {t('packs.state.notSearchable')}
                     </Badge>
                   )}
+                  {collisionText && (
+                    <Badge tone="warning" icon="⚠" title={collisionText}>
+                      {t('packs.state.notServed')}
+                    </Badge>
+                  )}
                 </div>
                 {reasonText && <p className="packs-card-reason hint">{reasonText}</p>}
+                {collisionText && <p className="packs-card-reason hint">{collisionText}</p>}
                 {p.description && <p className="packs-card-desc hint">{p.description}</p>}
                 <p className="packs-card-meta hint">{metaLine(p)}</p>
                 <div className="packs-card-actions">

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2755,6 +2755,13 @@ export const de: Record<keyof typeof en, string> = {
   'packs.state.notSearchable': 'Kein Volltextindex',
   'packs.state.notSearchableTitle':
     'Dieses Archiv hat keinen Volltextindex. Beim Fragen wird es übersprungen, seine Artikel bleiben aber lesbar.',
+  // #340 (rag-design D-Z16): ein Merkmal der bereitgestellten Bibliothek aus `packs:status.excluded` —
+  // zwei Dateien ergeben denselben Servernamen, und libkiwix behält nur das frühere Archiv.
+  'packs.state.notServed': 'Nicht bereitgestellt',
+  'packs.state.notServedTitle':
+    'Der Dateiname kollidiert mit „{title}“, deshalb wird nur dieses Paket bereitgestellt – diese Datei umbenennen, um beide zu nutzen.',
+  'packs.state.notServedTitleUnknown':
+    'Der Dateiname kollidiert mit dem eines anderen Pakets, deshalb wird nur jenes bereitgestellt – diese Datei umbenennen, um beide zu nutzen.',
   'packs.enable': 'Aktivieren',
   'packs.disable': 'Deaktivieren',
   'packs.working': 'Wird ausgeführt…',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2734,6 +2734,13 @@ export const en = {
   'packs.state.notSearchable': 'No full-text index',
   'packs.state.notSearchableTitle':
     'This archive has no full-text search index. It is skipped when asking, but its articles stay readable.',
+  // #340 (rag-design D-Z16): a served-library fact from `packs:status.excluded` — two files
+  // compute the same serving name, and libkiwix keeps only the earlier archive.
+  'packs.state.notServed': 'Not served',
+  'packs.state.notServedTitle':
+    'Its file name clashes with “{title}”, so only that pack is served — rename this file to use both.',
+  'packs.state.notServedTitleUnknown':
+    'Its file name clashes with another pack’s, so only that pack is served — rename this file to use both.',
   'packs.enable': 'Enable',
   'packs.disable': 'Disable',
   'packs.working': 'Working…',

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1983,6 +1983,21 @@ export interface KnowledgePackStatus {
   toolsInstalled: boolean
   refreshing: boolean
   revision: number
+  /**
+   * The packs left OUT of the served library because an earlier archive (the smaller UUID —
+   * libkiwix's own first-wins rule, rag-design D-Z11) already owns their serving name (#340,
+   * D-Z16). A served-library fact, not a pack-row fact: computed from the registry at every
+   * reconciliation and mutation, and from the resolved set at every library build. Additive;
+   * absent (an older main) or `null` (nothing computed yet this session) both read "not known".
+   */
+  excluded?: KnowledgePackCollision[] | null
+}
+
+/** One pack excluded from the served library because an earlier book already owns its name. */
+export interface KnowledgePackCollision {
+  packId: string
+  /** The pack id that KEEPS the name. */
+  collidesWith: string
 }
 
 /**

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -87,7 +87,7 @@ import { registerZimIpc } from '../../src/main/ipc/registerZimIpc'
 import { registerWorkspaceIpc } from '../../src/main/ipc/registerWorkspaceIpc'
 import { IPC } from '../../src/shared/ipc'
 import { DEFAULT_POLICY } from '../../src/main/services/policy'
-import type { KnowledgePackAddResult, PrivacyPolicy } from '../../src/shared/types'
+import type { KnowledgePackAddResult, KnowledgePackStatus, PrivacyPolicy } from '../../src/shared/types'
 import {
   WorkspaceController,
   createEncryptedVaultOnDisk,
@@ -2364,6 +2364,62 @@ describe('#340 — searchability is confirmed right after Add packs… / Enable 
       expect(unlocked).toMatchObject({ ok: true })
       expect(searchableOf(h, delta).searchable).toBeNull()
       expect(await waitUntil(() => searchableOf(h, delta).searchable === 'yes', 2_000)).toBe(true)
+    } finally {
+      await h.close()
+    }
+  }, 60_000)
+
+  // #340 (rag-design D-Z16): the collision surface. `packs:status` is the ONE lock-exempt
+  // `packs:*` channel — in-memory only — so `excluded` is the service's last computed list:
+  // null before this session computed one, recomputed from the registry at every reconciliation
+  // and mutation (no disk probe), authoritative at a library build, reset by the lock.
+  it('#340 packs:status.excluded names the serving-name collision loser: null before the session computed it, [] after a clean reconcile, the larger UUID after a same-leaf registration, cleared by disabling the loser, null again after a lock, recomputed by the next session', async () => {
+    const h = await sessionHarness()
+    try {
+      const db = h.db()
+      const status = async (): Promise<KnowledgePackStatus> =>
+        (await invoke(handlers, IPC.getKnowledgePackStatus)).result as KnowledgePackStatus
+      expect((await status()).excluded).toBeNull() // nothing computed yet this session
+      await h.svc.reconcile(db)
+      expect((await status()).excluded).toEqual([])
+
+      // Two archives with the SAME leaf in different folders compute the same serving name;
+      // libkiwix keeps the smaller UUID (D-Z11), so the larger one is the loser.
+      const first = await h.registerPack('same-leaf.zim', packUuid('0000cc03', 'first'))
+      const elsewhere = join(h.root, 'elsewhere')
+      mkdirSync(elsewhere, { recursive: true })
+      const secondPath = writeZimFixture(join(elsewhere, 'same-leaf.zim'), packUuid('0000cc03', 'second'), {
+        trailing: 'body of the second same-leaf archive'
+      })
+      const second = (await h.svc.registerPack(db, secondPath)).id
+      const [winnerId, loserId] = first < second ? [first, second] : [second, first]
+      expect((await status()).excluded).toEqual([{ packId: loserId, collidesWith: winnerId }])
+      // …and a library BUILD agrees (the authoritative, disk-resolved computation).
+      const library = await h.svc.ensureServer(db)
+      expect(library?.excluded).toEqual([{ packId: loserId, collidesWith: winnerId }])
+      expect((await status()).excluded).toEqual([{ packId: loserId, collidesWith: winnerId }])
+
+      // Disabling the loser clears the collision; enabling it brings it back — both from the
+      // registry, without a sidecar or a disk probe.
+      await invoke(handlers, IPC.setKnowledgePackEnabled, loserId, false)
+      expect((await status()).excluded).toEqual([])
+      await invoke(handlers, IPC.setKnowledgePackEnabled, loserId, true)
+      expect((await status()).excluded).toEqual([{ packId: loserId, collidesWith: winnerId }])
+
+      // A lock resets it (the exempt channel must not carry a closed workspace's list); the
+      // next session's reconciliation recomputes it.
+      await invoke(handlers, IPC.lockWorkspace)
+      expect(h.ctrl.isUnlocked()).toBe(false)
+      expect((await status()).excluded).toBeNull()
+      const { result: unlocked } = await invoke(handlers, IPC.unlockWorkspace, 'right-password')
+      expect(unlocked).toMatchObject({ ok: true })
+      expect(
+        await waitUntil(() => {
+          const s = h.svc.excluded()
+          return s !== null && s.length === 1 && s[0]!.packId === loserId
+        }, 2_000)
+      ).toBe(true)
+      expect((await status()).excluded).toEqual([{ packId: loserId, collidesWith: winnerId }])
     } finally {
       await h.close()
     }

--- a/apps/desktop/tests/integration/zim-ipc.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc.test.ts
@@ -76,6 +76,8 @@ function fakeZimService(db: () => Db, zimDir: string): unknown {
     },
     refreshing: () => false,
     revision: () => 0,
+    excluded: () => null, // #340 (D-Z16): nothing computed by this stand-in
+
     registerPack: (d: Db, p: string) => packs.registerPack(d, deps, p),
     removePack: (d: Db, id: string) => packs.removePack(d, id),
     setPackEnabled: (d: Db, id: string, enabled: boolean) => packs.setPackEnabled(d, id, enabled),
@@ -249,7 +251,8 @@ describe('packs IPC', () => {
     expect((await invoke(handlers, IPC.getKnowledgePackStatus)).result).toEqual({
       toolsInstalled: false,
       refreshing: false,
-      revision: 0
+      revision: 0,
+      excluded: null // #340 (D-Z16): no service ⇒ nothing computed
     })
   })
 

--- a/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
+++ b/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
@@ -103,6 +103,82 @@ describe('PacksPanel', () => {
     expect(screen.getAllByText(/4102 articles/).length).toBeGreaterThan(0)
   })
 
+  // #340 (rag-design D-Z16): the served library's collision losers ride `packs:status.excluded`
+  // — a served-library fact, so it is a badge + a visible reason line on the LOSER's row that
+  // names the winner, never a row field; a status without the field (an older main) or with
+  // `null` (nothing computed yet) shows nothing.
+  it('a serving-name collision loser gets a "Not served" badge naming the winner; null / absent status shows none', async () => {
+    const winner = pack({ id: 'uuid-aaaa', title: 'Klimawandel von Wikipedia' })
+    const loser = pack({ id: 'uuid-bbbb', title: 'Klimawandel (Kopie)', leaf: 'wikipedia_de_climate.zim' })
+    stubApi({
+      getKnowledgePackStatus: async () => ({
+        toolsInstalled: true,
+        refreshing: false,
+        revision: 0,
+        excluded: [{ packId: 'uuid-bbbb', collidesWith: 'uuid-aaaa' }]
+      }),
+      listKnowledgePacks: async () => [winner, loser]
+    })
+    const { unmount } = render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('Klimawandel (Kopie)')).toBeInTheDocument()
+    // The loser's row: the badge and the visible line naming the winner (guidelines §7 — the
+    // reason is reachable without a mouse). The winner's row carries neither.
+    expect(screen.getByText('Not served')).toBeInTheDocument()
+    expect(
+      screen.getByText(/clashes with “Klimawandel von Wikipedia”, so only that pack is served/)
+    ).toBeInTheDocument()
+    const loserCard = screen.getByText('Klimawandel (Kopie)').closest('li')
+    const winnerCard = screen.getByText('Klimawandel von Wikipedia').closest('li')
+    expect(loserCard).not.toBeNull()
+    expect(loserCard!.textContent).toContain('Not served')
+    expect(winnerCard!.textContent).not.toContain('Not served')
+    // Both stay Enabled: a collision is not a row state.
+    expect(screen.getAllByText('Enabled')).toHaveLength(2)
+    unmount()
+
+    // A winner the list no longer knows (a stale list): the generic line, still a badge.
+    stubApi({
+      getKnowledgePackStatus: async () => ({
+        toolsInstalled: true,
+        refreshing: false,
+        revision: 0,
+        excluded: [{ packId: 'uuid-bbbb', collidesWith: 'uuid-gone' }]
+      }),
+      listKnowledgePacks: async () => [loser]
+    })
+    const second = render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('Not served')).toBeInTheDocument()
+    expect(screen.getByText(/clashes with another pack’s/)).toBeInTheDocument()
+    second.unmount()
+
+    // `null` (nothing computed yet) and an ABSENT field (an older main): no badge at all.
+    for (const status of [
+      { toolsInstalled: true, refreshing: false, revision: 0, excluded: null },
+      { toolsInstalled: true, refreshing: false, revision: 0 }
+    ]) {
+      stubApi({
+        getKnowledgePackStatus: async () => status,
+        listKnowledgePacks: async () => [winner, loser]
+      })
+      const r = render(
+        <I18nProvider>
+          <PacksPanel />
+        </I18nProvider>
+      )
+      expect(await screen.findByText('Klimawandel (Kopie)')).toBeInTheDocument()
+      expect(screen.queryByText('Not served')).toBeNull()
+      r.unmount()
+    }
+  })
+
   it('shows the tools-missing hint and disables adding when kiwix-tools is absent', async () => {
     stubApi({
       getKnowledgePackStatus: async () => ({ toolsInstalled: false, refreshing: false, revision: 0 }),

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1719,8 +1719,12 @@ landing mid-add still REJECTS with the friendly locked copy) · `packs:remove`
 (tombstone, file untouched) · `packs:setEnabled` · `packs:refresh` (#301 P3b, finding L7 —
 schedules a background reconciliation and returns `{ started: boolean }` at once;
 completion arrives via the `packs:changed` event, not the return value) · `packs:status`
-(`KnowledgePackStatus = { toolsInstalled, refreshing, revision }` — additive over the P3a
-`{ toolsInstalled }` shape) · `packs:getArticle` (`PackArticle | null` — plain sectioned
+(`KnowledgePackStatus = { toolsInstalled, refreshing, revision, excluded? }` — additive over the P3a
+`{ toolsInstalled }` shape; `excluded?: KnowledgePackCollision[] | null` (#340, rag-design D-Z16)
+is the served library's collision losers `{ packId, collidesWith }` from the service's memory —
+recomputed from the registry at every reconciliation and mutation, from the resolved set at every
+library build, `null` until this session computed one and after a lock; absent on an older main —
+never a database read, so the channel stays lock-exempt) · `packs:getArticle` (`PackArticle | null` — plain sectioned
 TEXT, never HTML; the read follows exactly ONE same-book redirect — kiwix-serve answers a ZIM
 alias entry with `302 → /content/<book>/<target>` (P7 T19) — while a cross-book, chained or
 contract-refused target returns `null` and the locator does not change; a `/raw` read that
@@ -1868,4 +1872,5 @@ matrix (the `zim-real` row) for the full input table.
 
 **Lock-channel inventory:** `ipc-lock-coverage.test.ts`'s `registerZimIpc` group gained
 `packs:refresh` as a DB-touching (non-exempt) channel; `packs:status` remains the sole
-exempt channel (in-memory service state only).
+exempt channel (in-memory service state only — its `excluded` field, #340, is the service's
+cached list, never a query). The IPC surface is unchanged by the follow-up wave: 145 channels.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2508,9 +2508,9 @@ reports and phase plans were working papers; their full text lives in git histor
   exactly (`identity.ts`); when two packs would compute the SAME name, the smaller UUID
   wins by libkiwix's own ascending-map-order rule and the later pack is excluded from the
   served library until it is renamed, rather than answering under the winner's name (the
-  panel does not say so — deferred to the P9 successor issue #340 (opened at the #294 merge;
-  BUILD_STATE §5 item 21), since it is a served-library fact rather than a pack-row fact; the
-  per-answer note says "not searched: name collision with another pack"). The real-tool check that our computed map still matches a
+  panel shows a "Not served" badge on the later pack naming the pack that keeps the name —
+  `packs:status.excluded`, rag-design D-Z16, #340 — and the per-answer note says "not searched:
+  name collision with another pack"). The real-tool check that our computed map still matches a
   pinned kiwix-serve build is P7's (T19), not assumed here.
 - **At most twelve packs take part in one ask, and not every candidate they find is
   used.** Ticking a 13th pack is refused; an older or hand-edited selection above the

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2651,6 +2651,30 @@ offline article viewer. Files are registered in place, never copied.
   yes/no with ONE sidecar start and no Refresh; the next Refresh issues no `/suggest`; enable
   after a never-probed registration; a lock landing mid-probe writes nothing and the next
   session's reconcile confirms). Red with the IPC trigger removed.
+- **D-Z16 — the collision surface in the panel (follow-up wave, 2026-09-06; #340, the P6
+  decision (c)1 residual).** A serving-name collision loser (D-Z11: an earlier UUID owns the name,
+  the later pack is left out of the library XML) was enabled and available in the panel with
+  nothing to say why an ask reported it `not-served`. It is a served-library fact, not a
+  `KnowledgePack` row field, and `packs:status` is the ONE lock-exempt `packs:*` channel — in-memory
+  service state, never a database read — so the list rides that channel from memory:
+  `KnowledgePackStatus.excluded?: KnowledgePackCollision[] | null` (additive, optional; absent =
+  an older main, `null` = nothing computed yet this session), `KnowledgePackCollision = { packId,
+  collidesWith }` in `shared/types.ts` (`identity.ts`'s `ServingNameCollision` is now its alias).
+  `ZimService.lastExcluded` is recomputed under the producing operation and before its
+  `packs:changed` notice (so the panel's refetch sees it) at every reconciliation end and every
+  mutation from the REGISTRY (`servedRegistryRows`: enabled ∧ available ∧ non-tombstoned rows
+  with `recorded_path`; no disk probe — the reconcile writes the resolved winner there and the
+  serving name depends only on the leaf, so this equals the build's own input up to files that
+  vanished since the last pass), set from the disk-resolved set at every library build
+  (authoritative), and reset to null by `suspend()` so a locked workspace's list never outlives
+  it on the exempt channel. The panel shows a "Not served" badge plus a visible line naming the
+  pack that keeps the name (or a generic line when the list no longer knows it) on the LOSER's
+  row only; the picker keeps relying on the per-answer `not-served` outcome. No new channel (the
+  145-channel count stands), no preload change. Tests: `zim-ipc-session` "#340 packs:status.excluded
+  …" (null → [] → the larger UUID after a same-leaf registration → cleared by disabling → the build
+  agrees → null after a lock → recomputed by the next session), `KnowledgePacks.test.tsx` (badge +
+  winner named; stale winner; null / absent status show nothing), `zim-ipc` (the fake reports
+  null).
 
 ### Module map
 
@@ -2760,11 +2784,10 @@ over archive citations (they resolve as honest 'unresolved'); packs on the whole
 for non-Wikimedia ZIMs. Serving names are computed
 by the pinned libkiwix 14.1 rule (D-Z11) rather than read back from the running server —
 the real-tool check of that mapping is P7's (T19), not assumed. The name-collision surface
-(D-Z11's "excludes every later same-name book") is deliberately not shown on the
-`PacksPanel` row (P6): it is a property of the served library, computed at build time, not
-a `KnowledgePack` field — the per-answer outcome's `not-served` row already tells the user
-"not searched: name collision with another pack"; a `packs:status` addition to surface it
-in the panel is registered on the P9 successor issue #340 (BUILD_STATE §5 item 21).
+(D-Z11's "excludes every later same-name book") was deliberately not shown on the
+`PacksPanel` row at P6 — a served-library fact, not a `KnowledgePack` field — and is surfaced since
+the follow-up wave through `packs:status.excluded` (D-Z16, #340); the per-answer outcome's
+`not-served` row still says "not searched: name collision with another pack".
 
 ### Real acceptance (T19, P7 — the machine-drivable legs, 2026-09-06)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -819,7 +819,9 @@ Wikivoyage, …) at `library.kiwix.org`; download once, use forever offline.
    it can't be ticked — file missing, a different archive at that location, disabled, or no
    full-text search index; the panel itself shows a "No full-text index" badge on such a pack.
    The app checks that a moment after you add or enable a pack (and when you unlock or press
-   Refresh), so the badge appears on its own.
+   Refresh), so the badge appears on its own. Two archives whose file names differ only by
+   folder cannot both be served — the panel marks the later one "Not served" and names the
+   pack that keeps the name; rename one file to use both.
 
 Removing a pack's registration (the **Remove** button) only forgets it — the file itself is
 never deleted. An article from a pack that has no full-text search index is still readable:


### PR DESCRIPTION
Refs #340 (residual: the collision surface in the panel — `packs:status.excluded`). Refs #301. **Stacked on #349** (which is stacked on #348); retarget and rebase as each parent lands.

## What

A serving-name collision loser (rag-design D-Z11: two archives whose file names differ only by folder compute the same serving name; libkiwix keeps the smaller UUID and the later pack is left out of the library XML) showed in the panel as plainly "Enabled", with nothing to say why an ask reported it `not-served` (P6 decision (c)1 deferred the surface here). It is a served-library fact, not a `KnowledgePack` row field.

## Design (rag-design §17 **D-Z16**)

`packs:status` is the ONE lock-exempt `packs:*` channel — in-memory service state, never a database read (`ipc-lock-coverage` pins it) — so the list rides that channel from memory:

- **Shape (additive, optional):** `KnowledgePackStatus.excluded?: KnowledgePackCollision[] | null`; `KnowledgePackCollision = { packId, collidesWith }` in `shared/types.ts` (`identity.ts`'s `ServingNameCollision` becomes its alias). Absent = an older main, `null` = nothing computed yet this session.
- **Producer:** `ZimService.lastExcluded`, recomputed under the producing operation and before its `packs:changed` notice at every reconciliation end and every mutation (register / remove / enable) from the REGISTRY — `servedRegistryRows`: enabled ∧ available ∧ non-tombstoned rows with `recorded_path`, no disk probe (the reconcile writes the resolved winner there and the serving name depends only on the leaf, so it equals the build's own input up to files that vanished since the last pass) — set from the disk-resolved set at every library build (authoritative), and reset to `null` by `suspend()` so a locked workspace's list never outlives it on the exempt channel.
- **Panel:** a "Not served" badge plus a visible reason line naming the pack that keeps the name (a generic line when the list no longer knows it) on the LOSER's row only; the state badge stays "Enabled" (a collision is not a row state). EN + DE copy. The picker keeps relying on the per-answer `not-served` outcome.
- No new channel (the 145-channel count stands), no preload change.

Blast-radius note: `tmp/340-residuals.md` PR B (maintainer-local).

## Tests

- `zim-ipc-session.test.ts` NEW "#340 packs:status.excluded names the serving-name collision loser …": null before the session computed one → `[]` after a clean reconcile → the larger UUID after a same-leaf registration in another folder (and the library BUILD agrees) → cleared by disabling the loser, back on enable → `null` after a real lock → recomputed by the next session's reconciliation, all through the real handlers.
- `KnowledgePacks.test.tsx` NEW: the loser's badge + the line naming the winner (the winner's row carries neither; both stay Enabled), a stale winner → the generic line, `null` and an absent field → no badge.
- `zim-ipc.test.ts`: the fake service reports `null`; the no-service status carries `excluded: null`.
- Suites run: KnowledgePacks + zim-ipc-session + zim-ipc + ipc-lock-coverage + repo-hygiene + i18n + zim-identity — green after the one expectation update; typecheck green.

## Docs

rag-design §17 D-Z16 (+ the "Deliberately not built" paragraph corrected), data-contracts (the `packs:status` shape, the lock-channel inventory sentence, the unchanged 145-channel count), known-limitations "Serving names are computed…", user-guide §7b step 6, CHANGELOG `[Unreleased]` › Fixed, BUILD_STATE (wave entry step 3; 21(l) residual closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
