### PR TITLE
feat(zim): search the packs for the question's content words, one narrower retry on zero hits (#340 L3, D-Z18)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -119,7 +119,8 @@ loser's row; record rag-design **D-Z16**; tests `zim-ipc-session` "#340 packs:st
 on step 3; record design-guidelines §11.15 "Follow-up wave"):** per-row busy, an unavailable pack can be disabled, the language NAME in the meta line, the chip's "(disabled)" /
 "(not available)" state, `.footer-menu-btn`'s own shrink rule, no `reconcile-start` refetch. **Step 5 — #339 P8-1** (`feat/339-p8-1-kiwix-family`, design paper
 `tmp/339-p8-1-design.md`): the `kiwix_tools` family contract landed (record rag-design **D-Z17**); the consent step and the source-bundle code still wait on the owner's rulings.
-Next: #340 capabilities; (b)/(c) wait for the owner._
+**Step 6 — #340 L3** (`feat/340-l3-search-rewrite`, paper `tmp/340-capabilities-plan.md` C1): the question → `/search` pattern rewrite (record rag-design **D-Z18**; measured on the real
+K: pack raw-server 6/9 → 9/9 hit@5; fixture `quality-questions-de.json`, replayed by the manual smoke). Next: L1 / L2 (owner questions first), then C2–C4; (b)/(c) wait for the owner._
 
 _2026-09-06 — **ZIM knowledge packs (PR #294 → #301) — WAVE CLOSED: Phases 0–7 complete, #294 MERGED to master (`92e86a07`, 16:12 UTC), #301 closed by the merge.**_
 The PR's review remediation — 28 findings (H1–H4, M1–M11, L1–L9 with L10 withdrawn, DOC-1–DOC-4; three assessed High, H3 and DOC-1/DOC-2 Medium) — closed across P0–P6 on the integration branch `feat/zim-knowledge-packs`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,14 @@ from its first public `1.0.0` release onward.
   the panel used to show both as simply "Enabled", with the reason visible only in the note under
   an answer. The later pack now carries a "Not served" badge and a line naming the pack that keeps
   the name, with the fix (rename one file).
+- **Questions find the right knowledge-pack articles more often.** The pack server's search
+  requires every word of the question to appear in an article, and a Wikipedia archive treats
+  "which", "role", "plays" and the like as ordinary words — so "Which role does permafrost
+  play?" used to miss the Permafrost article. The app now searches the packs for the question's
+  content words only (the question itself is still what the answer is written from), and asks
+  once more with fewer words when the first search finds nothing. On the German climate archive
+  used for testing this took the questions that found their article from six of nine to nine
+  of nine.
 - **A knowledge pack you just added is checked for full-text search right away.** Until now the
   check ran only when you unlocked or pressed Refresh, so a pack added through *Add packs…* (or
   enabled after being added) showed no "No full-text index" badge until then, and a question asked

--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -3,6 +3,7 @@ import type { ExternalRetrievalOutput, RetrievedChunk } from '../rag'
 import { CHUNK_DEFAULTS, chunkSegments } from '../ingestion/chunker'
 import { fetchArticleHtml, searchPack } from './client'
 import { zimArticleToSegmentsAsync } from './html'
+import { searchPattern } from './query-rewrite'
 
 // Query-time candidate production for the ZIM retrieval arm (knowledge packs).
 // Per pack: Xapian full-text search (the archive's own index — the keyword stage we
@@ -186,11 +187,19 @@ export async function collectPackCandidates(
     if (abortFailure === undefined) abortFailure = err
   }
 
+  // #340 L3 (D-Z18): Xapian ANDs every word of the pattern, so the question's function and
+  // frame words are stripped before the search; the ORIGINAL question stays the reranker's
+  // query and the chunk picker's `terms`. A first search that finds nothing is retried ONCE
+  // with the narrower pattern (the kept terms of five or more characters) when that differs.
+  const rewrite = searchPattern(question)
   async function runPack(item: PackWork): Promise<void> {
     const { pack } = item
     let hits
     try {
-      hits = await searchPack(port, pack.id, question, ARTICLES_PER_PACK, signal)
+      hits = await searchPack(port, pack.id, rewrite.pattern, ARTICLES_PER_PACK, signal)
+      if (hits.length === 0 && rewrite.retry !== null) {
+        hits = await searchPack(port, pack.id, rewrite.retry, ARTICLES_PER_PACK, signal)
+      }
     } catch (err) {
       if (aborted()) return noteAbort(err)
       // Non-200 (a 404 included — ambiguous, never a capability verdict) or a network error.

--- a/apps/desktop/src/main/services/zim/query-rewrite.ts
+++ b/apps/desktop/src/main/services/zim/query-rewrite.ts
@@ -1,0 +1,96 @@
+// The question → `/search` pattern rewrite (#340 L3; rag-design §17 D-Z18).
+//
+// WHY. kiwix-serve hands the pattern to libzim's Xapian query parser (libzim 9.4.0
+// `search.cpp`): default operator AND, STEM_ALL with the archive's stemmer, the archive's own
+// stopper, and NO boolean / phrase / wildcard flags. So every word of a natural-language
+// question that the archive's stopper does not drop is ANDed into the query — and the pinned
+// German Wikipedia archives stop almost nothing ("welche", "rolle", "spielt" all return hits on
+// their own). Measured on the real climate pack (2026-09-06, ten German questions): the raw
+// question found the expected article in 6 of 9 answerable cases; dropping function words
+// alone reached 7 of 9 (AND still kept "rolle spielt", "funktioniert"); dropping the
+// question-FRAME words too reached 9 of 9 and was never worse. That is this module.
+//
+// WHAT. `searchPattern(question)` keeps the question's content words — in their original
+// spelling and order, so Xapian's stemmer and hyphen handling see exactly what the user typed
+// (`CO2-Konzentration`, `1850`) — and drops (a) function words and (b) question-frame words,
+// from CONSERVATIVE German + English lists applied together (only words that are function or
+// frame words in one language and not content words in the other; the question's language is
+// not known here). The ORIGINAL question stays the reranker's and the prompt's query — the
+// rewrite only decides which articles Xapian is asked for. When nothing survives the strip the
+// raw question is used unchanged. A `retry` pattern (the kept terms of five or more
+// characters) lets the arm ask once more when the first search finds nothing at all: with AND
+// semantics one short generic word can still zero a query, and one extra ~100 ms request is
+// cheaper than a "not found" the archive would have answered.
+
+/** German + English function words (articles, pronouns, prepositions, auxiliaries, …). */
+const STOP_WORDS = new Set<string>(
+  (
+    'der die das dem den des ein eine einer eines einem einen und oder aber sondern denn ist sind ' +
+    'war waren wird werden wurde wurden hat haben hatte hatten kann können könnte könnten muss ' +
+    'müssen soll sollen sollte darf dürfen mag mögen ich du er sie es wir ihr mich dich sich uns ' +
+    'euch mir dir ihm ihnen mein meine meinen meinem dein deine sein seine seinen seinem unser ' +
+    'unsere euer eure nicht kein keine keinen keinem auch noch nur schon sehr mehr als wie was wer ' +
+    'wo wann warum wieso weshalb welche welcher welches welchen welchem wem wen wessen bei beim im ' +
+    'in ins am an auf aus für mit nach von vom zu zum zur über unter vor hinter zwischen durch ' +
+    'gegen ohne um bis seit ob dass daß da doch so dann also etwa ja nein man dies diese dieser ' +
+    'dieses diesen diesem jene jener jenes hier dort damit dafür davon dazu darauf daran darin ' +
+    'dabei wenn weil falls sowie bzw ' +
+    'the a an and or but nor is are was were be been being has have had do does did can could ' +
+    'should would may might will shall must i you he she it we they me him her us them my your ' +
+    'his its our their not no also only very more most than as what who whom whose which where ' +
+    'when why how that this these those there here at by for from in into of on to with without ' +
+    'about over under between through during before after up down out off again further then ' +
+    'once all any both each few other some such own same so too just if because while until yet'
+  ).split(/\s+/)
+)
+
+/** Words that FRAME a question without naming its subject ("Welche Rolle spielt …", "Wie
+ *  funktioniert …", "What is the difference between …"). Content-neutral in a Wikipedia ask. */
+const FRAME_WORDS = new Set<string>(
+  (
+    'rolle rollen spielt spielen spielte funktioniert funktionieren bedeutet bedeuten heißt heisst ' +
+    'erkläre erklären erklär beschreibe beschreiben unterschied unterschiede vergleich vergleiche ' +
+    'vergleichen hoch groß gross viel viele gibt geben passiert geschieht entsteht entstehen ' +
+    'wichtig bitte nenne nennen zeige zeigen liste sag sage sagen fasse zusammen zusammenfassen ' +
+    'kurz genau eigentlich überhaupt ' +
+    'explain explains describe describes tell role roles play plays played work works working ' +
+    'mean means meaning meant difference differences differ compare comparison happen happens ' +
+    'happened important please list give gives name names define definition high much many ' +
+    'kind kinds type types sort sorts way ways use used uses purpose'
+  ).split(/\s+/)
+)
+
+/** The shortest kept term the zero-hit retry keeps (D-Z18). */
+export const RETRY_MIN_TERM_CHARS = 5
+
+export interface SearchRewrite {
+  /** The pattern to send first: the question's content words, original spelling and order. */
+  pattern: string
+  /** A narrower pattern to try ONCE when `pattern` finds nothing, or null when it would be the
+   *  same query (or empty): the kept terms of `RETRY_MIN_TERM_CHARS` or more characters. */
+  retry: string | null
+  /** True when the strip changed the question (false = the raw question is the pattern). */
+  rewritten: boolean
+}
+
+/** Tokens: letters/digits with inner hyphens (`CO2-Konzentration`), no trailing hyphen. */
+const TOKEN_RE = /[\p{L}\p{N}][\p{L}\p{N}-]*/gu
+
+export function searchPattern(question: string): SearchRewrite {
+  const raw = question.trim()
+  const kept: string[] = []
+  const seen = new Set<string>()
+  for (const m of raw.matchAll(TOKEN_RE)) {
+    const token = m[0].replace(/-+$/, '')
+    if (token === '') continue
+    const key = token.toLowerCase()
+    if (STOP_WORDS.has(key) || FRAME_WORDS.has(key) || seen.has(key)) continue
+    seen.add(key)
+    kept.push(token)
+  }
+  if (kept.length === 0) return { pattern: raw, retry: null, rewritten: false }
+  const pattern = kept.join(' ')
+  const longer = kept.filter((t) => t.length >= RETRY_MIN_TERM_CHARS)
+  const retry = kept.length >= 2 && longer.length > 0 && longer.length < kept.length ? longer.join(' ') : null
+  return { pattern, retry, rewritten: pattern !== raw }
+}

--- a/apps/desktop/tests/fixtures/zim/quality-questions-de.json
+++ b/apps/desktop/tests/fixtures/zim/quality-questions-de.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "#340 L3 (rag-design §17 D-Z18): the retrieval-quality fixture measured 2026-09-06 against the real pack wikipedia_de_climate-change_nopic_2026-07 (header UUID d30cd05e-b9ae-b7c2-52d7-c2b308e56554, 4102 articles) on kiwix-tools 3.8.1 win-x86_64 with no app code (raw /search, pageLength 5). `expectedTitles` lists the article titles that count as a hit@5 (any one of them among the top five). `rawHit` records whether the RAW question found one (the pre-L3 behaviour) and `answerable` whether the pack holds such an article at all. The manual smoke (tests/manual/zim-real.test.ts) replays this file when the registered archive is this pack and asserts every answerable question hits with the L3 rewrite; the unit suite zim-query-rewrite.test.ts pins the patterns. Raw evidence: ai_drive-archive/zim-wave-2026-09/evidence/l3-2026-09-06/.",
+  "packUuid": "d30cd05e-b9ae-b7c2-52d7-c2b308e56554",
+  "questions": [
+    { "question": "Welche Rolle spielt Methan beim Treibhauseffekt?", "expectedTitles": ["Treibhauseffekt", "Treibhausgas"], "rawHit": true, "answerable": true },
+    { "question": "Wie hoch ist die CO2-Konzentration in der Atmosphäre?", "expectedTitles": ["Keeling-Kurve", "Kohlenstoffdioxid"], "rawHit": true, "answerable": true },
+    { "question": "Was ist das Pariser Abkommen?", "expectedTitles": ["Übereinkommen von Paris"], "rawHit": true, "answerable": true },
+    { "question": "Warum steigt der Meeresspiegel?", "expectedTitles": ["Meeresspiegelanstieg seit 1850"], "rawHit": false, "answerable": true },
+    { "question": "Was bedeutet Klimasensitivität?", "expectedTitles": ["Klimasensitivität"], "rawHit": true, "answerable": true },
+    { "question": "Welche Folgen hat die globale Erwärmung für die Landwirtschaft?", "expectedTitles": ["Folgen der globalen Erwärmung"], "rawHit": true, "answerable": true },
+    { "question": "Was sind Kipppunkte im Klimasystem?", "expectedTitles": ["Kippelemente im Erdklimasystem"], "rawHit": true, "answerable": true },
+    { "question": "Welche Rolle spielt der Permafrost?", "expectedTitles": ["Permafrost"], "rawHit": false, "answerable": true },
+    { "question": "Wie funktioniert der Emissionshandel?", "expectedTitles": ["EU-Emissionshandel", "Emissionsrechtehandel"], "rawHit": false, "answerable": true },
+    { "question": "Was ist der Unterschied zwischen Wetter und Klima?", "expectedTitles": ["Klima"], "rawHit": false, "answerable": false }
+  ]
+}

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -57,6 +57,8 @@ function bigArticleHtml(): string {
 }
 /** Set by the fake sidecar once the big article's body has been written. */
 let bigArticleServed = false
+/** Every `/search` pattern the fixture server received, in order (#340 L3). */
+const searchPatterns: string[] = []
 /**
  * Article titles whose NEXT `/raw` read the fake sidecar CUTS SHORT — the measured kiwix-serve
  * 3.8.1 stall (#301 P7 T19): the 200, an honest `Content-Length` and most of the body arrive,
@@ -87,6 +89,7 @@ beforeAll(async () => {
         res.end('boom')
         return
       }
+      searchPatterns.push(url.searchParams.get('pattern') ?? '')
       const titles =
         book === 'pack-climate'
           ? ['Treibhausgas', 'Treibhauspotential']
@@ -94,7 +97,13 @@ beforeAll(async () => {
             ? ['Grossartikel']
             : book === 'pack-mixed'
               ? ['Kaputt', 'Schwefel']
-              : ['Schwefel']
+              : book === 'pack-retry'
+                ? // #340 L3: a book that answers ONLY the narrower retry pattern — the first
+                  // (broader) pattern finds nothing, the way an ANDed short generic word does.
+                  url.searchParams.get('pattern') === 'wirkt'
+                  ? ['Schwefel']
+                  : []
+                : ['Schwefel']
       res.writeHead(200, { 'content-type': 'application/xml' })
       res.end(searchXml(`book-${book}`, titles))
       return
@@ -249,9 +258,25 @@ describe('collectPackCandidates', () => {
     }
     setImmediate(cancelWhenServed)
 
-    await expect(
-      collectPackCandidates(port, [{ id: 'pack-big', title: 'Gross' }], 'Treibhausgas Landwirtschaft', signal)
-    ).rejects.toBe(reason)
+    // The PROPERTY this leg pins: an aborted ask REJECTS — it never resolves to an empty list.
+    // Which abort it rejects with is a scheduling fact, not the contract: the converter rejects
+    // with `signal.reason` at its next slice boundary, but since the P7 stall retry the client
+    // re-reads `signal.aborted` after an attempt and `combineSignals` reads it when the next
+    // request is created, so under load the transport can observe the cancellation first and
+    // reject with Node's own `AbortError` (seen three times on 2026-09-06 after heavy runs,
+    // never in isolation). Both are the ask's abort; neither is an empty list.
+    const err = await collectPackCandidates(
+      port,
+      [{ id: 'pack-big', title: 'Gross' }],
+      'Treibhausgas Landwirtschaft',
+      signal
+    ).then(
+      () => {
+        throw new Error('expected the aborted ask to reject, but it resolved')
+      },
+      (e: unknown) => e
+    )
+    expect(err === reason || (err instanceof Error && err.name === 'AbortError'), String(err)).toBe(true)
   })
 
   it('P1b a per-hit fetch failure is still skipped — only the conversion abort propagates', async () => {
@@ -262,6 +287,38 @@ describe('collectPackCandidates', () => {
     )
     expect(out.length).toBeGreaterThan(0)
     expect(out.every((c) => c.articlePath === 'Schwefel')).toBe(true)
+  })
+
+  // #340 L3 (D-Z18): the question's function and frame words never reach Xapian (it ANDs every
+  // word), and a first search that finds nothing is retried ONCE with the narrower pattern.
+  it('sends the rewritten pattern to /search and retries once, narrower, when the first search finds nothing', async () => {
+    searchPatterns.length = 0
+    const { candidates, outcomes } = await collectPackCandidates(
+      port,
+      [{ id: 'pack-retry', title: 'Retry' }],
+      'Wie wirkt CO2 auf das Eis?' // → 'wirkt CO2 Eis', retry 'wirkt'
+    )
+    expect(searchPatterns).toEqual(['wirkt CO2 Eis', 'wirkt'])
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(outcomes[0]).toMatchObject({ packId: 'pack-retry', status: 'searched', found: candidates.length })
+
+    // An ordinary question: the frame words are gone, ONE search, no retry when it hits.
+    searchPatterns.length = 0
+    const climate = await collectPackCandidates(
+      port,
+      [{ id: 'pack-climate', title: 'Klima' }],
+      'Welche Rolle spielt das Treibhausgas beim Treibhauspotential?'
+    )
+    expect(searchPatterns).toEqual(['Treibhausgas Treibhauspotential'])
+    expect(climate.candidates.length).toBeGreaterThan(0)
+
+    // Zero hits and NO narrower pattern to try (every kept term is long): exactly one search,
+    // an honest empty result.
+    searchPatterns.length = 0
+    const none = await collectPackCandidates(port, [{ id: 'pack-retry', title: 'Retry' }], 'Warum steigt der Meeresspiegel?')
+    expect(searchPatterns).toEqual(['steigt Meeresspiegel'])
+    expect(none.candidates).toEqual([])
+    expect(none.outcomes[0]).toMatchObject({ packId: 'pack-retry', status: 'searched', found: 0 })
   })
 
   it('isolates a failing pack — the healthy pack still contributes', async () => {

--- a/apps/desktop/tests/manual/zim-real.test.ts
+++ b/apps/desktop/tests/manual/zim-real.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, mkdtempSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
@@ -101,6 +101,32 @@ describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', (
         `[zim-real] ${basename(zimFile)}: ${candidates.length} candidates in ${ms.toFixed(0)} ms ` +
           `(first: "${first.sourceTitle}" › ${first.sectionLabel ?? '—'})`
       )
+
+      // #340 L3 (D-Z18): the retrieval-quality fixture, replayed only when the registered archive
+      // IS the fixture's pack (the expected titles are that pack's). Every answerable question
+      // must reach one of its expected articles among the top five the arm searched — the
+      // measured 9/9 of the rewrite (the raw question managed 6/9). Another archive is not a
+      // measurement of this fixture, and says so.
+      const fixture = JSON.parse(
+        readFileSync(join(__dirname, '..', 'fixtures', 'zim', 'quality-questions-de.json'), 'utf8')
+      ) as {
+        packUuid: string
+        questions: Array<{ question: string; expectedTitles: string[]; rawHit: boolean; answerable: boolean }>
+      }
+      if (pack.id === fixture.packUuid) {
+        const misses: string[] = []
+        for (const q of fixture.questions.filter((x) => x.answerable)) {
+          const { candidates: found } = await arm!(q.question)
+          const titles = [...new Set(found.map((c) => c.sourceTitle))].slice(0, 5)
+          if (!q.expectedTitles.some((t) => titles.includes(t))) misses.push(`${q.question} → ${titles.join(' | ')}`)
+        }
+        // eslint-disable-next-line no-console
+        console.info(`[zim-real] quality fixture: ${fixture.questions.filter((x) => x.answerable).length - misses.length}/${fixture.questions.filter((x) => x.answerable).length} answerable questions hit@5`)
+        expect(misses).toEqual([])
+      } else {
+        // eslint-disable-next-line no-console
+        console.info('[zim-real] quality fixture: the registered archive is not the fixture pack — not measured')
+      }
 
       // The viewer read — routed from the CURRENT serving map, never a filename-stem guess
       // (#301 P3b finding L4).

--- a/apps/desktop/tests/unit/zim-query-rewrite.test.ts
+++ b/apps/desktop/tests/unit/zim-query-rewrite.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { RETRY_MIN_TERM_CHARS, searchPattern } from '../../src/main/services/zim/query-rewrite'
+
+// #340 L3 (rag-design §17 D-Z18): the question → `/search` pattern rewrite. Xapian ANDs every
+// word the archive's stopper does not drop, and the pinned German Wikipedia archives stop next
+// to nothing — so the function AND frame words go, the content words stay as typed, and a
+// zero-hit first search gets one narrower retry. The ten measured questions of the 2026-09-06
+// real-pack run are the fixture (`tests/fixtures/zim/quality-questions-de.json`); this suite
+// pins the rewrite itself, no server.
+
+describe('searchPattern (#340 L3, D-Z18)', () => {
+  it('keeps the content words in their original spelling and order, drops function and frame words', () => {
+    expect(searchPattern('Welche Rolle spielt Methan beim Treibhauseffekt?').pattern).toBe('Methan Treibhauseffekt')
+    expect(searchPattern('Warum steigt der Meeresspiegel?').pattern).toBe('steigt Meeresspiegel')
+    expect(searchPattern('Wie funktioniert der Emissionshandel?').pattern).toBe('Emissionshandel')
+    expect(searchPattern('Was ist der Unterschied zwischen Wetter und Klima?').pattern).toBe('Wetter Klima')
+    expect(searchPattern('What is the role of methane in the greenhouse effect?').pattern).toBe('methane greenhouse effect')
+    expect(searchPattern('How does emissions trading work?').pattern).toBe('emissions trading')
+  })
+
+  it('keeps hyphenated terms, numbers and case as typed (Xapian stems and folds itself)', () => {
+    const r = searchPattern('Wie hoch ist die CO2-Konzentration in der Atmosphäre seit 1850?')
+    expect(r.pattern).toBe('CO2-Konzentration Atmosphäre 1850')
+    expect(r.rewritten).toBe(true)
+    // A trailing hyphen is noise, an inner one is part of the term.
+    expect(searchPattern('Kohlenstoff- und Methanemissionen').pattern).toBe('Kohlenstoff Methanemissionen')
+  })
+
+  it('never emits an empty pattern: a pure function/frame question falls back to the raw question', () => {
+    const r = searchPattern('Was ist das?')
+    expect(r.pattern).toBe('Was ist das?')
+    expect(r.rewritten).toBe(false)
+    expect(r.retry).toBeNull()
+    expect(searchPattern('   ').pattern).toBe('')
+  })
+
+  it('deduplicates repeated terms and leaves a single content word alone', () => {
+    expect(searchPattern('Klima Klima klima').pattern).toBe('Klima')
+    const one = searchPattern('Permafrost')
+    expect(one).toEqual({ pattern: 'Permafrost', retry: null, rewritten: false })
+  })
+
+  it('offers a narrower retry only when it differs from the first pattern', () => {
+    // Two kept terms, one short: the retry keeps the long one.
+    const r = searchPattern('Wie wirkt CO2 auf das Eis?')
+    expect(r.pattern).toBe('wirkt CO2 Eis')
+    expect(r.retry).toBe('wirkt')
+    // Every kept term is long enough: the retry would be the same query — none offered.
+    expect(searchPattern('Warum steigt der Meeresspiegel?').retry).toBeNull()
+    // Every kept term is short: nothing narrower to try.
+    expect(searchPattern('Was ist Eis und CO2?').retry).toBeNull()
+    expect(RETRY_MIN_TERM_CHARS).toBe(5)
+  })
+
+  it('reproduces the measured 2026-09-06 fixture patterns (the real-pack hit@5 9/9 forms)', () => {
+    const cases: Array<[string, string]> = [
+      ['Welche Rolle spielt Methan beim Treibhauseffekt?', 'Methan Treibhauseffekt'],
+      ['Wie hoch ist die CO2-Konzentration in der Atmosphäre?', 'CO2-Konzentration Atmosphäre'],
+      ['Was ist das Pariser Abkommen?', 'Pariser Abkommen'],
+      ['Warum steigt der Meeresspiegel?', 'steigt Meeresspiegel'],
+      ['Was bedeutet Klimasensitivität?', 'Klimasensitivität'],
+      ['Welche Folgen hat die globale Erwärmung für die Landwirtschaft?', 'Folgen globale Erwärmung Landwirtschaft'],
+      ['Was sind Kipppunkte im Klimasystem?', 'Kipppunkte Klimasystem'],
+      ['Welche Rolle spielt der Permafrost?', 'Permafrost'],
+      ['Wie funktioniert der Emissionshandel?', 'Emissionshandel']
+    ]
+    for (const [q, expected] of cases) expect(searchPattern(q).pattern, q).toBe(expected)
+  })
+})

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2525,7 +2525,7 @@ reports and phase plans were working papers; their full text lives in git histor
   a short or empty pack's unused share goes to the others — and at most two packs are
   searched at a time, under a twenty-second limit for the whole question (a pack cut off
   mid-search is reported as "failed: timed out", one never reached in time as "not
-  searched: out of time for this question"). None of this considers language: a German question against an
+  searched: out of time for this question"). The pack server ANDs every word of the search pattern, so the app sends only the question's content words (function and question-frame words stripped, `rag-design.md` §17 D-Z18) and retries once with fewer words when nothing is found; a question whose every content word must appear in one article can still miss. None of this considers language: a German question against an
   English pack simply scores poorly; the reranker sorts it out when present, and without
   one, expect occasional off-language chunks. Aggregation or superlative questions ("which
   scientists are famous Austrians") tend to surface list or enumeration articles rather than

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2706,6 +2706,31 @@ offline article viewer. Files are registered in place, never copied.
   support (P8-3), the on-drive corresponding-source bundle (P8-4), and the network-inventory
   prose (P8-5) — see "Deliberately not built" below.
 
+- **D-Z18 — the question → `/search` pattern rewrite (#340 L3, follow-up wave, 2026-09-06).**
+  The pinned kiwix-serve hands the pattern to libzim 9.4.0's Xapian query parser
+  (`search.cpp`): default operator **AND**, `STEM_ALL` with the archive's stemmer, the archive's
+  own stopper, and no boolean / phrase / wildcard flags — every question word the archive does
+  not stop is ANDed in, and the pinned German Wikipedia archives stop next to nothing
+  (`welche`, `rolle`, `spielt` each return hits on their own). Measured on the real climate pack
+  (raw server, ten German questions, hit@5, evidence
+  `ai_drive-archive/zim-wave-2026-09/evidence/l3-2026-09-06/`): the raw question 6 of 9
+  answerable; function words stripped 7 of 9 (AND still kept `rolle spielt`, `funktioniert`);
+  question-FRAME words stripped too **9 of 9**, never worse (Meeresspiegelanstieg, Permafrost,
+  EU-Emissionshandel recovered). `services/zim/query-rewrite.ts` `searchPattern(question)` keeps
+  the content words in their original spelling and order (`CO2-Konzentration`, `1850` — Xapian
+  stems and folds itself), drops the words of two CONSERVATIVE German + English lists applied
+  together (function words; frame words such as *Rolle spielt / funktioniert / bedeutet /
+  Unterschied zwischen*, *what is the role of / how does … work*), falls back to the raw question
+  when nothing survives, and offers a `retry` — the kept terms of `RETRY_MIN_TERM_CHARS = 5` or
+  more, only when that differs from the first pattern. `arm.ts` sends the pattern to `/search`
+  and, on ZERO hits with a retry available, asks once more (one extra ~100 ms request instead of
+  a "not found" the archive would have answered). The ORIGINAL question stays the reranker's
+  query, the prompt's question and the chunk picker's `queryTerms`; no constant of D-Z4 changes.
+  Fixture `tests/fixtures/zim/quality-questions-de.json` (the ten questions, expected titles,
+  the raw result); `zim-query-rewrite.test.ts` pins the rewrite; `zim-arm.test.ts` the retry;
+  the manual smoke replays the fixture when the registered archive is that pack and asserts
+  every answerable question hits.
+
 ### Module map
 
 `services/zim/`: `html.ts` (article HTML → segments; linear forward scanner with a work


### PR DESCRIPTION
Refs #340 (Phase 9, retrieval-quality lever L3 — the question → keywords rewrite before `/search`). Refs #301. **Stacked on #355** (→ #354 → #351 → #350 → #349 → #348); retarget and rebase as each parent lands. Plan: `tmp/340-capabilities-plan.md` C1 (maintainer-local); measurement evidence archived outside the repo.

## The finding, measured on real tools before any code

The pinned kiwix-serve hands the `/search` pattern to libzim 9.4.0's Xapian query parser with default operator **AND**, `STEM_ALL` with the archive's stemmer, the archive's own stopper, and no boolean/phrase/wildcard flags (`search.cpp`). The pinned German Wikipedia archives stop next to nothing (`welche`, `rolle`, `spielt` each return hits on their own), so every word of a question is ANDed in. Ten German questions against the real climate pack (raw server, hit@5): the raw question found the expected article in **6 of 9** answerable cases; function words stripped **7 of 9** (AND still kept `rolle spielt`, `funktioniert`); question-FRAME words stripped too **9 of 9**, never worse — Meeresspiegelanstieg, Permafrost and EU-Emissionshandel recovered.

## The change (rag-design §17 D-Z18)

- `services/zim/query-rewrite.ts` `searchPattern(question)`: keeps the content words in their original spelling and order (`CO2-Konzentration`, `1850` — Xapian stems and folds itself), drops the words of two CONSERVATIVE German + English lists applied together (function words; question-frame words such as *Rolle spielt / funktioniert / bedeutet / Unterschied zwischen*, *what is the role of / how does … work*), falls back to the raw question when nothing survives, and offers a narrower `retry` (the kept terms of five or more characters) only when that differs.
- `arm.ts`: the pattern goes to `/search`; on ZERO hits with a retry available, one more search (~100 ms) before reporting nothing. The ORIGINAL question stays the reranker's query, the prompt's question and the chunk picker's `queryTerms`. No constant of D-Z4 changes; no shape, IPC or lifecycle change.

## Tests and acceptance

- `tests/unit/zim-query-rewrite.test.ts` (the ten measured patterns, hyphens/numbers/case kept, the empty-strip fallback, dedup, the retry rule).
- `zim-arm.test.ts`: NEW leg — the fixture server records patterns; a book that answers only the narrower pattern proves the retry; an ordinary question issues one search; zero hits with no narrower pattern issues exactly one search and an honest empty result. **Also in this file:** the P1b abort leg failed a third time today under load — `combineSignals` reads the caller's `aborted` only when a request is created, so the transport can observe the mid-flight cancellation before the converter does; the leg now pins the property it was written for (an aborted ask REJECTS, never an empty list — the converter's reason or the transport's `AbortError`) instead of the reason's identity. Three consecutive green runs after the correction.
- `tests/fixtures/zim/quality-questions-de.json` (the ten questions, expected titles, the raw result, the pack UUID) and the manual smoke's new quality leg, replayed only when the registered archive is that pack: **on the real K: pack through the app's own arm, 9/9 answerable questions hit@5** (this session; `[zim-real] quality fixture: 9/9`). The smoke's existing legs stay green (19 candidates, 114 ms).
- Full suite green (see the run in the PR checks); typecheck green.

## Docs

rag-design §17 D-Z18, known-limitations (the retrieval-shape bullet), CHANGELOG `[Unreleased]` › Fixed (a user-visible change: questions find their pack articles more often), BUILD_STATE (wave entry step 6). Next levers L1 / L2 need owner questions first (a new outcome reason code; a constant's role) and are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
