### PR TITLE
feat(scripts): fetch-runtime --family kiwix_tools, the drive layout dirs, the drift legs (#339 P8-3)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -707,7 +707,8 @@ open round's item stays the last block of §5.)
 21. **ZIM knowledge packs — follow-up register (registered at the 2026-09-04 MVP; durable
     record: [`docs/rag-design.md`](docs/rag-design.md) §17 "Deliberately not built").**
     (a) **kiwix_tools provisioning** — P8 successor issue #339. P8-1 (the family contract) landed
-    on `feat/339-p8-1-kiwix-family`; open: P8-2 consent (owner ruling pending), P8-3 scripts,
+    on `feat/339-p8-1-kiwix-family`; P8-3 (`fetch-runtime --family kiwix_tools`, the drive layout, the drift legs; a real fetch
+    verified all eight hashes) landed on `feat/339-p8-3-kiwix-scripts`; open: P8-2 consent (owner ruling pending),
     P8-4 source bundle (owner ruling pending), P8-5 network-inventory prose, P8-6 the upstream
     report, P8-7 T20-a real-run / R-4 re-verification.
     (b) **Tier 2** (persistent import of selected articles into the corpus) — P9 successor issue #340.

--- a/apps/desktop/src/main/services/drive.ts
+++ b/apps/desktop/src/main/services/drive.ts
@@ -65,6 +65,10 @@ export const DRIVE_LAYOUT_DIRS: readonly string[] = [
   // a prebuilt Windows build only; the mac/linux dirs exist for the documented
   // source-build provisioning step (drive-layout.md).
   ...DRIVE_OS_DIRS.map((os) => `runtime/whisper.cpp/${os}`),
+  // Third sidecar family, OPTIONAL (#339 P8-3): the kiwix-tools knowledge-pack tools.
+  // Never fetched by `prepare-drive --with-assets` — a DIY user runs
+  // `fetch-runtime --family kiwix_tools` explicitly once they want ZIM knowledge packs.
+  ...DRIVE_OS_DIRS.map((os) => `runtime/kiwix-tools/${os}`),
   // OCR language files: `<lang>.traineddata.gz`, vendored at drive-build
   // time (runtime-sources.yaml `ocr:` block) — the engine never fetches at runtime.
   'ocr',

--- a/apps/desktop/tests/integration/script-drift.test.ts
+++ b/apps/desktop/tests/integration/script-drift.test.ts
@@ -179,6 +179,39 @@ describe('TS ↔ shell-script drift (runtime build matrix)', () => {
   })
 })
 
+// --- fetch-runtime.{ps1,sh} family allow-list (#339 P8-3) ---------------------------
+// The scripts hard-allow-list the families they know how to fetch (`-Family`/`--family`),
+// separately from the yaml-driven `canonicalBuilds()` net above — a family can be added to
+// runtime-sources.yaml (and even to `canonicalBuilds()`'s families) while the fetch scripts
+// still reject it at the CLI. `ocr` is a different asset shape (`files:`, not `builds:`) and
+// is hand-added to the expected set since it never appears in `parsed.families`.
+describe('TS ↔ shell-script drift (fetch-runtime family allow-list, #339 P8-3)', () => {
+  function yamlBuildFamilies(): string[] {
+    const parsed = validateRuntimeSources(parseYaml(read('model-manifests/runtime-sources.yaml')))
+    expect(parsed.errors, `runtime-sources.yaml must validate: ${parsed.errors.join('; ')}`).toEqual([])
+    return Object.keys(parsed.families ?? {}).sort()
+  }
+
+  it('fetch-runtime.ps1 -Family ValidateSet matches the yaml build families + ocr', () => {
+    const src = read('scripts/fetch-runtime.ps1')
+    const m = src.match(/\[ValidateSet\(([^)]+)\)\]/)
+    expect(m, 'fetch-runtime.ps1 -Family ValidateSet not found').not.toBeNull()
+    const families = m![1]
+      .split(',')
+      .map((s) => s.trim().replace(/^'|'$/g, ''))
+      .sort()
+    expect(families).toEqual([...yamlBuildFamilies(), 'ocr'].sort())
+  })
+
+  it('fetch-runtime.sh --family case allow-list matches the yaml build families + ocr', () => {
+    const src = read('scripts/fetch-runtime.sh')
+    const m = src.match(/case "\$FAMILY" in\n\s*([A-Za-z0-9_|]+)\)/)
+    expect(m, 'fetch-runtime.sh --family case allow-list not found').not.toBeNull()
+    const families = m![1].split('|').sort()
+    expect(families).toEqual([...yamlBuildFamilies(), 'ocr'].sort())
+  })
+})
+
 // --- Root license/attribution artifacts (LIC-1, full-audit 2026-07-12b) -------------
 // prepare-drive.{ps1,sh} COPY the three drive-root notice files and
 // build-commercial-drive.{ps1,sh} GATE on them — four re-spelled literals of the one

