### PR TITLE
feat(zim): name the Windows non-ASCII path refusal — 'path-unsupported' add-failure reason (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,11 @@ from its first public `1.0.0` release onward.
   A failed automatic check on a computer this drive doesn't recognize now tries again once each
   time you unlock, rather than repeatedly for the rest of that session; Check again on the
   Performance page always works right away in the meantime.
+- **Adding a knowledge pack from a path with an umlaut or accent on Windows now names the cause.**
+  On Windows, kiwix-manage cannot read an archive whose folder or file name contains a non-ASCII
+  character; the panel used to show the generic "could not be read by kiwix-manage" message, and
+  now tells you to move the file to a path made of ASCII characters — the drive's `zim/` folder
+  is simplest — and add it again.
 
 ## [0.1.59] — 2026-08-21
 

--- a/apps/desktop/src/main/ipc/registerZimIpc.ts
+++ b/apps/desktop/src/main/ipc/registerZimIpc.ts
@@ -33,17 +33,29 @@ import { workspaceAdmitsWork } from '../services/workspace-vault'
  * P5, finding L1, plan §9.19 (c)1). `ZimHeaderError` ⇒ the file is not a readable ZIM archive;
  * the "kiwix-tools is not installed" refusal (`ZimService.packDeps`) ⇒ tools missing;
  * `KiwixManageError` or the header/manager identity disagreement (`packs.ts registerPack`) ⇒
- * a manager problem; anything else ⇒ 'other'.
+ * a manager problem — UNLESS the tool actually ran and refused (`kind: 'exit'`, never a
+ * spawn/verify/timeout failure) on win32 over a path holding a non-ASCII character, which is
+ * the pinned kiwix-manage 3.8.1's known refusal (#340, owner ruling 2026-09-06, option M) and
+ * gets its own reason so the panel can name the workaround instead of the generic manager copy;
+ * anything else ⇒ 'other'.
  */
