### PR TITLE
feat(packs): the kiwix-tools consent step — install the knowledge-pack tools from inside the app (#339 P8-2)

### DIFF
--- a/apps/desktop/src/main/ipc/registerEngineIpc.ts
+++ b/apps/desktop/src/main/ipc/registerEngineIpc.ts
@@ -3,8 +3,9 @@ import { refreshGpuProbeAfterRuntimeInstall } from './registerBenchmarkIpc'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
 import type { EngineDownloadJob, EngineStatus } from '../../shared/types'
-import { EngineDownloadManager, engineStatus } from '../services/runtime-download'
+import { EngineDownloadManager, engineStatus, parseEngineDownloadRequest } from '../services/runtime-download'
 import { registeredSidecarPids } from '../services/runtime/sidecar'
+import { workspaceAdmitsWork } from '../services/workspace-vault'
 import { getSettings } from '../services/settings'
 import { loadPolicy } from '../services/policy'
 import { log } from '../services/logging'
@@ -44,6 +45,11 @@ export function whisperSidecarInUse(): boolean {
   return registeredSidecarPids('whisper_cpp').length > 0
 }
 
+/** Is a kiwix-serve / kiwix-manage child executing from `runtime/kiwix-tools/<os>/` (#339 P8-2)? */
+export function kiwixToolsInUse(): boolean {
+  return registeredSidecarPids('kiwix_tools').length > 0
+}
+
 export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManager): void {
   const ipcHandle = guardedHandleFor(ctx)
   const engine =
@@ -55,6 +61,16 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
   // itself is not re-run, and a probe that already lists a device is left alone.
   engine.onInstalled((families) => {
     if (families.includes('llama_cpp')) void refreshGpuProbeAfterRuntimeInstall(ctx)
+    // #339 P8-2: the knowledge-pack tools just arrived — the packs panel's status re-resolves
+    // the binaries on its next read, and the searchability cache key carries the tools
+    // fingerprint (rag-design §17 D-Z11/D-Z15), so one background reconcile re-probes every
+    // pack with the new bundle and announces the result through `packs:changed`. Only while
+    // the workspace still admits work: a lock that landed mid-download owns the teardown.
+    if (families.includes('kiwix_tools') && ctx.zim && workspaceAdmitsWork(ctx.workspace)) {
+      ctx.zim.reconcile(ctx.db).catch((err) => {
+        log.warn('Knowledge-pack reconcile after the tools install failed', String(err))
+      })
+    }
   })
 
   const gates = (): DownloadGates => {
@@ -70,11 +86,16 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
 
   ipcHandle(
     IPC.downloadEngine,
-    (): Promise<EngineDownloadJob> =>
+    (_e, raw?: unknown): Promise<EngineDownloadJob> =>
       engine.start({
         rootPath: ctx.paths.rootPath,
         manifestsDir: ctx.manifestsDir ?? null,
         gates: gates(),
+        // #339 P8-2: the OPTIONAL argument. Absent = the default install (required families
+        // only — the manager never reaches an optional family without it). The consent dialog
+        // sends `{ families: ['kiwix_tools'] }` after the licence acknowledgement; the payload
+        // is renderer input and is validated against the code's own family names.
+        ...parseEngineDownloadRequest(raw),
         // CODE-13 (full-audit 2026-07-11): a llama_cpp (re-)install pre-cleans the dir the
         // LIVE chat sidecar executes from — the manager refuses a job that would touch it
         // while a model runtime is up OR still starting (friendly copy; stop the model first).
@@ -84,7 +105,10 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
         // and a whisper_cpp install mid-transcription/dictation. Installs touching only the other
         // family still proceed.
         llamaSidecarActive: llamaSidecarInUse(),
-        whisperActive: whisperSidecarInUse()
+        whisperActive: whisperSidecarInUse(),
+        // #339 P8-1 R-e / P8-2: a kiwix_tools (re-)install pre-cleans the dir a live
+        // kiwix-serve / kiwix-manage child executes from — refused while one is registered.
+        kiwixToolsActive: kiwixToolsInUse()
       })
   )
 

--- a/apps/desktop/src/main/ipc/registerEngineIpc.ts
+++ b/apps/desktop/src/main/ipc/registerEngineIpc.ts
@@ -68,6 +68,8 @@ export function registerEngineIpc(ctx: AppContext, manager?: EngineDownloadManag
     // the workspace still admits work: a lock that landed mid-download owns the teardown.
     if (families.includes('kiwix_tools') && ctx.zim && workspaceAdmitsWork(ctx.workspace)) {
       ctx.zim.reconcile(ctx.db).catch((err) => {
+        // A lock that lands mid-pass aborts it by design — not a failure worth a warning.
+        if (err instanceof Error && err.name === 'AbortError') return
         log.warn('Knowledge-pack reconcile after the tools install failed', String(err))
       })
     }

--- a/apps/desktop/src/main/services/assets.ts
+++ b/apps/desktop/src/main/services/assets.ts
@@ -296,6 +296,13 @@ export interface SidecarFamilySpec {
    * request installs it.
    */
   optional?: boolean
+  /**
+   * The licence the consent dialog asks the user to acknowledge before an OPTIONAL family is
+   * fetched (#339 P8-2), SPDX-style. CODE-side on purpose: a user-writable drive yaml must not
+   * be able to change what the user is told they are accepting. Required families carry none —
+   * their permissive licences ride the notices files, not a consent step.
+   */
+  license?: string
 }
 
 /**
@@ -310,7 +317,12 @@ export const SIDECAR_FAMILY_SPECS: readonly SidecarFamilySpec[] = [
     family: 'kiwix_tools',
     binaryBase: KIWIX_SERVE_BINARY_BASE,
     alsoRequired: [KIWIX_MANAGE_BINARY_BASE],
-    optional: true
+    optional: true,
+    // The grant as read from the pinned source trees (docs/model-policy.md "Sidecar binaries —
+    // kiwix-tools"): kiwix-tools + libkiwix GPL-3.0-or-later, statically linked against
+    // GPL-2.0-or-later (libzim with GPL-3.0-or-later files, Xapian) and LGPL-2.1-or-later
+    // (libmicrohttpd) — the combined work is GPL-3.0-or-later.
+    license: 'GPL-3.0-or-later'
   }
 ]
 

--- a/apps/desktop/src/main/services/runtime-download.ts
+++ b/apps/desktop/src/main/services/runtime-download.ts
@@ -19,6 +19,7 @@ import {
   markerBinaryKey,
   planRuntimeDownload,
   requiredInstallFiles,
+  runtimeBinaryPresent,
   runtimeInstallCurrent,
   selectRuntimeBuild,
   verifyDownloadedFile,
@@ -171,13 +172,18 @@ export function parseEngineDownloadRequest(raw: unknown): { families?: EngineFam
   if (!Array.isArray(families) || families.length === 0) {
     throw new Error(tMain('main.engine.badRequest'))
   }
-  const known = SIDECAR_FAMILY_SPECS.map((s) => s.family)
   const out: EngineFamily[] = []
   for (const f of families) {
-    const match = known.find((k) => k === f)
-    if (!match || out.includes(match)) throw new Error(tMain('main.engine.badRequest'))
-    out.push(match)
+    const spec = SIDECAR_FAMILY_SPECS.find((s) => s.family === f)
+    if (!spec || out.includes(spec.family)) throw new Error(tMain('main.engine.badRequest'))
+    out.push(spec.family)
   }
+  // A request never mixes an optional (separately consented) family with a required one: the
+  // consent dialog sends the optional family alone, the engine button sends nothing. A mixed
+  // payload is not an escalation (a current family is never re-installed) but it would blur
+  // which request carried the acknowledgement, so it is refused outright.
+  const optional = out.filter((f) => SIDECAR_FAMILY_SPECS.find((s) => s.family === f)?.optional === true)
+  if (optional.length > 0 && optional.length !== out.length) throw new Error(tMain('main.engine.badRequest'))
   return { families: out }
 }
 
@@ -215,8 +221,11 @@ export function engineStatus(
         version: e.version,
         sizeBytes: e.build.sizeBytes ?? null,
         url: e.build.url,
-        license: e.license ?? 'unknown',
-        installed: !missingOptional.includes(e)
+        license: e.license ?? '',
+        // EVERY declared file, not just the primary binary: the packs panel's own
+        // `toolsInstalled` needs serve AND manage, and the consent surface must never say
+        // "installed" while the panel says "missing" (review finding, 2026-09-06).
+        installed: runtimeBinaryPresent(e.plan)
       }))
   }
 }

--- a/apps/desktop/src/main/services/runtime-download.ts
+++ b/apps/desktop/src/main/services/runtime-download.ts
@@ -118,6 +118,8 @@ interface EnginePlan {
   plan: RuntimeDownloadPlan
   /** From the CODE spec (`SIDECAR_FAMILY_SPECS`), never from the drive's yaml (#339 P8-1). */
   optional: boolean
+  /** The code-side licence string an optional family's consent dialog shows (#339 P8-2). */
+  license: string | null
 }
 
 /**
@@ -143,9 +145,40 @@ function availableEngines(
       alsoRequired: spec.alsoRequired,
       declaredExecutables: sources.executables
     })
-    out.push({ family: spec.family, version: sources.version, build, plan, optional: spec.optional === true })
+    out.push({
+      family: spec.family,
+      version: sources.version,
+      build,
+      plan,
+      optional: spec.optional === true,
+      license: spec.license ?? null
+    })
   }
   return out
+}
+
+/**
+ * Validate the renderer's `downloadEngine` payload (#339 P8-2). Renderer input is untrusted:
+ * anything but "absent" or `{ families: [<known family>, …] }` is rejected with friendly copy,
+ * and the parsed list is rebuilt from the code's own family names (never the caller's strings
+ * echoed back). Absent / `{}` = the default install (`families` undefined).
+ */
+export function parseEngineDownloadRequest(raw: unknown): { families?: EngineFamily[] } {
+  if (raw === undefined || raw === null) return {}
+  if (typeof raw !== 'object' || Array.isArray(raw)) throw new Error(tMain('main.engine.badRequest'))
+  const families = (raw as { families?: unknown }).families
+  if (families === undefined) return {}
+  if (!Array.isArray(families) || families.length === 0) {
+    throw new Error(tMain('main.engine.badRequest'))
+  }
+  const known = SIDECAR_FAMILY_SPECS.map((s) => s.family)
+  const out: EngineFamily[] = []
+  for (const f of families) {
+    const match = known.find((k) => k === f)
+    if (!match || out.includes(match)) throw new Error(tMain('main.engine.badRequest'))
+    out.push(match)
+  }
+  return { families: out }
 }
 
 /**
@@ -173,7 +206,18 @@ export function engineStatus(
     version: llama?.version ?? null,
     backend: llama?.build.backend ?? null,
     missingFamilies: missingRequired.map((e) => e.family),
-    missingOptionalFamilies: missingOptional.map((e) => e.family)
+    missingOptionalFamilies: missingOptional.map((e) => e.family),
+    // #339 P8-2: what the consent dialog states, from the pin + the code-side spec — never copy.
+    optionalFamilies: engines
+      .filter((e) => e.optional)
+      .map((e) => ({
+        family: e.family,
+        version: e.version,
+        sizeBytes: e.build.sizeBytes ?? null,
+        url: e.build.url,
+        license: e.license ?? 'unknown',
+        installed: !missingOptional.includes(e)
+      }))
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -33,6 +33,7 @@ import type {
   DownloadJob,
   DriveStatus,
   EngineDownloadJob,
+  EngineDownloadRequest,
   EngineStatus,
   EvidenceExportRecord,
   EvidenceLinkInput,
@@ -175,8 +176,16 @@ const api = {
   // ---- In-app engine (llama.cpp sidecar) downloader ----
   /** Is the real AI engine installed, and (if not) can it be fetched for this host? */
   getEngineStatus: (): Promise<EngineStatus> => ipcRenderer.invoke(IPC.getEngineStatus),
-  /** Start fetching + extracting the host's llama-server build. Gated like model downloads. */
-  downloadEngine: (): Promise<EngineDownloadJob> => ipcRenderer.invoke(IPC.downloadEngine),
+  /**
+   * Start fetching + extracting the host's engine build(s). Gated like model downloads. No
+   * argument = the DEFAULT install (every missing required family: llama.cpp, whisper.cpp) —
+   * never an optional one. `{ families: ['kiwix_tools'] }` is how the consent dialog installs
+   * the knowledge-pack tools after the user acknowledged their licence (#339 P8-2).
+   */
+  downloadEngine: (request?: EngineDownloadRequest): Promise<EngineDownloadJob> =>
+    request === undefined
+      ? ipcRenderer.invoke(IPC.downloadEngine)
+      : ipcRenderer.invoke(IPC.downloadEngine, request),
   /** Poll the engine-download job's progress/status. */
   getEngineJob: (jobId: string): Promise<EngineDownloadJob> =>
     ipcRenderer.invoke(IPC.getEngineJob, jobId),

--- a/apps/desktop/src/renderer/components/KnowledgePackToolsDialog.tsx
+++ b/apps/desktop/src/renderer/components/KnowledgePackToolsDialog.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import type { EngineOptionalFamily } from '@shared/types'
+import { ConfirmDialog } from './Dialog'
+import { englishTranslator, type Translator } from './translator'
+
+// Knowledge-pack tools install consent (#339 P8-2, the owner's 2026-09-06 ruling): the SAME
+// shape as the model-download confirm (`ModelsScreen.tsx` confirmDialog, ~842-897) — a
+// `<dl class="kv">` of Size / License / From, a hint line, and a REQUIRED acknowledgement
+// checkbox (confirm disabled until ticked). Shared by BOTH entry points — the Knowledge-packs
+// panel's notice and the Models screen's quiet row — so the two surfaces can never present
+// different facts or a different bar for consent. Every fact comes from `family` (an
+// `EngineOptionalFamily`, sourced from the pinned yaml / the code-side family spec, never from
+// copy — see `docs/data-contracts.md` "#339 P8-2 additions").
+
+export interface KnowledgePackToolsDialogProps {
+  open: boolean
+  family: EngineOptionalFamily
+  downloadsEnabled: boolean
+  /** Why downloads are blocked (the SAME gate/copy as ModelsScreen's engine banners — reused via
+   *  `lib/downloadGate.ts` so the two can't diverge), or null when they are allowed. */
+  blockedReason: string | null
+  onConfirm: () => void
+  onCancel: () => void
+  /** Bound translate fn (i18n record §5 ⑤); English default, like every other shared component. */
+  t?: Translator
+}
+
+/** GB/MB size string — same rounding as `PacksPanel.tsx`'s `formatSize` (GB from ~0.95 GB up). */
+function formatFamilySize(bytes: number): string {
+  const gb = bytes / (1024 * 1024 * 1024)
+  if (gb >= 0.95) return `${gb.toFixed(1)} GB`
+  return `${Math.max(1, Math.round(bytes / (1024 * 1024)))} MB`
+}
+
+/** The one licence this dialog is scoped to links to the canonical GNU text. */
+const GPL_3_0_URL = 'https://www.gnu.org/licenses/gpl-3.0.html'
+
+/**
+ * The licence link's href + host, or null when it must not render as a link (#236, mirroring
+ * `ModelsScreen.tsx`'s `licenseLink`): only for the `GPL-3.0-or-later` licence this dialog knows
+ * about, and only when the fixed URL parses as https.
+ */
+function licenseLink(license: string): { href: string; host: string } | null {
+  if (license !== 'GPL-3.0-or-later') return null
+  try {
+    const parsed = new URL(GPL_3_0_URL)
+    return parsed.protocol === 'https:' ? { href: parsed.href, host: parsed.host } : null
+  } catch {
+    return null
+  }
+}
+
+export function KnowledgePackToolsDialog({
+  open,
+  family,
+  downloadsEnabled,
+  blockedReason,
+  onConfirm,
+  onCancel,
+  t = englishTranslator
+}: KnowledgePackToolsDialogProps): JSX.Element {
+  const [ack, setAck] = useState(false)
+  // Reset the tick every time the dialog opens — a stale acknowledgement must never survive a
+  // close + re-open (a new family, or the same one after a failed attempt).
+  useEffect(() => {
+    if (open) setAck(false)
+  }, [open])
+  const license = licenseLink(family.license)
+  return (
+    <ConfirmDialog
+      open={open}
+      title={t('packs.tools.confirm.title')}
+      confirmLabel={t('packs.tools.confirm.start')}
+      t={t}
+      confirmDisabled={!ack || !downloadsEnabled}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    >
+      <p>{t('packs.tools.confirm.explain', { version: family.version })}</p>
+      <dl className="kv">
+        <dt>{t('models.confirm.size')}</dt>
+        <dd>
+          {family.sizeBytes != null ? formatFamilySize(family.sizeBytes) : t('packs.tools.sizeUnknown')}
+        </dd>
+        <dt>{t('models.confirm.license')}</dt>
+        <dd>
+          {family.license}
+          {license && (
+            <>
+              {' — '}
+              <a href={license.href} target="_blank" rel="noreferrer">
+                {t('models.confirm.readLicense')}
+              </a>
+              {/* Mirrors ModelsScreen's confirm dialog (#236): the destination host is shown. */}
+              {' ('}
+              <code>{license.host}</code>
+              {')'}
+            </>
+          )}
+        </dd>
+        <dt>{t('models.confirm.from')}</dt>
+        <dd>
+          <code>{family.url}</code>
+        </dd>
+      </dl>
+      <p className="hint">{t('packs.tools.confirm.hint')}</p>
+      <label className="toggle">
+        <input
+          type="checkbox"
+          checked={ack}
+          disabled={!downloadsEnabled}
+          onChange={(e) => setAck(e.target.checked)}
+        />
+        <span>{t('packs.tools.confirm.ack', { license: family.license })}</span>
+      </label>
+      {blockedReason && <p className="hint">{blockedReason}</p>}
+    </ConfirmDialog>
+  )
+}

--- a/apps/desktop/src/renderer/components/index.ts
+++ b/apps/desktop/src/renderer/components/index.ts
@@ -11,6 +11,10 @@ export { ErrorBanner, type ErrorBannerProps } from './ErrorBanner'
 export { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary'
 export { ToastProvider, useToast, TOAST_DURATION_MS } from './Toast'
 export { Modal, ConfirmDialog, type ModalProps, type ConfirmDialogProps } from './Dialog'
+export {
+  KnowledgePackToolsDialog,
+  type KnowledgePackToolsDialogProps
+} from './KnowledgePackToolsDialog'
 export { SegmentedControl, type SegmentedControlProps, type SegmentedOption } from './SegmentedControl'
 export { Switch, type SwitchProps } from './Switch'
 export { Chip, type ChipProps } from './Chip'

--- a/apps/desktop/src/renderer/lib/downloadGate.ts
+++ b/apps/desktop/src/renderer/lib/downloadGate.ts
@@ -1,0 +1,25 @@
+import type { PolicyStatus } from '@shared/types'
+import type { Translator } from '../components/translator'
+
+// The network-download gate (guidelines: the drive POLICY is the ceiling, the Settings toggle
+// the SWITCH — the copy distinguishes the two, "disabled by policy" vs. "turn it on in
+// Settings"). Extracted from `ModelsScreen.tsx` (previously ~498-504, inlined there) so the
+// knowledge-pack tools install (#339 P8-2, `useKnowledgePackToolsInstall.ts`) reads the SAME
+// gate/copy — two surfaces asking the same yes/no must never diverge.
+
+export interface DownloadGate {
+  downloadsEnabled: boolean
+  /** Why downloads are blocked, or null when they are allowed. */
+  blockedReason: string | null
+}
+
+export function computeDownloadGate(policy: PolicyStatus | null, t: Translator): DownloadGate {
+  const downloadsAllowedByPolicy = policy?.policy.network.allowModelDownloads ?? false
+  const downloadsEnabled = downloadsAllowedByPolicy && (policy?.allowNetworkSetting ?? false)
+  const blockedReason = !downloadsAllowedByPolicy
+    ? t('models.downloads.blockedByPolicy')
+    : !(policy?.allowNetworkSetting ?? false)
+      ? t('models.downloads.enableInSettings')
+      : null
+  return { downloadsEnabled, blockedReason }
+}

--- a/apps/desktop/src/renderer/lib/useKnowledgePackToolsInstall.ts
+++ b/apps/desktop/src/renderer/lib/useKnowledgePackToolsInstall.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from 'react'
+import type { EngineDownloadJob, EngineOptionalFamily, EngineStatus, PolicyStatus } from '@shared/types'
+import { friendlyIpcError } from './errors'
+import { computeDownloadGate } from './downloadGate'
+import { useT } from '../i18n'
+
+// Shared by the Knowledge-packs panel notice AND the Models screen's quiet row (#339 P8-2, the
+// owner's ruling): both entry points install the SAME optional family (`kiwix_tools`) through
+// the SAME confirm dialog (`KnowledgePackToolsDialog.tsx`), so this hook carries the one
+// poll/cancel/remembered-job pattern instead of two copies that could drift — it mirrors
+// ModelsScreen's own engine-job handling (`ModelsScreen.tsx` ~340-372 poll, ~905-985 banner).
+
+const JOB_LIVE: ReadonlySet<EngineDownloadJob['status']> = new Set([
+  'queued',
+  'downloading',
+  'verifying',
+  'extracting'
+])
+
+// Module-scoped (like ModelsScreen's `rememberedEngineJob`): a remount during a LIVE install —
+// leaving and re-entering the Documents screen, or the Models screen — keeps showing progress
+// instead of losing the job.
+let rememberedJob: EngineDownloadJob | null = null
+
+/** Test/preview-only reset. Production code never calls this (mirrors ModelsScreen's own). */
+export function __resetKnowledgePackToolsInstallForTests(): void {
+  rememberedJob = null
+}
+
+export interface KnowledgePackToolsInstall {
+  /** The `kiwix_tools` entry of `optionalFamilies` — null while loading, absent, or installed. */
+  family: EngineOptionalFamily | null
+  downloadsEnabled: boolean
+  blockedReason: string | null
+  job: EngineDownloadJob | null
+  /** `job` is in a live (queued/downloading/verifying/extracting) state. */
+  live: boolean
+  error: string | null
+  start: () => Promise<void>
+  cancel: () => Promise<void>
+}
+
+/**
+ * `active` gates the lazy `getEngineStatus`/`getPolicy` fetch: the caller passes `false` while
+ * the affordance need not exist yet — PacksPanel: `toolsInstalled` is true; ModelsScreen: the
+ * family isn't in `missingOptionalFamilies` — so the existing PacksPanel tests (which stub only
+ * `getKnowledgePackStatus`/`listKnowledgePacks`) keep passing untouched, and `assertNoUnexpected
+ * ApiCalls()` stays meaningful. The fetch runs once per `active` transition to true, not on
+ * every render. `onDone` fires exactly once, on the `done` transition only (never `failed` /
+ * `cancelled`) — the caller re-derives its own install state from its own refresh instead of
+ * this hook guessing at it.
+ */
+export function useKnowledgePackToolsInstall(
+  active: boolean,
+  onDone: () => void
+): KnowledgePackToolsInstall {
+  const { t } = useT()
+  const [family, setFamily] = useState<EngineOptionalFamily | null>(null)
+  const [policy, setPolicy] = useState<PolicyStatus | null>(null)
+  const [job, setJob] = useState<EngineDownloadJob | null>(rememberedJob)
+  const [error, setError] = useState<string | null>(null)
+  const jobRef = useRef<EngineDownloadJob | null>(rememberedJob)
+  const mountedRef = useRef(true)
+  const onDoneRef = useRef(onDone)
+  onDoneRef.current = onDone
+  const fetchedRef = useRef(false)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  // Lazy load: only once `active` and only once per mount (a re-render while active stays true
+  // must not re-fetch).
+  useEffect(() => {
+    if (!active || fetchedRef.current) return
+    fetchedRef.current = true
+    Promise.all([window.api.getEngineStatus(), window.api.getPolicy()])
+      .then(([engine, p]: [EngineStatus | undefined, PolicyStatus | undefined]) => {
+        if (!mountedRef.current) return
+        // `?.` tolerates an older/partial preload (or a test stub that never supplied these) —
+        // same defensive shape as ModelsScreen's own `getEngineStatus?.()` degrade.
+        setFamily(
+          engine?.optionalFamilies?.find((f) => f.family === 'kiwix_tools' && !f.installed) ?? null
+        )
+        setPolicy(p ?? null)
+      })
+      .catch((e) => {
+        if (!mountedRef.current) return
+        setError(friendlyIpcError(e))
+      })
+  }, [active])
+
+  // Poll the live install job (same async-with-polling shape as ModelsScreen's engine poll).
+  useEffect(() => {
+    jobRef.current = job
+    rememberedJob = job
+    if (!job || !JOB_LIVE.has(job.status)) return
+    const timer = setInterval(() => {
+      window.api
+        .getEngineJob(job.jobId)
+        .then((next) => {
+          if (!mountedRef.current) return
+          // A response for a job that is no longer current (a new install accepted meanwhile)
+          // must never overwrite the newer job (mirrors ModelsScreen's F2/B1 guard).
+          if (jobRef.current?.jobId !== job.jobId || next.jobId !== job.jobId) return
+          setJob(next)
+          // Fire exactly once, on the live → 'done' transition (never 'failed' / 'cancelled',
+          // and never again once polling has already stopped — 'done' drops out of JOB_LIVE so
+          // the interval above is not rescheduled on the next effect run).
+          if (next.status === 'done' && JOB_LIVE.has(jobRef.current?.status ?? 'done')) {
+            onDoneRef.current()
+          }
+        })
+        .catch(() => undefined)
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [job?.jobId, job?.status])
+
+  async function start(): Promise<void> {
+    setError(null)
+    try {
+      const started = await window.api.downloadEngine({ families: ['kiwix_tools'] })
+      rememberedJob = started
+      if (mountedRef.current) setJob(started)
+    } catch (e) {
+      if (mountedRef.current) setError(friendlyIpcError(e))
+    }
+  }
+
+  async function cancel(): Promise<void> {
+    if (!job) return
+    try {
+      const next = await window.api.cancelEngineDownload(job.jobId)
+      rememberedJob = next
+      if (mountedRef.current) setJob(next)
+    } catch (e) {
+      if (mountedRef.current) setError(friendlyIpcError(e))
+    }
+  }
+
+  const gate = computeDownloadGate(policy, t)
+  return {
+    family,
+    downloadsEnabled: gate.downloadsEnabled,
+    blockedReason: gate.blockedReason,
+    job,
+    live: job != null && JOB_LIVE.has(job.status),
+    error,
+    start,
+    cancel
+  }
+}

--- a/apps/desktop/src/renderer/screens/ModelsScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ModelsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Badge, Banner, Button, ConfirmDialog, EmptyState, ErrorBanner, Progress, SegmentedControl, Spinner, type BadgeTone } from '../components'
+import { Badge, Banner, Button, ConfirmDialog, EmptyState, ErrorBanner, KnowledgePackToolsDialog, Progress, SegmentedControl, Spinner, type BadgeTone } from '../components'
 import {
   groupModelVariants,
   matchesModelSearch,
@@ -12,7 +12,9 @@ import {
   isModelOnDrive,
   orderPickerModels
 } from '../lib/modelAvailability'
+import { computeDownloadGate } from '../lib/downloadGate'
 import { friendlyIpcError, runAndSurface } from '../lib/errors'
+import { useKnowledgePackToolsInstall } from '../lib/useKnowledgePackToolsInstall'
 import { useT } from '../i18n'
 import type { MessageKey, UiLanguage } from '@shared/i18n'
 import type {
@@ -220,6 +222,15 @@ export function ModelsScreen(): JSX.Element {
   const [engine, setEngine] = useState<EngineStatus | null>(null)
   const [engineJob, setEngineJob] = useState<EngineDownloadJob | null>(rememberedEngineJob)
   const engineJobRef = useRef<EngineDownloadJob | null>(rememberedEngineJob)
+  // #339 P8-2 (the owner's ruling): the quiet "knowledge-pack tools" row below the two engine
+  // banners — the SAME confirm dialog/hook the Knowledge-packs panel notice uses, so the two
+  // entry points can never present different facts. Only fetches its own getEngineStatus/
+  // getPolicy while `packToolsMissing` is true (the hook's lazy-load contract).
+  const [packToolsDialogOpen, setPackToolsDialogOpen] = useState(false)
+  const packToolsMissing = engine?.missingOptionalFamilies?.includes('kiwix_tools') ?? false
+  const packToolsInstall = useKnowledgePackToolsInstall(packToolsMissing, () => {
+    void runAndSurface(refresh, (m) => mountedRef.current && setError(m))
+  })
   // Mounted flag (audit FE-4): refresh() and the download/engine polls below resolve async; a
   // parked tick can land AFTER unmount (clearing the interval doesn't abort the in-flight
   // promise). Guard every setState behind this so ModelsScreen joins the uniform FE-4 discipline.
@@ -495,18 +506,21 @@ export function ModelsScreen(): JSX.Element {
   // Download gates: the drive policy is the ceiling, the Settings toggle the
   // switch. The copy distinguishes the two — "disabled by policy" vs. "turn it on in
   // Settings" — reusing the PolicyStatus distinction the Privacy & data tab makes.
-  const downloadsAllowedByPolicy = policy?.policy.network.allowModelDownloads ?? false
-  const downloadsEnabled = downloadsAllowedByPolicy && (policy?.allowNetworkSetting ?? false)
-  const downloadsBlockedReason = !downloadsAllowedByPolicy
-    ? t('models.downloads.blockedByPolicy')
-    : !(policy?.allowNetworkSetting ?? false)
-      ? t('models.downloads.enableInSettings')
-      : null
+  // #339 P8-2: extracted to `lib/downloadGate.ts` so the knowledge-pack tools install (same
+  // gate, same copy) can never diverge from this screen's own engine/model download gate.
+  const { downloadsEnabled, blockedReason: downloadsBlockedReason } = computeDownloadGate(policy, t)
   // A withdrawn source (#196) is NOT downloadable — the network-gate banner above the list
   // must not appear for a screen whose only "missing" models can never be fetched anyway.
   const anyDownloadable = models.some(
     (m) => m.download && !m.download.withdrawn && (m.state === 'missing' || m.state === 'checksum_failed')
   )
+
+  // #339 P8-2: the knowledge-pack tools install job's download percentage, same shape as the
+  // engine banner's own `pct` (see `engineBanner` below).
+  const packToolsPct =
+    packToolsInstall.job && packToolsInstall.job.totalBytes && packToolsInstall.job.totalBytes > 0
+      ? Math.min(100, Math.round((packToolsInstall.job.receivedBytes / packToolsInstall.job.totalBytes) * 100))
+      : null
 
   // Retry (panel, terminal result only): resolve the EXACT model id from the current list and run
   // it through the same confirmation as every other download — the same gates, the same license
@@ -1011,6 +1025,49 @@ export function ModelsScreen(): JSX.Element {
           installKey: 'models.voiceEngine.install'
         })}
 
+      {/* #339 P8-2 (the owner's ruling): a QUIET row for the OPTIONAL knowledge-pack tools —
+          visually lighter than the two engine banners above (a hint line, not a Banner) — shown
+          only while `missingOptionalFamilies` names `kiwix_tools` (never when installed or
+          absent from the field, e.g. an older main). "Install…" opens the SAME consent dialog
+          the Knowledge-packs panel's own notice opens. */}
+      {engine && packToolsMissing && (
+        <div className="packs-tools-hint">
+          <p className="hint">{t('models.packTools.row')}</p>
+          {packToolsInstall.live && packToolsInstall.job ? (
+            <div className="download-progress">
+              <Progress
+                label={
+                  packToolsInstall.job.status === 'extracting'
+                    ? t('packs.tools.extracting')
+                    : packToolsInstall.job.status === 'verifying'
+                      ? t('packs.tools.verifying')
+                      : packToolsPct != null
+                        ? t('packs.tools.progress', { pct: packToolsPct })
+                        : t('packs.tools.downloadingNoTotal')
+                }
+                value={packToolsPct != null ? packToolsInstall.job.receivedBytes : undefined}
+                max={packToolsPct != null ? (packToolsInstall.job.totalBytes ?? undefined) : undefined}
+              />
+              <Button size="sm" onClick={() => void packToolsInstall.cancel()}>
+                {t('models.download.cancel')}
+              </Button>
+            </div>
+          ) : packToolsInstall.job?.status === 'failed' ? (
+            <div className="download-progress">
+              <p className="hint">{t('packs.tools.failed')}</p>
+              {packToolsInstall.job.error && <p className="hint">{packToolsInstall.job.error}</p>}
+              <Button size="sm" onClick={() => setPackToolsDialogOpen(true)}>
+                {t('models.engine.retry')}
+              </Button>
+            </div>
+          ) : (
+            <Button size="sm" onClick={() => setPackToolsDialogOpen(true)}>
+              {t('models.packTools.install')}
+            </Button>
+          )}
+        </div>
+      )}
+
       {models.length === 0 && (
         <EmptyState
           title={t('models.empty.title')}
@@ -1208,6 +1265,21 @@ export function ModelsScreen(): JSX.Element {
       <ErrorBanner message={error} t={t} />
 
       {confirming && confirmDialog(confirming)}
+
+      {packToolsInstall.family && (
+        <KnowledgePackToolsDialog
+          open={packToolsDialogOpen}
+          family={packToolsInstall.family}
+          downloadsEnabled={packToolsInstall.downloadsEnabled}
+          blockedReason={packToolsInstall.blockedReason}
+          onConfirm={() => {
+            setPackToolsDialogOpen(false)
+            void packToolsInstall.start()
+          }}
+          onCancel={() => setPackToolsDialogOpen(false)}
+          t={t}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
+++ b/apps/desktop/src/renderer/screens/documents/PacksPanel.tsx
@@ -6,8 +6,19 @@ import type {
 } from '@shared/types'
 import type { KnowledgePackCollision } from '@shared/types'
 import type { MessageKey } from '@shared/i18n'
-import { Badge, Button, ConfirmDialog, EmptyState, ErrorBanner, Spinner, useToast } from '../../components'
+import {
+  Badge,
+  Button,
+  ConfirmDialog,
+  EmptyState,
+  ErrorBanner,
+  KnowledgePackToolsDialog,
+  Progress,
+  Spinner,
+  useToast
+} from '../../components'
 import { friendlyIpcError } from '../../lib/errors'
+import { useKnowledgePackToolsInstall } from '../../lib/useKnowledgePackToolsInstall'
 import { useT } from '../../i18n'
 
 // Knowledge packs management (ZIM wave) — the Documents screen's "Knowledge packs"
@@ -65,6 +76,14 @@ function formatSize(tCount: ReturnType<typeof useT>['tCount'], bytes: number | n
   return `${Math.max(1, Math.round(bytes / (1024 * 1024)))} MB`
 }
 
+/** The tools-install job's download percentage, or null with no known total (indeterminate) —
+ *  same shape as ModelsScreen's own engine-download progress. */
+function toolsPct(job: { receivedBytes: number; totalBytes: number | null }): number | null {
+  return job.totalBytes && job.totalBytes > 0
+    ? Math.min(100, Math.round((job.receivedBytes / job.totalBytes) * 100))
+    : null
+}
+
 export function PacksPanel(): JSX.Element {
   const { t, tCount, lang } = useT()
   const showToast = useToast()
@@ -77,6 +96,16 @@ export function PacksPanel(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<'add' | 'refresh' | string | null>(null)
   const [confirmRemove, setConfirmRemove] = useState<KnowledgePack | null>(null)
+  // #339 P8-2 (the owner's ruling): the "kiwix-tools not installed" notice's own install action.
+  // The hook only fetches getEngineStatus/getPolicy while the tools are actually missing — a
+  // workspace whose tools are already installed never makes these calls (KnowledgePacks.test.tsx
+  // leg (d)). `refresh()` on `done` makes the notice disappear even before the packs:changed
+  // broadcast's own refetch lands.
+  const [toolsDialogOpen, setToolsDialogOpen] = useState(false)
+  const toolsInstall = useKnowledgePackToolsInstall(!toolsInstalled, () => {
+    showToast(t('packs.tools.doneToast'))
+    void refresh()
+  })
   const mountedRef = useRef(true)
   // Ignore an event whose epoch is below the last one seen — an old session's late
   // announcement (0 before anything has been observed; a real epoch starts at 1).
@@ -217,9 +246,43 @@ export function PacksPanel(): JSX.Element {
       <ErrorBanner message={error} t={t} />
 
       {!toolsInstalled && (
-        <p className="hint packs-tools-hint">
-          <span aria-hidden="true">○</span> {t('packs.toolsMissing')}
-        </p>
+        <div className="packs-tools-hint">
+          <p className="hint">
+            <span aria-hidden="true">○</span> {t('packs.toolsMissing')}
+          </p>
+          {toolsInstall.live && toolsInstall.job ? (
+            <div className="download-progress">
+              <Progress
+                label={
+                  toolsInstall.job.status === 'extracting'
+                    ? t('packs.tools.extracting')
+                    : toolsInstall.job.status === 'verifying'
+                      ? t('packs.tools.verifying')
+                      : toolsPct(toolsInstall.job) != null
+                        ? t('packs.tools.progress', { pct: toolsPct(toolsInstall.job)! })
+                        : t('packs.tools.downloadingNoTotal')
+                }
+                value={toolsPct(toolsInstall.job) != null ? toolsInstall.job.receivedBytes : undefined}
+                max={toolsPct(toolsInstall.job) != null ? (toolsInstall.job.totalBytes ?? undefined) : undefined}
+              />
+              <Button size="sm" onClick={() => void toolsInstall.cancel()}>
+                {t('models.download.cancel')}
+              </Button>
+            </div>
+          ) : toolsInstall.job?.status === 'failed' ? (
+            <div className="download-progress">
+              <p className="hint">{t('packs.tools.failed')}</p>
+              {toolsInstall.job.error && <p className="hint">{toolsInstall.job.error}</p>}
+              <Button size="sm" variant="primary" onClick={() => setToolsDialogOpen(true)}>
+                {t('models.engine.retry')}
+              </Button>
+            </div>
+          ) : (
+            <Button size="sm" variant="primary" onClick={() => setToolsDialogOpen(true)}>
+              {t('packs.tools.install')}
+            </Button>
+          )}
+        </div>
       )}
 
       <div className="actions">
@@ -364,6 +427,21 @@ export function PacksPanel(): JSX.Element {
       >
         {t('packs.removeBody')}
       </ConfirmDialog>
+
+      {toolsInstall.family && (
+        <KnowledgePackToolsDialog
+          open={toolsDialogOpen}
+          family={toolsInstall.family}
+          downloadsEnabled={toolsInstall.downloadsEnabled}
+          blockedReason={toolsInstall.blockedReason}
+          onConfirm={() => {
+            setToolsDialogOpen(false)
+            void toolsInstall.start()
+          }}
+          onCancel={() => setToolsDialogOpen(false)}
+          t={t}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1191,6 +1191,12 @@ export const de: Record<keyof typeof en, string> = {
     'Chat- und Dokumentantworten funktionieren auf diesem Laufwerk bereits. Die Sprach-Engine ist ' +
     'optional — installiere sie nur, wenn du Nachrichten per Mikrofon diktieren möchtest.',
   'models.voiceEngine.install': 'Sprach-Engine installieren',
+  // #339 P8-2: ein ruhiger Hinweis (leichter als die beiden Engine-Banner oben) für die
+  // OPTIONALEN Wissenspaket-Werkzeuge (kiwix_tools) — nur sichtbar, solange
+  // `missingOptionalFamilies` sie nennt. „Installieren…“ öffnet denselben Bestätigungsdialog
+  // wie der Hinweis im Wissenspakete-Panel (`KnowledgePackToolsDialog.tsx`).
+  'models.packTools.row': 'Wissenspaket-Werkzeuge: nicht installiert',
+  'models.packTools.install': 'Installieren…',
   'models.ram.needs': 'Braucht mindestens {min} GB RAM',
   'models.ram.machine': ' — dieser Computer hat etwa {ram} GB',
   'models.ram.advice': '. Wähle ein kleineres Modell — die Qualität bleibt top.',
@@ -2741,6 +2747,28 @@ export const de: Record<keyof typeof en, string> = {
   'packs.emptyTitle': 'Noch keine Wissenspakete',
   'packs.emptyLine': 'Ein ZIM-Archiv hinzufügen oder in den zim-Ordner des Laufwerks kopieren und diese Ansicht erneut öffnen.',
   'packs.toolsMissing': 'Die kiwix-tools-Programme sind auf diesem Laufwerk nicht installiert; Pakete können daher nicht hinzugefügt oder durchsucht werden. Der Installationsschritt steht in der Fehlerbehebung unter „Das Panel meldet, dass kiwix-tools fehlen“.',
+  // #339 P8-2 (die Entscheidung des Owners, 2026-09-06): die Installations-Aktion des Panel-
+  // Hinweises — derselbe Bestätigungsdialog wie bei einem Modell-Download
+  // (`KnowledgePackToolsDialog.tsx`); Bestätigen ruft `downloadEngine({ families: ['kiwix_tools'] })`.
+  'packs.tools.install': 'Wissenspaket-Werkzeuge installieren…',
+  'packs.tools.confirm.title': 'Wissenspaket-Werkzeuge installieren?',
+  'packs.tools.confirm.explain':
+    'kiwix-tools {version} — die Programme, die Wissenspakete (ZIM-Archive) bereitstellen — ' +
+    'werden vom Server des Kiwix-Projekts heruntergeladen und vor der Nutzung geprüft. Sie ' +
+    'sind optional: Chat und Dokumente funktionieren auch ohne sie.',
+  'packs.tools.confirm.hint':
+    'Der Download wird vor der Nutzung geprüft, und nichts über dich oder deine Dokumente wird ' +
+    'gesendet. Die Werkzeuge werden nur für Wissenspakete gebraucht.',
+  'packs.tools.confirm.ack':
+    'Ich habe die {license}-Lizenzbedingungen von kiwix-tools gelesen und akzeptiere sie',
+  'packs.tools.confirm.start': 'Download starten',
+  'packs.tools.sizeUnknown': 'unbekannt',
+  'packs.tools.progress': 'Wissenspaket-Werkzeuge werden installiert… {pct} %',
+  'packs.tools.downloadingNoTotal': 'Wissenspaket-Werkzeuge werden installiert…',
+  'packs.tools.verifying': 'Wissenspaket-Werkzeuge werden geprüft…',
+  'packs.tools.extracting': 'Wissenspaket-Werkzeuge werden entpackt…',
+  'packs.tools.failed': 'Installation der Wissenspaket-Werkzeuge fehlgeschlagen.',
+  'packs.tools.doneToast': 'Wissenspaket-Werkzeuge installiert',
   'packs.addedToast.one': 'Wissenspaket hinzugefügt',
   'packs.addedToast.other': '{count} Wissenspakete hinzugefügt',
   // #301 P5, Fund L1 (Plan §9.19 (c)3): die Ergebnisse des typisierten Hinzufügen-DTOs.

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2469,6 +2469,8 @@ export const de: Record<keyof typeof en, string> = {
   'main.engine.knowledgePackToolsRunning':
     'Die Wissenspaket-Werkzeuge können nicht ersetzt werden, während ein Paket bereitgestellt wird. ' +
     'Sperre den Arbeitsbereich oder warte, bis die aktuelle Frage beantwortet ist, und versuche es dann erneut.',
+  // #339 P8-2: die downloadEngine-Anfrage nannte etwas, das keine Engine-Familie ist.
+  'main.engine.badRequest': 'Die Anfrage zur Engine-Installation wurde nicht verstanden. Bitte versuche es erneut.',
   'main.docs.locked': 'Der Arbeitsbereich ist gesperrt. Entsperre ihn, um Dokumente zu verwalten.',
   'main.docs.processing':
     'Dieses Dokument wird noch verarbeitet. Warte, bis der Import fertig ist.',

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -2474,7 +2474,7 @@ export const de: Record<keyof typeof en, string> = {
   // #339 P8-1: die kiwix_tools-Familie räumt runtime/kiwix-tools/<os>/ bei jeder (Neu-)Installation auf.
   'main.engine.knowledgePackToolsRunning':
     'Die Wissenspaket-Werkzeuge können nicht ersetzt werden, während ein Paket bereitgestellt wird. ' +
-    'Sperre den Arbeitsbereich oder warte, bis die aktuelle Frage beantwortet ist, und versuche es dann erneut.',
+    'Sperre den Arbeitsbereich oder warte, bis die aktuelle Frage beantwortet ist, und versuche es dann erneut – oder starte die App neu, falls der Hinweis bleibt.',
   // #339 P8-2: die downloadEngine-Anfrage nannte etwas, das keine Engine-Familie ist.
   'main.engine.badRequest': 'Die Anfrage zur Engine-Installation wurde nicht verstanden. Bitte versuche es erneut.',
   'main.docs.locked': 'Der Arbeitsbereich ist gesperrt. Entsperre ihn, um Dokumente zu verwalten.',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2443,6 +2443,8 @@ export const en = {
   // #339 P8-1: the kiwix_tools family pre-cleans runtime/kiwix-tools/<os>/ on (re-)install.
   'main.engine.knowledgePackToolsRunning':
     "The knowledge-pack tools can't be replaced while a pack is being served. Lock the workspace or wait for the current question to finish, then try again.",
+  // #339 P8-2: the `downloadEngine` payload named something that is not an engine family.
+  'main.engine.badRequest': 'The engine install request was not understood. Please try again.',
   'main.docs.locked': 'Workspace is locked. Unlock it to manage documents.',
   'main.docs.processing': 'This document is still being processed. Wait for the import to finish.',
   'main.docs.tooManyPaths': 'Too many files were selected at once. Choose a folder instead.',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1158,6 +1158,12 @@ export const en = {
     'Chat and document answers already work on this drive. The voice engine is optional — ' +
     'install it only if you want to dictate messages with your microphone.',
   'models.voiceEngine.install': 'Install voice engine',
+  // #339 P8-2: a quiet row (lighter than the two engine banners above) for the OPTIONAL
+  // knowledge-pack tools (kiwix_tools) — shown only while `missingOptionalFamilies` names it.
+  // "Install…" opens the SAME consent dialog the Knowledge-packs panel's own notice opens
+  // (`KnowledgePackToolsDialog.tsx`).
+  'models.packTools.row': 'Knowledge-pack tools: not installed',
+  'models.packTools.install': 'Install…',
   // RAM-gate copy, composed of full clauses (spec §11.4 — never "your hardware is bad").
   'models.ram.needs': 'Needs at least {min} GB RAM',
   'models.ram.machine': ' — this computer has about {ram} GB',
@@ -2717,6 +2723,28 @@ export const en = {
   'packs.emptyTitle': 'No knowledge packs yet',
   'packs.emptyLine': 'Add a ZIM archive, or copy one into the drive’s zim folder and reopen this view.',
   'packs.toolsMissing': 'The kiwix-tools binaries are not installed on this drive, so packs cannot be added or searched. See Troubleshooting → “The panel says kiwix-tools are missing” for the install step.',
+  // #339 P8-2 (the owner's ruling, 2026-09-06): the panel notice's own install action — the SAME
+  // consent dialog shape as a model download (`KnowledgePackToolsDialog.tsx`), confirming calls
+  // `downloadEngine({ families: ['kiwix_tools'] })`. `sizeUnknown` covers a pin with no
+  // `size_bytes`; `downloadingNoTotal`/`verifying`/`extracting` mirror `models.engine.*`.
+  'packs.tools.install': 'Install the knowledge-pack tools…',
+  'packs.tools.confirm.title': 'Install the knowledge-pack tools?',
+  'packs.tools.confirm.explain':
+    'kiwix-tools {version} — the programs that serve knowledge packs (ZIM archives) — will be ' +
+    'downloaded from the Kiwix project’s server and verified before use. They are optional: ' +
+    'chat and documents work without them.',
+  'packs.tools.confirm.hint':
+    'The download is verified before it is used, and nothing about you or your documents is ' +
+    'sent. The tools are needed only for knowledge packs.',
+  'packs.tools.confirm.ack': 'I have read and accept the {license} license terms of kiwix-tools',
+  'packs.tools.confirm.start': 'Start download',
+  'packs.tools.sizeUnknown': 'unknown',
+  'packs.tools.progress': 'Installing the knowledge-pack tools… {pct} %',
+  'packs.tools.downloadingNoTotal': 'Installing the knowledge-pack tools…',
+  'packs.tools.verifying': 'Verifying the knowledge-pack tools…',
+  'packs.tools.extracting': 'Unpacking the knowledge-pack tools…',
+  'packs.tools.failed': 'Installing the knowledge-pack tools failed.',
+  'packs.tools.doneToast': 'Knowledge-pack tools installed',
   'packs.addedToast.one': 'Knowledge pack added',
   'packs.addedToast.other': '{count} knowledge packs added',
   // #301 P5, finding L1 (plan §9.19 (c)3): the typed add-result DTO's outcomes. `addPartial` is

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2448,7 +2448,7 @@ export const en = {
     "The voice engine can't be replaced while audio is being transcribed. Wait for it to finish, then try again.",
   // #339 P8-1: the kiwix_tools family pre-cleans runtime/kiwix-tools/<os>/ on (re-)install.
   'main.engine.knowledgePackToolsRunning':
-    "The knowledge-pack tools can't be replaced while a pack is being served. Lock the workspace or wait for the current question to finish, then try again.",
+    "The knowledge-pack tools can't be replaced while a pack is being served. Lock the workspace or wait for the current question to finish, then try again — or restart the app if the notice stays.",
   // #339 P8-2: the `downloadEngine` payload named something that is not an engine family.
   'main.engine.badRequest': 'The engine install request was not understood. Please try again.',
   'main.docs.locked': 'Workspace is locked. Unlock it to manage documents.',

--- a/apps/desktop/src/shared/runtime-sources.ts
+++ b/apps/desktop/src/shared/runtime-sources.ts
@@ -59,6 +59,12 @@ export interface RuntimeBuild {
    * marker. Absent (every llama / whisper build) = nothing beyond the executables.
    */
   runtimeFiles?: string[]
+  /**
+   * The archive's size in bytes as pinned with its SHA-256 (#339 P8-2) — what the consent
+   * dialog shows BEFORE any request is made (the engine job's `totalBytes` only exists once
+   * the download started). Declarative; a positive integer when present. Absent = unknown.
+   */
+  sizeBytes?: number
 }
 
 export interface RuntimeSources {
@@ -260,6 +266,17 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
           })
         }
       }
+      // #339 P8-2: the pinned archive size the consent dialog shows. Optional; when present it
+      // must be a positive integer (a wrong size is a pin error, not a runtime concern).
+      const sizeRaw = b['size_bytes']
+      let sizeBytes: number | undefined
+      let sizeOk = true
+      if (sizeRaw !== undefined) {
+        if (typeof sizeRaw !== 'number' || !Number.isInteger(sizeRaw) || sizeRaw <= 0) {
+          errors.push(`${where}.size_bytes must be a positive integer when present`)
+          sizeOk = false
+        } else sizeBytes = sizeRaw
+      }
       if (
         typeof osRaw === 'string' &&
         OS_KEYS.includes(osRaw as RuntimeOs) &&
@@ -269,7 +286,8 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
         typeof shaRaw === 'string' &&
         typeof extractTo === 'string' &&
         !isUnsafeDrivePath(extractTo.trim()) &&
-        runtimeFilesOk
+        runtimeFilesOk &&
+        sizeOk
       ) {
         builds.push({
           os: osRaw as RuntimeOs,
@@ -278,7 +296,8 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
           url: url.trim(),
           sha256: shaRaw.trim().toLowerCase(),
           extractTo: extractTo.trim(),
-          ...(runtimeFiles && runtimeFiles.length > 0 ? { runtimeFiles } : {})
+          ...(runtimeFiles && runtimeFiles.length > 0 ? { runtimeFiles } : {}),
+          ...(sizeBytes !== undefined ? { sizeBytes } : {})
         })
       }
     })

--- a/apps/desktop/src/shared/runtime-sources.ts
+++ b/apps/desktop/src/shared/runtime-sources.ts
@@ -62,7 +62,7 @@ export interface RuntimeBuild {
   /**
    * The archive's size in bytes as pinned with its SHA-256 (#339 P8-2) — what the consent
    * dialog shows BEFORE any request is made (the engine job's `totalBytes` only exists once
-   * the download started). Declarative; a positive integer when present. Absent = unknown.
+   * the download started). A label, never an integrity input: absent OR malformed = unknown.
    */
   sizeBytes?: number
 }
@@ -266,17 +266,13 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
           })
         }
       }
-      // #339 P8-2: the pinned archive size the consent dialog shows. Optional; when present it
-      // must be a positive integer (a wrong size is a pin error, not a runtime concern).
+      // #339 P8-2: the pinned archive size the consent dialog shows — a LABEL, never an
+      // integrity input (the download is verified by SHA-256 alone). So a malformed value is
+      // treated as "unknown" rather than failing the file: a typo in a dialog figure must not
+      // disable every engine install on the drive (review finding, 2026-09-06).
       const sizeRaw = b['size_bytes']
-      let sizeBytes: number | undefined
-      let sizeOk = true
-      if (sizeRaw !== undefined) {
-        if (typeof sizeRaw !== 'number' || !Number.isInteger(sizeRaw) || sizeRaw <= 0) {
-          errors.push(`${where}.size_bytes must be a positive integer when present`)
-          sizeOk = false
-        } else sizeBytes = sizeRaw
-      }
+      const sizeBytes =
+        typeof sizeRaw === 'number' && Number.isInteger(sizeRaw) && sizeRaw > 0 ? sizeRaw : undefined
       if (
         typeof osRaw === 'string' &&
         OS_KEYS.includes(osRaw as RuntimeOs) &&
@@ -286,8 +282,7 @@ function validateFamily(block: Record<string, unknown>, prefix: string, errors: 
         typeof shaRaw === 'string' &&
         typeof extractTo === 'string' &&
         !isUnsafeDrivePath(extractTo.trim()) &&
-        runtimeFilesOk &&
-        sizeOk
+        runtimeFilesOk
       ) {
         builds.push({
           os: osRaw as RuntimeOs,

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -4,6 +4,7 @@
 
 import { t, type UiLanguageSetting } from './i18n'
 import type { SkillKind, SkillNoteRef, SkillPermissions, SkillTrustedLevel } from './skill-manifest'
+import type { RuntimeFamily } from './runtime-sources'
 export type { SkillNoteRef } from './skill-manifest'
 
 export type HardwareProfile = 'TINY' | 'LITE' | 'BALANCED' | 'PRO' | 'UNKNOWN'
@@ -716,7 +717,7 @@ export interface EngineOptionalFamily {
  * sends it from the consent dialog after the user acknowledged the licence.
  */
 export interface EngineDownloadRequest {
-  families?: string[]
+  families?: RuntimeFamily[]
 }
 
 // ---- Image understanding (vision) — image-understanding plan §9.3 ----

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -684,6 +684,39 @@ export interface EngineStatus {
    * Optional on the type so an older renderer simply ignores it.
    */
   missingOptionalFamilies?: string[]
+  /**
+   * Every OPTIONAL family with a host build, as the consent surface needs it (#339 P8-2): what
+   * the dialog states — size, licence, source — comes from the pinned sources, never from copy.
+   * `license` is the CODE-side family spec's string (a drive's user-writable yaml cannot change
+   * what the user is asked to acknowledge). Optional on the type: an older renderer ignores it.
+   */
+  optionalFamilies?: EngineOptionalFamily[]
+}
+
+/** One optional sidecar family as the consent dialog presents it (#339 P8-2). */
+export interface EngineOptionalFamily {
+  /** The family key (`kiwix_tools`). */
+  family: string
+  /** Pinned upstream release (the yaml's `version`). */
+  version: string
+  /** The host build's archive size from the yaml's `size_bytes`, or null when the pin has none. */
+  sizeBytes: number | null
+  /** The pinned download URL of the host build — the dialog shows its host. */
+  url: string
+  /** The licence the user acknowledges (SPDX-style, e.g. `GPL-3.0-or-later`). */
+  license: string
+  /** True when the family's primary binary is on the drive. */
+  installed: boolean
+}
+
+/**
+ * The `downloadEngine` IPC payload (#339 P8-2). Absent / `{}` = the DEFAULT install (every
+ * missing REQUIRED family — never an optional one). `families` restricts the job to the named
+ * families and is the ONLY way an optional family (`kiwix_tools`) is ever fetched: the renderer
+ * sends it from the consent dialog after the user acknowledged the licence.
+ */
+export interface EngineDownloadRequest {
+  families?: string[]
 }
 
 // ---- Image understanding (vision) — image-understanding plan §9.3 ----

--- a/apps/desktop/tests/integration/assets.test.ts
+++ b/apps/desktop/tests/integration/assets.test.ts
@@ -607,6 +607,11 @@ describe('committed model-manifests/runtime-sources.yaml (Phase 14 pin)', () => 
     const linux = kiwix!.builds.find((b) => b.os === 'linux')
     expect(linux?.arch).toBe('x64')
     expect(linux?.extractTo).toBe('runtime/kiwix-tools/linux')
+
+    // #339 P8-2: the sizes the consent dialog shows, pinned with the SHA-256s — nothing at
+    // runtime can catch a mistyped figure (the download verifies the hash only), so this can.
+    const sizes = Object.fromEntries(kiwix!.builds.map((b) => [`${b.os}/${b.arch}`, b.sizeBytes]))
+    expect(sizes).toEqual({ 'win/x64': 18_301_924, 'mac/arm64': 10_254_751, 'mac/x64': 10_768_392, 'linux/x64': 21_503_420 })
   })
 })
 

--- a/apps/desktop/tests/integration/engine-consent-ipc.test.ts
+++ b/apps/desktop/tests/integration/engine-consent-ipc.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { stringify } from 'yaml'
@@ -33,7 +33,7 @@ vi.mock('electron', () => ({
 import { IPC } from '../../src/shared/ipc'
 import { registerEngineIpc } from '../../src/main/ipc/registerEngineIpc'
 import { EngineDownloadManager, hostRuntimeArch, hostRuntimeOs, type ExtractFn } from '../../src/main/services/runtime-download'
-import type { FetchFn } from '../../src/main/services/assets'
+import { SIDECAR_FAMILY_SPECS, type FetchFn } from '../../src/main/services/assets'
 import { llamaServerBinaryName, registerSidecarChild, unregisterSidecarChild } from '../../src/main/services/runtime/sidecar'
 import { updateSettings } from '../../src/main/services/settings'
 import { invoke, type IpcHandlers } from '../helpers/ipc'
@@ -163,7 +163,11 @@ describe('downloadEngine({ families }) — the consent step (#339 P8-2)', () => 
       { families: ['kiwix-tools'] },
       { families: [] },
       { families: ['kiwix_tools', 'kiwix_tools'] },
+      // An optional family never rides with a required one: the dialog sends kiwix alone,
+      // the engine button sends nothing — a mixed payload blurs which request was consented.
+      { families: ['llama_cpp', 'kiwix_tools'] },
       { families: 'kiwix_tools' },
+      { families: { length: 1, 0: 'kiwix_tools' } },
       'kiwix_tools',
       ['kiwix_tools'],
       42
@@ -213,5 +217,18 @@ describe('downloadEngine({ families }) — the consent step (#339 P8-2)', () => 
     // Readiness is still the chat family's fact alone (P8-1 ruling 3): kiwix changed nothing.
     expect(after.installed).toBe(false)
     expect(after.missingFamilies).toEqual(['llama_cpp'])
+    // `installed` means EVERY declared file — the panel's own `toolsInstalled` needs serve AND
+    // manage, and the consent row must never say "installed" while the panel says "missing".
+    rmSync(join(kiwixDir(d.root), exe('kiwix-manage')))
+    const half = (await invoke(d.handlers, IPC.getEngineStatus)).result as EngineStatus
+    expect(half.optionalFamilies?.[0]?.installed).toBe(false)
+  })
+
+  it('every optional family the code declares carries the licence its consent dialog names, and it is the one the drive notices state', () => {
+    const optional = SIDECAR_FAMILY_SPECS.filter((s) => s.optional === true)
+    expect(optional.map((s) => s.family)).toEqual(['kiwix_tools'])
+    for (const spec of optional) expect(spec.license, spec.family).toMatch(/^[A-Za-z0-9.+-]+$/)
+    const notices = readFileSync(join(__dirname, '..', '..', '..', '..', 'DRIVE-NOTICES.md'), 'utf8')
+    expect(notices).toContain(`### kiwix-tools 3.8.1 — ${SIDECAR_FAMILY_SPECS.find((s) => s.family === 'kiwix_tools')?.license}`)
   })
 })

--- a/apps/desktop/tests/integration/engine-consent-ipc.test.ts
+++ b/apps/desktop/tests/integration/engine-consent-ipc.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { stringify } from 'yaml'
+
+// #339 P8-2 — the consent step's IPC contract, through the REAL `downloadEngine` handler:
+//
+//   1. `{ families: ['kiwix_tools'] }` installs the optional family and nothing else, and ONE
+//      knowledge-pack reconcile follows the completed install (the searchability cache key
+//      carries the tools fingerprint — D-Z11/D-Z15 — so the packs re-probe with the new bundle);
+//   2. the argument-less call (the "Install the AI engine" button) still NEVER fetches kiwix;
+//   3. the payload is renderer input: an unknown family, an empty list, a duplicate, a
+//      non-object or a non-list `families` is refused before any gate or network is touched;
+//   4. `kiwixToolsActive` is wired from the per-family sidecar PID registry (P8-1 R-e): a live
+//      kiwix child refuses the install with the friendly copy, an unregistered one admits it;
+//   5. `getEngineStatus` carries `optionalFamilies` — size from the pin's `size_bytes`, the
+//      code-side licence, the pinned URL — and `installed` flips after the install.
+//
+// Electron is mocked so `ipcMain.handle` records handlers; the network and the extraction are
+// fakes (zero-network, no shell-out), the DB and policy are real files under a temp root.
+
+const ipcState = vi.hoisted(() => ({ handlers: new Map<string, unknown>() }))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: unknown) => ipcState.handlers.set(channel, fn),
+    removeHandler: (channel: string) => ipcState.handlers.delete(channel)
+  },
+  app: { getVersion: () => '0.0.0-test' }
+}))
+
+import { IPC } from '../../src/shared/ipc'
+import { registerEngineIpc } from '../../src/main/ipc/registerEngineIpc'
+import { EngineDownloadManager, hostRuntimeArch, hostRuntimeOs, type ExtractFn } from '../../src/main/services/runtime-download'
+import type { FetchFn } from '../../src/main/services/assets'
+import { llamaServerBinaryName, registerSidecarChild, unregisterSidecarChild } from '../../src/main/services/runtime/sidecar'
+import { updateSettings } from '../../src/main/services/settings'
+import { invoke, type IpcHandlers } from '../helpers/ipc'
+import { closePerformanceFixture, ctxWith, freshRoot, seededDb } from '../helpers/performance-fixture'
+import type { EngineDownloadJob, EngineStatus } from '../../src/shared/types'
+
+const handlers = ipcState.handlers as IpcHandlers
+const HOST_OS = hostRuntimeOs()
+const HOST_ARCH = hostRuntimeArch()
+const BIN_NAME = llamaServerBinaryName()
+const exe = (base: string): string => (HOST_OS === 'win' ? `${base}.exe` : base)
+const KIWIX_FILES = [exe('kiwix-serve'), exe('kiwix-manage'), exe('kiwix-search'), 'icudt74.dll']
+const BODY = 'archive-bytes'
+const SHA = createHash('sha256').update(BODY).digest('hex')
+const KIWIX_SIZE = 18_301_924
+
+const okFetch: FetchFn = async () => new Response(BODY, { status: 200, headers: { 'content-length': String(BODY.length) } })
+/** Drops the family's declared files at the extract root (the flat-zip shape). */
+const extractAll: ExtractFn = async (_archive, destDir) => {
+  await mkdir(destDir, { recursive: true })
+  for (const f of [BIN_NAME, ...KIWIX_FILES]) await writeFile(join(destDir, f), `bytes of ${f}`)
+}
+
+interface Drive {
+  root: string
+  handlers: IpcHandlers
+  manager: EngineDownloadManager
+  fetchSpy: ReturnType<typeof vi.fn>
+  reconcile: ReturnType<typeof vi.fn>
+}
+
+/** A drive whose yaml pins the chat engine + the optional kiwix_tools family for this host,
+ *  with a policy that allows downloads and the network setting on; the engine IPC registered
+ *  over a real DB. `ctx.zim` is a stub whose `reconcile` the completed-install hook must call. */
+function makeDrive(): Drive {
+  const root = freshRoot()
+  const manifests = join(root, 'model-manifests')
+  mkdirSync(manifests, { recursive: true })
+  mkdirSync(join(root, 'config'), { recursive: true })
+  writeFileSync(join(root, 'config', 'policy.json'), JSON.stringify({ network: { allow_model_downloads: true } }))
+  writeFileSync(
+    join(manifests, 'runtime-sources.yaml'),
+    stringify({
+      llama_cpp: {
+        version: 'btest',
+        builds: [{ os: HOST_OS, arch: HOST_ARCH, backend: 'cpu', url: 'https://example.test/llama.zip', sha256: SHA, extract_to: `runtime/llama.cpp/${HOST_OS}` }]
+      },
+      kiwix_tools: {
+        version: '3.8.1',
+        optional: true,
+        executables: ['kiwix-serve', 'kiwix-manage', 'kiwix-search'],
+        builds: [
+          {
+            os: HOST_OS,
+            arch: HOST_ARCH,
+            backend: 'cpu',
+            url: 'https://download.kiwix.org/release/kiwix-tools/kiwix-tools_test-3.8.1.zip',
+            sha256: SHA,
+            size_bytes: KIWIX_SIZE,
+            extract_to: `runtime/kiwix-tools/${HOST_OS}`,
+            runtime_files: ['icudt74.dll']
+          }
+        ]
+      }
+    })
+  )
+  const db = seededDb(root)
+  updateSettings(db, { allowNetwork: true })
+  const reconcile = vi.fn(async () => undefined)
+  const fetchSpy = vi.fn(okFetch)
+  const ctx = ctxWith(root, db, {
+    paths: { rootPath: root, workspacePath: join(root, 'workspace'), configPath: join(root, 'config') },
+    manifestsDir: manifests,
+    runtime: { activeModelId: () => null, status: () => ({ running: false, modelId: null, startingModelId: null, port: null, healthy: false, message: '' }) },
+    zim: { reconcile }
+  })
+  handlers.clear()
+  const manager = new EngineDownloadManager({ fetchImpl: fetchSpy as unknown as FetchFn, extractImpl: extractAll })
+  registerEngineIpc(ctx, manager)
+  return { root, handlers, manager, fetchSpy, reconcile }
+}
+
+async function settle(d: Drive, job: EngineDownloadJob): Promise<EngineDownloadJob> {
+  await vi.waitFor(() => expect(['done', 'failed', 'cancelled']).toContain(d.manager.get(job.jobId).status), { timeout: 5000 })
+  return d.manager.get(job.jobId)
+}
+
+const kiwixDir = (root: string): string => join(root, 'runtime', 'kiwix-tools', HOST_OS)
+const llamaBin = (root: string): string => join(root, 'runtime', 'llama.cpp', HOST_OS, BIN_NAME)
+
+afterEach(async () => {
+  await closePerformanceFixture()
+})
+
+describe('downloadEngine({ families }) — the consent step (#339 P8-2)', () => {
+  it('installs the optional kiwix_tools family on an explicit request and reconciles the packs once afterwards', async () => {
+    const d = makeDrive()
+    const { result } = await invoke(d.handlers, IPC.downloadEngine, { families: ['kiwix_tools'] })
+    const job = await settle(d, result as EngineDownloadJob)
+    expect(job.status).toBe('done')
+    for (const f of KIWIX_FILES) expect(existsSync(join(kiwixDir(d.root), f)), f).toBe(true)
+    // Only the requested family: the chat engine was NOT fetched by a kiwix request.
+    expect(existsSync(llamaBin(d.root))).toBe(false)
+    expect(d.fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(d.fetchSpy.mock.calls[0]?.[0])).toContain('download.kiwix.org')
+    // The completed install re-probes the packs with the new bundle — exactly once.
+    await vi.waitFor(() => expect(d.reconcile).toHaveBeenCalledTimes(1))
+  })
+
+  it('the argument-less call still never fetches kiwix_tools, and installing the chat engine reconciles nothing', async () => {
+    const d = makeDrive()
+    const { result } = await invoke(d.handlers, IPC.downloadEngine)
+    const job = await settle(d, result as EngineDownloadJob)
+    expect(job.status).toBe('done')
+    expect(existsSync(llamaBin(d.root))).toBe(true)
+    expect(existsSync(kiwixDir(d.root))).toBe(false)
+    expect(d.fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(d.fetchSpy.mock.calls[0]?.[0])).not.toContain('kiwix')
+    await new Promise((r) => setTimeout(r, 20))
+    expect(d.reconcile).not.toHaveBeenCalled()
+  })
+
+  it('refuses a malformed payload before any gate or network is touched', async () => {
+    const d = makeDrive()
+    const bad: unknown[] = [
+      { families: ['../kiwix_tools'] },
+      { families: ['kiwix-tools'] },
+      { families: [] },
+      { families: ['kiwix_tools', 'kiwix_tools'] },
+      { families: 'kiwix_tools' },
+      'kiwix_tools',
+      ['kiwix_tools'],
+      42
+    ]
+    for (const payload of bad) {
+      await expect(invoke(d.handlers, IPC.downloadEngine, payload), JSON.stringify(payload)).rejects.toThrow(/was not understood/i)
+    }
+    expect(d.fetchSpy).not.toHaveBeenCalled()
+    expect(d.manager.activeJob()).toBeNull()
+  })
+
+  it('is refused while a kiwix child is registered in the sidecar PID registry, and admitted once it is gone', async () => {
+    const d = makeDrive()
+    registerSidecarChild(7339, 'kiwix_tools')
+    try {
+      await expect(invoke(d.handlers, IPC.downloadEngine, { families: ['kiwix_tools'] })).rejects.toThrow(/knowledge-pack tools/i)
+      expect(d.fetchSpy).not.toHaveBeenCalled()
+      // A live kiwix child does not block the CHAT engine.
+      const { result } = await invoke(d.handlers, IPC.downloadEngine)
+      expect((await settle(d, result as EngineDownloadJob)).status).toBe('done')
+    } finally {
+      unregisterSidecarChild(7339)
+    }
+    const { result } = await invoke(d.handlers, IPC.downloadEngine, { families: ['kiwix_tools'] })
+    expect((await settle(d, result as EngineDownloadJob)).status).toBe('done')
+  })
+
+  it('getEngineStatus states what the dialog shows: the pinned size, the code-side licence, the pinned URL, and installed flips', async () => {
+    const d = makeDrive()
+    const before = (await invoke(d.handlers, IPC.getEngineStatus)).result as EngineStatus
+    expect(before.missingOptionalFamilies).toEqual(['kiwix_tools'])
+    expect(before.optionalFamilies).toEqual([
+      {
+        family: 'kiwix_tools',
+        version: '3.8.1',
+        sizeBytes: KIWIX_SIZE,
+        url: 'https://download.kiwix.org/release/kiwix-tools/kiwix-tools_test-3.8.1.zip',
+        license: 'GPL-3.0-or-later',
+        installed: false
+      }
+    ])
+    const { result } = await invoke(d.handlers, IPC.downloadEngine, { families: ['kiwix_tools'] })
+    await settle(d, result as EngineDownloadJob)
+    const after = (await invoke(d.handlers, IPC.getEngineStatus)).result as EngineStatus
+    expect(after.missingOptionalFamilies).toEqual([])
+    expect(after.optionalFamilies?.[0]?.installed).toBe(true)
+    // Readiness is still the chat family's fact alone (P8-1 ruling 3): kiwix changed nothing.
+    expect(after.installed).toBe(false)
+    expect(after.missingFamilies).toEqual(['llama_cpp'])
+  })
+})

--- a/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
+++ b/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 import { render, screen, cleanup, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
@@ -11,6 +11,7 @@ import { SourcesDisclosure } from '../../src/renderer/chat/SourcesDisclosure'
 import { ChatScreen } from '../../src/renderer/screens/ChatScreen'
 import { I18nProvider, UI_LANGUAGE_STORAGE_KEY } from '../../src/renderer/i18n'
 import { ToastProvider } from '../../src/renderer/components'
+import { __resetKnowledgePackToolsInstallForTests } from '../../src/renderer/lib/useKnowledgePackToolsInstall'
 import { t as tr, tCount as trCount, type UiLanguage } from '../../src/shared/i18n'
 import type {
   Citation,
@@ -18,14 +19,19 @@ import type {
   Conversation,
   DocumentInfo,
   DocumentScope,
+  EngineDownloadJob,
+  EngineOptionalFamily,
+  EngineStatus,
   KnowledgePack,
   KnowledgePackOutcome,
   KnowledgePackOutcomeReason,
   KnowledgePacksChangedEvent,
+  PolicyStatus,
   RuntimeStatus
 } from '../../src/shared/types'
 import { MAX_SELECTED_PACKS } from '../../src/shared/types'
-import { stubApi } from '../helpers/renderer'
+import { stubApi, assertNoUnexpectedApiCalls } from '../helpers/renderer'
+import { makePolicyStatus } from '../helpers/status'
 
 // Knowledge packs (ZIM wave) renderer surfaces: the PacksPanel management list, the
 // ScopePopover pack sources (incl. packIds preservation on unrelated toggles), and the
@@ -69,6 +75,40 @@ function pack(over: Partial<KnowledgePack> = {}): KnowledgePack {
   }
 }
 
+/** #339 P8-2: a `kiwix_tools` `EngineOptionalFamily` fixture — the pinned facts the consent
+ *  dialog states. `sizeBytes: 18301924` is the exact figure the dialog's Size row must round
+ *  to "17 MB" (18301924 / 1024 / 1024 ≈ 17.45). */
+function engineOptionalFamily(over: Partial<EngineOptionalFamily> = {}): EngineOptionalFamily {
+  return {
+    family: 'kiwix_tools',
+    version: '3.8.1',
+    sizeBytes: 18301924,
+    url: 'https://download.kiwix.org/release/kiwix-tools/kiwix-tools_win-i686-3.8.1.zip',
+    license: 'GPL-3.0-or-later',
+    installed: false,
+    ...over
+  }
+}
+
+/** An `EngineStatus` naming `kiwix_tools` as missing-but-fetchable, everything else installed. */
+function engineStatusWithMissingTools(over: Partial<EngineStatus> = {}): EngineStatus {
+  return {
+    installed: true,
+    available: true,
+    version: '1.0.0',
+    backend: 'cpu',
+    missingFamilies: [],
+    missingOptionalFamilies: ['kiwix_tools'],
+    optionalFamilies: [engineOptionalFamily()],
+    ...over
+  }
+}
+
+/** A `PolicyStatus` that allows downloads outright (the SAME shape ModelsScreen's own tests use). */
+function allowedPolicy(): PolicyStatus {
+  return makePolicyStatus({ network: { allowModelDownloads: true }, allowNetworkSetting: true })
+}
+
 beforeAll(() => {
   // T18-a leg (f) mounts the real ChatScreen, whose transcript scrolls on mount.
   Object.defineProperty(window.HTMLElement.prototype, 'scrollTo', {
@@ -76,6 +116,13 @@ beforeAll(() => {
     writable: true,
     value: () => {}
   })
+})
+
+beforeEach(() => {
+  // #339 P8-2: the tools-install hook's remembered job is MODULE state (like ModelsScreen's own
+  // rememberedEngineJob) so it survives a remount mid-install — tests must start from a known
+  // (no job) state instead of inheriting whatever the previous case left behind.
+  __resetKnowledgePackToolsInstallForTests()
 })
 
 afterEach(() => {
@@ -249,6 +296,196 @@ describe('PacksPanel', () => {
     )
     expect(await screen.findByText(/kiwix-tools binaries are not installed/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add packs…' })).toBeDisabled()
+  })
+
+  // #339 P8-2 (the owner's ruling, 2026-09-06): the tools-missing notice's own install action —
+  // the SAME consent dialog shape as a model download, stating facts from `EngineOptionalFamily`
+  // (never from copy), confirming calls `downloadEngine({ families: ['kiwix_tools'] })`, and a
+  // completed job toasts + refetches (`refresh()` directly, ahead of the `packs:changed` broadcast).
+  it('#339 P8-2: the tools-missing notice offers an Install action; the consent dialog states the pinned facts and confirming installs, then a done job toasts and refetches', async () => {
+    const user = userEvent.setup()
+    let toolsInstalled = false
+    const downloadEngine = vi.fn(
+      async (): Promise<EngineDownloadJob> => ({
+        jobId: 'k1',
+        status: 'downloading',
+        receivedBytes: 0,
+        totalBytes: 100,
+        unverified: false,
+        binaryPath: null,
+        error: null
+      })
+    )
+    let pollCount = 0
+    const getEngineJob = vi.fn(async (): Promise<EngineDownloadJob> => {
+      pollCount++
+      return pollCount === 1
+        ? {
+            jobId: 'k1',
+            status: 'downloading',
+            receivedBytes: 50,
+            totalBytes: 100,
+            unverified: false,
+            binaryPath: null,
+            error: null
+          }
+        : {
+            jobId: 'k1',
+            status: 'done',
+            receivedBytes: 100,
+            totalBytes: 100,
+            unverified: false,
+            binaryPath: '/drive/runtime/kiwix-tools/kiwix-manage',
+            error: null
+          }
+    })
+    stubApi({
+      getKnowledgePackStatus: vi.fn(async () => ({ toolsInstalled, refreshing: false, revision: 0 })),
+      listKnowledgePacks: vi.fn(async () => []),
+      getEngineStatus: vi.fn(async () => engineStatusWithMissingTools()),
+      getPolicy: vi.fn(async () => allowedPolicy()),
+      downloadEngine,
+      getEngineJob
+    })
+    render(
+      <I18nProvider>
+        <ToastProvider>
+          <PacksPanel />
+        </ToastProvider>
+      </I18nProvider>
+    )
+    expect(await screen.findByText(/kiwix-tools binaries are not installed/)).toBeInTheDocument()
+    await user.click(await screen.findByRole('button', { name: 'Install the knowledge-pack tools…' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Install the knowledge-pack tools?')).toBeInTheDocument()
+
+    // Size / License / From — every fact comes from the fixture's `EngineOptionalFamily`.
+    expect(within(dialog).getByText('17 MB')).toBeInTheDocument()
+    const licenseDt = within(dialog).getByText('License')
+    expect(licenseDt.nextElementSibling?.textContent).toContain('GPL-3.0-or-later')
+    const licenseLink = within(dialog).getByRole('link', { name: 'read the license' })
+    expect(licenseLink).toHaveAttribute('href', 'https://www.gnu.org/licenses/gpl-3.0.html')
+    expect(within(dialog).getByText('www.gnu.org')).toBeInTheDocument()
+    const fromDt = within(dialog).getByText('From')
+    expect(fromDt.nextElementSibling?.textContent).toContain('download.kiwix.org')
+
+    const confirmBtn = within(dialog).getByRole('button', { name: 'Start download' })
+    expect(confirmBtn).toBeDisabled()
+    await user.click(within(dialog).getByRole('checkbox'))
+    expect(confirmBtn).toBeEnabled()
+    await user.click(confirmBtn)
+    expect(downloadEngine).toHaveBeenCalledWith({ families: ['kiwix_tools'] })
+
+    expect(
+      await screen.findByText('Installing the knowledge-pack tools… 50 %', undefined, { timeout: 5000 })
+    ).toBeInTheDocument()
+    toolsInstalled = true
+    expect(
+      await screen.findByText('Knowledge-pack tools installed', undefined, { timeout: 5000 })
+    ).toBeInTheDocument()
+  })
+
+  // The two gate-off cases share the SAME copy ModelsScreen's own download gate uses
+  // (`lib/downloadGate.ts`) — a policy denial and a Settings toggle off never diverge.
+  it.each([
+    [
+      'the drive policy denies downloads',
+      makePolicyStatus({ network: { allowModelDownloads: false }, allowNetworkSetting: true }),
+      'models.downloads.blockedByPolicy'
+    ],
+    [
+      'the Settings toggle is off',
+      makePolicyStatus({ network: { allowModelDownloads: true }, allowNetworkSetting: false }),
+      'models.downloads.enableInSettings'
+    ]
+  ] as const)(
+    '#339 P8-2: the gate off (%s) keeps confirm disabled even when ticked and shows the same reason text as ModelsScreen',
+    async (_label, policy, reasonKey) => {
+      const user = userEvent.setup()
+      stubApi({
+        getKnowledgePackStatus: async () => ({ toolsInstalled: false, refreshing: false, revision: 0 }),
+        listKnowledgePacks: async () => [],
+        getEngineStatus: async () => engineStatusWithMissingTools(),
+        getPolicy: async () => policy
+      })
+      render(
+        <I18nProvider>
+          <PacksPanel />
+        </I18nProvider>
+      )
+      await user.click(await screen.findByRole('button', { name: 'Install the knowledge-pack tools…' }))
+      const dialog = await screen.findByRole('dialog')
+      const checkbox = within(dialog).getByRole('checkbox')
+      expect(checkbox).toBeDisabled()
+      await user.click(checkbox) // no-op: the box is disabled, ticking it must not change anything
+      const confirmBtn = within(dialog).getByRole('button', { name: 'Start download' })
+      expect(confirmBtn).toBeDisabled()
+      expect(within(dialog).getByText(tr('en', reasonKey))).toBeInTheDocument()
+    }
+  )
+
+  it('#339 P8-2: a failed install shows the error and Try again', async () => {
+    const user = userEvent.setup()
+    const downloadEngine = vi.fn(
+      async (): Promise<EngineDownloadJob> => ({
+        jobId: 'kf',
+        status: 'downloading',
+        receivedBytes: 0,
+        totalBytes: 100,
+        unverified: false,
+        binaryPath: null,
+        error: null
+      })
+    )
+    const getEngineJob = vi.fn(
+      async (): Promise<EngineDownloadJob> => ({
+        jobId: 'kf',
+        status: 'failed',
+        receivedBytes: 0,
+        totalBytes: 100,
+        unverified: false,
+        binaryPath: null,
+        error: 'kiwix-tools archive checksum mismatch'
+      })
+    )
+    stubApi({
+      getKnowledgePackStatus: async () => ({ toolsInstalled: false, refreshing: false, revision: 0 }),
+      listKnowledgePacks: async () => [],
+      getEngineStatus: async () => engineStatusWithMissingTools(),
+      getPolicy: async () => allowedPolicy(),
+      downloadEngine,
+      getEngineJob
+    })
+    render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    await user.click(await screen.findByRole('button', { name: 'Install the knowledge-pack tools…' }))
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('checkbox'))
+    await user.click(within(dialog).getByRole('button', { name: 'Start download' }))
+    expect(
+      await screen.findByText('Installing the knowledge-pack tools failed.', undefined, { timeout: 5000 })
+    ).toBeInTheDocument()
+    expect(screen.getByText('kiwix-tools archive checksum mismatch')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('#339 P8-2: never calls getEngineStatus or getPolicy while the tools are already installed', async () => {
+    stubApi({
+      getKnowledgePackStatus: async () => ({ toolsInstalled: true, refreshing: false, revision: 0 }),
+      listKnowledgePacks: async () => [pack()],
+      onKnowledgePacksChanged: () => () => {}
+    })
+    render(
+      <I18nProvider>
+        <PacksPanel />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('Klimawandel von Wikipedia')).toBeInTheDocument()
+    expect(screen.queryByText(/kiwix-tools binaries are not installed/)).toBeNull()
+    assertNoUnexpectedApiCalls()
   })
 
   it('add flow calls the main-side dialog channel and refreshes on success', async () => {

--- a/apps/desktop/tests/renderer/ModelsScreen.test.tsx
+++ b/apps/desktop/tests/renderer/ModelsScreen.test.tsx
@@ -6,10 +6,13 @@ import {
   ModelsScreen,
   __resetModelsScreenMemoryForTests
 } from '../../src/renderer/screens/ModelsScreen'
+import { __resetKnowledgePackToolsInstallForTests } from '../../src/renderer/lib/useKnowledgePackToolsInstall'
 import {
   DEFAULT_SETTINGS,
   type AppStatus,
   type DownloadJob,
+  type EngineDownloadJob,
+  type EngineOptionalFamily,
   type EngineStatus,
   type ModelInfo,
   type PolicyStatus,
@@ -85,6 +88,10 @@ afterEach(cleanup)
 // start from a known state instead of inheriting whatever the previous case left behind.
 beforeEach(() => {
   __resetModelsScreenMemoryForTests()
+  // #339 P8-2: the knowledge-pack tools install hook keeps its job in MODULE state too (the
+  // same remembered-job pattern) — reset it alongside so a live/failed job from one test never
+  // leaks into the next.
+  __resetKnowledgePackToolsInstallForTests()
 })
 
 describe('ModelsScreen — download gates (plan §6.1: explain WHY, policy vs Settings)', () => {
@@ -2120,5 +2127,128 @@ describe('ModelsScreen — repair visibility and group face (PR #302 F3/F5, C1)'
       'aria-expanded',
       'true'
     )
+  })
+})
+
+// #339 P8-2 (the owner's ruling, 2026-09-06): the Models screen's quiet "knowledge-pack tools"
+// row — the same consent dialog the Knowledge-packs panel notice opens — and the existing
+// engine-install action's own argument-less `downloadEngine()` call, unchanged by this feature.
+describe('ModelsScreen — knowledge-pack tools row (#339 P8-2)', () => {
+  function engineOptionalFamily(over: Partial<EngineOptionalFamily> = {}): EngineOptionalFamily {
+    return {
+      family: 'kiwix_tools',
+      version: '3.8.1',
+      sizeBytes: 18301924,
+      url: 'https://download.kiwix.org/release/kiwix-tools/kiwix-tools_win-i686-3.8.1.zip',
+      license: 'GPL-3.0-or-later',
+      installed: false,
+      ...over
+    }
+  }
+
+  function engineWithMissingTools(over: Partial<EngineStatus> = {}): EngineStatus {
+    return {
+      installed: true,
+      available: true,
+      version: '1.0.0',
+      backend: 'cpu',
+      missingFamilies: [],
+      missingOptionalFamilies: ['kiwix_tools'],
+      optionalFamilies: [engineOptionalFamily()],
+      ...over
+    }
+  }
+
+  it('missingOptionalFamilies names kiwix_tools → the quiet row and Install… render and open the consent dialog', async () => {
+    const user = userEvent.setup()
+    stubApi({
+      listModels: vi.fn(async () => []),
+      getSettings: vi.fn(async () => ({ ...DEFAULT_SETTINGS })),
+      getPolicy: vi.fn(async () => policyStatus({ downloadsAllowed: true, settingOn: true })),
+      getAppStatus: vi.fn(async () => appStatus),
+      getEngineStatus: vi.fn(async () => engineWithMissingTools())
+    })
+    render(<ModelsScreen />)
+    expect(await screen.findByText('Knowledge-pack tools: not installed')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Install…' }))
+    expect(await screen.findByText('Install the knowledge-pack tools?')).toBeInTheDocument()
+  })
+
+  it('an installed family (missingOptionalFamilies empty) shows no row', async () => {
+    stubApi({
+      listModels: vi.fn(async () => []),
+      getSettings: vi.fn(async () => ({ ...DEFAULT_SETTINGS })),
+      getPolicy: vi.fn(async () => policyStatus({ downloadsAllowed: true, settingOn: true })),
+      getAppStatus: vi.fn(async () => appStatus),
+      getEngineStatus: vi.fn(async () =>
+        engineWithMissingTools({
+          missingOptionalFamilies: [],
+          optionalFamilies: [engineOptionalFamily({ installed: true })]
+        })
+      )
+    })
+    render(<ModelsScreen />)
+    expect(await screen.findByRole('heading', { name: 'AI Model' })).toBeInTheDocument()
+    // Give the (idle) hook effect a tick to have run, then assert the row never appears.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(screen.queryByText('Knowledge-pack tools: not installed')).not.toBeInTheDocument()
+  })
+
+  // An `optionalFamilies`-less / `missingOptionalFamilies`-less EngineStatus (an older main) must
+  // render exactly like "absent" — never a crash, never a phantom row.
+  it('an EngineStatus with neither field (an older main) shows no row', async () => {
+    stubApi({
+      listModels: vi.fn(async () => []),
+      getSettings: vi.fn(async () => ({ ...DEFAULT_SETTINGS })),
+      getPolicy: vi.fn(async () => policyStatus({ downloadsAllowed: true, settingOn: true })),
+      getAppStatus: vi.fn(async () => appStatus),
+      getEngineStatus: vi.fn(async () => ({
+        installed: true,
+        available: true,
+        version: '1.0.0',
+        backend: 'cpu',
+        missingFamilies: []
+      }))
+    })
+    render(<ModelsScreen />)
+    expect(await screen.findByRole('heading', { name: 'AI Model' })).toBeInTheDocument()
+    expect(screen.queryByText('Knowledge-pack tools: not installed')).not.toBeInTheDocument()
+  })
+
+  // SH-1-style regression guard for #339 P8-2: the pre-existing "Install AI engine" banner
+  // action must keep calling the argument-less default install — only the NEW consent dialog
+  // is allowed to pass `{ families: ['kiwix_tools'] }`.
+  it('the existing "Install AI engine" action still calls downloadEngine with NO arguments', async () => {
+    const user = userEvent.setup()
+    const downloadEngine = vi.fn(async () => ({
+      jobId: 'e1',
+      status: 'cancelled' as const,
+      receivedBytes: 0,
+      totalBytes: null,
+      unverified: false,
+      binaryPath: null,
+      error: null
+    }))
+    stubApi({
+      listModels: vi.fn(async () => []),
+      getSettings: vi.fn(async () => ({ ...DEFAULT_SETTINGS })),
+      getPolicy: vi.fn(async () => policyStatus({ downloadsAllowed: true, settingOn: true })),
+      getAppStatus: vi.fn(async () => appStatus),
+      getEngineStatus: vi.fn(
+        async (): Promise<EngineStatus> => ({
+          installed: false,
+          available: true,
+          version: null,
+          backend: null,
+          missingFamilies: ['llama_cpp']
+        })
+      ),
+      downloadEngine
+    })
+    render(<ModelsScreen />)
+    await user.click(await screen.findByRole('button', { name: 'Install AI engine' }))
+    expect(downloadEngine).toHaveBeenCalledTimes(1)
+    expect(downloadEngine).toHaveBeenCalledWith()
+    expect(downloadEngine.mock.calls[0]).toHaveLength(0)
   })
 })

--- a/apps/desktop/tests/unit/preload-engine.test.ts
+++ b/apps/desktop/tests/unit/preload-engine.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Preload-surface test for the engine downloader's `downloadEngine` payload (#339 P8-2): the
+// channel is unchanged, its payload is new. The argument-less call must keep invoking the
+// channel with NO payload (the main handler's default install — required families only), and
+// the consent dialog's per-family request must reach the channel verbatim. Same capture trick
+// as preload-vision.test.ts: mock electron to grab the exposed bridge object.
+
+const bridge = vi.hoisted(() => ({ api: undefined as unknown }))
+const ipc = vi.hoisted(() => ({
+  invoke: vi.fn(async () => undefined),
+  on: vi.fn(),
+  removeListener: vi.fn()
+}))
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (_key: string, api: unknown) => {
+      bridge.api = api
+    }
+  },
+  ipcRenderer: ipc,
+  webUtils: { getPathForFile: () => '' }
+}))
+
+import { IPC } from '../../src/shared/ipc'
+import type { PreloadApi } from '../../src/preload/index'
+
+async function loadApi(): Promise<PreloadApi> {
+  await import('../../src/preload/index')
+  return bridge.api as PreloadApi
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('preload — engine downloader surface (#339 P8-2)', () => {
+  it('downloadEngine() with no argument invokes the channel with no payload (the default install)', async () => {
+    const api = await loadApi()
+    await api.downloadEngine()
+    expect(ipc.invoke).toHaveBeenCalledTimes(1)
+    expect(ipc.invoke).toHaveBeenCalledWith(IPC.downloadEngine)
+    expect(ipc.invoke.mock.calls[0]).toHaveLength(1)
+  })
+
+  it('downloadEngine({ families }) forwards the request object verbatim on the same channel', async () => {
+    const api = await loadApi()
+    const request = { families: ['kiwix_tools'] }
+    await api.downloadEngine(request)
+    expect(ipc.invoke).toHaveBeenCalledWith(IPC.downloadEngine, request)
+    expect(IPC.downloadEngine).toBe('engine:download')
+  })
+})

--- a/apps/desktop/tests/unit/preload-engine.test.ts
+++ b/apps/desktop/tests/unit/preload-engine.test.ts
@@ -24,6 +24,7 @@ vi.mock('electron', () => ({
 
 import { IPC } from '../../src/shared/ipc'
 import type { PreloadApi } from '../../src/preload/index'
+import type { EngineDownloadRequest } from '../../src/shared/types'
 
 async function loadApi(): Promise<PreloadApi> {
   await import('../../src/preload/index')
@@ -45,7 +46,7 @@ describe('preload — engine downloader surface (#339 P8-2)', () => {
 
   it('downloadEngine({ families }) forwards the request object verbatim on the same channel', async () => {
     const api = await loadApi()
-    const request = { families: ['kiwix_tools'] }
+    const request: EngineDownloadRequest = { families: ['kiwix_tools'] }
     await api.downloadEngine(request)
     expect(ipc.invoke).toHaveBeenCalledWith(IPC.downloadEngine, request)
     expect(IPC.downloadEngine).toBe('engine:download')

--- a/apps/desktop/tests/unit/runtime-sources.test.ts
+++ b/apps/desktop/tests/unit/runtime-sources.test.ts
@@ -283,7 +283,7 @@ describe('validateRuntimeSources', () => {
     })
 
     // #339 P8-2: the pinned archive size the consent dialog shows before any request is made.
-    it('accepts a positive-integer size_bytes per build and rejects anything else', () => {
+    it('reads a positive-integer size_bytes per build and treats anything else as unknown — never as a file error', () => {
       const ok = validateRuntimeSources({
         ...base(),
         kiwix_tools: { version: '3.8.1', optional: true, builds: [{ ...kiwixBuild, size_bytes: 18301924 }, { ...kiwixBuild, os: 'linux', url: 'https://x.test/l.tar.gz', extract_to: 'runtime/kiwix-tools/linux', runtime_files: undefined }] }
@@ -291,10 +291,13 @@ describe('validateRuntimeSources', () => {
       expect(ok.errors).toEqual([])
       expect(ok.families?.kiwix_tools?.builds[0]?.sizeBytes).toBe(18301924)
       expect(ok.families?.kiwix_tools?.builds[1]?.sizeBytes).toBeUndefined()
+      // A label, not an integrity input: a typo in the dialog figure must not disable every
+      // engine install on the drive, so the build is kept and the size reads as unknown.
       for (const size_bytes of [0, -1, 1.5, '18301924', null]) {
-        const bad = validateRuntimeSources({ ...base(), kiwix_tools: { version: '3.8.1', builds: [{ ...kiwixBuild, size_bytes }] } })
-        expect(bad.ok, JSON.stringify(size_bytes)).toBe(false)
-        expect(bad.errors.some((e) => e.includes('size_bytes')), JSON.stringify(size_bytes)).toBe(true)
+        const res = validateRuntimeSources({ ...base(), kiwix_tools: { version: '3.8.1', builds: [{ ...kiwixBuild, size_bytes }] } })
+        expect(res.ok, JSON.stringify(size_bytes)).toBe(true)
+        expect(res.families?.kiwix_tools?.builds).toHaveLength(1)
+        expect(res.families?.kiwix_tools?.builds[0]?.sizeBytes, JSON.stringify(size_bytes)).toBeUndefined()
       }
     })
 

--- a/apps/desktop/tests/unit/runtime-sources.test.ts
+++ b/apps/desktop/tests/unit/runtime-sources.test.ts
@@ -282,6 +282,22 @@ describe('validateRuntimeSources', () => {
       }
     })
 
+    // #339 P8-2: the pinned archive size the consent dialog shows before any request is made.
+    it('accepts a positive-integer size_bytes per build and rejects anything else', () => {
+      const ok = validateRuntimeSources({
+        ...base(),
+        kiwix_tools: { version: '3.8.1', optional: true, builds: [{ ...kiwixBuild, size_bytes: 18301924 }, { ...kiwixBuild, os: 'linux', url: 'https://x.test/l.tar.gz', extract_to: 'runtime/kiwix-tools/linux', runtime_files: undefined }] }
+      })
+      expect(ok.errors).toEqual([])
+      expect(ok.families?.kiwix_tools?.builds[0]?.sizeBytes).toBe(18301924)
+      expect(ok.families?.kiwix_tools?.builds[1]?.sizeBytes).toBeUndefined()
+      for (const size_bytes of [0, -1, 1.5, '18301924', null]) {
+        const bad = validateRuntimeSources({ ...base(), kiwix_tools: { version: '3.8.1', builds: [{ ...kiwixBuild, size_bytes }] } })
+        expect(bad.ok, JSON.stringify(size_bytes)).toBe(false)
+        expect(bad.errors.some((e) => e.includes('size_bytes')), JSON.stringify(size_bytes)).toBe(true)
+      }
+    })
+
     it('rejects a non-boolean optional flag and a non-mapping block', () => {
       const bad = validateRuntimeSources({ ...base(), kiwix_tools: { version: '3.8.1', optional: 'yes', builds: [kiwixBuild] } })
       expect(bad.ok).toBe(false)

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1553,7 +1553,7 @@ charter-required index so a contributor consulting the declared source of truth 
 whole renderer-visible surface.
 
 - **Engine (llama.cpp/whisper.cpp sidecar) downloader** — `getEngineStatus(): Promise<EngineStatus>`
-  (`installed`/`available`/`version`/`backend`/`missingFamilies`), `downloadEngine(): Promise<EngineDownloadJob>`,
+  (`installed`/`available`/`version`/`backend`/`missingFamilies`), `downloadEngine(request?: EngineDownloadRequest): Promise<EngineDownloadJob>`,
   `getEngineJob(jobId)`, `cancelEngineDownload(jobId)` (a UI caller since #144; `verifying`/
   `extracting` are cancellable states — F-33). `EngineDownloadJob` =
   `{ jobId, status: queued|downloading|verifying|extracting|done|failed|cancelled, receivedBytes,
@@ -1579,8 +1579,25 @@ whole renderer-visible surface.
   grandfathered positional params (`platforms`, `appVersion`); the gate's `checks` record gains
   `optionalRuntimesConsistent: boolean` (an optional family is either fully provisioned — every
   declared file present, hashed and matching — or entirely absent; never folded into
-  `runtimeCurrent`/`runtimeHashed`). **No new IPC channel** (the count stays 145) and **no
-  preload change** — `missingOptionalFamilies` and the gate additions ride the existing
+  `runtimeCurrent`/`runtimeHashed`).
+  **#339 P8-2 additions (the consent step; the channel is unchanged, its PAYLOAD is new):**
+  `downloadEngine` takes an OPTIONAL `EngineDownloadRequest = { families?: string[] }`. Absent
+  (the preload sends NO payload — pinned by `preload-engine.test.ts`) = the default install,
+  required families only. `{ families: ['kiwix_tools'] }` is the ONLY way the optional family is
+  ever fetched; the main handler validates the payload against the code's family names
+  (`parseEngineDownloadRequest` — an unknown name, an empty list, a duplicate or a non-object
+  rejects with `main.engine.badRequest`) and passes `kiwixToolsActive` from the per-family
+  sidecar PID registry (P8-1 R-e), so the install is refused while a pack is being served.
+  `EngineStatus` gains `optionalFamilies?: EngineOptionalFamily[]` = `{ family, version,
+  sizeBytes: number | null, url, license, installed }` — what the dialog states, read from the
+  pinned yaml (`version`, `url`, the new per-build `size_bytes`, validated as a positive
+  integer, `RuntimeBuild.sizeBytes?`) and from the CODE-side `SidecarFamilySpec.license`
+  (`GPL-3.0-or-later` for kiwix_tools) — never from copy or from the drive's user-writable yaml.
+  After a job that installed `kiwix_tools` completes, the main side runs ONE background
+  `ZimService.reconcile` (the searchability key carries the tools fingerprint, D-Z11/D-Z15) and
+  the panel learns the result through `packs:changed`; the network gate is unchanged
+  (`policy.network.allowModelDownloads ∧ allowNetwork`). **P8-1 shipped no IPC channel** (the
+  count stays 145) and **no preload change** — `missingOptionalFamilies` and the gate additions ride the existing
   `engineStatus` payload / the existing assert-tool call, unread by the renderer until the
   consent step (#339 P8-2).
 - **Image understanding (vision)** — `imageGetStatus(): Promise<VisionStatus>`,

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1168,6 +1168,30 @@ packs at `reconcile-end` / `mutation` only, never at `reconcile-start`. The coll
 §17 D-Z16 (`packs:status.excluded` → the "Not served" badge naming the winner). Tests:
 `KnowledgePacks.test.tsx` ("#340 nits …", the chip-state leg), `ChatPacksRefresh.test.tsx`.
 
+**P8-2 consent surfaces (2026-09-06, #339):** the owner's ruling on the "kiwix-tools not
+installed" notice gained TWO entry points to the same optional-family install — the
+Knowledge-packs panel notice's own "Install the knowledge-pack tools…" button, and a mirror row
+on the Models screen ("Knowledge-pack tools: not installed · Install…", shown only while
+`EngineStatus.missingOptionalFamilies` names `kiwix_tools`). Both open the SAME
+`KnowledgePackToolsDialog` — deliberately the model-download confirm's shape (`<dl class="kv">`
+of Size / License / From, a hint line, a REQUIRED acknowledgement checkbox that disables Start
+download until ticked) rather than a new pattern, because this download carries the same two
+facts a model download does — a network fetch and a licence to accept — and a user who has
+already learned one dialog shape should not have to learn a second. The facts (size, licence,
+source URL) are typed off `EngineOptionalFamily`, never copy, so the dialog cannot state
+something the pinned build doesn't back. The acknowledgement is required for the same reason a
+model's is: this is the one place kiwix-tools' GPL-3.0-or-later terms are surfaced at all. The
+network gate reuses the Models screen's own copy verbatim (`lib/downloadGate.ts`, extracted from
+`ModelsScreen.tsx` so the two surfaces read one computation) — "disabled by policy" and "turn it
+on in Settings" must never diverge by entry point. The Models-screen row is a `<p className=
+"hint">`-styled block, not a `Banner`, deliberately lighter than the chat/voice engine banners
+above it — the tools are optional in a way the chat engine is not, and the row must read as
+secondary. `lib/useKnowledgePackToolsInstall.ts` is the shared poll/cancel/remembered-job hook
+(mirroring `ModelsScreen.tsx`'s own engine-job handling) — it fetches `getEngineStatus`/
+`getPolicy` lazily, only while the affordance is actually needed, so a workspace with the tools
+already installed makes neither call. Tests: `KnowledgePacks.test.tsx` ("#339 P8-2: …" legs),
+`ModelsScreen.test.tsx` ("ModelsScreen — knowledge-pack tools row" describe block).
+
 ---
 
 ## 12. Chat-UI polish pass — design record (IMPLEMENTED 2026-06-13)

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2730,6 +2730,39 @@ offline article viewer. Files are registered in place, never copied.
   the raw result); `zim-query-rewrite.test.ts` pins the rewrite; `zim-arm.test.ts` the retry;
   the manual smoke replays the fixture when the registered archive is that pack and asserts
   every answerable question hits.
+- **D-Z19 — the kiwix-tools consent step (#339 P8-2, owner ruling 2026-09-06).** The optional
+  `kiwix_tools` family (D-Z17) becomes reachable from inside the app through ONE consent
+  dialog with two entry points: the Knowledge-packs panel's "kiwix-tools not installed" notice
+  gains an "Install the knowledge-pack tools…" action, and the AI Model screen shows a quiet
+  mirror row ("Knowledge-pack tools: not installed · Install…") — the engine banner was
+  rejected as a surface because it renders only while `llama_cpp` / `whisper_cpp` is missing.
+  The dialog is the model-download `ConfirmDialog` shape — Size / License / From rows, a hint,
+  and a REQUIRED licence acknowledgement (the confirm stays disabled until it is ticked) — and
+  states facts from the pin, never from copy: `EngineStatus.optionalFamilies[]` carries the
+  yaml's `version`, the host build's `url` and its new per-build `size_bytes` (a label, never an
+  integrity input — a malformed value reads as unknown rather than failing the file), and the
+  licence string from the CODE-side `SidecarFamilySpec.license` (`GPL-3.0-or-later`; a
+  user-writable drive yaml cannot change what the user is asked to accept). `installed` there
+  means every declared file, the panel's own `toolsInstalled` rule. Confirming sends
+  `downloadEngine({ families: ['kiwix_tools'] })` — the channel is unchanged, the PAYLOAD is new
+  (`EngineDownloadRequest`): absent = the default install (required families only — the
+  argument-less "Install the AI engine" button still never fetches kiwix, D-Z17), the list is
+  validated in main against the code's own family names, and a payload mixing an optional
+  family with a required one is refused so the acknowledgement always travels with the family
+  alone. The main handler also passes `kiwixToolsActive` from the per-family sidecar PID registry
+  (P8-1 R-e: a kiwix-serve / kiwix-manage child refuses the re-install with friendly copy), and
+  after a completed kiwix install runs ONE background `ZimService.reconcile` — the searchability
+  key carries the tools fingerprint (D-Z11 / D-Z15), so every pack is re-probed with the new
+  bundle and the panel learns the result through `packs:changed`; the hook is skipped when the
+  workspace no longer admits work. The network gate is REUSED, not extended
+  (`policy.network.allowModelDownloads ∧ allowNetwork`, the owner's ruling: no new policy key —
+  the surfaced copy says "engine and knowledge-pack tools", P8-5). Tests:
+  `engine-consent-ipc.test.ts` (the explicit request installs kiwix alone and reconciles once;
+  the argument-less call never fetches it; malformed and mixed payloads are refused before any
+  gate; the PID-registry refusal; `optionalFamilies` from the pin; the every-file `installed`),
+  `preload-engine.test.ts` (no payload when absent), `KnowledgePacks.test.tsx` /
+  `ModelsScreen.test.tsx` (the two surfaces, the required acknowledgement, the gate-off reason).
+  Record of the UI: design-guidelines §11.15 "P8-2 consent surfaces".
 
   **2026-09-06 amendment, #353 — the document-frequency ladder.** The length-based `retry`
   cannot help a pattern whose kept terms are ALL already `RETRY_MIN_TERM_CHARS` or longer: a

--- a/model-manifests/runtime-sources.yaml
+++ b/model-manifests/runtime-sources.yaml
@@ -150,6 +150,9 @@ kiwix_tools:
       backend: cpu
       url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_win-x86_64-3.8.1.zip
       sha256: fcd01ed2b93e9a68632c7863c83b9f66bf64406a66357be1df7b8b75596f3e45
+      # size_bytes (#339 P8-2): the pinned archive's size, shown by the consent dialog before
+      # any request is made. Measured with the SHA-256 (docs/model-policy.md).
+      size_bytes: 18301924
       extract_to: runtime/kiwix-tools/win
       # The win zip is FLAT (eight files, no top folder): three exes + these five DLLs.
       # The exes do not start without them.
@@ -159,18 +162,21 @@ kiwix_tools:
       backend: cpu
       url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_macos-arm64-3.8.1.tar.gz
       sha256: 222e8398ca50ac005a7e92cf0116e0c83e3c44c79cab0bb7f6537943d517e8d3
+      size_bytes: 10254751
       extract_to: runtime/kiwix-tools/mac
     - os: mac
       arch: x64
       backend: cpu
       url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_macos-x86_64-3.8.1.tar.gz
       sha256: 70219e56f7c274e1fc0db8487abdcc91bde9a6f2923958894c0c81ee24b06c01
+      size_bytes: 10768392
       extract_to: runtime/kiwix-tools/mac
     - os: linux
       arch: x64
       backend: cpu
       url: https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-x86_64-3.8.1.tar.gz
       sha256: 46557f9a3c3eaada2556a957cf5bc662c07dc6286e8924e04fa3a173f83ff6dd
+      size_bytes: 21503420
       extract_to: runtime/kiwix-tools/linux
 
 # OCR LANGUAGE DATA (Phase 38, D32): a NEW ASSET CLASS on this yaml — plain verified


### PR DESCRIPTION
Refs #339 — owner ruling 1 of 2026-09-06 (an A-shaped confirm dialog from the Knowledge-packs panel, plus a mirror row on the AI Model screen; the network gate key is reused).

**Contract (main + preload).** `downloadEngine` takes an OPTIONAL `EngineDownloadRequest = { families?: RuntimeFamily[] }` — the channel is unchanged, the payload is new. Absent (the preload sends no payload) = the default install, required families only; `{ families: ['kiwix_tools'] }` is the only way the optional family is ever fetched. The main handler validates the payload against the code's family names (unknown, empty, duplicate, non-object and MIXED optional+required payloads are refused before any gate), passes `kiwixToolsActive` from the per-family sidecar PID registry (P8-1 R-e), and after a completed kiwix install runs one background pack reconcile (the searchability key carries the tools fingerprint, so every pack is re-probed and the panel learns it through `packs:changed`). `EngineStatus` gains `optionalFamilies[]` = `{ family, version, sizeBytes, url, license, installed }` — the dialog's facts come from the pinned yaml (new per-build `size_bytes`, a label never an integrity input) and the code-side `SidecarFamilySpec.license`, never from copy; `installed` means every declared file.

**Surfaces (renderer).** `KnowledgePackToolsDialog` (the model-download `ConfirmDialog` shape: Size / License / From, hint, a REQUIRED licence acknowledgement — confirm disabled until ticked and while the download gate is off, with the same reason copy as the engine banners via the extracted `lib/downloadGate.ts`), shared by the panel notice's "Install the knowledge-pack tools…" action and the Models screen's quiet "Knowledge-pack tools: not installed · Install…" row through one hook (`useKnowledgePackToolsInstall`: lazy status/policy fetch only while the tools are missing, poll / cancel / retry, toast + refetch on done). The argument-less "Install AI engine" button still calls `downloadEngine()` with no argument.

**Review.** Opus adversarial review of the contract: no blockers; its findings landed in `3cff5e11` (every-file `installed`, tolerant `size_bytes`, typed `families`, mixed payloads refused, quiet AbortError in the hook, size + licence pins). Accepted residual: an `uncertain` kiwix child pins the in-use guard until restart (the refusal copy now says so).

**Tests.** `engine-consent-ipc.test.ts` (6 legs through the real handler), `preload-engine.test.ts`, `runtime-sources.test.ts` (size_bytes), `assets.test.ts` (the four size pins), `KnowledgePacks.test.tsx` / `ModelsScreen.test.tsx` (both surfaces, the required acknowledgement, the gate-off reason, no status/policy calls while installed, the argument-less engine button). Records: data-contracts "#339 P8-2 additions", rag-design §17 D-Z19, design-guidelines §11.15 "P8-2 consent surfaces", i18n EN+DE. Typecheck clean; full suite 416 files / 6,670 passed / 89 skipped (master: 414 / 6,657 / 83).

Stacked on this PR: P8-5 (the network-inventory prose) and P8-4 (the corresponding-source bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)