--- a/apps/desktop/tests/integration/script-execution.test.ts
+++ b/apps/desktop/tests/integration/script-execution.test.ts
@@ -44,6 +44,36 @@ function runtimeSourcesYaml(sha: string): string {
     '      url: https://example.invalid/llama-b9585-bin-ubuntu-vulkan-x64.tar.gz',
     `      sha256: ${sha}`,
     '      extract_to: runtime/llama.cpp/linux',
+    'kiwix_tools:',
+    "  version: '3.8.1'",
+    '  optional: true',
+    '  executables: [kiwix-serve, kiwix-manage, kiwix-search]',
+    '  builds:',
+    '    - os: win',
+    '      arch: x64',
+    '      backend: cpu',
+    '      url: https://example.invalid/kiwix-tools_win-x86_64-3.8.1.zip',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/kiwix-tools/win',
+    '      runtime_files: [icudt74.dll, icuin74.dll, icuio74.dll, icutu74.dll, icuuc74.dll]',
+    '    - os: mac',
+    '      arch: arm64',
+    '      backend: cpu',
+    '      url: https://example.invalid/kiwix-tools_macos-arm64-3.8.1.tar.gz',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/kiwix-tools/mac',
+    '    - os: mac',
+    '      arch: x64',
+    '      backend: cpu',
+    '      url: https://example.invalid/kiwix-tools_macos-x86_64-3.8.1.tar.gz',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/kiwix-tools/mac',
+    '    - os: linux',
+    '      arch: x64',
+    '      backend: cpu',
+    '      url: https://example.invalid/kiwix-tools_linux-x86_64-3.8.1.tar.gz',
+    `      sha256: ${sha}`,
+    '      extract_to: runtime/kiwix-tools/linux',
     'ocr:',
     '  version: 4.0.0_best_int',
     '  files:',
@@ -218,6 +248,39 @@ for (const leg of LEGS) {
         expect(r.status, out).toBe(1)
         expect(out).toMatch(/placeholder/i)
         expect(existsSync(join(root, 'ocr')) ? readdirSync(join(root, 'ocr')) : []).toEqual([])
+      })
+    })
+
+    // #339 P8-3: kiwix_tools is the first multi-file, multi-build OPTIONAL family the
+    // scripts fetch. A dry run for each of the four pinned builds (win + the two mac archs
+    // + linux) must print that build's full required-file plan (the executables the yaml's
+    // `executables:` declares, plus win's ICU `runtime_files:`) without touching the
+    // network, and must never require --Family/--family to guess right without --os/--arch.
+    describe('fetch-runtime kiwix_tools family — dry run enumerates every build (#339 P8-3)', () => {
+      it.each([
+        ['win', 'x64', ['kiwix-serve.exe', 'kiwix-manage.exe', 'kiwix-search.exe', 'icudt74.dll', 'icuin74.dll', 'icuio74.dll', 'icutu74.dll', 'icuuc74.dll']],
+        ['mac', 'arm64', ['kiwix-serve', 'kiwix-manage', 'kiwix-search']],
+        ['mac', 'x64', ['kiwix-serve', 'kiwix-manage', 'kiwix-search']],
+        ['linux', 'x64', ['kiwix-serve', 'kiwix-manage', 'kiwix-search']]
+      ] as const)('%s/%s: prints the required-file plan, offline, exit 0', (os, arch, files) => {
+        const root = scratchTarget(REAL_SHA)
+        const r = leg.run(fetcher, [
+          f('Target'),
+          root,
+          f('Family'),
+          'kiwix_tools',
+          f('Os'),
+          os,
+          f('Arch'),
+          arch,
+          f('DryRun')
+        ])
+        const out = text(r)
+        expect(r.status, out).toBe(0)
+        expect(out).toMatch(/dry run/i)
+        for (const file of files) expect(out, `${os}/${arch}: expected ${file} in the plan`).toContain(file)
+        // Nothing extracted — dry run touches no network and creates no runtime/ tree.
+        expect(existsSync(join(root, 'runtime', 'kiwix-tools'))).toBe(false)
       })
     })
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -300,7 +300,7 @@ out on a fresh machine with no Node/npm); their layout + config shapes mirror th
 |---|---|
 | `prepare-drive.{ps1,sh}` | Create the directory tree, copy manifests + **the committed `app-skills/` product skills** (wholesale, like manifests — S9; `user-skills/` is left empty) + user docs + **the root license/attribution notices** (`LICENSE`, `THIRD-PARTY-NOTICES.md`, `DRIVE-NOTICES.md` — LIC-1), generate `config/{drive,policy}.json`. `-DryRun`/`--dry-run` prints the plan. `-Dev`/`--dev` → a plaintext developer drive. **`-WithAssets`/`--with-assets`** then runs `fetch-models` + `fetch-runtime` (forwarding `-AcceptLicense`/`--accept-license`) for a launch-ready drive — by default fetching a small **default set** (~10.4 GB: chat model Ministral 3 8B + embeddings + reranker + Whisper transcriber + Qwen2.5-VL vision) **plus both sidecar runtimes** (`llama.cpp` + `whisper.cpp`, the latter Windows-only/best-effort); **`-AllModels`/`--all-models`** fetches every model instead (runtimes either way). |
 | `fetch-models.{ps1,sh}` | Download + **resume** + **SHA-256-verify** each weight with a `download:` block to its `models/...` path. `-Only <id>`/`--only` for one model; `-AcceptLicense`/`--accept-license` for the license gate; `-DryRun`/`--dry-run`. Real-hash mismatch → delete partial + exit 1. Idempotent (present + verified → skip). |