-function classifyAddFailure(err: unknown): KnowledgePackAddFailureReason {
+function classifyAddFailure(
+  err: unknown,
+  path: string,
+  platform: NodeJS.Platform
+): KnowledgePackAddFailureReason {
   if (err instanceof ZimHeaderError) return 'not-a-zim'
-  if (err instanceof KiwixManageError) return 'manager'
+  if (err instanceof KiwixManageError) {
+    if (err.kind === 'exit' && platform === 'win32' && /[^\x00-\x7F]/.test(path)) return 'path-unsupported'
+    return 'manager'
+  }
   if (err instanceof Error && /kiwix-tools is not installed/.test(err.message)) return 'tools-missing'
   if (err instanceof Error && /reported a different archive identity/.test(err.message)) return 'manager'
   return 'other'
 }
 
-export function registerZimIpc(ctx: AppContext): void {
+export function registerZimIpc(ctx: AppContext, opts: { platform?: NodeJS.Platform } = {}): void {
+  const platform = opts.platform ?? process.platform
   const ipcHandle = guardedHandleFor(ctx)
   const requireUnlocked = (): void => {
     // AUD-02: workspaceAdmitsWork, never a bare isUnlocked() (see registerCollectionsIpc).
@@ -151,7 +163,7 @@ export function registerZimIpc(ctx: AppContext): void {
             throw new Error(tMain('main.docs.locked'))
           }
           failed++
-          const reason = classifyAddFailure(err)
+          const reason = classifyAddFailure(err, path, platform)
           if (failureReason === null) failureReason = reason
           // Protected diagnostic ONLY: the error class + reason code, never the message or the
           // path (#301 P5, finding L1) — the manager's own stderr can carry an absolute path.

--- a/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
+++ b/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
@@ -37,6 +37,8 @@ function addFailedKey(reason: KnowledgePackAddFailureReason | null): MessageKey 
       return 'packs.addFailed.toolsMissing'
     case 'manager':
       return 'packs.addFailed.manager'
+    case 'path-unsupported':
+      return 'packs.addFailed.pathUnsupported'
     default:
       return 'packs.addFailed.other'
   }

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2746,6 +2746,10 @@ export const de: Record<keyof typeof en, string> = {
   'packs.addFailed.notAZim': 'Die gewählte Datei ist kein lesbares ZIM-Archiv.',
   'packs.addFailed.toolsMissing': 'Die kiwix-tools-Programme sind auf diesem Laufwerk nicht installiert; Pakete können daher nicht hinzugefügt oder durchsucht werden. Der Installationsschritt steht im Benutzerhandbuch.',
   'packs.addFailed.manager': 'Das Archiv konnte nicht von kiwix-manage gelesen werden. Prüfe, ob die Datei vollständig ist, und versuch es noch einmal.',
+  // #340 (Owner-Entscheid 2026-09-06, Option M): das fest eingestellte kiwix-manage 3.8.1
+  // weigert sich bei jedem Windows-Pfad mit einem Nicht-ASCII-Zeichen. Nennt Ursache und
+  // Abhilfe — nie den rohen Pfad.
+  'packs.addFailed.pathUnsupported': 'Unter Windows kann kiwix-manage kein Archiv lesen, dessen Ordner- oder Dateiname einen Umlaut, einen Akzent oder ein anderes Nicht-ASCII-Zeichen enthält. Verschieb die Datei an einen Pfad ohne solche Zeichen – am einfachsten in den „zim“-Ordner des Laufwerks – und füge sie erneut hinzu.',
   'packs.addFailed.other': 'Das Archiv konnte nicht hinzugefügt werden.',
   'packs.removedToast': 'Wissenspaket entfernt',
   'packs.articleCount.one': '{count} Artikel',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2724,6 +2724,9 @@ export const en = {
   'packs.addFailed.notAZim': 'The chosen file is not a readable ZIM archive.',
   'packs.addFailed.toolsMissing': 'The kiwix-tools binaries are not installed on this drive, so packs cannot be added or searched. See the user guide for the manual install step.',
   'packs.addFailed.manager': 'The archive could not be read by kiwix-manage. Check that the file is complete and try again.',
+  // #340 (owner ruling 2026-09-06, option M): the pinned kiwix-manage 3.8.1 refuses any Windows
+  // path holding a non-ASCII character. Names the cause and the workaround — never the raw path.
+  'packs.addFailed.pathUnsupported': 'On Windows, kiwix-manage cannot read an archive whose folder or file name contains an umlaut, an accent or another non-ASCII character. Move the file to a path without such characters — the drive’s zim/ folder is simplest — and add it again.',
   'packs.addFailed.other': 'The archive could not be added.',
   'packs.removedToast': 'Knowledge pack removed',
   'packs.articleCount.one': '{count} article',

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1960,9 +1960,17 @@ export interface KnowledgePackOutcome {
 /**
  * Why one archive of a `packs:add` batch was not registered (#301 P5, finding L1, plan §9.19
  * (c)). NEVER free text — the raw manager stderr/path stays in the protected diagnostic log
- * only (`log.warn`), never on this DTO, never in the audit.
+ * only (`log.warn`), never on this DTO, never in the audit. `'path-unsupported'` (#340, owner
+ * ruling 2026-09-06, option M) is set ONLY on win32 when the pinned kiwix-manage 3.8.1 ran and
+ * refused (a `KiwixManageError` of `kind: 'exit'`) AND the archive's path contains a non-ASCII
+ * character — never on other platforms, and never for a spawn/verify/timeout failure.
  */
-export type KnowledgePackAddFailureReason = 'not-a-zim' | 'tools-missing' | 'manager' | 'other'
+export type KnowledgePackAddFailureReason =
+  | 'not-a-zim'
+  | 'tools-missing'
+  | 'manager'
+  | 'path-unsupported'
+  | 'other'
 
 /**
  * The result of `packs:add` (#301 P5, finding L1, plan §9.19 (c)) — replaces the old

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -240,6 +240,10 @@ interface HarnessOptions {
   failReEncrypt?: boolean
   /** Shorten the ZIM settle bound (5 s in production) through the registry seam on ctx. */
   settleBoundMs?: number
+  /** `registerZimIpc`'s platform seam (#340) — defaults to `process.platform` like production;
+   *  pin it to drive the win32-only `'path-unsupported'` classification independently of the
+   *  host running the suite. */
+  platform?: NodeJS.Platform
 }
 
 async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness> {
@@ -493,7 +497,7 @@ async function sessionHarness(opts: HarnessOptions = {}): Promise<SessionHarness
       auditCalls.push({ type, message, metadata })
   } as unknown as AppContext
 
-  registerZimIpc(ctx)
+  registerZimIpc(ctx, { platform: opts.platform })
   registerWorkspaceIpc(ctx)
 
   const full: SessionHarness = {
@@ -1875,6 +1879,50 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
       }
     } finally {
       await h.close()
+    }
+  })
+})
+
+// #340 (owner ruling 2026-09-06, option M): the pinned kiwix-manage 3.8.1 refuses to read an
+// archive whose path holds a non-ASCII character, and on Windows the panel used to show only
+// the generic "manager" copy. `classifyAddFailure` (registerZimIpc.ts) now maps that refusal to
+// 'path-unsupported' — but ONLY when the platform is win32 AND the tool actually ran and exited
+// non-zero (a real `KiwixManageError` of `kind: 'exit'`, produced here by the fake manageSpawn
+// child exiting 1, exactly like the existing 'manager' DTO legs above).
+describe('packs:add classifies a non-ASCII-path manager refusal as path-unsupported on win32 only (#340)', () => {
+  it('win32 + non-ASCII path + manager exit => path-unsupported; the same fixture on linux stays manager', async () => {
+    const win = await sessionHarness({ platform: 'win32' })
+    try {
+      const badPath = win.addPackFile('Jörg-test.zim')
+      win.hooks.manage = async (_libraryXmlPath: string, zimPath: string) => {
+        throw new Error(`Cannot add ZIM ${zimPath} to the library.`)
+      }
+      dialogState.paths = [badPath]
+      dialogState.canceled = false
+      const { result } = await invoke(handlers, IPC.addKnowledgePacks)
+      const dto = result as KnowledgePackAddResult
+      expect(dto.outcome).toBe('failure')
+      expect(dto.failed).toBe(1)
+      expect(dto.failureReason).toBe('path-unsupported')
+      // The reason code is a CODE — never the path itself.
+      expect(JSON.stringify(dto)).not.toContain(badPath)
+    } finally {
+      await win.close()
+    }
+
+    const linux = await sessionHarness({ platform: 'linux' })
+    try {
+      const badPath = linux.addPackFile('Jörg-test.zim')
+      linux.hooks.manage = async (_libraryXmlPath: string, zimPath: string) => {
+        throw new Error(`Cannot add ZIM ${zimPath} to the library.`)
+      }
+      dialogState.paths = [badPath]
+      dialogState.canceled = false
+      const { result } = await invoke(handlers, IPC.addKnowledgePacks)
+      const dto = result as KnowledgePackAddResult
+      expect(dto.failureReason).toBe('manager')
+    } finally {
+      await linux.close()
     }
   })
 })

