### PR TITLE
fix(zim): the P6/P7 renderer nits — per-row busy, language names, chip state, footer shrink rule (#340)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -115,7 +115,9 @@ post-registration searchability probe (`fix/340-post-registration-probe`, stacke
 `zim-ipc-session` "#340 …" (four legs, red without the trigger). Owner questions (b) non-ASCII message vs metadata and (c) LaTeX strip / normalise / render posted on #340 — their
 code waits. **Step 3 — 21(l) the collision surface (`feat/340-packs-status-excluded`, stacked on step 2):** `KnowledgePackStatus.excluded?` from the service's memory (registry
 recompute at reconcile end + every mutation, the build authoritative, reset on suspend; the exempt channel never reads the DB), a "Not served" badge naming the winner on the
-loser's row; record rag-design **D-Z16**; tests `zim-ipc-session` "#340 packs:status.excluded …", `KnowledgePacks.test.tsx`. Next: the UI nits, then #339, then #340 capabilities._
+loser's row; record rag-design **D-Z16**; tests `zim-ipc-session` "#340 packs:status.excluded …", `KnowledgePacks.test.tsx`. **Step 4 — 21(l) the UI nits (`fix/340-packs-ui-nits`, stacked
+on step 3; record design-guidelines §11.15 "Follow-up wave"):** per-row busy, an unavailable pack can be disabled, the language NAME in the meta line, the chip's "(disabled)" /
+"(not available)" state, `.footer-menu-btn`'s own shrink rule, no `reconcile-start` refetch. Next: #339 (plan note first), then #340 capabilities; (b)/(c) wait for the owner._
 
 _2026-09-06 — **ZIM knowledge packs (PR #294 → #301) — WAVE CLOSED: Phases 0–7 complete, #294 MERGED to master (`92e86a07`, 16:12 UTC), #301 closed by the merge.**_
 The PR's review remediation — 28 findings (H1–H4, M1–M11, L1–L9 with L10 withdrawn, DOC-1–DOC-4; three assessed High, H3 and DOC-1/DOC-2 Medium) — closed across P0–P6 on the integration branch `feat/zim-knowledge-packs`;
@@ -718,8 +720,7 @@ open round's item stays the last block of §5.)
     (j) **P4 — CLOSED (2026-09-06):** M3/M6/M7/M8/M10 — effective documents-off scope, reranker-failure interleave, fair pack allocation under a per-ask deadline, refreshable searchability, per-ask
     pack outcomes. Record: rag-design D-Z4/D-Z11/D-Z12.
     (k) **P6 — CLOSED (2026-09-06):** T18-a implemented (design/frontend review); the (c) "Open article from a review" residual closed. Record: design-guidelines §11.15.
-    (l) **P7 residual register (2026-09-06):** the collision surface — CLOSED, follow-up wave step 3 (`packs:status.excluded`, rag-design D-Z16; the per-answer "not-served" row stays); PacksPanel: an unavailable pack can only be removed, not disabled (low, P9); every row's action buttons disable while one row is busy (low, P9); ChatScreen refetches on both
-    `reconcile-start` and `-end` of one epoch (cosmetic, P9); the pack meta line shows the raw ISO 639-3 code unlabelled (copy nit, P9); `.footer-menu-btn` has no overflow rule of its own (low, P9);
+    (l) **P7 residual register (2026-09-06):** the collision surface — CLOSED, follow-up wave step 3 (`packs:status.excluded`, rag-design D-Z16; the per-answer "not-served" row stays); the five PacksPanel / ChatScreen / meta-line / footer-button nits — CLOSED, follow-up wave step 4 (design-guidelines §11.15 "Follow-up wave");
     accepted deviation: the ScopePopover is non-modal (design-guidelines §11.15 decision 1, P6); T18-b — RECORDED 2026-09-06 (run by the orchestrator at the owner's request in real Electron against the real packs; rag-design §17 "Real acceptance" → "T18-b"; it surfaced T19 finding 3: kiwix-serve 3.8.1 win-x86_64 cuts ~5–20 % of large /raw reads short (the body's last part never arrives) — upstream, mitigated by the P7 fix PR 2, upstream report on #339); T19 the owner's Electron/drive legs — (vi) the relocated drive with
     persisted citations and (vii) live lock/unlock/failed lock PASSED 2026-09-06 on the real K: drive (rag-design §17 "Real acceptance" → "The owner's legs"; observations: a failed lock leaves the chat
     engine stopped until a model is re-selected — #344, FIXED in the follow-up wave (2026-09-06 dated entry); a pack added via Add packs… stays searchability-unknown until Refresh — FIXED, D-Z15 (follow-up wave step 2); LaTeX echoed in answers — #340, owner ruling pending), (viii) the offline ask + viewer PASSED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **Small knowledge-pack polish.** The packs panel shows each archive's language by name ("German")
+  instead of a three-letter code; while one pack is being enabled, disabled or removed, the other
+  rows' buttons stay usable; a pack whose file is missing can be disabled, not only removed; and
+  the "Answering from" chip in a chat says "(disabled)" or "(not available)" after a ticked pack
+  changed state, instead of naming it as if it would be searched.
 - **The knowledge-packs panel now says when two packs clash on a file name.** Two archives with
   the same file name in different folders cannot both be served — only the earlier one is — and
   the panel used to show both as simply "Enabled", with the reason visible only in the note under

--- a/apps/desktop/src/renderer/chat/ScopePopover.tsx
+++ b/apps/desktop/src/renderer/chat/ScopePopover.tsx
@@ -83,7 +83,22 @@ export function scopeSources(
   // Knowledge packs: name a single pack, count several (the projects pattern).
   if (packIds.length === 1) {
     const pack = packs.find((k) => k.id === packIds[0])
-    parts.push(pack ? t('chat.scope.packNamed', { name: pack.title }) : tCount('chat.scope.packCount', 1))
+    if (!pack) parts.push(tCount('chat.scope.packCount', 1))
+    else {
+      // #340 nit (T18-b observation): a ticked pack that was disabled or went missing afterwards
+      // is still named by the chip — with its state, so the readout never claims a source the
+      // ask will skip. The same state words the popover row uses.
+      const state = !pack.available
+        ? t('chat.scope.packUnavailable')
+        : !pack.enabled
+          ? t('chat.scope.packDisabled')
+          : null
+      parts.push(
+        state
+          ? t('chat.scope.packNamedState', { name: pack.title, state })
+          : t('chat.scope.packNamed', { name: pack.title })
+      )
+    }
   } else if (packIds.length > 1) {
     parts.push(tCount('chat.scope.packCount', packIds.length))
   }

--- a/apps/desktop/src/renderer/screens/ChatScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ChatScreen.tsx
@@ -565,6 +565,9 @@ export function ChatScreen({
     return window.api.onKnowledgePacksChanged?.((event: KnowledgePacksChangedEvent) => {
       if (event.epoch < lastPacksEpochRef.current) return
       lastPacksEpochRef.current = event.epoch
+      // #340 nit: `reconcile-start` announces that a pass BEGAN — the pack set cannot have moved
+      // yet, so refetching there and again at `reconcile-end` cost one extra DB read per pass.
+      if (event.reason === 'reconcile-start') return
       void (async () => {
         try {
           setPacks((await window.api.listKnowledgePacks?.()) ?? [])

--- a/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
+++ b/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
@@ -42,6 +42,20 @@ function addFailedKey(reason: KnowledgePackAddFailureReason | null): MessageKey 
   }
 }
 
+/**
+ * An archive's ISO 639-3 language code as a name in the UI language (#340 nit): `deu` → "German"
+ * / "Deutsch". The raw code stays when the platform cannot name it (`fallback: 'none'` answers
+ * undefined for an unknown code; an environment without `Intl.DisplayNames` throws).
+ */
+function languageName(uiLang: string, code: string): string {
+  try {
+    const name = new Intl.DisplayNames([uiLang], { type: 'language', fallback: 'none' }).of(code)
+    return name && name !== code ? name : code
+  } catch {
+    return code
+  }
+}
+
 function formatSize(tCount: ReturnType<typeof useT>['tCount'], bytes: number | null): string | null {
   if (bytes == null || bytes <= 0) return null
   const gb = bytes / (1024 * 1024 * 1024)
@@ -50,7 +64,7 @@ function formatSize(tCount: ReturnType<typeof useT>['tCount'], bytes: number | n
 }
 
 export function PacksPanel(): JSX.Element {
-  const { t, tCount } = useT()
+  const { t, tCount, lang } = useT()
   const showToast = useToast()
   const [packs, setPacks] = useState<KnowledgePack[] | null>(null)
   const [toolsInstalled, setToolsInstalled] = useState(true)
@@ -187,7 +201,7 @@ export function PacksPanel(): JSX.Element {
 
   const metaLine = (p: KnowledgePack): string => {
     const parts: string[] = []
-    if (p.language) parts.push(p.language)
+    if (p.language) parts.push(languageName(lang, p.language))
     if (p.articleCount != null) parts.push(tCount('packs.articleCount', p.articleCount))
     const size = formatSize(tCount, p.sizeBytes)
     if (size) parts.push(size)
@@ -302,9 +316,12 @@ export function PacksPanel(): JSX.Element {
                 {p.description && <p className="packs-card-desc hint">{p.description}</p>}
                 <p className="packs-card-meta hint">{metaLine(p)}</p>
                 <div className="packs-card-actions">
+                  {/* #340 nits: only THIS row's buttons disable while it is busy (another row's
+                      toggle or remove is an independent operation), and an unavailable pack can
+                      be disabled too — the flag is the user's, whatever the file is doing. */}
                   <Button
                     size="sm"
-                    disabled={busy !== null || !p.available}
+                    disabled={busy === p.id}
                     aria-label={t(p.enabled ? 'packs.disableNamed' : 'packs.enableNamed', { title: p.title })}
                     onClick={() => void onToggle(p)}
                   >
@@ -321,7 +338,7 @@ export function PacksPanel(): JSX.Element {
                   <Button
                     size="sm"
                     className="danger"
-                    disabled={busy !== null}
+                    disabled={busy === p.id}
                     aria-label={t('packs.removeNamed', { title: p.title })}
                     onClick={() => setConfirmRemove(p)}
                   >

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -855,6 +855,10 @@ code, pre, kbd { font-family: var(--font-mono); }
   font-size: var(--text-sm);
   cursor: pointer;
   padding: 3px 8px;
+  /* #340 nit: the trigger may shrink inside a narrow footer on its own, not only under
+     .scope-footer-wrap — a long label inside it then ellipsises instead of overflowing. */
+  min-width: 0;
+  max-width: 100%;
 }
 /* Inline file glyph in the chat-scope footer button / conversation meta line — muted,
    sized to the surrounding text (not accent: these are quiet labels, not actions). */

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2667,6 +2667,8 @@ export const de: Record<keyof typeof en, string> = {
   'chat.scope.packsTitle': 'Wissenspakete',
   'chat.scope.packUnavailable': 'nicht verfügbar',
   'chat.scope.packNamed': 'Paket: {name}',
+  // #340: der Chip nennt ein angehaktes, aber deaktiviertes / nicht verfügbares Paket MIT diesem Zustand.
+  'chat.scope.packNamedState': 'Paket: {name} ({state})',
   'chat.scope.packCount.one': '{count} Wissenspaket',
   'chat.scope.packCount.other': '{count} Wissenspakete',
   // Dokumente-Schalter (#301 P4, Befund M10): die ausdrückliche Wahl „aus den Paketen

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2637,6 +2637,8 @@ export const en = {
   'chat.scope.packsTitle': 'Knowledge packs',
   'chat.scope.packUnavailable': 'not available',
   'chat.scope.packNamed': 'Pack: {name}',
+  // #340 nit: the chip names a ticked pack that is disabled / unavailable WITH that state.
+  'chat.scope.packNamedState': 'Pack: {name} ({state})',
   'chat.scope.packCount.one': '{count} knowledge pack',
   'chat.scope.packCount.other': '{count} knowledge packs',
   // Documents toggle (#301 P4, finding M10): the explicit "answer from the packs, not from my

--- a/apps/desktop/tests/renderer/ChatPacksRefresh.test.tsx
+++ b/apps/desktop/tests/renderer/ChatPacksRefresh.test.tsx
@@ -126,6 +126,40 @@ afterEach(() => {
 })
 
 describe('ChatScreen — mounted-consumer refresh on packs:changed (#301 P3b, T13)', () => {
+  // #340 nit: `reconcile-start` says a pass BEGAN — the pack set cannot have moved yet — so the
+  // chat refetches at `reconcile-end` / `mutation` only, one DB read per pass instead of two.
+  it('a reconcile-start event does not refetch; the following reconcile-end does', async () => {
+    const user = userEvent.setup()
+    const docConv = conv()
+    const emitter = packsEventEmitter()
+    const listKnowledgePacks = vi.fn(async () => [pack()])
+    stubApi({
+      listConversations: vi.fn(async () => [docConv]),
+      getRuntimeStatus: vi.fn(async () => runningStatus),
+      listMessages: vi.fn(async () => []),
+      listDocuments: vi.fn(async () => [docInfo('d1', 'contract.pdf')]),
+      listCollections: vi.fn(async () => [collection({})]),
+      listAttachments: vi.fn(async () => []),
+      listKnowledgePacks,
+      onKnowledgePacksChanged: emitter.onKnowledgePacksChanged
+    })
+    render(<ChatScreen onNavigate={() => {}} />)
+    await user.click(await screen.findByText('Doc Q&A'))
+    await waitFor(() => expect(listKnowledgePacks).toHaveBeenCalledTimes(1))
+
+    // A start notice under a NEWER epoch than anything seen: honoured as an epoch, not a refetch.
+    await act(async () => {
+      emitter.emit({ epoch: 2, revision: 2, refreshing: true, reason: 'reconcile-start' })
+    })
+    expect(listKnowledgePacks).toHaveBeenCalledTimes(1) // a flushed ceiling, not a proof of absence
+    act(() => emitter.emit({ epoch: 2, revision: 2, refreshing: false, reason: 'reconcile-end' }))
+    await waitFor(() => expect(listKnowledgePacks).toHaveBeenCalledTimes(2))
+    // …and the epoch the start notice carried was recorded: an OLDER end notice is ignored.
+    act(() => emitter.emit({ epoch: 1, revision: 1, refreshing: false, reason: 'reconcile-end' }))
+    await act(async () => {})
+    expect(listKnowledgePacks).toHaveBeenCalledTimes(2)
+  })
+
   it('a reconcile-end event refetches packs and the mounted ScopePopover shows the new pack', async () => {
     const user = userEvent.setup()
     const docConv = conv()

--- a/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
+++ b/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
@@ -101,6 +101,64 @@ describe('PacksPanel', () => {
     expect(screen.getByText('Enabled')).toBeInTheDocument()
     expect(screen.getByText('File missing')).toBeInTheDocument()
     expect(screen.getAllByText(/4102 articles/).length).toBeGreaterThan(0)
+    // #340 nit: the ISO 639-3 code is shown as a language NAME in the UI language, never raw.
+    expect(screen.getAllByText(/German · 4102 articles/).length).toBe(2)
+    expect(screen.queryByText(/\bdeu\b/)).toBeNull()
+    // #340 nit: an unavailable pack can be disabled, not only removed.
+    expect(screen.getByRole('button', { name: 'Disable Chemie von Wikipedia' })).toBeEnabled()
+  })
+
+  // #340 nits: a row's buttons disable only while THAT row is busy — another row's toggle or
+  // remove is an independent operation — and the meta line's language name follows the UI
+  // language, with the raw code kept only when the platform cannot name it.
+  it('#340 nits: only the busy row disables, an unavailable pack can be disabled, the language is named in German too and an unknown code stays raw', async () => {
+    let release!: () => void
+    const parked = new Promise<void>((r) => (release = r))
+    const setKnowledgePackEnabled = vi.fn(async () => {
+      await parked
+    })
+    stubApi({
+      getKnowledgePackStatus: async () => ({ toolsInstalled: true, refreshing: false, revision: 0 }),
+      listKnowledgePacks: async () => [
+        pack(),
+        pack({ id: 'uuid-gone', title: 'Chemie von Wikipedia', available: false, enabled: true, language: 'zzz' })
+      ],
+      setKnowledgePackEnabled
+    })
+    const user = userEvent.setup()
+    const first = render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('Klimawandel von Wikipedia')).toBeInTheDocument()
+    // The unknown code echoes back as itself — no invented name.
+    expect(screen.getByText(/^zzz · 4102 articles/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Disable Klimawandel von Wikipedia' }))
+    await waitFor(() => expect(setKnowledgePackEnabled).toHaveBeenCalledWith('uuid-climate', false))
+    // This row is working; the other row's buttons are untouched.
+    expect(screen.getByRole('button', { name: 'Disable Klimawandel von Wikipedia' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Remove Klimawandel von Wikipedia' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Disable Chemie von Wikipedia' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Remove Chemie von Wikipedia' })).toBeEnabled()
+    release()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Disable Klimawandel von Wikipedia' })).toBeEnabled()
+    )
+    // …and the unavailable pack's Disable really reaches the bridge.
+    await user.click(screen.getByRole('button', { name: 'Disable Chemie von Wikipedia' }))
+    await waitFor(() => expect(setKnowledgePackEnabled).toHaveBeenCalledWith('uuid-gone', false))
+    first.unmount()
+
+    window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, 'de')
+    render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('Klimawandel von Wikipedia')).toBeInTheDocument()
+    expect(screen.getByText(/^Deutsch · 4102 Artikel/)).toBeInTheDocument()
   })
 
   // #340 (rag-design D-Z16): the served library's collision losers ride `packs:status.excluded`
@@ -740,6 +798,47 @@ describe('ScopePopover — knowledge packs', () => {
     // Toggling a PACK while documents are off preserves the flag (spread-preservation).
     await user.click(screen.getByRole('checkbox', { name: /Klimawandel von Wikipedia/ }))
     expect(emitted.at(-1)).toEqual({ collectionIds: [], documentIds: [], documentsOff: true })
+  })
+
+  // #340 nit (the T18-b observation): a ticked pack that was disabled or went missing afterwards
+  // is still named by the chip — WITH its state, in the popover row's own words — so the
+  // "Answering from:" readout never claims a source the ask will skip.
+  it('the chip names a ticked pack that is disabled or unavailable with its state', () => {
+    stubApi({})
+    const scope = { collectionIds: [], documentIds: [], packIds: ['uuid-climate'] }
+    const disabled = render(
+      <I18nProvider>
+        <ScopePopover
+          docs={[doc]}
+          collections={collections}
+          packs={[pack({ enabled: false })]}
+          scope={scope}
+          onChangeScope={() => {}}
+        />
+      </I18nProvider>
+    )
+    expect(screen.getByRole('button')).toHaveTextContent('Pack: Klimawandel von Wikipedia (disabled)')
+    disabled.unmount()
+    const missing = render(
+      <I18nProvider>
+        <ScopePopover
+          docs={[doc]}
+          collections={collections}
+          packs={[pack({ available: false, unavailableReason: 'missing' })]}
+          scope={scope}
+          onChangeScope={() => {}}
+        />
+      </I18nProvider>
+    )
+    expect(screen.getByRole('button')).toHaveTextContent('Pack: Klimawandel von Wikipedia (not available)')
+    missing.unmount()
+    render(
+      <I18nProvider>
+        <ScopePopover docs={[doc]} collections={collections} packs={[pack()]} scope={scope} onChangeScope={() => {}} />
+      </I18nProvider>
+    )
+    expect(screen.getByRole('button')).toHaveTextContent('Pack: Klimawandel von Wikipedia')
+    expect(screen.getByRole('button')).not.toHaveTextContent('(')
   })
 
   it('the chip says "documents off" beside the packs phrase, the hint names what stays on, and the reset clears the flag', async () => {

--- a/apps/desktop/tests/unit/zim-ui-layout-rules.test.ts
+++ b/apps/desktop/tests/unit/zim-ui-layout-rules.test.ts
@@ -36,6 +36,9 @@ describe('knowledge-pack layout rules (#301 P6) — the stylesheet carries what 
     expect(label).toContain('text-overflow: ellipsis')
     expect(label).toContain('white-space: nowrap')
     expect(rule('.scope-footer-wrap .footer-menu-btn')).toContain('min-width: 0')
+    // #340 nit: the trigger carries its own shrink rule, not only under the scope wrapper.
+    expect(rule('.footer-menu-btn')).toContain('min-width: 0')
+    expect(rule('.footer-menu-btn')).toContain('max-width: 100%')
   })
 
   it('the pack card head wraps a long title with its badges; the list is a reset <ul>', () => {

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1154,6 +1154,20 @@ pack/popover/review renderer suites and `token-contrast.test.ts` all green; a re
 visual pass in both themes/languages is recorded separately (T18-b) — renderer mocks alone don't
 close visual acceptance (§11.4's standing caveat).
 
+**Follow-up wave (2026-09-06, #340 — the P6/P7 renderer residuals, decided as built):** (1) a
+pack row's Enable/Disable and Remove buttons disable only while THAT row is busy (another row's
+toggle or remove is an independent operation; Add packs… and Refresh keep their global disable);
+(2) an unavailable pack can be disabled, not only removed — the flag is the user's, whatever the
+file is doing; (3) the meta line shows the archive's language as a NAME in the UI language via
+`Intl.DisplayNames` ("German" / "Deutsch"), the raw ISO 639-3 code only when the platform cannot
+name it; (4) the "Answering from:" chip names a ticked pack that is disabled or unavailable WITH
+that state, in the popover row's own words ("Pack: … (disabled)"), so the readout never claims a
+source the ask will skip; (5) `.footer-menu-btn` carries its own `min-width: 0; max-width: 100%`
+(pinned by `zim-ui-layout-rules.test.ts`), not only under `.scope-footer-wrap`; (6) Chat refetches
+packs at `reconcile-end` / `mutation` only, never at `reconcile-start`. The collision surface is
+§17 D-Z16 (`packs:status.excluded` → the "Not served" badge naming the winner). Tests:
+`KnowledgePacks.test.tsx` ("#340 nits …", the chip-state leg), `ChatPacksRefresh.test.tsx`.
+
 ---
 
 ## 12. Chat-UI polish pass — design record (IMPLEMENTED 2026-06-13)


### PR DESCRIPTION
Refs #340 (the P6/P7 renderer nits, BUILD_STATE §5 item 21(l)). Refs #301. **Stacked on #350** (→ #349 → #348); retarget and rebase as each parent lands.

## What (renderer only; no shape, IPC or preload change)

Recorded in `docs/design-guidelines.md` §11.15 "Follow-up wave":

1. A pack row's Enable/Disable and Remove buttons disable only while THAT row is busy — another row's toggle or remove is an independent operation (Add packs… / Refresh keep their global disable).
2. An unavailable pack can be disabled, not only removed — the flag is the user's, whatever the file is doing (the popover's D6 rule reaches the panel).
3. The meta line shows the archive's language as a NAME in the UI language (`Intl.DisplayNames`: "German" / "Deutsch"); the raw ISO 639-3 code only when the platform cannot name it (`fallback: 'none'` → the code echoes back).
4. The "Answering from:" chip names a ticked pack that is disabled or unavailable WITH that state, in the popover row's own words ("Pack: … (disabled)" / "(not available)") — the T18-b observation.
5. `.footer-menu-btn` carries its own `min-width: 0; max-width: 100%`, not only under `.scope-footer-wrap`.
6. Chat refetches packs at `reconcile-end` / `mutation` only, never at `reconcile-start` (one DB read per pass instead of two); the epoch the start notice carries is still recorded.

EN + DE copy (`chat.scope.packNamedState`). Blast-radius note: `tmp/340-residuals.md` PR C.

## Tests

`KnowledgePacks.test.tsx`: the first panel test asserts "German · 4102 articles" and an enabled Disable on the missing pack; NEW "#340 nits …" (a parked toggle on one row leaves the other row's buttons enabled, the unavailable pack's Disable reaches the bridge, an unknown code stays raw, "Deutsch · 4102 Artikel" under DE); NEW chip-state leg (disabled / not available / plain). `ChatPacksRefresh.test.tsx`: NEW "a reconcile-start event does not refetch; the following reconcile-end does" (an older end notice is still ignored). `zim-ui-layout-rules.test.ts` pins the base rule. Suites run: those four + i18n + repo-hygiene — green; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
