### PR TITLE
test(engine): the kiwix cancel-during-extraction leg waits for the cancelled run to settle (#339 P8-1)

### DIFF
--- a/apps/desktop/tests/integration/engine-download.test.ts
+++ b/apps/desktop/tests/integration/engine-download.test.ts
@@ -782,8 +782,21 @@ describe('kiwix_tools — the optional two-executable family (#339 P8-1, T20-a)'
     mgr.cancel(started.jobId)
     release()
     expect((await runToEnd(mgr, started.jobId)).status).toBe('cancelled')
+    // `status` flips to 'cancelled' the instant cancel() is called, but the gated extractor is
+    // still writing its files: wait for the run to SETTLE (the F-33 busy latch — `activeJob()`
+    // stays non-null until then) before the next install pre-cleans the same directory, and
+    // re-install through the SAME manager so its latch, not a second manager, orders the two.
+    // The master CI run after the merge caught exactly that race on ubuntu-22.x.
+    const settleStart = Date.now()
+    while (mgr.activeJob() !== null) {
+      if (Date.now() - settleStart > 5000) throw new Error('the cancelled run never settled')
+      await new Promise((r) => setTimeout(r, 2))
+    }
     expect(existsSync(runtimeMarkerPath(KIWIX_DIR(rootPath)))).toBe(false)
-    const again = await installKiwix(rootPath, manifestsDir)
+    const again = await runToEnd(
+      mgr,
+      (await mgr.start({ rootPath, manifestsDir, gates: ALLOW, families: ['kiwix_tools'] })).jobId
+    )
     expect(again.status).toBe('done')
     expect(existsSync(runtimeMarkerPath(KIWIX_DIR(rootPath)))).toBe(true)
   })


### PR DESCRIPTION
Master's CI run on the merge result (ab0f060d) went red on ubuntu-22.x in one NEW test of #354: the cancel-during-extraction leg re-installed through a second EngineDownloadManager while the first job's gated extractor was still writing after the cancel (`status` flips to cancelled at once; the run settles later — the F-33 latch), so the second job's pre-clean raced the late writes. Every PR run before the merge was green; this is a race in the test, not in the product. The leg now waits for `activeJob()` to clear and re-installs through the same manager. Three consecutive green runs locally; typecheck green. Refs #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)