--- a/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
+++ b/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
@@ -339,6 +339,7 @@ describe('PacksPanel', () => {
     ['not-a-zim', 'The chosen file is not a readable ZIM archive.'],
     ['tools-missing', /kiwix-tools binaries are not installed/],
     ['manager', 'The archive could not be read by kiwix-manage. Check that the file is complete and try again.'],
+    ['path-unsupported', /kiwix-manage cannot read an archive whose folder or file name contains/],
     ['other', 'The archive could not be added.']
   ] as const)('add flow: failure (%s) shows the reason’s banner text, never a different one', async (reason, expected) => {
     const addKnowledgePacks = vi.fn(async () => ({
@@ -373,6 +374,7 @@ describe('PacksPanel', () => {
       'manager',
       'Das Archiv konnte nicht von kiwix-manage gelesen werden. Prüfe, ob die Datei vollständig ist, und versuch es noch einmal.'
     ],
+    ['path-unsupported', /kiwix-manage kein Archiv lesen, dessen Ordner- oder Dateiname/],
     ['other', 'Das Archiv konnte nicht hinzugefügt werden.']
   ] as const)('add flow (DE): failure (%s) shows the German reason banner', async (reason, expected) => {
     window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, 'de')

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1736,9 +1736,13 @@ CI are unaffected.
 `packs:add` (native picker + registration in ONE main-side handler — no renderer-supplied
 archive path exists on this surface; returns `KnowledgePackAddResult` (#301 P5, finding L1):
 `{ outcome: 'cancelled' | 'success' | 'partial' | 'failure', added: KnowledgePack[], failed:
-number, failureReason: 'not-a-zim' | 'tools-missing' | 'manager' | 'other' | null }` — the
-invariants of §9.19 (c)1 in one sentence; codes only, never a path or a tool's stderr; a lock
-landing mid-add still REJECTS with the friendly locked copy) · `packs:remove`
+number, failureReason: 'not-a-zim' | 'tools-missing' | 'manager' | 'path-unsupported' | 'other' |
+null }` — the invariants of §9.19 (c)1 in one sentence; codes only, never a path or a tool's
+stderr; a lock landing mid-add still REJECTS with the friendly locked copy. `'path-unsupported'`
+(#340, owner ruling 2026-09-06, option M) is set ONLY when the platform is win32 AND the
+archive's path holds a non-ASCII character AND the manager actually ran and exited non-zero (a
+`KiwixManageError` of `kind: 'exit'`) — a spawn/verify/timeout failure, or any other platform,
+still classifies as `'manager'`) · `packs:remove`
 (tombstone, file untouched) · `packs:setEnabled` · `packs:refresh` (#301 P3b, finding L7 —
 schedules a background reconciliation and returns `{ started: boolean }` at once;
 completion arrives via the `packs:changed` event, not the return value) · `packs:status`

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2464,12 +2464,11 @@ reports and phase plans were working papers; their full text lives in git histor
   pinned `kiwix-manage` 3.8.1 refuses to read a file whose folder or file name contains an
   umlaut, an accent or any other non-ASCII character ("Cannot add ZIM … to the library.") — a
   limit of the tool's own path handling, found on real tools at P7 (`rag-design.md` §17 "Real
-  acceptance"). The panel reports the add as failed with the generic "could not be read by
-  kiwix-manage" message; the workaround is to put the file in the drive's `zim/` folder or any
-  other path without such characters (a Windows user folder such as `C:\Users\Jörg\Downloads`
-  hits this). Serving is not affected — a pack registered from an ASCII path stays readable and
-  searchable. A reason-specific message, or reading the archive's metadata without
-  `kiwix-manage`, is on the P9 successor issue #340.
+  acceptance"). The panel now names the cause and the workaround; the workaround is to put the
+  file in the drive's `zim/` folder or any other path without such characters (a Windows user
+  folder such as `C:\Users\Jörg\Downloads` hits this). Serving is not affected — a pack
+  registered from an ASCII path stays readable and searchable. (#340, decided 2026-09-06: a
+  reason-specific message; the archive's metadata is still read through `kiwix-manage`.)
 - **A redirect entry (an alias title) opens the article it points to — one hop, same pack.**
   About half of a Wikipedia ZIM's entries are redirects; `kiwix-serve` answers them with a 302
   rather than the target's bytes, and the viewer follows exactly one such hop inside the same

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -603,7 +603,7 @@ ICU DLLs (`icudt74.dll`, `icuin74.dll`, `icuio74.dll`, `icutu74.dll`, `icuuc74.d
 right beside `kiwix-serve.exe` and `kiwix-manage.exe` — kiwix-serve won't start without them.
 The version is pinned; a different kiwix-tools release is not supported.
 
-### "The archive could not be read by kiwix-manage" — but the file is fine
+### "kiwix-manage cannot read an archive whose … name contains …"
 
 On Windows the pinned kiwix-manage cannot open an archive whose folder or file name contains an
 umlaut, an accent or any other non-ASCII character (for example a file under


### PR DESCRIPTION
Refs #340 — owner ruling (b) of 2026-09-06, option M.

On Windows the pinned kiwix-manage 3.8.1 refuses an archive whose folder or file name contains an umlaut, an accent or any other non-ASCII character; the panel showed the generic "could not be read by kiwix-manage" copy.

- `KnowledgePackAddFailureReason` gains `'path-unsupported'` (additive). Set ONLY when the tool ran and refused (`KiwixManageError` of kind `exit`) on win32 for a path holding a non-ASCII character — never on other platforms, never for a spawn/verify/timeout failure. `registerZimIpc` gains an optional `{ platform }` seam (defaults to `process.platform`).
- PacksPanel maps it to new EN/DE copy that names the workaround (an ASCII path, e.g. the drive's `zim/` folder).
- Docs: data-contracts add-result codes, known-limitations, troubleshooting entry retitled, CHANGELOG.

Tests: `zim-ipc-session.test.ts` "packs:add classifies a non-ASCII-path manager refusal as path-unsupported on win32 only (#340)" (win32 → `path-unsupported`, linux → `manager`; red without the fix), `KnowledgePacks.test.tsx` EN+DE banner rows. Typecheck clean; full suite 414 files / 6,655 passed / 89 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)