### PR TITLE
feat(zim): normalise <math alttext> LaTeX to plain text in the converter (#340 (c))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,10 @@ from its first public `1.0.0` release onward.
   character; the panel used to show the generic "could not be read by kiwix-manage" message, and
   now tells you to move the file to a path made of ASCII characters — the drive's `zim/` folder
   is simplest — and add it again.
+- **Formulas from a knowledge pack now read as text, not as typesetting code.** Arrows,
+  fractions, roots, Greek letters and signs are written out, and lowered or raised characters sit
+  on the line — CO2, m2, Fe3+ — which is how you type them when searching. Anything unreadable is
+  left as it was. Passages saved in earlier evidence reviews keep the older form.
 
 ## [0.1.59] — 2026-08-21
 

--- a/apps/desktop/src/main/services/zim/html.ts
+++ b/apps/desktop/src/main/services/zim/html.ts
@@ -1,4 +1,5 @@
 import type { ExtractedSegment } from '../ingestion/parsers'
+import { normalizeMath } from './math'
 
 // ZIM article HTML → ExtractedSegment[] (knowledge packs, query-time retrieval arm).
 //
@@ -19,9 +20,9 @@ import type { ExtractedSegment } from '../ingestion/parsers'
 // Dropped subtrees: head, script/style/noscript (raw-text aware), tables (infoboxes and
 // data tables scramble into `header: value` noise without geometry), figures/images, nav,
 // and `<sup class="mw-ref">` citation brackets ([1][2] — noise for retrieval; other <sup>
-// like m<sup>2</sup> keeps its text). `<math>` emits its `alttext` LaTeX and skips the
-// MathML subtree; the `<img>` fallback that follows is dropped with all images, so each
-// formula appears exactly once.
+// like m<sup>2</sup> keeps its text). `<math>` emits its alttext normalised to plain text
+// (`math.ts`, #340) and skips the MathML subtree; the `<img>` fallback that follows is
+// dropped with all images, so each formula appears exactly once.
 //
 // ---------------------------------------------------------------------------------------
 // LINEAR FORWARD SCANNER — complexity record (PR #294 review H1)
@@ -908,7 +909,7 @@ export function* zimArticleSlices(
     if (!isClose && name === 'math') {
       // The LaTeX source rides in alttext; emit it once, skip the MathML rendering tree.
       const alt = attrValue(attrs, 'alttext')
-      if (alt) emit(` ${decodeEntities(alt)} `)
+      if (alt) emit(` ${normalizeMath(decodeEntities(alt))} `)
       if (!selfClosing) mathDepth = 1
       continue
     }

--- a/apps/desktop/src/main/services/zim/math.ts
+++ b/apps/desktop/src/main/services/zim/math.ts
@@ -1,0 +1,392 @@
+// LaTeX alttext → plain text, for ZIM `<math alttext>` (#340; rag-design §17 D-Z3).
+//
+// `html.ts` emits a formula's alttext once, entity-decoded (`normalizeMath(decodeEntities(alt))`)
+// and drops the MathML rendering subtree. This module turns that decoded LaTeX source into
+// plain text: `\frac{1}{2}mv^{2}` → `1/2mv2`, `\alpha \le \beta` → `α ≤ β`. Sub/superscripts
+// become PLAIN characters, never ₂/² — `<sub>/<sup>` already render plain elsewhere in the
+// converter, and the retrieval-arm tokeniser (`arm.ts` `queryTerms` = `/[\p{L}\p{N}]{3,}/gu`,
+// `overlapScore` = `includes`) treats `₂` as `\p{N}`, so a typed "CO2" would never match a
+// literal `CO₂` — that's the mechanical reason, not just cosmetics.
+//
+// A single-cursor tokenizer over an explicit stack, NOT regexes: nested braces (real in the
+// corpus — nested `\frac`) need either a nested quantifier or a fixpoint loop, both
+// super-linear. Each input index is consumed once; only `\frac`/`\sqrt` arguments materialise
+// into a new string, so the worst case is O(n · fracDepth) char copies — bounded by
+// MAX_INPUT_CHARS and MAX_DEPTH below, never by the size of an untrusted document.
+//
+// Returns the input UNCHANGED (never throws, never partially normalises) iff: over the char
+// cap, unbalanced braces, nesting past MAX_DEPTH, or an argument-taking command missing its
+// argument. An unrecognised `\command` is emitted raw with its backslash, and the brace group
+// immediately after it keeps its braces — the rest of the string still normalises around it.
+
+export const MAX_INPUT_CHARS = 4_000
+export const MAX_DEPTH = 64
+
+/** Zero-argument commands that render as one plain string. */
+const SYMBOLS: Readonly<Record<string, string>> = {
+  // Greek — lower case
+  alpha: 'α', beta: 'β', gamma: 'γ', delta: 'δ', epsilon: 'ε', varepsilon: 'ε',
+  zeta: 'ζ', eta: 'η', theta: 'θ', vartheta: 'ϑ', iota: 'ι', kappa: 'κ', varkappa: 'ϰ',
+  lambda: 'λ', mu: 'μ', nu: 'ν', xi: 'ξ', omicron: 'ο', pi: 'π', varpi: 'ϖ',
+  rho: 'ρ', varrho: 'ϱ', sigma: 'σ', varsigma: 'ς', tau: 'τ', upsilon: 'υ',
+  phi: 'φ', varphi: 'φ', chi: 'χ', psi: 'ψ', omega: 'ω',
+  // Greek — upper case (the eleven LaTeX defines)
+  Gamma: 'Γ', Delta: 'Δ', Theta: 'Θ', Lambda: 'Λ', Xi: 'Ξ', Pi: 'Π', Sigma: 'Σ',
+  Upsilon: 'Υ', Phi: 'Φ', Psi: 'Ψ', Omega: 'Ω',
+  // Arrows
+  rightarrow: '→', to: '→', longrightarrow: '→', xrightarrow: '→',
+  leftarrow: '←', gets: '←', longleftarrow: '←',
+  leftrightarrow: '↔', longleftrightarrow: '↔',
+  Rightarrow: '⇒', implies: '⇒', Longrightarrow: '⇒',
+  Leftarrow: '⇐', Longleftarrow: '⇐',
+  Leftrightarrow: '⇔', iff: '⇔', Longleftrightarrow: '⇔',
+  rightleftharpoons: '⇌', leftrightharpoons: '⇋',
+  uparrow: '↑', downarrow: '↓', mapsto: '↦', nearrow: '↗', searrow: '↘',
+  // Binary operators
+  times: '×', cdot: '·', cdotp: '·', div: '÷', pm: '±', mp: '∓',
+  ast: '*', star: '*', bullet: '•', setminus: '\\', oplus: '⊕', otimes: '⊗',
+  // Relations
+  le: '≤', leq: '≤', leqslant: '≤', ge: '≥', geq: '≥', geqslant: '≥',
+  ne: '≠', neq: '≠', ll: '≪', gg: '≫', lt: '<', gt: '>',
+  approx: '≈', sim: '~', simeq: '≃', cong: '≅', equiv: '≡', propto: '∝',
+  // Analysis / sets / logic
+  infty: '∞', partial: '∂', nabla: '∇', sum: 'Σ', prod: 'Π',
+  int: '∫', iint: '∬', iiint: '∭', oint: '∮',
+  in: '∈', notin: '∉', ni: '∋', subset: '⊂', subseteq: '⊆', supset: '⊃', supseteq: '⊇',
+  cup: '∪', cap: '∩', emptyset: '∅', varnothing: '∅',
+  forall: '∀', exists: '∃', nexists: '∄', neg: '¬', lnot: '¬',
+  land: '∧', wedge: '∧', lor: '∨', vee: '∨', perp: '⊥', parallel: '∥', angle: '∠',
+  // Miscellany
+  degree: '°', prime: '′', dots: '…', ldots: '…', cdots: '…', vdots: '⋮', ddots: '⋱',
+  aleph: 'ℵ', ell: 'ℓ', hbar: 'ℏ', Re: 'ℜ', Im: 'ℑ', imath: 'i', jmath: 'j',
+  langle: '⟨', rangle: '⟩', lbrace: '{', rbrace: '}', vert: '|', mid: '|', backslash: '\\',
+  // Function names render as their own word
+  sin: 'sin', cos: 'cos', tan: 'tan', cot: 'cot', sec: 'sec', csc: 'csc',
+  arcsin: 'arcsin', arccos: 'arccos', arctan: 'arctan',
+  sinh: 'sinh', cosh: 'cosh', tanh: 'tanh', coth: 'coth',
+  log: 'log', ln: 'ln', lg: 'lg', exp: 'exp', lim: 'lim', limsup: 'limsup', liminf: 'liminf',
+  max: 'max', min: 'min', sup: 'sup', inf: 'inf', det: 'det', dim: 'dim', ker: 'ker',
+  deg: 'deg', arg: 'arg', gcd: 'gcd', bmod: 'mod',
+  // Escaped literals (single-character command names)
+  '{': '{', '}': '}', '%': '%', '$': '$', '&': '&', '#': '#', _: '_'
+}
+
+/** Zero-argument commands that render as one space. */
+const SPACES = new Set([',', ';', ':', ' ', '\\', 'quad', 'qquad', 'enspace', 'thinspace', 'medspace', 'thickspace'])
+
+/** Zero-argument commands that render as nothing. */
+const DROPPED = new Set([
+  '!', 'negthinspace', 'displaystyle', 'textstyle', 'scriptstyle', 'scriptscriptstyle',
+  'limits', 'nolimits', 'mathstrut', 'nonumber'
+])
+
+/** Delimiter-size commands: render as nothing and swallow a following `.` (null delimiter). */
+const DELIMS = new Set([
+  'left', 'right', 'middle',
+  'big', 'Big', 'bigg', 'Bigg',
+  'bigl', 'bigr', 'Bigl', 'Bigr', 'biggl', 'biggr', 'Biggl', 'Biggr',
+  'bigm', 'Bigm', 'biggm', 'Biggm'
+])
+
+/** One-argument commands whose argument is kept and whose own markup disappears. */
+const UNWRAP = new Set([
+  'text', 'textrm', 'textit', 'textbf', 'textsf', 'texttt', 'textnormal',
+  'mathrm', 'mathbf', 'mathit', 'mathsf', 'mathtt', 'mathnormal',
+  'mathbb', 'mathcal', 'mathfrak', 'mathscr', 'boldsymbol', 'bm',
+  'mbox', 'hbox', 'operatorname', 'ce',
+  'overline', 'underline', 'bar', 'vec', 'hat', 'widehat', 'tilde', 'widetilde',
+  'dot', 'ddot', 'dddot', 'acute', 'grave', 'check', 'breve', 'mathring',
+  'overrightarrow', 'overleftarrow', 'overbrace', 'underbrace'
+])
+
+const isSpace = (c: string): boolean =>
+  c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f' || c === '\v'
+const isLetter = (c: string): boolean => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+const isAlnum = (c: string): boolean => isLetter(c) || (c >= '0' && c <= '9')
+
+/** Balance + depth pre-pass. */
+function scanOk(src: string): boolean {
+  let depth = 0
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (c === '{') {
+      depth++
+      if (depth > MAX_DEPTH) return false
+    } else if (c === '}') {
+      depth--
+      if (depth < 0) return false
+    }
+  }
+  return depth === 0
+}
+
+const COMPOUND = /[ +\-*/=±∓×·÷]/
+
+function wrapped(s: string): boolean {
+  if (s.length < 2 || s[0] !== '(' || s[s.length - 1] !== ')') return false
+  let d = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '(') d++
+    else if (s[i] === ')') {
+      d--
+      if (d === 0) return i === s.length - 1
+    }
+  }
+  return false
+}
+
+const wrap = (s: string): string => (s.length > 0 && COMPOUND.test(s) && !wrapped(s) ? `(${s})` : s)
+
+interface FracOp {
+  kind: 'frac'
+  args: string[]
+  need: 2
+  opt: null
+}
+
+interface SqrtOp {
+  kind: 'sqrt'
+  args: string[]
+  need: 1
+  opt: string | null
+}
+
+type Op = FracOp | SqrtOp
+
+interface Frame {
+  start: number
+  op: Op | null
+  keepBraces: boolean
+}
+
+function render(src: string): string | null {
+  const out: string[] = []
+  const stack: Frame[] = [{ start: 0, op: null, keepBraces: false }]
+  let afterScript = false
+  let keepNext = false
+  let i = 0
+  const n = src.length
+
+  const top = (): Frame => stack[stack.length - 1]
+
+  /** Trim emitted trailing spaces, never below the open frame's start. */
+  const trimTail = (): void => {
+    while (out.length > top().start && out[out.length - 1] === ' ') out.pop()
+  }
+
+  const applyOp = (op: Op): void => {
+    if (op.kind === 'frac') out.push(`${wrap(op.args[0])}/${wrap(op.args[1])}`)
+    else out.push(`${op.opt ?? ''}√${wrap(op.args[0])}`)
+  }
+
+  /** Ask for the next argument of `op` (or of an unwrap when `op` is null). false = malformed. */
+  const requestArg = (op: Op | null): boolean => {
+    while (i < n && isSpace(src[i])) i++
+    if (i >= n) return false
+    if (src[i] === '{') {
+      i++
+      stack.push({ start: out.length, op, keepBraces: false })
+      return true
+    }
+    if (src[i] === '\\' || isAlnum(src[i])) {
+      // A single-token argument. A command token is rendered by the main loop; for an
+      // op we take only the simple alphanumeric form and refuse the rest.
+      if (isAlnum(src[i])) {
+        const ch = src[i++]
+        if (op === null) out.push(ch)
+        else {
+          op.args.push(ch)
+          if (op.args.length === op.need) applyOp(op)
+          else return requestArg(op)
+        }
+        return true
+      }
+      if (op === null) return true // `\mathrm\alpha` — let the main loop render the command
+      return false
+    }
+    return false
+  }
+
+  while (i < n) {
+    const c = src[i]
+
+    if (c === '{') {
+      i++
+      stack.push({ start: out.length, op: null, keepBraces: keepNext })
+      if (keepNext) out.push('{')
+      keepNext = false
+      afterScript = false
+      continue
+    }
+
+    if (c === '}') {
+      const f = stack.pop()
+      if (f === undefined || stack.length === 0) return null // guarded by scanOk
+      i++
+      keepNext = false
+      afterScript = false
+      if (f.op === null) {
+        if (f.keepBraces) out.push('}')
+        continue
+      }
+      const text = out.splice(f.start).join('').trim()
+      f.op.args.push(text)
+      if (f.op.args.length === f.op.need) applyOp(f.op)
+      else if (!requestArg(f.op)) return null
+      continue
+    }
+
+    if (c === '_' || c === '^') {
+      // Sub- and superscripts become PLAIN characters: drop the marker, drop the space the
+      // TeX printer leaves before it, and let the operand render normally.
+      i++
+      trimTail()
+      while (i < n && isSpace(src[i])) i++
+      afterScript = true
+      keepNext = false
+      continue
+    }
+
+    if (c === '\\') {
+      const start = i
+      i++
+      if (i >= n) {
+        out.push('\\')
+        break
+      }
+      let name: string
+      let word = false
+      if (isLetter(src[i])) {
+        const from = i
+        while (i < n && isLetter(src[i])) i++
+        name = src.slice(from, i)
+        word = true
+        if (i < n && src[i] === '*') i++ // \operatorname*
+      } else {
+        name = src[i]
+        i++
+      }
+      const spacedBefore = out.length > top().start && out[out.length - 1] === ' '
+      /** TeX absorbs the space that terminates a control word; one is kept when the symbol
+       *  had a space on its left, or when the replacement ends in a letter (\sin x). */
+      const swallow = (emitted: string): void => {
+        if (!word) return
+        let j = i
+        while (j < n && isSpace(src[j])) j++
+        if (j === i) return
+        i = j
+        const last = emitted.slice(-1)
+        const nextIsRelation = j < n && (src[j] === '=' || src[j] === '<' || src[j] === '>' || src[j] === '+')
+        if (emitted.length > 0 && (spacedBefore || isLetter(last) || nextIsRelation)) out.push(' ')
+      }
+
+      if (name === 'circ') {
+        out.push(afterScript ? '°' : '∘')
+        swallow('°')
+        afterScript = false
+        keepNext = false
+        continue
+      }
+      if (DROPPED.has(name)) {
+        swallow('')
+        afterScript = false
+        keepNext = false
+        continue
+      }
+      if (SPACES.has(name)) {
+        out.push(' ')
+        afterScript = false
+        keepNext = false
+        continue
+      }
+      if (DELIMS.has(name)) {
+        let j = i
+        while (j < n && isSpace(src[j])) j++
+        if (j < n && src[j] === '.') i = j + 1
+        else swallow('')
+        afterScript = false
+        keepNext = false
+        continue
+      }
+      if (Object.hasOwn(SYMBOLS, name)) {
+        out.push(SYMBOLS[name])
+        swallow(SYMBOLS[name])
+        afterScript = false
+        keepNext = false
+        continue
+      }
+      if (UNWRAP.has(name)) {
+        afterScript = false
+        keepNext = false
+        if (!requestArg(null)) return null
+        continue
+      }
+      if (name === 'frac' || name === 'dfrac' || name === 'tfrac' || name === 'cfrac') {
+        afterScript = false
+        keepNext = false
+        if (!requestArg({ kind: 'frac', args: [], need: 2, opt: null })) return null
+        continue
+      }
+      if (name === 'sqrt') {
+        afterScript = false
+        keepNext = false
+        let opt: string | null = null
+        let j = i
+        while (j < n && isSpace(src[j])) j++
+        if (j < n && src[j] === '[') {
+          const close = src.indexOf(']', j + 1)
+          if (close < 0) return null
+          opt = normalizeMath(src.slice(j + 1, close))
+          i = close + 1
+        }
+        if (!requestArg({ kind: 'sqrt', args: [], need: 1, opt })) return null
+        continue
+      }
+      // Unknown: the command stays raw, and the brace group it introduces keeps its braces.
+      out.push(src.slice(start, i))
+      afterScript = false
+      keepNext = true
+      continue
+    }
+
+    if (isSpace(c)) {
+      let j = i
+      while (j < n && isSpace(src[j])) j++
+      i = j
+      if (out.length > top().start || stack.length > 1) out.push(' ')
+      afterScript = false
+      continue
+    }
+
+    if (c === '~') {
+      i++
+      out.push(' ')
+      afterScript = false
+      keepNext = false
+      continue
+    }
+
+    out.push(c)
+    i++
+    afterScript = false
+    keepNext = false
+  }
+
+  if (stack.length !== 1 || stack[0].op !== null) return null
+  return out.join('').replace(/\s+/g, ' ').trim()
+}
+
+/** Normalise a LaTeX source string (already entity-decoded) to plain text. Never throws;
+ *  returns the input unchanged when it exceeds the char cap or fails to parse cleanly
+ *  (unbalanced braces, nesting past MAX_DEPTH, an argument-taking command missing its
+ *  argument) — callers always get back displayable text. */
+export function normalizeMath(latex: string): string {
+  if (latex.length === 0 || latex.length > MAX_INPUT_CHARS) return latex
+  if (!scanOk(latex)) return latex
+  const rendered = render(latex)
+  return rendered === null ? latex : rendered
+}