-| `fetch-runtime.{ps1,sh}` | Read `runtime-sources.yaml`, pick the host build (`-Os/-Arch/-Backend` overrides; **default = the first listed build: Vulkan on win/linux, Metal on mac**; `-Backend cpu` fetches the pure-CPU safety net into `runtime/llama.cpp/<os>/cpu/`), download + verify the archive, extract into the build's `extract_to` (`chmod +x` on mac/linux), and write a `.hilbertraum-runtime.json` install marker. Idempotent **via the marker** (version + backend must match — a missing/stale marker re-fetches, so a CPU-era drive actually upgrades); `-DryRun`/`--dry-run`. `-Family`/`--family` selects the asset family: `llama_cpp` (default), `whisper_cpp` (the transcriber CLI), or `ocr` (language files). |
+| `fetch-runtime.{ps1,sh}` | Read `runtime-sources.yaml`, pick the host build (`-Os/-Arch/-Backend` overrides; **default = the first listed build: Vulkan on win/linux, Metal on mac**; `-Backend cpu` fetches the pure-CPU safety net into `runtime/llama.cpp/<os>/cpu/`), download + verify the archive, extract into the build's `extract_to` (`chmod +x` on mac/linux), and write a `.hilbertraum-runtime.json` install marker. Idempotent **via the marker** (version + backend must match — a missing/stale marker re-fetches, so a CPU-era drive actually upgrades); `-DryRun`/`--dry-run`. `-Family`/`--family` selects the asset family: `llama_cpp` (default), `whisper_cpp` (the transcriber CLI), `kiwix_tools` (optional; the knowledge-pack tools — `kiwix-serve`/`kiwix-manage`/`kiwix-search` plus, on Windows, the five ICU DLLs; never part of `--with-assets`, only fetched by an explicit `--family kiwix_tools`, #339 P8-3), or `ocr` (language files). |
 | `verify-models.{ps1,sh}` | SHA-256 each present weight vs its manifest hash (placeholder → *UNVERIFIED*; real mismatch → fail/exit 1). `-Generate`/`--generate` writes `config/checksums.json`. |
 | `setup-dev.{ps1,sh}` | Dev bootstrap: `NODE_OPTIONS=--use-system-ca npm ci` (R6, set only when Node ≥ 22.15 supports the flag; skipped gracefully otherwise; `npm ci` = lockfile-exact, never rewrites `package-lock.json` — issue #49, the dev half of hardening L-8) + build + test smoke. |
 | `release-issues-section.sh` | Not drive prep: `.github/workflows/release.yml` runs it while building a tag and appends its output to the release notes. It emits an "Issues resolved" section — the ISSUES closed by the PRs merged since the last **published** release (the same baseline GitHub's own generated "What's Changed" uses, so the two agree), resolved via each commit's associated PRs + `closingIssuesReferences` rather than by parsing "(#N)" out of subjects (which would miss true merge commits). Read-only `gh` API calls, so it is locally testable: `scripts/release-issues-section.sh HilbertraumAI/HilbertRaum master`. Best-effort by design — a failure is downgraded to a workflow warning, so release notes can never block a release build. |
@@ -752,16 +752,19 @@ these harnesses prove the *current* pin (the drive's previous binary was b9585).
 | `model-eval` | `HILBERTRAUM_MODEL_EVAL` | the model-recommendation ladder on real hardware |
 | `zim-real` | `HILBERTRAUM_ZIM_SMOKE` | real `kiwix-manage` registration, the real `kiwix-serve` sidecar, Xapian search, the offline article viewer read — fully offline. **FAIL-CLOSED (#301 P5, finding L8):** requested with a missing/invalid tools dir, either binary absent, a non-ZIM file or an unset query **FAILS** the run instead of silently skipping it |
 
-**Manual install of the pinned kiwix-tools bundle (until P8-3).** `zim-real`'s tools directory
-is not fetched by any script yet: download the pinned **kiwix-tools 3.8.1, win-x86_64** zip
-(see `model-policy.md` "Sidecar binaries — kiwix-tools" for the exact bundle/hashes) and
-unzip the WHOLE archive under `runtime/kiwix-tools/<os>/` (Windows needs its five ICU DLLs
-beside the two exes). A hand-placed bundle like this has no install marker and resolves
-through the hashless `skip-legacy` verifier path (residual R-1) rather than integrity
-verification; an in-app install (the family contract landed at #339 P8-1) writes that marker
-instead, and both `kiwix-serve` and `kiwix-manage` then verify normally — but no user-reachable
-install exists yet (the consent step is P8-2). The drive scripts' own `--family kiwix_tools`
-support is P8-3 — none of that lands here.
+**Installing the pinned kiwix-tools bundle.** `fetch-runtime --family kiwix_tools` (#339 P8-3)
+downloads, SHA-256-verifies and extracts the pinned **kiwix-tools 3.8.1** archive for the host
+(or `--os`/`--arch` to provision another OS's dir), writes a `.hilbertraum-runtime.json` install
+marker hashing every required file (`kiwix-serve`, `kiwix-manage`, `kiwix-search`, and on
+Windows the five ICU DLLs), and `chmod +x`s the executables on mac/linux — exactly like the
+`llama_cpp`/`whisper_cpp` families, except it is never fetched by `prepare-drive --with-assets`
+(the family is optional: a DIY user runs the command explicitly once they want ZIM knowledge
+packs). A manual unzip of the pinned zip (see `model-policy.md` "Sidecar binaries —
+kiwix-tools" for the exact bundle/hashes) under `runtime/kiwix-tools/<os>/` remains a fallback
+that still works, but leaves no install marker and so resolves through the hashless
+`skip-legacy` verifier path (residual R-1) instead of integrity verification — prefer the
+script. An in-app install (the consent step, P8-2) is still to come; `kiwix-serve` and
+`kiwix-manage` verify normally against either the script's marker or an in-app one.
 
 **Optional harness *inputs* (point a harness at a specific artifact).** Distinct from the on-switch
 env vars in the table above, several harnesses additionally read an **artifact-pointer input**,

--- a/scripts/fetch-runtime.ps1
+++ b/scripts/fetch-runtime.ps1
@@ -46,9 +46,11 @@
 .PARAMETER Family
   Which asset family to fetch from runtime-sources.yaml: llama_cpp (default; the
   llama-server binary), whisper_cpp (the whisper-cli transcriber, Phase 36 -- same
-  verify + marker logic), or ocr (Phase 38: the vendored OCR language files, plain
-  sha256-verified downloads into ocr/ -- no extraction, no marker; idempotency IS the
-  hash).
+  verify + marker logic), kiwix_tools (#339 P8-3: the OPTIONAL knowledge-pack tools --
+  kiwix-serve/kiwix-manage/kiwix-search plus the five ICU DLLs on Windows; never fetched
+  by prepare-drive -WithAssets, only by an explicit -Family kiwix_tools), or ocr (Phase 38:
+  the vendored OCR language files, plain sha256-verified downloads into ocr/ -- no
+  extraction, no marker; idempotency IS the hash).
 
 .PARAMETER Commercial
   Drive-builder mode: refuse a placeholder hash before any download, re-fetch a hashless
@@ -61,6 +63,7 @@
   .\scripts\fetch-runtime.ps1 -Target E:\
   .\scripts\fetch-runtime.ps1 -Target E:\ -Os linux -Arch x64 -DryRun
   .\scripts\fetch-runtime.ps1 -Target E:\ -Family whisper_cpp
+  .\scripts\fetch-runtime.ps1 -Target E:\ -Family kiwix_tools
   .\scripts\fetch-runtime.ps1 -Target E:\ -Family ocr -Commercial
 #>
 [CmdletBinding()]
@@ -69,7 +72,7 @@ param(
   [string] $Os,
   [string] $Arch,
   [string] $Backend,
-  [ValidateSet('llama_cpp', 'whisper_cpp', 'ocr')] [string] $Family = 'llama_cpp',
+  [ValidateSet('llama_cpp', 'whisper_cpp', 'kiwix_tools', 'ocr')] [string] $Family = 'llama_cpp',
   [switch] $Commercial,
   [switch] $DryRun
 )
@@ -113,6 +116,51 @@ function Invoke-CurlResilient {
     }
   }
   return $false
+}
+
+# #339 P8-3: parse a flow-sequence value ("[a, b, c]", or "[]"/empty) into a string array.
+# Mirrors the flow-sequence shape runtime-sources.yaml uses for `executables:`/`runtime_files:`.
+function Get-FlowListValue {
+  param([string] $Raw)
+  $inner = $Raw.Trim()
+  if ($inner.StartsWith('[') -and $inner.EndsWith(']')) { $inner = $inner.Substring(1, $inner.Length - 2) }
+  if ($inner.Trim() -eq '') { return @() }
+  return @($inner -split ',' | ForEach-Object { $_.Trim().Trim('"').Trim("'") } | Where-Object { $_ -ne '' })
+}
+
+# #339 P8-3: the committed yaml spells `executables:`/`runtime_files:` as a one-line flow
+# sequence, but a hand-edited drive yaml might use a block sequence instead
+# (`executables:` alone, then `  - item` lines). Collapse any such block into the inline
+# flow form BEFORE the line-by-line parser below runs, so it only ever has to handle one
+# shape. Deliberately scoped to just these two keys -- `builds:`/`files:` are lists of
+# MAPPINGS ("- os: win"), not scalars, and are already handled by the per-item parsers below.
+function ConvertTo-FlowListLines {
+  param([string[]] $Lines)
+  $out = New-Object System.Collections.Generic.List[string]
+  $i = 0
+  while ($i -lt $Lines.Count) {
+    $line = $Lines[$i]
+    if ($line -match '^(\s*)(executables|runtime_files)\s*:\s*$') {
+      $indent = $Matches[1]
+      $key = $Matches[2]
+      $items = @()
+      $j = $i + 1
+      while ($j -lt $Lines.Count) {
+        if ($Lines[$j] -match '^(\s+)-\s*(.+?)\s*$' -and $Matches[1].Length -gt $indent.Length) {
+          $items += $Matches[2].Trim().Trim('"').Trim("'")
+          $j++
+        } else { break }
+      }
+      if ($items.Count -gt 0) {
+        $out.Add("$indent$key`: [$($items -join ', ')]")
+        $i = $j
+        continue
+      }
+    }
+    $out.Add($line)
+    $i++
+  }
+  return $out.ToArray()
 }
 
 # Normalize -Target to a full path: curl.exe resolves relative paths against the PROCESS
@@ -260,11 +308,13 @@ if ($Family -eq 'ocr') {
 # BLOCK-AWARE since Phase 36: the file holds TWO top-level families (llama_cpp +
 # whisper_cpp) with the same shape -- only the selected -Family's version/builds are
 # collected, so the whisper builds can never leak into a llama selection or vice versa.
-$lines = (Get-Content -Path $SourcesFile) -split "`n"
+$lines = ConvertTo-FlowListLines ((Get-Content -Path $SourcesFile) -split "`n")
 $version = $null
 $builds = @()
 $current = $null
 $topKey = $null
+$familyExecutables = @()
+$familyExecutablesSet = $false
 foreach ($raw in $lines) {
   $line = $raw.TrimEnd()
   if ($line -match '^\s*#') { continue }
@@ -279,6 +329,14 @@ foreach ($raw in $lines) {
   # committed `version: b9196   # PLACEHOLDER ...` used to leak the comment into the value.
   if (-not $version -and $line -match '^\s*version\s*:\s*(.+?)\s*$') {
     $version = ($Matches[1] -replace '\s+#.*$', '').Trim().Trim('"').Trim("'"); continue
+  }
+  # #339 P8-3: the FAMILY-level `executables:` list (a family shipping more than one
+  # executable, e.g. kiwix_tools: [kiwix-serve, kiwix-manage, kiwix-search]). Only
+  # meaningful before the `builds:` list starts (-not $current).
+  if (-not $current -and -not $familyExecutablesSet -and $line -match '^\s*executables\s*:\s*(.+?)\s*$') {
+    $familyExecutables = Get-FlowListValue (($Matches[1] -replace '\s+#.*$', '').Trim())
+    $familyExecutablesSet = $true
+    continue
   }
   if ($line -match '^\s*-\s*os\s*:\s*(.+?)\s*$') {
     if ($current) { $builds += $current }
@@ -328,11 +386,26 @@ if ($build.extract_to -match '\.\.' -or $build.extract_to -match '^[/\\]' -or $b
 
 $IsRealSha = { param($h) $h -match '^[a-f0-9]{64}$' }
 $extractTo = Join-Path $Target ($build.extract_to -replace '/', [IO.Path]::DirectorySeparatorChar)
-# Binary name follows the FAMILY + the SELECTED build's OS (we may be provisioning the
-# mac/linux dir from a Windows build machine), mirroring assets.ts sidecarBinaryName.
-$binaryBase = if ($Family -eq 'whisper_cpp') { 'whisper-cli' } else { 'llama-server' }
+# #339 P8-3: EXECUTABLE LIST per family (mirrors assets.ts SIDECAR_FAMILY_SPECS +
+# planRuntimeDownload) -- the primary base name per family, plus the yaml's family-level
+# `executables:` when present (its first entry is always the primary; llama_cpp/whisper_cpp
+# declare no `executables:`, so their required set stays the single binary it always was).
+$PrimaryBase = if ($Family -eq 'whisper_cpp') { 'whisper-cli' } elseif ($Family -eq 'kiwix_tools') { 'kiwix-serve' } else { 'llama-server' }
+$executableBases = @($PrimaryBase)
+foreach ($e in $familyExecutables) { if ($executableBases -notcontains $e) { $executableBases += $e } }
+# Binary name(s) follow the SELECTED build's OS (we may be provisioning the mac/linux dir
+# from a Windows build machine), mirroring assets.ts sidecarBinaryName. $binaryName/$binaryPath
+# keep referring to the PRIMARY only -- the flatten step below locates the archive's nested
+# folder by the primary executable, exactly as before.
+$binaryBase = $PrimaryBase
 $binaryName = if ($build.os -eq 'win') { "$binaryBase.exe" } else { $binaryBase }
 $binaryPath = Join-Path $extractTo $binaryName
+$requiredExecNames = @($executableBases | ForEach-Object { if ($build.os -eq 'win') { "$_.exe" } else { $_ } })
+$runtimeFileNames = @()
+if ($build.runtime_files) { $runtimeFileNames = Get-FlowListValue ([string]$build.runtime_files) }
+# Every file this install must produce: the executables, then the build's runtime_files
+# (verbatim -- they already carry their own extension). Mirrors assets.ts requiredInstallFiles.
+$requiredFileNames = @($requiredExecNames + $runtimeFileNames)
 $markerPath = Join-Path $extractTo '.hilbertraum-runtime.json'
 $sha = ([string]$build.sha256).ToLower()
 
@@ -340,26 +413,35 @@ Write-Host "Fetch runtime -> $Target" -ForegroundColor Cyan
 Write-Host ("  build: {0}/{1} {2} @ {3}" -f $build.os, $build.arch, $build.backend, $version)
 Write-Host ("  url:   {0}" -f $build.url)
 Write-Host ("  into:  {0}" -f $extractTo)
+Write-Host ("  files: {0}" -f ($requiredFileNames -join ', '))
 
 # Idempotent skip is MARKER-based (Phase 14, mirrors assets.ts runtimeInstallCurrent):
 # "binary exists" alone would silently keep a CPU-era build in place after the default
-# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend
-# -- and, under -Commercial, records the binary's hash (a hashless legacy marker is
-# re-fetched, #234).
+# became vulkan. Skip only when EVERY required file is present (#339 P8-3 -- a half-installed
+# multi-file family is not "present", mirrors assets.ts runtimeBinaryPresent) and
+# .hilbertraum-runtime.json matches the selected version+backend -- and, under -Commercial,
+# records a hash for EVERY required file (a hashless legacy marker is re-fetched, #234).
 if (Test-Path $binaryPath) {
   $skip = $false
   $why = 'install marker is missing or differs'
-  if (Test-Path $markerPath) {
+  $allPresent = -not ($requiredFileNames | Where-Object { -not (Test-Path (Join-Path $extractTo $_)) })
+  if (-not $allPresent) {
+    $why = 'one or more required files are missing'
+  } elseif (Test-Path $markerPath) {
     try {
       $marker = Get-Content -Path $markerPath -Raw | ConvertFrom-Json
       if ($marker.version -eq $version -and $marker.backend -eq $build.backend) {
         $skip = $true
         if ($Commercial) {
-          $recorded = $null
-          if ($marker.binaries) { $recorded = $marker.binaries.PSObject.Properties[$binaryName].Value }
-          if (-not $recorded -or -not (& $IsRealSha ([string]$recorded).ToLower())) {
+          $allHashedMarker = $true
+          foreach ($f in $requiredFileNames) {
+            $recorded = $null
+            if ($marker.binaries) { $recorded = $marker.binaries.PSObject.Properties[$f].Value }
+            if (-not $recorded -or -not (& $IsRealSha ([string]$recorded).ToLower())) { $allHashedMarker = $false; break }
+          }
+          if (-not $allHashedMarker) {
             $skip = $false
-            $why = 'install marker records no binary hash (legacy) -- commercial mode'
+            $why = 'install marker records no binary hash for one or more required files (legacy) -- commercial mode'
           }
         }
       }
@@ -490,29 +572,61 @@ if (-not (Test-Path $binaryPath)) {
   }
 }
 
-if (Test-Path $binaryPath) {
-  # Record exactly which build is installed (UTF-8 without BOM -- PS 5.1 Set-Content
-  # would prepend one and break Node's JSON.parse). Mirrors assets.ts writeRuntimeMarker.
-  # `binaries` records the extracted binary's own SHA-256 so the app can re-hash it
-  # immediately before spawn (binary-verifier.ts, #234). The key is the binary's
-  # name relative to the extract dir (here it sits at the root after the flatten above).
-  # Only a VERIFIED archive earns that hash (#234): an unverified install must not mint
-  # a marker the sell gate and the spawn verifier would trust.
-  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-  $markerHead = '{"version":"' + $version + '","backend":"' + $build.backend + '","os":"' + $build.os + '","arch":"' + $build.arch + '"'
-  if ($archiveVerified) {
-    $binSha = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash.ToLower()
-    $markerJson = $markerHead + ',"binaries":{"' + $binaryName + '":"' + $binSha + '"}}'
+if (-not (Test-Path $binaryPath)) {
+  Write-Host "  FAIL: $binaryName not found under $extractTo after extraction -- the release archive layout may have changed." -ForegroundColor Red
+  exit 1
+}
+
+# #339 P8-3: post-extract completeness check -- EVERY required file (every declared
+# executable + runtime file), not just the primary. Mirrors assets.ts requiredInstallFiles /
+# the app's own post-extract check (runtime-download.ts installOne). A half-installed
+# multi-file family (e.g. the kiwix ICU DLLs left behind by a differently-shaped archive)
+# must fail loudly instead of writing a marker that claims a complete install.
+$missingRequired = @($requiredFileNames | Where-Object { -not (Test-Path (Join-Path $extractTo $_)) })
+if ($missingRequired.Count -gt 0) {
+  Write-Host ("  FAIL: required file(s) missing under {0} after extraction: {1}" -f $extractTo, ($missingRequired -join ', ')) -ForegroundColor Red
+  exit 1
+}
+
+if ($build.os -ne 'win') {
+  foreach ($f in $requiredExecNames) {
+    Write-Host "  NOTE: exec bit for $f cannot be set from Windows; exFAT mounts are typically all-executable, otherwise chmod +x it on the target OS." -ForegroundColor Yellow
+  }
+}
+
+# Record exactly which build is installed (UTF-8 without BOM -- PS 5.1 Set-Content
+# would prepend one and break Node's JSON.parse). Mirrors assets.ts writeRuntimeMarker.
+# `binaries` records every required file's own SHA-256 (keyed exactly like markerBinaryKey --
+# the path relative to the extract dir, posix separators; everything here is flat) so the
+# app can re-hash each executable immediately before spawn (binary-verifier.ts, #234) and the
+# sell gate can check the runtime files too. ALL-OR-NOTHING (#339 P8-3, mirrors
+# runtime-download.ts installOne): only a VERIFIED archive earns hashes at all, and a hashing
+# failure on ANY required file drops the whole map rather than writing a partial one -- the
+# verifier and the sell gate must never disagree about one install.
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+$markerHead = '{"version":"' + $version + '","backend":"' + $build.backend + '","os":"' + $build.os + '","arch":"' + $build.arch + '"'
+if ($archiveVerified) {
+  $allHashed = $true
+  $entries = @()
+  foreach ($f in $requiredFileNames) {
+    try {
+      $h = (Get-FileHash -Path (Join-Path $extractTo $f) -Algorithm SHA256).Hash.ToLower()
+      $entries += ('"' + $f + '":"' + $h + '"')
+    } catch {
+      $allHashed = $false
+      break
+    }
+  }
+  if ($allHashed) {
+    $markerJson = $markerHead + ',"binaries":{' + ($entries -join ',') + '}}'
   } else {
     $markerJson = $markerHead + '}'
-    Write-Host "  marker written WITHOUT a binary hash (archive unverified) -- the sell gate refuses this install" -ForegroundColor Yellow
+    Write-Host "  marker written WITHOUT binary hashes (could not hash every required file) -- the sell gate refuses this install" -ForegroundColor Yellow
   }
-  [System.IO.File]::WriteAllText($markerPath, $markerJson, $utf8NoBom)
-  Write-Host "  extracted $binaryName (+ .hilbertraum-runtime.json install marker)" -ForegroundColor Green
-  if ($build.os -ne 'win') {
-    Write-Host "  NOTE: exec bit for $binaryName cannot be set from Windows; exFAT mounts are typically all-executable, otherwise chmod +x it on the target OS." -ForegroundColor Yellow
-  }
-  exit 0
+} else {
+  $markerJson = $markerHead + '}'
+  Write-Host "  marker written WITHOUT a binary hash (archive unverified) -- the sell gate refuses this install" -ForegroundColor Yellow
 }
-Write-Host "  FAIL: $binaryName not found under $extractTo after extraction -- the release archive layout may have changed." -ForegroundColor Red
-exit 1
+[System.IO.File]::WriteAllText($markerPath, $markerJson, $utf8NoBom)
+Write-Host ("  extracted {0} (+ .hilbertraum-runtime.json install marker)" -f ($requiredFileNames -join ', ')) -ForegroundColor Green
+exit 0

--- a/scripts/fetch-runtime.sh
+++ b/scripts/fetch-runtime.sh
@@ -28,12 +28,15 @@
 #
 # --family selects the asset family: llama_cpp (default, llama-server), whisper_cpp
 # (the whisper-cli transcriber, runtime/whisper.cpp/<os>/ — same verify + marker
-# logic), or ocr (Phase 38: the vendored OCR language files, plain sha256-verified
-# downloads into ocr/ — no extraction, no marker; idempotency IS the hash).
+# logic), kiwix_tools (#339 P8-3: the OPTIONAL knowledge-pack tools —
+# kiwix-serve/kiwix-manage/kiwix-search plus the five ICU DLLs on Windows; never fetched
+# by prepare-drive --with-assets, only by an explicit --family kiwix_tools), or ocr
+# (Phase 38: the vendored OCR language files, plain sha256-verified downloads into ocr/ —
+# no extraction, no marker; idempotency IS the hash).
 #
 # Usage:
 #   scripts/fetch-runtime.sh --target /Volumes/HILBERTRAUM \
-#       [--os linux] [--arch x64] [--backend cpu] [--family whisper_cpp|ocr] [--commercial] [--dry-run]
+#       [--os linux] [--arch x64] [--backend cpu] [--family whisper_cpp|kiwix_tools|ocr] [--commercial] [--dry-run]
 set -euo pipefail
 
 TARGET=""; OS=""; ARCH=""; BACKEND=""; FAMILY="llama_cpp"; COMMERCIAL=0; DRY_RUN=0
@@ -57,8 +60,8 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -z "$TARGET" ]] && { echo "Error: --target <drive-root> is required" >&2; exit 2; }
 case "$FAMILY" in
-  llama_cpp|whisper_cpp|ocr) ;;
-  *) echo "Error: --family must be llama_cpp, whisper_cpp, or ocr" >&2; exit 2 ;;
+  llama_cpp|whisper_cpp|kiwix_tools|ocr) ;;
+  *) echo "Error: --family must be llama_cpp, whisper_cpp, kiwix_tools, or ocr" >&2; exit 2 ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -120,6 +123,61 @@ sha256_of() {
   # \ed6156…"). Stdin has no filename, so nothing is ever escaped.
   if command -v sha256sum >/dev/null 2>&1; then sha256sum < "$1" | awk '{print $1}'
   else shasum -a 256 < "$1" | awk '{print $1}'; fi
+}
+
+# #339 P8-3: parse a flow-sequence string ("[a, b, c]", or "[]"/empty) into words on
+# stdout, one per line. Mirrors the .ps1 Get-FlowListValue twin.
+flow_list_items() {
+  local raw="$1"
+  raw="${raw#\[}"; raw="${raw%\]}"
+  [[ -z "${raw//[[:space:]]/}" ]] && return 0
+  local IFS=','
+  local -a parts
+  read -ra parts <<< "$raw"
+  local p
+  for p in "${parts[@]}"; do
+    p="$(echo "$p" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | tr -d '"'"'"'')"
+    [[ -n "$p" ]] && echo "$p"
+  done
+}
+
+# #339 P8-3: the committed yaml spells `executables:`/`runtime_files:` as a one-line flow
+# sequence, but a hand-edited drive yaml might use a block sequence instead (`key:` alone,
+# then indented `- item` lines). Collapse any such block into the inline flow form BEFORE
+# the line-by-line parsers below run, so they only ever see one shape. Scoped to just these
+# two keys — `builds:`/`files:` are lists of MAPPINGS ("- os: win"), not scalars, and are
+# already handled by the per-item parsers below. Reads the global RAW_LINES array, writes
+# the global PP_LINES array.
+collapse_block_lists() {
+  local n=${#RAW_LINES[@]} i=0
+  PP_LINES=()
+  while (( i < n )); do
+    local line="${RAW_LINES[$i]%$'\r'}"
+    if [[ "$line" =~ ^([[:space:]]*)(executables|runtime_files)[[:space:]]*:[[:space:]]*$ ]]; then
+      local indent="${BASH_REMATCH[1]}" key="${BASH_REMATCH[2]}"
+      local items="" found=0
+      local j=$((i + 1))
+      while (( j < n )); do
+        local cand="${RAW_LINES[$j]%$'\r'}"
+        if [[ "$cand" =~ ^([[:space:]]+)-[[:space:]]*(.+)$ ]] && (( ${#BASH_REMATCH[1]} > ${#indent} )); then
+          local item
+          item="$(echo "${BASH_REMATCH[2]}" | sed 's/[[:space:]]*$//' | tr -d '"'"'"'')"
+          items="${items:+$items, }$item"
+          found=1
+          j=$((j + 1))
+        else
+          break
+        fi
+      done
+      if [[ $found -eq 1 ]]; then
+        PP_LINES+=("${indent}${key}: [${items}]")
+        i=$j
+        continue
+      fi
+    fi
+    PP_LINES+=("$line")
+    i=$((i + 1))
+  done
 }
 
 # --- The ocr family (Phase 38, D32): plain verified FILES, not build archives -------
@@ -238,14 +296,17 @@ fi
 # whisper_cpp) with the same shape — only the selected --family's version/builds are
 # collected, so the whisper builds can never leak into a llama selection or vice versa.
 VERSION=""
-declare -a B_OS B_ARCH B_BACKEND B_URL B_SHA B_EXTRACT
+declare -a B_OS B_ARCH B_BACKEND B_URL B_SHA B_EXTRACT B_RUNTIME
 idx=-1
 TOP_KEY=""
+FAMILY_EXECUTABLES=""
 # Strip an inline YAML comment (whitespace + '#' + rest) before unquoting (M17) — the
 # committed `version: b9196   # PLACEHOLDER …` used to leak the comment into the value.
 strip_value() { echo "$1" | sed 's/[[:space:]][[:space:]]*#.*$//' | tr -d '"'"'"'' | sed 's/[[:space:]]*$//'; }
 
-while IFS= read -r raw; do
+mapfile -t RAW_LINES < "$SOURCES_FILE"
+collapse_block_lists
+for raw in "${PP_LINES[@]}"; do
   line="${raw%$'\r'}"
   [[ "$line" =~ ^[[:space:]]*# ]] && continue
   # A non-indented `key:` line starts a new top-level family block.
@@ -256,6 +317,12 @@ while IFS= read -r raw; do
   [[ "$TOP_KEY" == "$FAMILY" ]] || continue
   if [[ -z "$VERSION" && "$line" =~ ^[[:space:]]*version[[:space:]]*:[[:space:]]*(.+)$ ]]; then
     VERSION="$(strip_value "${BASH_REMATCH[1]}")"; continue
+  fi
+  # #339 P8-3: the FAMILY-level `executables:` list (a family shipping more than one
+  # executable, e.g. kiwix_tools: [kiwix-serve, kiwix-manage, kiwix-search]). Only
+  # meaningful before the `builds:` list starts ($idx -lt 0).
+  if [[ $idx -lt 0 && -z "$FAMILY_EXECUTABLES" && "$line" =~ ^[[:space:]]*executables[[:space:]]*:[[:space:]]*(.+)$ ]]; then
+    FAMILY_EXECUTABLES="$(strip_value "${BASH_REMATCH[1]}")"; continue
   fi
   if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*os[[:space:]]*:[[:space:]]*(.+)$ ]]; then
     idx=$((idx + 1))
@@ -271,9 +338,10 @@ while IFS= read -r raw; do
       url) B_URL[$idx]="$val" ;;
       sha256) B_SHA[$idx]="$(echo "$val" | tr '[:upper:]' '[:lower:]')" ;;
       extract_to) B_EXTRACT[$idx]="$val" ;;
+      runtime_files) B_RUNTIME[$idx]="$val" ;;
     esac
   fi
-done < "$SOURCES_FILE"
+done
 
 [[ -z "$VERSION" ]] && { echo "runtime-sources.yaml: missing $FAMILY.version (is the $FAMILY block present?)" >&2; exit 2; }
 
@@ -318,11 +386,40 @@ case "${B_EXTRACT[$SEL]}" in
 esac
 
 EXTRACT_TO="$TARGET/${B_EXTRACT[$SEL]}"
-# Binary name follows the FAMILY + the selected build's OS (mirrors assets.ts
-# sidecarBinaryName): llama-server for llama_cpp, whisper-cli for whisper_cpp.
-BIN_BASE="llama-server"; [[ "$FAMILY" == "whisper_cpp" ]] && BIN_BASE="whisper-cli"
+# #339 P8-3: EXECUTABLE LIST per family (mirrors assets.ts SIDECAR_FAMILY_SPECS +
+# planRuntimeDownload) — the primary base name per family, plus the yaml's family-level
+# `executables:` when present (its first entry is always the primary; llama_cpp/whisper_cpp
+# declare no `executables:`, so their required set stays the single binary it always was).
+PRIMARY_BASE="llama-server"
+[[ "$FAMILY" == "whisper_cpp" ]] && PRIMARY_BASE="whisper-cli"
+[[ "$FAMILY" == "kiwix_tools" ]] && PRIMARY_BASE="kiwix-serve"
+declare -a EXEC_BASES=("$PRIMARY_BASE")
+if [[ -n "$FAMILY_EXECUTABLES" ]]; then
+  while IFS= read -r e; do
+    already=0
+    for existing in "${EXEC_BASES[@]}"; do [[ "$existing" == "$e" ]] && already=1 && break; done
+    [[ $already -eq 0 ]] && EXEC_BASES+=("$e")
+  done < <(flow_list_items "$FAMILY_EXECUTABLES")
+fi
+# Binary name(s) follow the SELECTED build's OS (mirrors assets.ts sidecarBinaryName).
+# BIN_BASE/BIN_NAME/BIN_PATH keep referring to the PRIMARY only — the flatten step below
+# locates the archive's nested folder by the primary executable, exactly as before.
+BIN_BASE="$PRIMARY_BASE"
 BIN_NAME="$BIN_BASE"; [[ "${B_OS[$SEL]}" == "win" ]] && BIN_NAME="$BIN_BASE.exe"
 BIN_PATH="$EXTRACT_TO/$BIN_NAME"
+declare -a EXEC_NAMES=()
+for b in "${EXEC_BASES[@]}"; do
+  if [[ "${B_OS[$SEL]}" == "win" ]]; then EXEC_NAMES+=("$b.exe"); else EXEC_NAMES+=("$b"); fi
+done
+declare -a RUNTIME_FILE_NAMES=()
+RUNTIME_FILES_RAW="${B_RUNTIME[$SEL]:-}"
+if [[ -n "$RUNTIME_FILES_RAW" ]]; then
+  while IFS= read -r f; do RUNTIME_FILE_NAMES+=("$f"); done < <(flow_list_items "$RUNTIME_FILES_RAW")
+fi
+# Every file this install must produce: the executables, then the build's runtime_files
+# (verbatim — they already carry their own extension). Mirrors assets.ts requiredInstallFiles.
+declare -a REQUIRED_FILE_NAMES=("${EXEC_NAMES[@]}")
+if [[ ${#RUNTIME_FILE_NAMES[@]} -gt 0 ]]; then REQUIRED_FILE_NAMES+=("${RUNTIME_FILE_NAMES[@]}"); fi
 MARKER_PATH="$EXTRACT_TO/.hilbertraum-runtime.json"
 URL="${B_URL[$SEL]}"
 SHA="${B_SHA[$SEL]}"
@@ -331,27 +428,43 @@ echo "Fetch runtime -> $TARGET"
 echo "  build: ${B_OS[$SEL]}/${B_ARCH[$SEL]} ${B_BACKEND[$SEL]} @ $VERSION"
 echo "  url:   $URL"
 echo "  into:  $EXTRACT_TO"
+echo "  files: ${REQUIRED_FILE_NAMES[*]}"
+
+# marker_hash_for KEY MARKER_PATH — the recorded hash for one marker key (parsed with sed,
+# no jq dep; the marker is written by us as flat single-line JSON).
+marker_hash_for() {
+  sed -n 's/.*"binaries":{[^}]*"'"$1"'":"\([a-fA-F0-9]\{64\}\)".*/\1/p' "$2" | tr '[:upper:]' '[:lower:]'
+}
 
 # Idempotent skip is MARKER-based (Phase 14, mirrors assets.ts runtimeInstallCurrent):
 # "binary exists" alone would silently keep a CPU-era build in place after the default
-# became vulkan. Skip only when .hilbertraum-runtime.json matches the selected version+backend
-# — and, under --commercial, records the binary's hash (a hashless legacy marker is
-# re-fetched, #234).
+# became vulkan. Skip only when EVERY required file is present (#339 P8-3 — a half-installed
+# multi-file family is not "present", mirrors assets.ts runtimeBinaryPresent) and
+# .hilbertraum-runtime.json matches the selected version+backend — and, under --commercial,
+# records a hash for EVERY required file (a hashless legacy marker is re-fetched, #234).
 if [[ -f "$BIN_PATH" ]]; then
   SKIP=0
   WHY="install marker is missing or differs"
-  if [[ -f "$MARKER_PATH" ]]; then
-    # The marker is written by us as flat single-line JSON — parse with sed (no jq dep).
+  ALL_PRESENT=1
+  for f in "${REQUIRED_FILE_NAMES[@]}"; do
+    [[ -f "$EXTRACT_TO/$f" ]] || { ALL_PRESENT=0; break; }
+  done
+  if [[ $ALL_PRESENT -eq 0 ]]; then
+    WHY="one or more required files are missing"
+  elif [[ -f "$MARKER_PATH" ]]; then
     m_version="$(sed -n 's/.*"version":"\([^"]*\)".*/\1/p' "$MARKER_PATH")"
     m_backend="$(sed -n 's/.*"backend":"\([^"]*\)".*/\1/p' "$MARKER_PATH")"
     if [[ "$m_version" == "$VERSION" && "$m_backend" == "${B_BACKEND[$SEL]}" ]]; then
       SKIP=1
       if [[ $COMMERCIAL -eq 1 ]]; then
-        m_hash="$(sed -n 's/.*"binaries":{[^}]*"'"$BIN_NAME"'":"\([a-fA-F0-9]\{64\}\)".*/\1/p' "$MARKER_PATH" | tr '[:upper:]' '[:lower:]')"
-        if ! is_real_sha "$m_hash"; then
-          SKIP=0
-          WHY="install marker records no binary hash (legacy) — commercial mode"
-        fi
+        for f in "${REQUIRED_FILE_NAMES[@]}"; do
+          m_hash="$(marker_hash_for "$f" "$MARKER_PATH")"
+          if ! is_real_sha "$m_hash"; then
+            SKIP=0
+            WHY="install marker records no binary hash for one or more required files (legacy) — commercial mode"
+            break
+          fi
+        done
       fi
     fi
   fi
@@ -479,25 +592,61 @@ if [[ ! -f "$BIN_PATH" ]]; then
   fi
 fi
 
-if [[ -f "$BIN_PATH" ]]; then
-  chmod +x "$BIN_PATH" 2>/dev/null || true
-  # Record exactly which build is installed (mirrors assets.ts writeRuntimeMarker). The
-  # `binaries` map records the extracted binary's own SHA-256 (keyed by its name relative
-  # to the extract dir — it sits at the root after the flatten above) so the app can
-  # re-hash it immediately before spawn (binary-verifier.ts, #234). Only a
-  # VERIFIED archive earns that hash (#234): an unverified install must not mint a
-  # marker the sell gate and the spawn verifier would trust.
-  if [[ $ARCHIVE_VERIFIED -eq 1 ]]; then
-    BIN_SHA="$(sha256_of "$BIN_PATH")"
-    printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s","binaries":{"%s":"%s"}}' \
-      "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" "$BIN_NAME" "$BIN_SHA" > "$MARKER_PATH"
+if [[ ! -f "$BIN_PATH" ]]; then
+  echo "  FAIL: $BIN_NAME not found under $EXTRACT_TO after extraction — the release archive layout may have changed." >&2
+  exit 1
+fi
+
+# #339 P8-3: post-extract completeness check — EVERY required file (every declared
+# executable + runtime file), not just the primary. Mirrors assets.ts requiredInstallFiles /
+# the app's own post-extract check (runtime-download.ts installOne). A half-installed
+# multi-file family (e.g. the kiwix ICU DLLs left behind by a differently-shaped archive)
+# must fail loudly instead of writing a marker that claims a complete install.
+declare -a MISSING_REQUIRED=()
+for f in "${REQUIRED_FILE_NAMES[@]}"; do
+  [[ -f "$EXTRACT_TO/$f" ]] || MISSING_REQUIRED+=("$f")
+done
+if [[ ${#MISSING_REQUIRED[@]} -gt 0 ]]; then
+  echo "  FAIL: required file(s) missing under $EXTRACT_TO after extraction: ${MISSING_REQUIRED[*]}" >&2
+  exit 1
+fi
+
+for exe in "${EXEC_NAMES[@]}"; do
+  chmod +x "$EXTRACT_TO/$exe" 2>/dev/null || true
+done
+
+# Record exactly which build is installed (mirrors assets.ts writeRuntimeMarker). The
+# `binaries` map records every required file's own SHA-256 (keyed exactly like
+# markerBinaryKey — the path relative to the extract dir; everything here is flat) so the
+# app can re-hash each executable immediately before spawn (binary-verifier.ts, #234) and
+# the sell gate can check the runtime files too. ALL-OR-NOTHING (#339 P8-3, mirrors
+# runtime-download.ts installOne): only a VERIFIED archive earns hashes at all, and a
+# hashing failure on ANY required file drops the whole map rather than writing a partial
+# one — the verifier and the sell gate must never disagree about one install.
+if [[ $ARCHIVE_VERIFIED -eq 1 ]]; then
+  ALL_HASHED=1
+  declare -a ENTRIES=()
+  for f in "${REQUIRED_FILE_NAMES[@]}"; do
+    if h="$(sha256_of "$EXTRACT_TO/$f" 2>/dev/null)"; then
+      ENTRIES+=("\"$f\":\"$h\"")
+    else
+      ALL_HASHED=0
+      break
+    fi
+  done
+  if [[ $ALL_HASHED -eq 1 ]]; then
+    BIN_MAP="$(IFS=,; echo "${ENTRIES[*]}")"
+    printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s","binaries":{%s}}' \
+      "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" "$BIN_MAP" > "$MARKER_PATH"
   else
     printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s"}' \
       "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" > "$MARKER_PATH"
-    echo "  marker written WITHOUT a binary hash (archive unverified) — the sell gate refuses this install"
+    echo "  marker written WITHOUT binary hashes (could not hash every required file) — the sell gate refuses this install"
   fi
-  echo "  extracted + chmod +x $BIN_NAME (+ .hilbertraum-runtime.json install marker)"
-  exit 0
+else
+  printf '{"version":"%s","backend":"%s","os":"%s","arch":"%s"}' \
+    "$VERSION" "${B_BACKEND[$SEL]}" "${B_OS[$SEL]}" "${B_ARCH[$SEL]}" > "$MARKER_PATH"
+  echo "  marker written WITHOUT a binary hash (archive unverified) — the sell gate refuses this install"
 fi
-echo "  FAIL: $BIN_NAME not found under $EXTRACT_TO after extraction — the release archive layout may have changed." >&2
-exit 1
+echo "  extracted + chmod +x ${EXEC_NAMES[*]} (+ .hilbertraum-runtime.json install marker)"
+exit 0

--- a/scripts/prepare-drive.ps1
+++ b/scripts/prepare-drive.ps1
@@ -40,7 +40,9 @@
   language files (deu/eng traineddata for scanned-PDF and photo text recognition, Phase 38 --
   OS-independent, ~4 MB). The user downloads any other models (larger chat models) from inside
   the app. Without this flag the behaviour is unchanged (layout + config; you drop artifacts
-  in by hand).
+  in by hand). The OPTIONAL knowledge-pack tools (kiwix-tools, #339 P8-3) are never fetched
+  here -- run `fetch-runtime.ps1 -Family kiwix_tools` separately once you want ZIM knowledge
+  packs.
 
 .PARAMETER AllModels
   With -WithAssets, fetch ALL models with a download block (every chat model + embeddings +
@@ -113,6 +115,11 @@ $Dirs = @(
   'runtime/whisper.cpp/win',
   'runtime/whisper.cpp/mac',
   'runtime/whisper.cpp/linux',
+  # Third sidecar family, OPTIONAL -- #339 P8-3: the kiwix-tools knowledge-pack tools. Never
+  # fetched by -WithAssets -- run fetch-runtime.ps1 -Family kiwix_tools separately.
+  'runtime/kiwix-tools/win',
+  'runtime/kiwix-tools/mac',
+  'runtime/kiwix-tools/linux',
   'ocr',
   'zim',
   'logs',

--- a/scripts/prepare-drive.sh
+++ b/scripts/prepare-drive.sh
@@ -16,7 +16,9 @@
 # (llama.cpp + whisper.cpp) and the OCR language files (deu/eng traineddata for scanned-PDF
 # and photo text recognition, Phase 38 — OS-independent, ~4 MB). The user downloads any
 # other models (larger chat models) from inside the app. Pass --all-models to fetch every
-# model instead (the sidecar runtimes + OCR files are fetched either way).
+# model instead (the sidecar runtimes + OCR files are fetched either way). The OPTIONAL
+# knowledge-pack tools (kiwix-tools, #339 P8-3) are never fetched here — run
+# `fetch-runtime.sh --family kiwix_tools` separately once you want ZIM knowledge packs.
 #
 # Usage:
 #   scripts/prepare-drive.sh --target /Volumes/HILBERTRAUM [--dry-run] [--force] \
@@ -89,6 +91,11 @@ DIRS=(
   runtime/whisper.cpp/win
   runtime/whisper.cpp/mac
   runtime/whisper.cpp/linux
+  # Third sidecar family, OPTIONAL -- #339 P8-3: the kiwix-tools knowledge-pack tools. Never
+  # fetched by --with-assets -- run fetch-runtime.sh --family kiwix_tools separately.
+  runtime/kiwix-tools/win
+  runtime/kiwix-tools/mac
+  runtime/kiwix-tools/linux
   ocr
   zim
   logs


### PR DESCRIPTION
Refs #339 (Phase 8, step P8-3 — the drive scripts). Refs #301. **Stacked on #354** (P8-1) → #351 → #350 → #349 → #348; retarget and rebase as each parent lands. Scope and blast radius: `tmp/339-kiwix-provisioning-plan.md` "P8-3" (maintainer-local).

## What

- **`fetch-runtime.{ps1,sh} --family kiwix_tools`**: the family allow-list; a per-family EXECUTABLE LIST replaces the two-way binary-base branch (the primary — `llama-server` / `whisper-cli` / `kiwix-serve` — plus the yaml's family-level `executables`); the per-build `runtime_files` (the five ICU DLLs on win); extraction stays wholesale and the flatten moves every sibling (both shapes: the flat win zip, the one-folder mac/linux tarballs); a post-extract completeness check names any missing file and writes no marker; the marker records a SHA-256 for EVERY required file, keyed exactly like the app's `markerBinaryKey`, all-or-nothing; `--commercial` semantics unchanged (a verified archive earns the hashes); `chmod +x` every executable on POSIX. The ocr path is untouched; llama/whisper keep their single-binary sets.
- **Layout**: `runtime/kiwix-tools/<os>` joins `DRIVE_LAYOUT_DIRS` (`drive.ts`) and both `prepare-drive` dir arrays. `--with-assets` never fetches the optional family — its help text says so; a DIY user runs `fetch-runtime --family kiwix_tools` explicitly.
- **Deliberately not here**: the `build-commercial-drive` matrix rows and the Kit's mac arch choice — a Kit must not carry the binaries without the corresponding-source bundle, which is P8-4 and waits on the owner's layout ruling; the drift net's "the builders skip exactly the optional families" leg therefore stays true.

## Tests

`script-drift.test.ts` (the dir arrays pinned to `DRIVE_LAYOUT_DIRS`; NEW: both twins' family allow-lists equal the yaml's build families + `ocr`), `script-execution.test.ts` (NEW: a dry run of all four `kiwix_tools` builds offline, the per-build file list printed, nothing fetched), `drive`, `commercial-drive`, `repo-hygiene` — green on the PowerShell and bash legs; typecheck green; full suite 6,650 passed / 0 failed per the implementing agent's run.

**Real-tool leg (dev-time, this machine, win x64, live `download.kiwix.org`)**: the script reported the archive VERIFIED against the yaml pin; all eight files landed under `runtime/kiwix-tools/win`; the marker's `binaries` map carried all eight keys and an independent SHA-256 of each file matched its recorded hash. Evidence in the plan note; the temp target was deleted afterwards.

## Docs

`docs/packaging.md` (the `-Family` values; the manual-install paragraph now leads with the script path, manual unzip is the `skip-legacy` fallback), BUILD_STATE 21(a). No user-facing change (no CHANGELOG entry): the app's UI still has no way to request the family (P8-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