--- a/apps/desktop/tests/unit/zim-html.test.ts
+++ b/apps/desktop/tests/unit/zim-html.test.ts
@@ -57,9 +57,10 @@ describe('zimArticleToSegments', () => {
     expect(all).toContain('25 m2 gemessen')
   })
 
-  it('emits each formula once, as its alttext LaTeX', () => {
-    const hits = all.match(/S\+O_\{2\}/g) ?? []
+  it('emits each formula once, normalised to plain text', () => {
+    const hits = all.match(/S\+O2→SO2/g) ?? []
     expect(hits).toHaveLength(1)
+    expect(all).not.toContain('\\displaystyle')
     expect(all).not.toContain('MJX-TeXAtom') // MathML internals never leak
   })
 
@@ -203,7 +204,10 @@ const NON_WIKIPEDIA: ReadonlyArray<{
   {
     file: 'parsoid-datamw.html',
     title: 'Ammonia synthesis',
-    contains: ['iron catalyst at high pressure and moderate temperature', 'N_2 + 3H_2'],
+    contains: [
+      'iron catalyst at high pressure and moderate temperature',
+      'N2 + 3H2 → 2NH3'
+    ],
     minSegments: 4,
     minChars: 1200,
     omits: [
@@ -323,6 +327,12 @@ describe('zimArticleToSegments — H1 linear scanner', () => {
       expect(r.segments.length, f.file).toBeGreaterThanOrEqual(f.minSegments)
       expect(text.length, f.file).toBeGreaterThanOrEqual(f.minChars)
     }
+  })
+
+  it('normalises a math alttext after decoding its entities (decode-then-normalise order)', () => {
+    const html = '<p><math alttext="\\text{CO}_2 &lt; 400"></math></p>'
+    const text = textOf(zimArticleToSegments(html))
+    expect(text).toContain('CO2 < 400')
   })
 
   it('emits a live, monotone counter: zero only for empty input, and never wall-clock', () => {

--- a/apps/desktop/tests/unit/zim-math.test.ts
+++ b/apps/desktop/tests/unit/zim-math.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_DEPTH, MAX_INPUT_CHARS, normalizeMath } from '../../src/main/services/zim/math'
+
+// LaTeX alttext → plain text normaliser for the ZIM converter (#340; rag-design §17 D-Z3).
+// Every row below reproduces the design's verified table (design §1 survey table + §2 rule
+// table), checked against a working prototype before this TS port was written.
+
+type Row = readonly [latex: string, expected: string]
+
+// The two fixtures also used by zim-html.test.ts (fixtures/zim/article.html and
+// fixtures/zim/parsoid-datamw.html).
+const FIXTURES: readonly Row[] = [
+  ['{\\displaystyle \\mathrm {S+O_{2}\\rightarrow SO_{2}} }', 'S+O2→SO2'],
+  ['\\mathrm{N_2 + 3H_2} \\rightarrow \\mathrm{2NH_3}', 'N2 + 3H2 → 2NH3']
+]
+
+// Extracted with zimdump from wikipedia_de_climate-change_mini_2026-07.zim, 2026-09-06
+// (5 articles, 7 formulas: Omegalage, Öleinheit ×2, Revelle-Faktor, Δ18O ×2, Δ13C).
+const REAL_ARCHIVE: readonly Row[] = [
+  ['{\\displaystyle \\Omega }', 'Ω'],
+  ['{\\displaystyle \\mathrm {1\\,{\\ddot {O}}E=41{,}868\\,MJ} }', '1 OE=41,868 MJ'],
+  ['{\\displaystyle {\\mathsf {ML^{2}T^{-2}}}}', 'ML2T-2'],
+  [
+    '{\\displaystyle {\\frac {\\Delta [\\mathrm {CO} _{2}]/[\\mathrm {CO} _{2}]}{\\Delta [DIC]/[DIC]}}}',
+    '(Δ[CO2]/[CO2])/(Δ[DIC]/[DIC])'
+  ],
+  ['{\\displaystyle W;\\,E}', 'W; E'],
+  [
+    '{\\displaystyle \\delta ^{18}\\mathrm {O} ={\\Biggl (}{\\frac {{\\bigl (}{\\frac {^{18}\\mathrm {O} }{^{16}\\mathrm {O} }}{\\bigr )}_{\\text{Probe}}}{{\\bigl (}{\\frac {^{18}\\mathrm {O} }{^{16}\\mathrm {O} }}{\\bigr )}_{\\text{Standard}}}}-1{\\Biggr )}\\cdot 1000\\ ^{o}\\!/\\!_{oo}}',
+    'δ18O =(((18O/16O)Probe)/((18O/16O)Standard)-1)·1000o/oo'
+  ],
+  [
+    '{\\displaystyle \\delta ^{13}\\mathrm {C} ={\\Biggl (}{\\frac {{\\bigl (}{\\frac {^{13}\\mathrm {C} }{^{12}\\mathrm {C} }}{\\bigr )}_{\\text{Probe}}}{{\\bigl (}{\\frac {^{13}\\mathrm {C} }{^{12}\\mathrm {C} }}{\\bigr )}_{\\text{Standard}}}}-1{\\Biggr )}\\cdot 1000\\ ^{o}\\!/\\!_{oo}}',
+    'δ13C =(((13C/12C)Probe)/((13C/12C)Standard)-1)·1000o/oo'
+  ]
+]
+
+// The UNWRAP family (text, mathrm, mathbb, overline, vec, operatorname, …): the command
+// disappears, its one argument is kept and normalises like anything else.
+const UNWRAP_ROWS: readonly Row[] = [
+  ['\\text{CO}_2', 'CO2'],
+  ['\\mathrm{Fe}^{3+}', 'Fe3+'],
+  ['\\mathrm{SO_4^{2-}}', 'SO42-'],
+  ['\\mathrm{Ca}^{2+} + 2\\mathrm{OH}^-', 'Ca2+ + 2OH-'],
+  ['\\mathrm{H_2SO_4}', 'H2SO4'],
+  ['^{14}\\mathrm{C}', '14C'],
+  ['x \\in \\mathbb{R}', 'x ∈ R'],
+  ['\\vec{v} \\cdot \\vec{w}', 'v · w'],
+  ['\\overline{AB}', 'AB'],
+  ['\\operatorname{d}\\!x', 'dx'],
+  ['T = 300\\,\\mathrm{K}', 'T = 300 K'],
+  ['\\text{Anteil in }\\%', 'Anteil in %'],
+  ['a\\text{ und }b', 'a und b'],
+  ['\\mathrm{CO_2\\text{-}Konzentration}', 'CO2-Konzentration']
+]
+
+// frac/sqrt (every row that exercises wrap()), arrows, operators, relations and Greek letters.
+const OPERATOR_ROWS: readonly Row[] = [
+  ['E=mc^{2}', 'E=mc2'],
+  ['\\frac{1}{2}mv^{2}', '1/2mv2'],
+  ['10^{-3}', '10-3'],
+  ['H_2O', 'H2O'],
+  ['\\alpha \\beta', 'αβ'],
+  ['\\phi \\varphi \\Phi', 'φφΦ'],
+  ['\\sqrt{2}', '√2'],
+  ['\\sqrt[3]{8}', '3√8'],
+  ['\\sqrt[n]{x}', 'n√x'],
+  ['\\frac{a+b}{c}', '(a+b)/c'],
+  ['\\frac{a}{b+c}', 'a/(b+c)'],
+  ['\\frac{(a+b)}{c}', '(a+b)/c'],
+  ['\\frac{a b}{c}', '(a b)/c'],
+  ['\\frac{1}{2}', '1/2'],
+  ['\\frac{\\frac{a}{b}}{c}', '(a/b)/c'],
+  ['a \\le b \\ge c \\approx d \\ne e', 'a ≤ b ≥ c ≈ d ≠ e'],
+  ['\\lambda = \\frac{c}{f}', 'λ = c/f'],
+  ['\\lambda > 0', 'λ > 0'],
+  ['\\Delta T \\approx 1{,}5\\,^\\circ\\mathrm{C}', 'ΔT ≈ 1,5°C'],
+  ['25^\\circ \\mathrm{C}', '25°C'],
+  ['f \\circ g', 'f ∘ g'],
+  ['\\sum_{i=1}^{n} i^2', 'Σi=1n i2'],
+  ['\\int_0^\\infty e^{-x}\\,dx', '∫0∞e-x dx'],
+  ['\\left( \\frac{a}{b} \\right)', '( a/b )'],
+  ['\\sin x + \\ln 2', 'sin x + ln 2'],
+  ['100\\,\\%', '100 %'],
+  ['\\frac{1}{2} \\text{ der } \\mathrm{CO_2}\\text{-Emissionen}', '1/2 der CO2-Emissionen']
+]
+
+// Malformed / over-limit input: returned byte-identical, never partially normalised.
+const UNCHANGED_INPUTS: readonly string[] = [
+  '\\frac{a}',
+  'x=\\frac{a}',
+  '{a',
+  'a}b',
+  'a } b',
+  '\\unknowncmd{x}',
+  '\\foo bar',
+  '\\begin{aligned} x \\end{aligned}',
+  ''
+]
+
+const ALL_MAPPED_ROWS: readonly Row[] = [...FIXTURES, ...REAL_ARCHIVE, ...UNWRAP_ROWS, ...OPERATOR_ROWS]
+
+describe('normalizeMath', () => {
+  it('normalises the two fixture formulas shared with zim-html.test.ts', () => {
+    for (const [latex, expected] of FIXTURES) expect(normalizeMath(latex), latex).toBe(expected)
+  })
+
+  it('normalises the seven real formulas from the climate-change ZIM archive', () => {
+    for (const [latex, expected] of REAL_ARCHIVE) expect(normalizeMath(latex), latex).toBe(expected)
+  })
+
+  it('renders sub/superscripts as plain characters, never ₂/² Unicode', () => {
+    // `<sub>/<sup>` already render plain elsewhere in the converter, and the retrieval-arm
+    // tokeniser treats a Unicode subscript/superscript digit as `\p{N}` — a typed "CO2" would
+    // never match a literal "CO₂". Every mapped row in this suite must stay plain-character.
+    const scriptGlyphs = /[₀-₉⁰-⁹²³¹]/u
+    for (const [latex, expected] of ALL_MAPPED_ROWS) {
+      const out = normalizeMath(latex)
+      expect(out, latex).toBe(expected)
+      expect(out, latex).not.toMatch(scriptGlyphs)
+    }
+    // The corpus prints a space before the script marker inside `\mathrm {…}`; the plain-
+    // character rule still applies.
+    expect(normalizeMath('\\mathrm {CO} _{2}')).toBe('CO2')
+  })
+
+  it('unwraps text/mathrm/mathbb/overline/vec/operatorname and keeps the argument', () => {
+    for (const [latex, expected] of UNWRAP_ROWS) expect(normalizeMath(latex), latex).toBe(expected)
+  })
+
+  it('renders frac/sqrt (every wrap() row), arrows, operators, relations and Greek letters', () => {
+    for (const [latex, expected] of OPERATOR_ROWS) expect(normalizeMath(latex), latex).toBe(expected)
+  })
+
+  it('keeps an unrecognised command raw while the rest of the string still normalises', () => {
+    expect(normalizeMath('\\alpha+\\unknown{x}')).toBe('α+\\unknown{x}')
+  })
+
+  it('returns the input unchanged on malformed LaTeX or input past the length/depth caps', () => {
+    for (const s of UNCHANGED_INPUTS) expect(normalizeMath(s), s).toBe(s)
+
+    const tooDeep = '{'.repeat(MAX_DEPTH + 1) + '\\alpha' + '}'.repeat(MAX_DEPTH + 1)
+    expect(normalizeMath(tooDeep)).toBe(tooDeep)
+
+    const tooLong = 'a'.repeat(MAX_INPUT_CHARS + 1)
+    expect(normalizeMath(tooLong)).toBe(tooLong)
+  })
+
+  it('takes already-decoded entities as plain characters (html.ts decodes before calling in)', () => {
+    expect(normalizeMath('a < b')).toBe('a < b')
+    expect(normalizeMath('a & b')).toBe('a & b')
+    expect(normalizeMath('\\text{a > b}')).toBe('a > b')
+  })
+
+  it('stays within generous time bounds on adversarial input — the cap and depth guards are the real oracle, not the timing', () => {
+    // Five inputs past MAX_INPUT_CHARS: normalizeMath returns immediately on the length
+    // check, before any scan, so all five together should take microseconds, not milliseconds.
+    const overCapBombs: readonly string[] = [
+      '{'.repeat(50_000) + 'x' + '}'.repeat(50_000),
+      '\\frac{'.repeat(20_000),
+      '\\text{'.repeat(20_000),
+      '^{'.repeat(50_000),
+      'a'.repeat(100_000)
+    ]
+    const bombStart = process.hrtime.bigint()
+    for (const bomb of overCapBombs) expect(normalizeMath(bomb)).toBe(bomb)
+    const bombMs = Number(process.hrtime.bigint() - bombStart) / 1e6
+    expect(bombMs).toBeLessThan(50)
+
+    // Four inputs at or just under the char cap, each still fully scanned and rendered.
+    // Measured ~25 ms for 100 passes; the 1000 ms ceiling is generous on purpose.
+    const atCapPathologies: readonly string[] = [
+      '\\frac{a+b}{c-d}'.repeat(260).slice(0, MAX_INPUT_CHARS),
+      '{'.repeat(60) + 'a+b '.repeat(400) + '}'.repeat(60),
+      '\\alpha ^{2}'.repeat(300),
+      'x_{i}'.repeat(700)
+    ]
+    const capStart = process.hrtime.bigint()
+    for (let pass = 0; pass < 100; pass++) {
+      for (const s of atCapPathologies) normalizeMath(s)
+    }
+    const capMs = Number(process.hrtime.bigint() - capStart) / 1e6
+    expect(capMs).toBeLessThan(1000)
+  })
+})

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2331,6 +2331,48 @@ offline article viewer. Files are registered in place, never copied.
   gated: (i) 1 MiB sync total 18.4–19.2 ms warm (cold 22–24 ms) — the ≈ 15 % price of
   divisibility; (ii) the 60-conversion batch 31–33 ms vs 50. No laptop re-run: the reference's
   decisive figure was not within 20 % of the bound. Logs: `tmp/zim-wave/p7/d2/` (maintainer-local).
+
+  **D-Z3 amendment — LaTeX alttext normalised to plain text (#340, 2026-09-06).** The `<math
+  alttext>` LaTeX source `html.ts` extracts (above) is no longer kept as raw TeX: `math.ts`'s
+  `normalizeMath()` turns it into plain text before it reaches a segment — arrows, fractions,
+  roots, Greek letters, operators and relations are written out (`\rightarrow` → `→`,
+  `\frac{1}{2}` → `1/2`, `\sqrt{2}` → `√2`, `\alpha` → `α`), and the UNWRAP family (`\text`,
+  `\mathrm`, `\mathbb`, `\operatorname`, …) disappears while its one argument survives. The call
+  order is `normalizeMath(decodeEntities(alt))` (`html.ts:911`) — the normaliser only ever sees
+  already-decoded text.
+
+  Sub/superscripts become PLAIN characters, never ₂/² Unicode — `E=mc^{2}` → `E=mc2`, not
+  `E=mc²` — for two mechanical reasons, not cosmetics: `<sub>/<sup>` already render plain
+  elsewhere in this same converter (`25 m2`, not `25 m²`), and the retrieval-arm tokeniser
+  (`arm.ts` `queryTerms` = `/[\p{L}\p{N}]{3,}/gu`, `overlapScore` = `includes`) treats `₂` as a
+  `\p{N}` character distinct from `2`, so a query typed as "CO2" would never match a literal
+  `CO₂` sitting in a chunk. The accepted lossy case that falls out of the same rule: `10^{-3}` →
+  `10-3`, indistinguishable from a subtraction once flattened — judged an acceptable trade
+  against the retrieval win.
+
+  What stays raw: an unrecognised `\command` is emitted with its backslash, and the brace group
+  immediately after it keeps its braces, while the rest of the string still normalises around
+  it. The WHOLE input is returned byte-identical (never partially normalised) under exactly four
+  conditions: over `MAX_INPUT_CHARS` (4,000 — the longest real formula measured is 262 chars),
+  unbalanced braces, nesting past `MAX_DEPTH` (64), or an argument-taking command (`\frac`,
+  `\sqrt`, the UNWRAP family) missing its argument.
+
+  `math.ts` is a single-cursor tokenizer over an explicit stack, not a regex: the corpus has
+  real nested `\frac`, and matching nested braces with a regex needs either a nested quantifier
+  or a fixpoint loop, both super-linear. Each input index is consumed once; only `\frac`/`\sqrt`
+  arguments materialise into a new string, so the worst case is O(n · fracDepth) ≤ ~256 k char
+  copies, bounded by the two caps above — measured 0.16 ms at the cap, and inputs over the cap
+  return in well under a microsecond (the length check runs before any scan).
+
+  Post-processing was already not charged to `work` (`html.ts:151-160`); the normaliser adds
+  nothing to that accounting, and P1b's cooperative slicing is unaffected — `normalizeMath` runs
+  entirely inside the `<math>` token handler, never across a slice boundary. `EXCERPT_GUARD_LINE`
+  and the rest of the grounded-data prompt framing are untouched: this change only reshapes text
+  that was already going to be quoted in an excerpt, never the framing around it. Evidence
+  excerpts persisted before this change keep their raw LaTeX by design — no migration; only
+  newly fetched or re-converted articles pick up plain-text formulas. Tests:
+  `tests/unit/zim-math.test.ts` (new, the full verified table) and `tests/unit/zim-html.test.ts`'s
+  "emits each formula once, normalised to plain text".
 - **D-Z4 — one seam in `retrieve()`.** An optional `ExternalRetrievalArm` (parameter 8)
   appends candidates between the chunk-row join and the rerank, so rerank, dedup, token
   budget and `[Sn]` labelling treat archive and document chunks uniformly. No reranker →
@@ -2735,7 +2777,8 @@ offline article viewer. Files are registered in place, never copied.
 
 `services/zim/`: `html.ts` (article HTML → segments; linear forward scanner with a work
 budget and `truncated` signal — PR #294 review H1; cooperatively sliced, async on the ask
-path — P1b), `client.ts` (node:http + search/
+path — P1b), `math.ts` (`<math alttext>` LaTeX → plain text, a single-cursor tokenizer —
+#340, D-Z3 amendment), `client.ts` (node:http + search/
 library XML parsing; the ONE entry-key encoder with the L5 contract — controls, dot
 segments, 2048-char bound; URL-shaped and empty-segment keys accepted, P5; `KiwixBook.tags`
 + `probeSearchable` — the `/suggest` capability probe, D-Z11, P4), `tools.ts`


### PR DESCRIPTION
Refs #340 — owner ruling (c) of 2026-09-06: option N (normalise), with the refinement that sub- and superscripts become PLAIN characters (`CO2`, `m2`, `Fe3+`), never `₂`/`²`.

A real model echoed `$\text{CO}_2$` and `{\displaystyle \mathrm {S+O_{2}\rightarrow SO_{2}} }` into answers, and the chunk picker's literal match never saw "CO2". The converter now emits each `<math alttext>` through a new pure module, `services/zim/math.ts`: fonts/`\operatorname`/accents unwrap, `\frac{a}{b}` → `a/b` (parenthesised when compound), `\sqrt{x}` → `√x`, arrows / operators / relations / Greek → Unicode, spacing and delimiter-size commands disappear, `{\displaystyle …}` and bare braces go; an unknown `\command` stays raw (with its brace group) while the rest normalises, and the whole value is returned untouched when unbalanced, deeper than 64, over 4,000 chars or missing an argument. A single-cursor tokenizer, not regexes (nested braces): each index consumed once, ~256 k char copies worst case, 0.16 ms measured at the cap. `work` is not charged and the P1b slicing is unchanged. Persisted evidence excerpts keep their raw LaTeX by design (no migration).

Design verified against a prototype on the two committed fixtures and all seven formulas of the real mini climate archive (`S+O2→SO2`, `N2 + 3H2 → 2NH3`, `(Δ[CO2]/[CO2])/(Δ[DIC]/[DIC])`, …).

Tests: `zim-math.test.ts` (nine legs incl. the 47-row table, the plain-character rule, the raw/unchanged cases, the adversarial bound), `zim-html.test.ts` "emits each formula once, normalised to plain text" (red before, green after) + the decode-then-normalise converter case. Records: rag-design §17 D-Z3 amendment, module map, CHANGELOG. Typecheck clean; full suite 415 files / 6,662 passed / 89 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)