### PR TITLE
docs(privacy): the network inventory says models + engine + knowledge-pack tools (#339 P8-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,10 @@ from its first public `1.0.0` release onward.
   fractions, roots, Greek letters and signs are written out, and lowered or raised characters sit
   on the line — CO2, m2, Fe3+ — which is how you type them when searching. Anything unreadable is
   left as it was. Passages saved in earlier evidence reviews keep the older form.
+- **The privacy notice and Settings screen now name every optional download.** The wording in
+  Settings → Privacy & data and the Privacy notice now says the internet-access setting also
+  covers the AI engine and the optional knowledge-pack tools, not only models, since one setting
+  and one confirmation dialog already covered all three; nothing about what is allowed changed.
 
 ## [0.1.59] — 2026-08-21
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,7 +34,8 @@ described under "Letting other apps on this computer use your model" below.
   the translation is produced **on this device** by a local translation model — your text and
   documents are never sent off-device, and no cloud translation service is ever involved.
 - **No embedding upload.** Vector indexes stay local.
-- **No automatic model downloads** unless you explicitly opt in.
+- **No automatic downloads.** Models, the AI engine, and the optional knowledge-pack tools are
+  only ever fetched after you explicitly opt in.
 
 ## What data is stored, and where
 
@@ -61,7 +62,12 @@ folder):
   after you lock the workspace and after you remove a pack's registration from the app
   (removing a pack only forgets it — the file itself is untouched). Each pack's title,
   language and file location are stored as workspace metadata, inside the encrypted
-  database in encrypted mode, like the rest of your settings. While unlocked, the app also
+  database in encrypted mode, like the rest of your settings. The kiwix-tools programs that
+  read and serve packs (`kiwix-serve`, `kiwix-manage`) are a separate, optional download
+  (GPL-3.0-or-later, from `download.kiwix.org`) — offered from the **Knowledge packs** panel's
+  tools-missing notice or a mirror on the **AI Model** screen the first time you need them, and
+  SHA-256-verified like every other download; or you can place the binaries on the drive
+  yourself. While unlocked, the app also
   keeps a small generated index file naming your enabled packs' titles and file locations,
   in plain text, under `workspace/zim-transient/`; it is removed when you lock, quit, or
   start the app, though a crash can leave it behind until the next successful
@@ -80,10 +86,11 @@ copying text anywhere else.
 The app's **core path — chat, documents, indexing, search — always stays local** and makes no
 network calls. A visible indicator (in the chat header; clicking it opens
 Settings → **Privacy & data**) tells you the current state honestly: **Local · Offline** when
-no network is permitted, or "Downloads allowed — chats and documents stay local" when it is. The
-only thing the app uses the internet for is downloading/updating models + the AI engine. That setting is now
-**on by default** so a fresh install can fetch models out of the box — but it stays bounded:
-every download is explicit and confirmed, and you can turn it off in Settings:
+no network is permitted, or "Downloads allowed — chats and documents stay local" when it is.
+The only things the app ever downloads are AI models, the AI engine and the optional
+knowledge-pack tools — each one only after you confirm it, each one verified before use. That
+setting is now **on by default** so a fresh install can fetch models out of the box — but it
+stays bounded: every download is explicit and confirmed, and you can turn it off in Settings:
 
 ```
 [x] Allow internet access for model downloads and updates
@@ -98,23 +105,28 @@ The built-in browser engine's own background fetches are switched off as well: s
 disabled, because the engine would otherwise download a spelling dictionary from a Google-operated
 server on Windows and Linux the first time you type.
 
-## Model downloads — the app's only use of the internet
+## Model, engine and knowledge-pack-tool downloads — the app's only use of the internet
 
-The **only** thing the app can use the internet for is fetching a model file you ask for, from the
-**Models** screen. Three things must all be true before a single byte moves:
+The **only** thing the app can use the internet for is fetching a model file, the AI engine, or
+the optional knowledge-pack tools — from the **AI Model** screen, or, for the knowledge-pack
+tools, also from the **Knowledge packs** panel's tools-missing notice. Three things must all be
+true before a single byte moves:
 
-1. The drive's policy permits model downloads (drives — including prepared commercial drives —
-   ship with this **permitted** so you can add models; a drive `policy` can turn it off entirely).
+1. The drive's policy permits these downloads (drives — including prepared commercial drives —
+   ship with this **permitted** so you can add models, the engine or the knowledge-pack tools; a
+   drive `policy` can turn it off entirely).
 2. You left the Settings checkbox above on (it is **on** by default for a fresh install, unless the
    drive's policy disables it) — or turned it back on if you had switched it off.
 3. You confirmed that specific download in a dialog showing its size, license, and source address —
-   including explicitly accepting the model's license when it hasn't been pre-reviewed.
+   including explicitly accepting the license when it hasn't been pre-reviewed. The knowledge-pack
+   tools are GPL-3.0-or-later and always show that license for you to accept.
 
-The request goes only to the address printed in the model's local manifest; nothing about you, your
-prompts, or your documents is sent. There are **no update checks, no model catalog, and no
-background downloads** — with the checkbox off (or no internet at all) the app is fully usable and
-makes no internet calls. Every downloaded file is checked against its expected checksum before the
-app will use it.
+The request goes only to the address printed in the model's local manifest — the knowledge-pack
+tools instead ride the pinned `runtime-sources.yaml`, not a model manifest, but the same
+address-only, no-telemetry rule applies. Nothing about you, your prompts, or your documents is
+ever sent. There are **no update checks, no model catalog, and no background downloads** — with
+the checkbox off (or no internet at all) the app is fully usable and makes no internet calls.
+Every downloaded file is checked against its expected checksum before the app will use it.
 
 ## Letting other apps on this computer use your model (local API)
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@
   and can be scoped to your library, a project, a section, specific documents, or the files
   attached to a chat.
 - 📚 **Knowledge packs (optional).** Register ZIM archives — such as an offline Wikipedia — as
-  per-chat sources searched alongside your documents. Needs the kiwix-tools binaries placed
-  on the drive; the app downloads nothing.
+  per-chat sources searched alongside your documents. Needs the kiwix-tools binaries (GPL-3.0-or-later)
+  on the drive — the app offers to install them in-app with your consent, the first time you need
+  them, or you can place them yourself.
 - 🖼️ **Image understanding.** Ask questions about a picture with a local vision model. The analysis
   history is encrypted at rest and can be deleted.
 - 🎙️ **Audio and voice.** Transcribe audio files with Whisper, dictate prompts, and OCR scanned pages.
@@ -130,8 +131,12 @@ checksums. If no release is listed yet, build from source below; the result is t
 - The download is the app only. A working chat needs two more downloads, both offered on the
   **AI Model** screen inside the app: the AI engine (the `llama.cpp` runtime; the screen shows
   an install banner until it is present, and without it started models run in demo mode with
-  simulated answers) and an AI model of your choice. Every download asks first and is
-  SHA-256-verified. Repo users can instead provision everything up front with step 2 below.
+  simulated answers) and an AI model of your choice. A third download is optional: the
+  kiwix-tools binaries (GPL-3.0-or-later) that power offline knowledge packs, offered from the
+  **Knowledge packs** panel's tools-missing notice or a mirror on the **AI Model** screen, only
+  once you ask for it. The only things the app ever downloads are AI models, the AI engine and
+  the optional knowledge-pack tools — each one only after you confirm it, each one verified
+  before use. Repo users can instead provision everything up front with step 2 below.
 - **Windows:** the build is unsigned for now, so SmartScreen shows "Windows protected your PC".
   Click **More info → Run anyway**.
 - **macOS:** the `.app` is unsigned too. If Gatekeeper blocks the first launch, allow it under
@@ -200,14 +205,16 @@ what is already there. You can also fetch piecemeal (`fetch-models` / `fetch-run
 > `-WithAssets` skips it with a note; build it from source as described in
 > [`docs/packaging.md`](docs/packaging.md).
 
-> `runtime-sources.yaml` is pinned to a real `llama.cpp` release (b9849, bumped from b9585 on
-> 2026-07-01 as the Qwen3.5 compatibility gate) with real per-OS URLs and SHA-256 checksums
-> from the official GitHub Releases API digest metadata. `fetch-runtime` downloads, verifies,
-> extracts (zip and tar.gz), and flattens the binaries for all three OSes from any host. Model
-> weight URLs are real Hugging Face links, and the bundled manifests carry real pinned SHA-256
-> hashes (captured from verified downloads with `verify-models --generate`), so `fetch-models`
-> checks every weight against them. To bump the runtime later, see
-> [`docs/model-policy.md`](docs/model-policy.md).
+> `runtime-sources.yaml` pins all three sidecar families — `llama.cpp`, `whisper.cpp`, and the
+> optional `kiwix-tools` — plus the OCR language-file block, each with real per-OS URLs and
+> SHA-256 checksums. The `llama.cpp` block is pinned to a real release (b9849, bumped from b9585
+> on 2026-07-01 as the Qwen3.5 compatibility gate) from the official GitHub Releases API digest
+> metadata. `fetch-runtime` downloads, verifies, extracts (zip and tar.gz), and flattens the
+> binaries for all three OSes from any host — `fetch-runtime --family kiwix_tools` fetches the
+> optional knowledge-pack tools the same way. Model weight URLs are real Hugging Face links, and
+> the bundled manifests carry real pinned SHA-256 hashes (captured from verified downloads with
+> `verify-models --generate`), so `fetch-models` checks every weight against them. To bump a
+> runtime later, see [`docs/model-policy.md`](docs/model-policy.md).
 
 ### 3. Point the app at your models
 
@@ -385,6 +392,21 @@ slice at a time, add tests, keep `npm run typecheck` clean, and update the docs 
 their own licenses (see [`docs/model-policy.md`](docs/model-policy.md)). Third-party notices
 for the npm packages bundled into packaged builds:
 [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md).
+
+**Native sidecars — a separate license class.** The `llama.cpp`/`whisper.cpp` runtimes and the
+OCR language data are permissively licensed (MIT and Apache-2.0, respectively). The optional
+`kiwix-tools` sidecar is different: it is copyleft (GPL-3.0-or-later), statically linked against
+GPL-2.0-or-later-with-GPL-3.0-or-later-files libzim and GPL-2.0-or-later Xapian, plus
+LGPL-2.1-or-later libmicrohttpd. It is not linked into HilbertRaum — the app spawns it as a
+separate program and talks to it over loopback HTTP — so HilbertRaum's own GPL-3.0-or-later
+licensing is unaffected either way (see [`docs/model-policy.md`](docs/model-policy.md) "Sidecar
+binaries — kiwix-tools"). A preloaded Kit that ships the kiwix-tools binaries carries their
+complete corresponding source in `runtime/kiwix-tools/source/` — that is the rule a shipping Kit
+follows, not a claim that the bundle exists in this repository today. A commercial build that
+cannot carry these source archives must not ship kiwix-tools; the app then shows the panel's
+tools-missing hint and the user installs the family in-app (their download, their consent). Full
+notices and the per-component license table: [`DRIVE-NOTICES.md`](DRIVE-NOTICES.md) and
+[`docs/model-policy.md`](docs/model-policy.md).
 
 Our promise: the HilbertRaum core is free software and will stay under GPL-3.0-or-later, in
 every version we publish here, forever. To fund its open development, we additionally offer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,9 +53,10 @@ HilbertRaum is a **local-first, offline** application. Full details live in
   the audit trail, the log, or a support export.
 - **No model weights or user data in version control.**
 - **Engine binaries re-hashed before every spawn** — each bundled `llama-server` (chat + translation
-  sidecars), whisper, and GPU-probe binary is verified against its recorded install hash immediately
-  before it is executed. A packaged build refuses to spawn a tampered binary and falls back; dev
-  builds are inert. Downloaded model files are separately checksum-verified before first use.
+  sidecars), whisper, GPU-probe, and (when installed) the optional `kiwix-serve`/`kiwix-manage`
+  binary is verified against its recorded install hash immediately before it is executed. A
+  packaged build refuses to spawn a tampered binary and falls back; dev builds are inert. Downloaded
+  model files are separately checksum-verified before first use.
 - **User skill packs are treated as untrusted input** — a drop-in `SKILL.md` pack is third-party
   content, so it is size-gated on import (over-cap packs are rejected) and its tools run through the
   same audited bridge with a **frozen document scope they cannot widen**.
@@ -78,7 +79,8 @@ HilbertRaum is a **local-first, offline** application. Full details live in
 - **Fail-closed packaged policy** — a packaged commercial build enforces its `policy.json` strictly,
   regardless of the user setting. A policy can only *restrict*: e.g. it may disable model downloads
   entirely (drives ship with downloads permitted by default, so this is an available restriction, not
-  the shipped default).
+  the shipped default). The same download gate also covers the AI engine and the optional
+  knowledge-pack tools — there is no separate policy key for either.
 
 ## Known limitations
 - Offline enforcement in the MVP is by **design + policy/UX**, not a hard OS-level firewall.

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1296,8 +1296,9 @@ export const de: Record<keyof typeof en, string> = {
   'settings.network.title': 'Privatsphäre & Offline-Modus',
   'settings.network.allow': 'Internetzugriff für Modell-Downloads und Updates erlauben',
   'settings.network.hint':
-    'Standardmäßig aus. Solange das aus ist, stellt die App keinerlei Internetverbindung ' +
-    'her. Eingeschaltet ermöglicht es nur Modell-Downloads über den KI-Modell-Bereich — ' +
+    'Standardmäßig an, damit eine frische Installation gleich Modelle herunterladen kann. ' +
+    'Ausgeschaltet stellt die App keinerlei Internetverbindung her. Eingeschaltet ermöglicht ' +
+    'es Downloads für Modelle, die KI-Engine und die optionalen Wissenspaket-Werkzeuge — ' +
     'jeder Download fragt zuerst nach deiner Bestätigung, und eine Laufwerksrichtlinie ' +
     'kann Downloads ganz deaktiviert lassen. Deine Fragen und Dokumente verlassen dieses ' +
     'Gerät in keinem Fall.',
@@ -1574,7 +1575,8 @@ export const de: Record<keyof typeof en, string> = {
   'privacy.statement.online':
     'HilbertRaum führt das KI-Modell auf deinem Laptop aus. Deine Fragen, ' +
     'Dokumente, Embeddings und Chat-Verläufe bleiben lokal — auch mit aktiviertem ' +
-    'Internetzugriff nutzen nur Modell-Downloads das Netzwerk.',
+    'Internetzugriff nutzen nur Downloads (Modelle, die KI-Engine und die optionalen ' +
+    'Wissenspaket-Werkzeuge) das Netzwerk.',
   'privacy.statement.noUploads':
     'Diese App sendet deine Daten an keine Cloud-KI-Anbieter. Es gibt keine Uploads von ' +
     'Fragen, Dokumenten oder Embeddings, keine Telemetrie, keine Analytik und keine ' +
@@ -1584,7 +1586,8 @@ export const de: Record<keyof typeof en, string> = {
   'privacy.networkState.disabledByPolicy': 'Netzwerkzugriff durch Richtlinie deaktiviert.',
   'privacy.networkState.offDefault': 'Der Offline-Modus ist an (Netzwerk standardmäßig aus).',
   'privacy.networkState.enabled':
-    'Internetzugriff ist für Modell-Downloads und Updates aktiviert.',
+    'Internetzugriff ist für Downloads aktiviert: Modelle, die KI-Engine und die optionalen ' +
+    'Wissenspaket-Werkzeuge.',
   'privacy.network.noFiles': 'Keine Fragen oder Dateien verlassen dieses Gerät.',
   'privacy.network.effective': 'Effektiver Zustand',
   'privacy.network.effectiveOffline': 'Offline (keine Internetzugriffe)',
@@ -1599,10 +1602,11 @@ export const de: Record<keyof typeof en, string> = {
   'privacy.network.telemetryValue':
     'Nichts verlässt dieses Gerät — es gibt kein Tracking, das man abschalten müsste',
   'privacy.network.hint':
-    'Die App warnt vor jeder Internetaktion. Das Internet nutzt sie einzig zum Herunterladen ' +
-    'oder Aktualisieren von Modellen — standardmäßig aus und nur über den Allgemein-Tab ' +
-    'aktivierbar. Eine Laufwerksrichtlinie kann das komplett deaktivieren. Die lokale API ' +
-    'weiter unten ist eine getrennte, freiwillige Funktion, die nie ins Internet geht.',
+    'Die App warnt vor jeder Internetaktion. Sie lädt einzig KI-Modelle, die KI-Engine und ' +
+    'die optionalen Wissenspaket-Werkzeuge herunter — jeweils erst nach deiner Bestätigung ' +
+    'und jeweils vor der Nutzung geprüft. Das ist standardmäßig an und über den ' +
+    'Allgemein-Tab abschaltbar. Eine Laufwerksrichtlinie kann das komplett deaktivieren. Die ' +
+    'lokale API weiter unten ist eine getrennte, freiwillige Funktion, die nie ins Internet geht.',
   'privacy.data.title': 'Wo deine Daten liegen',
   'privacy.data.driveRoot': 'Laufwerksstamm',
   'privacy.data.workspace': 'Arbeitsbereich',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -1255,10 +1255,11 @@ export const en = {
   'settings.network.title': 'Privacy & Offline Mode',
   'settings.network.allow': 'Allow internet access for model downloads and updates',
   'settings.network.hint':
-    'Off by default. When off, the app makes no internet calls. Turning it on only enables ' +
-    'model downloads from the AI Model screen — each one asks for confirmation first, and a ' +
-    'drive policy can keep downloads disabled entirely. Your prompts and documents never ' +
-    'leave this device regardless of this setting.',
+    'On by default, so a fresh install can fetch a model out of the box. When off, the app ' +
+    'makes no internet calls. Turning it on enables downloads for models, the AI engine, and ' +
+    'the optional knowledge-pack tools — each one asks for confirmation first, and a drive ' +
+    'policy can keep downloads disabled entirely. Your prompts and documents never leave this ' +
+    'device regardless of this setting.',
   'settings.appearance.title': 'Appearance',
   'settings.appearance.aria': 'Theme',
   'settings.appearance.system': 'System',
@@ -1534,7 +1535,7 @@ export const en = {
   'privacy.statement.online':
     'HilbertRaum runs the AI model on your laptop. Your prompts, documents, ' +
     'embeddings, and chat history stay local — even with internet access enabled, only ' +
-    'model downloads use the network.',
+    'downloads (models, the AI engine, and the optional knowledge-pack tools) use the network.',
   'privacy.statement.noUploads':
     'This app does not send your data to cloud AI providers. There are no prompt, ' +
     'document, or embedding uploads, no telemetry, no analytics, and no remote crash ' +
@@ -1543,7 +1544,9 @@ export const en = {
   'privacy.networkState.noPolicy': 'Offline Mode is on.',
   'privacy.networkState.disabledByPolicy': 'Network access disabled by policy.',
   'privacy.networkState.offDefault': 'Offline Mode is on (network off by default).',
-  'privacy.networkState.enabled': 'Internet access is enabled for model downloads and updates.',
+  'privacy.networkState.enabled':
+    'Internet access is enabled for downloads: models, the AI engine, and the optional ' +
+    'knowledge-pack tools.',
   'privacy.network.noFiles': 'No prompts or files leave this device.',
   'privacy.network.effective': 'Effective state',
   'privacy.network.effectiveOffline': 'Offline (no internet calls)',
@@ -1557,10 +1560,11 @@ export const en = {
   'privacy.network.telemetry': 'Telemetry',
   'privacy.network.telemetryValue': 'Nothing leaves this device — there’s no tracking to turn off',
   'privacy.network.hint':
-    'The app warns before any internet action. The only thing it uses the internet for is ' +
-    'downloading or updating models, which is off by default and must be enabled on the ' +
-    'General tab. A drive policy can disable it entirely. The Local API below is a separate, ' +
-    'opt-in feature that never touches the internet.',
+    'The app warns before any internet action. The only things the app ever downloads are AI ' +
+    'models, the AI engine and the optional knowledge-pack tools — each one only after you ' +
+    'confirm it, each one verified before use. This is on by default and can be turned off on ' +
+    'the General tab. A drive policy can disable it entirely. The Local API below is a ' +
+    'separate, opt-in feature that never touches the internet.',
   'privacy.data.title': 'Where your data lives',
   'privacy.data.driveRoot': 'Drive root',
   'privacy.data.workspace': 'Workspace',

--- a/apps/desktop/tests/integration/repo-hygiene.test.ts
+++ b/apps/desktop/tests/integration/repo-hygiene.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
+import { en } from '../../src/shared/i18n'
 
 // Issue #49: different npm versions compute the lockfile `peer` flags differently (a
 // long-standing npm/Arborist behaviour), so with an unpinned npm every contributor's
@@ -865,6 +866,36 @@ describe('repo hygiene — the ZIM required-check inventory is honest (PR #294 �
     expect(
       oneLine(securityModel).includes(sentence),
       'security-model.md must quote the R-9 sentence verbatim (the counterpart it introduces)'
+    ).toBe(true)
+  })
+
+  it('the network-inventory sentence is stated identically wherever it lives (#339 P8-5)', () => {
+    // The app's network footprint grew a third leg (the optional kiwix-tools family, #339
+    // P8-1/P8-2): models + the AI engine + the optional knowledge-pack tools, all behind the
+    // same gate. This ONE sentence is the shared statement of that inventory — pinned
+    // VERBATIM across every doc that states it, and echoed in the Settings/Privacy tab hint
+    // (en.ts `privacy.network.hint`) so the UI copy cannot drift from the docs silently.
+    const oneLine = (s: string): string => s.replace(/\s+/g, ' ')
+    const sentence =
+      'The only things the app ever downloads are AI models, the AI engine and the optional ' +
+      'knowledge-pack tools — each one only after you confirm it, each one verified before use.'
+    const privacy = readFileSync(join(repoRoot, 'PRIVACY.md'), 'utf8')
+    const readme = readFileSync(join(repoRoot, 'README.md'), 'utf8')
+    const userGuide = readFileSync(join(repoRoot, 'docs', 'user-guide.md'), 'utf8')
+    const securityModelDoc = readFileSync(join(repoRoot, 'docs', 'security-model.md'), 'utf8')
+
+    expect(oneLine(privacy).includes(sentence), 'PRIVACY.md must state the sentence verbatim').toBe(true)
+    expect(oneLine(readme).includes(sentence), 'README.md must state the sentence verbatim').toBe(true)
+    expect(oneLine(userGuide).includes(sentence), 'user-guide.md must state the sentence verbatim').toBe(
+      true
+    )
+    expect(
+      oneLine(securityModelDoc).includes(sentence),
+      'security-model.md must state the sentence verbatim'
+    ).toBe(true)
+    expect(
+      oneLine(en['privacy.network.hint']).includes(sentence),
+      'en.ts privacy.network.hint must state the sentence verbatim so the UI cannot drift from the docs'
     ).toBe(true)
   })
 })

--- a/docs/drive-layout.md
+++ b/docs/drive-layout.md
@@ -75,10 +75,11 @@ HILBERTRAUM/
 ├── models/{chat,embeddings,reranker,transcriber,vision,translation}/ # weights (git-ignored; transcriber/ = whisper GGML .bin; vision/ = the GGUF + its mmproj projector, image understanding V1–V5; translation/ = TranslateGemma GGUF, TG wave)
 ├── runtime/kiwix-tools/{win,mac,linux}/        # THIRD sidecar family: kiwix-serve + kiwix-manage + kiwix-search
 │   └── .hilbertraum-runtime.json                       #   (knowledge packs; OPTIONAL — never a readiness prerequisite). Install
-│                                                #   marker: a hash per executable + per ICU DLL (win only). An in-app install
-│                                                #   writes it (#339 P8-1); no user-reachable install exists yet (P8-2); the
-│                                                #   drive scripts follow in P8-3 — until then the bundle is placed manually
-│                                                #   (rag-design §17 D-Z17)
+│                                                #   marker: a hash per executable + per ICU DLL (win only). An in-app
+│                                                #   install writes it (#339 P8-1/P8-2, the Knowledge-packs-panel /
+│                                                #   AI-Model-screen consent dialog); `fetch-runtime --family kiwix_tools`
+│                                                #   is the scripted DIY path (P8-3); a hand-placed bundle still works as a
+│                                                #   last-resort fallback but carries no marker (rag-design §17 D-Z17)
 ├── ocr/                                        # OCR language files: {deu,eng}.traineddata.gz — plain sha256-verified, git-ignored
 ├── zim/                                        # Knowledge packs: ZIM archives (offline Wikipedia etc.) — PLAIN read-only
 │                                                #   files, never copied into the encrypted workspace (not the document

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2447,18 +2447,19 @@ reports and phase plans were working papers; their full text lives in git histor
 
 ## Knowledge packs — ZIM archives ([`rag-design.md`](rag-design.md) §17)
 
-- **No user-reachable install of kiwix-tools exists yet.** The `kiwix_tools` family is now in
-  `runtime-sources.yaml`, the in-app engine installer and the commercial-drive sell gate (#339
-  P8-1) — but `downloadEngine()` still takes no arguments and no UI offers the family, so nothing
-  a user can click actually fetches it yet; that consent step is P8-2. Until then, the drive
-  scripts' own `--family kiwix_tools` support (P8-3, PR #355) is the recommended way in — see
-  [`troubleshooting.md`](troubleshooting.md) "The panel says kiwix-tools are missing" for the
-  exact command and the manual-unzip fallback. A hand-placed bundle carries no install marker and
-  is replaced **wholesale** by the first in-app install once P8-2 ships (the installer pre-cleans
-  the family's directory before extracting) — so a manually provisioned drive is not stranded, it
-  is simply superseded the first time someone installs the family from inside the app. Manually
-  provisioned packs (the binaries correctly placed, archives registered) already work end to end
-  today; only the in-app install step is missing.
+- **A hand-placed kiwix-tools bundle carries no install marker.** The `kiwix_tools` family can
+  now be installed from inside the app (the Knowledge-packs panel's tools-missing notice, or the
+  mirror row on the AI Model screen, #339 P8-2) or via `fetch-runtime --family kiwix_tools`
+  (#339 P8-3) — both write a `.hilbertraum-runtime.json` marker hashing every required file, so
+  `kiwix-serve`/`kiwix-manage` verify normally before every spawn. Unzipping the archive under
+  `runtime/kiwix-tools/<os>/` by hand still works as a last-resort fallback, but leaves no
+  marker, so it resolves through the hashless `skip-legacy` verifier path (residual R-1) instead
+  of integrity verification — and it is replaced **wholesale** the first time someone installs
+  the family from inside the app or the script (the installer pre-cleans the family's directory
+  before extracting), so a manually provisioned drive is not stranded, only superseded. The
+  in-app install needs **Settings → Allow internet access for model downloads and updates** on
+  and a drive policy that permits downloads (the same gate models and the engine use). Linux and
+  macOS builders without the in-app path use the script.
 - **On Windows, an archive can only be added from a path made of ASCII characters.** The
   pinned `kiwix-manage` 3.8.1 refuses to read a file whose folder or file name contains an
   umlaut, an accent or any other non-ASCII character ("Cannot add ZIM … to the library.") — a

--- a/docs/model-policy.md
+++ b/docs/model-policy.md
@@ -671,9 +671,12 @@ inventory) is what would confirm any conveyance.
 `runtime-sources.yaml` pins the **`kiwix_tools:`** block — the THIRD sidecar family and the
 first **`optional: true`** one: it is never part of the default engine-install selection and
 never counted toward `engineStatus().installed`/`missingFamilies` — only an explicit
-`families: ['kiwix_tools']` request installs it (the consent surface that sends that request is
-P8-2; until then `EngineStatus.missingOptionalFamilies` reports the family separately, additive
-and optional so a pre-#339 renderer simply ignores it). The family also ships **more than one
+`families: ['kiwix_tools']` request installs it. The consent surface that sends that request
+landed at P8-2: the Knowledge-packs panel's tools-missing notice and a mirror row on the AI
+Model screen, each requiring the user to accept the GPL-3.0-or-later license before the request
+goes out, gated by the same `policy.network.allowModelDownloads ∧ allowNetwork` check as models
+and the engine. `EngineStatus.missingOptionalFamilies` reports the family separately, additive
+and optional so a pre-#339 renderer simply ignores it. The family also ships **more than one
 executable**: `executables: [kiwix-serve, kiwix-manage, kiwix-search]`, base names only
 (`sidecarBinaryName` adds `.exe` on win; the first entry is the primary binary,
 `plan.binaryPath`). Per build, `runtime_files` lists non-executable files the executables cannot
@@ -787,12 +790,15 @@ source-bundle (P8-4) rulings that gate any conveyance (plan §3).
 > per-file headers of all five copyleft source trees (re-fetching the source tarballs too) before
 > promoting any of it. A version bump here is a licence re-review, not a mechanical edit.
 
-Placement on the drive today is **manual**: unzip the whole bundle under
-`runtime/kiwix-tools/<os>/`. A hand-placed bundle carries no install marker and resolves through
-the hashless `skip-legacy` verifier path (residual R-1) rather than integrity verification; an
-in-app install (family contract landed, #339 P8-1) writes the marker described above and both
-`kiwix-serve` and `kiwix-manage` verify normally — but no user-reachable install exists yet
-(`downloadEngine` still takes no arguments; the consent step is P8-2).
+The user path is the in-app **consent dialog** (#339 P8-2, `downloadEngine({ families:
+['kiwix_tools'] })`): the Knowledge-packs panel's tools-missing notice, or the mirror row on the
+AI Model screen, states the size, the GPL-3.0-or-later license and the source, and installs the
+family once accepted — writing the marker described above, so both `kiwix-serve` and
+`kiwix-manage` verify normally. The builder/DIY path is `fetch-runtime --family kiwix_tools`
+(#339 P8-3, same marker). Hand-placing the bundle under `runtime/kiwix-tools/<os>/` remains a
+**last-resort fallback**: it carries no install marker and resolves through the hashless
+`skip-legacy` verifier path (residual R-1) rather than integrity verification, and is replaced
+wholesale by the first in-app or scripted install.
 
 ## The vision role + mmproj projector (image understanding, Phases V1–V5)
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -752,19 +752,21 @@ these harnesses prove the *current* pin (the drive's previous binary was b9585).
 | `model-eval` | `HILBERTRAUM_MODEL_EVAL` | the model-recommendation ladder on real hardware |
 | `zim-real` | `HILBERTRAUM_ZIM_SMOKE` | real `kiwix-manage` registration, the real `kiwix-serve` sidecar, Xapian search, the offline article viewer read — fully offline. **FAIL-CLOSED (#301 P5, finding L8):** requested with a missing/invalid tools dir, either binary absent, a non-ZIM file or an unset query **FAILS** the run instead of silently skipping it |
 
-**Installing the pinned kiwix-tools bundle.** `fetch-runtime --family kiwix_tools` (#339 P8-3)
+**Installing the pinned kiwix-tools bundle.** The user path is the in-app **consent dialog**
+(#339 P8-2): the Knowledge-packs panel's tools-missing notice, or the mirror row on the AI Model
+screen, states the size, the GPL-3.0-or-later license and the source, and installs the family
+once you accept. The builder/DIY path is `fetch-runtime --family kiwix_tools` (#339 P8-3), which
 downloads, SHA-256-verifies and extracts the pinned **kiwix-tools 3.8.1** archive for the host
 (or `--os`/`--arch` to provision another OS's dir), writes a `.hilbertraum-runtime.json` install
 marker hashing every required file (`kiwix-serve`, `kiwix-manage`, `kiwix-search`, and on
 Windows the five ICU DLLs), and `chmod +x`s the executables on mac/linux — exactly like the
 `llama_cpp`/`whisper_cpp` families, except it is never fetched by `prepare-drive --with-assets`
-(the family is optional: a DIY user runs the command explicitly once they want ZIM knowledge
-packs). A manual unzip of the pinned zip (see `model-policy.md` "Sidecar binaries —
-kiwix-tools" for the exact bundle/hashes) under `runtime/kiwix-tools/<os>/` remains a fallback
-that still works, but leaves no install marker and so resolves through the hashless
-`skip-legacy` verifier path (residual R-1) instead of integrity verification — prefer the
-script. An in-app install (the consent step, P8-2) is still to come; `kiwix-serve` and
-`kiwix-manage` verify normally against either the script's marker or an in-app one.
+(the family is optional). A manual unzip of the pinned zip (see `model-policy.md` "Sidecar
+binaries — kiwix-tools" for the exact bundle/hashes) under `runtime/kiwix-tools/<os>/` is the
+**last-resort fallback**: it still works, but leaves no install marker and so resolves through
+the hashless `skip-legacy` verifier path (residual R-1) instead of integrity verification —
+prefer the in-app install or the script. `kiwix-serve` and `kiwix-manage` verify normally
+against a marker from either the script or an in-app install.
 
 **Optional harness *inputs* (point a harness at a specific artifact).** Distinct from the on-switch
 env vars in the table above, several harnesses additionally read an **artifact-pointer input**,

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2948,12 +2948,12 @@ outcomes notice over every reason code); `ReviewEvidencePane.test.tsx` / `Review
 
 ### Deliberately not built (MVP cut; §5 item 21 tracks the follow-ups)
 
-Provisioning of the `kiwix_tools` family: the family contract itself landed (#339 P8-1,
-D-Z17) — `runtime-sources.yaml`, the in-app installer, the sell gate. Still open: the consent
-step that lets a user reach the installer (P8-2), the drive scripts' `fetch-runtime`/
-`prepare-drive` support (P8-3), the on-drive corresponding-source bundle (P8-4), and the
-network-inventory prose in PRIVACY/README/user-guide/security-model (P8-5) — until P8-2 lands,
-binaries are still placed manually. Also not built: persistent article import (Tier 2); an
+Provisioning of the `kiwix_tools` family: the family contract landed (#339 P8-1, D-Z17) —
+`runtime-sources.yaml`, the in-app installer, the sell gate. The consent step that lets a user
+reach the installer (P8-2), the drive scripts' `fetch-runtime`/`prepare-drive` support (P8-3),
+and the network-inventory prose in PRIVACY/README/user-guide/security-model (P8-5) have since
+landed too. Still open: the on-drive corresponding-source bundle (P8-4), in flight as a sibling
+PR. Also not built: persistent article import (Tier 2); an
 in-app ZIM catalog/downloader; evidence review
 over archive citations (they resolve as honest 'unresolved'); packs on the whole-document
 / compare paths (disclosed per answer as `mode`, not queried — P4); quality guarantees

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -176,14 +176,18 @@ content). The OS microphone indicator is the recording signal; the app adds no o
 ## Offline posture (spec §3.6)
 
 The app makes **no outbound network calls in its core path** — this is a property of the code, not a
-firewall. Two layers make it visible and defensible:
+firewall. The only things the app ever downloads are AI models, the AI engine and the optional
+knowledge-pack tools — each one only after you confirm it, each one verified before use. Two
+layers make it visible and defensible:
 
 ### 1. Policy precedence (`services/policy.ts`)
 `config/policy.json` and `config/drive.json` are **optional** (developer runs fall back to defaults)
 and are merged over `DEFAULT_POLICY`, where **update checks and telemetry are off** (no toggle
 exists for either) and — since Phase 18 (wave-1 decision D3 — architecture.md "In-app model downloader") — `allow_model_downloads` is
 **permitted**, so that with no policy file the spec §3.6 user toggle is the effective downloads
-gate. The policy models the spec §6 shape (`network` / `workspace` / `models` blocks).
+gate. The same key also gates the AI engine and the optional knowledge-pack-tools downloads
+(#339 P8-2, owner-ruled: no new policy key, the one gate covers all three). The policy models
+the spec §6 shape (`network` / `workspace` / `models` blocks).
 
 **Fail-closed on a packaged build (audit M-4, 2026-06-13).** The base the file is merged over —
 and the fallback for a **missing / malformed / partial** `policy.json` — depends on the build type
@@ -206,7 +210,8 @@ and the fallback for a **missing / malformed / partial** `policy.json` — depen
   release notes point users to (the policy is the ceiling, so the Settings toggle could not
   re-enable it). The standalone posture relaxes **two** network ceilings:
   `allow_model_downloads` (still gated by the `allowNetwork` setting + a per-download
-  confirmation, downloads SHA-256-verified against their manifests) and — since the local-api
+  confirmation; this covers model, engine and optional knowledge-pack-tool downloads alike,
+  each SHA-256-verified before use) and — since the local-api
   wave, owner decision O3 — `allow_local_api` (a loopback-only INBOUND ceiling; the feature
   stays default-off behind its own consent dialog, and without this it would be policy-dead on
   every standalone install); update checks + telemetry stay denied, and the
@@ -230,6 +235,11 @@ networkAllowedByPolicy = policy.network.allowModelDownloads || policy.network.al
 networkAllowed         = networkAllowedByPolicy && userSetting.allowNetwork
 offlineMode            = !networkAllowed
 ```
+
+The optional knowledge-pack tools (`kiwix_tools`) reuse `allowModelDownloads` rather than adding
+a policy key of their own (owner-ruled 2026-09-06, #339 P8-2) — a drive that restricts model
+downloads restricts the knowledge-pack-tools install the same way, with no separate switch to
+keep in sync.
 
 Consequences:
 - **The shipped default permits downloads, but only when a policy also allows them.** `allowNetwork`
@@ -1520,7 +1530,11 @@ exactly as they could alter the engine binary or any on-drive asset. A hash mani
 same writable drive would be **unanchored** (the attacker rewrites it too), so it buys nothing; real
 integrity needs **off-drive signing**, a Tier-3 prerequisite not in scope. This is the **same residual
 already accepted for the engine binary and the on-drive sidecars** — documented here and in
-`known-limitations.md`, not papered over. The blast radius is bounded: a tampered instruction skill is
+`known-limitations.md`, not papered over. (A downloaded `kiwix-tools` install improves on this: it is
+hashed per executable into the same `.hilbertraum-runtime.json` marker as the other sidecars and
+re-verified before every spawn, exactly like `llama-server`; only a hand-placed, marker-less bundle
+still resolves through the hashless `skip-legacy` path this residual describes.) The blast radius is
+bounded: a tampered instruction skill is
 still only injected reference text behind the prompt-injection guard — it cannot run code, reach the
 network, read other files, or widen document scope (the structural ceilings, §14).
 
@@ -1994,7 +2008,8 @@ re-checked by `assertSafeDownloadUrl`: **https-only** *and* a **loopback/private
 (127/8, 10/8, 172.16/12, 192.168/16, 169.254/16, `localhost`, IPv6 `::1`/`fe80:`/`fc`/`fd`), with a
 **max-redirect** cap. The body is rejected once it exceeds the smallest of {`Content-Length`,
 caller `maxBytes`} + margin, with a global backstop when neither is known. All callers (model
-weights, runtime sidecar, OCR files) get this for free because they share the seam.
+weights, the runtime sidecars — llama.cpp, whisper.cpp, and the optional kiwix-tools — and OCR
+files) get this for free because they share the seam.
 
 **F15 (audit-postmerge-2026-06-29) — IPv4-mapped IPv6 closed.** The deny-list classifier
 (`isPrivateOrLoopbackHost`) matched the mapped form only in its **dotted-decimal** spelling
@@ -2014,7 +2029,9 @@ one only when the manifest carried `size_bytes`, so a redirected / `Content-Leng
 collapsed the cap to the 64 GiB backstop (a disk-fill nuisance on small USB drives; the bytes fail
 SHA verify afterwards). Now **both downloaders always pass a bounded cap**: the engine path passes a
 per-family ceiling (`ENGINE_DOWNLOAD_MAX_BYTES` = 2 GiB — engine archives are tens-to-low-hundreds of
-MB), and the model path passes the manifest's exact `size_bytes` when known, else a bounded **per-role
+MB; the same ceiling covers the optional `kiwix_tools` family, whose per-platform archives are
+10-20 MB, since it installs through the same `installOne` path), and the model path passes the
+manifest's exact `size_bytes` when known, else a bounded **per-role
 default** (`modelWeightMaxBytes`: chat/vision 40 GiB, transcriber 8 GiB, embeddings/reranker 4 GiB).
 The backstop itself was lowered 64 → 48 GiB and is now unreachable from production (defence-in-depth
 for a future caller). Residual: the cap is a disk-fill bound, not an integrity control — wrong bytes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -596,8 +596,13 @@ just happened. The app can simply ask again.
 ### The panel says kiwix-tools are missing
 
 Knowledge packs are served by two small programs from the Kiwix project, kiwix-serve and
-kiwix-manage (the pinned bundle also carries kiwix-search, which the app does not use). Until
-the in-app install step lands (#339), place them on the drive yourself.
+kiwix-manage. The Knowledge packs panel (and a mirror row on the AI Model screen) offers to
+install them for you: a dialog states the download size, the GPL-3.0-or-later license and the
+source (`download.kiwix.org`), and asks you to accept the license before it fetches and
+SHA-256-verifies the pinned kiwix-tools 3.8.1 release for your platform. That install needs
+**Settings → Allow internet access for model downloads and updates** to be on (it is on by
+default) and a drive policy that permits downloads.
+
 
 **Preferred: run the fetch script.** From the repository, against the drive:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -603,8 +603,8 @@ SHA-256-verifies the pinned kiwix-tools 3.8.1 release for your platform. That in
 **Settings → Allow internet access for model downloads and updates** to be on (it is on by
 default) and a drive policy that permits downloads.
 
-
-**Preferred: run the fetch script.** From the repository, against the drive:
+**Without the in-app path (a scripted or Linux/macOS drive): run the fetch script.** From the
+repository, against the drive:
 
 - Windows: `scripts\fetch-runtime.ps1 -Target <drive-root> -Family kiwix_tools`
 - macOS/Linux: `scripts/fetch-runtime.sh --target <drive-root> --family kiwix_tools`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,7 +100,7 @@ HilbertRaum mark at the top is the **Home** button. Settings has four tabs: **Ge
 
 A quiet **🔒 Local · Offline** status sits in the chat header. Hover it for the short version — *"Everything stays on this drive. No internet
 connection is used."* — or click it to open the full privacy details. If you have enabled
-internet access for model downloads, it says so honestly: **Local · Downloads allowed**
+internet access for downloads, it says so honestly: **Local · Downloads allowed**
 (your chats and documents stay local either way).
 
 ### The Home screen
@@ -168,13 +168,14 @@ can turn this off under **Settings → Load the selected model automatically**.
 ### Downloading a model (optional)
 
 A model marked **Not downloaded** can be fetched from inside the app — for example the larger
-8B model after you upgrade to a 16 GB laptop. This is the **only** thing the app ever uses the
-internet for, and it never happens by itself:
+8B model after you upgrade to a 16 GB laptop. The only things the app ever downloads are AI
+models, the AI engine and the optional knowledge-pack tools — each one only after you confirm
+it, each one verified before use. None of it ever happens by itself:
 
 1. Open **Settings** and make sure **Allow internet access for model downloads and updates**
    is on (it is **on by default**, including on prepared commercial drives, unless this drive's
    builder deliberately disabled downloads in the drive's policy — rare; the app is fully usable
-   without it either way).
+   without it either way). The same setting also gates engine and knowledge-pack-tool downloads.
 2. On **AI Model**, click **Download** on the model you want. A confirmation shows the size,
    the license (with a link that names the site it points to), and the address the file comes
    from. If the model's license hasn't been pre-reviewed, you'll also tick a box accepting it.
@@ -795,10 +796,11 @@ A *knowledge pack* is a ZIM archive — a compressed offline copy of a reference
 The Kiwix project publishes thousands (Wikipedia in ~100 languages, Wiktionary,
 Wikivoyage, …) at `library.kiwix.org`; download once, use forever offline.
 
-1. **One-time setup:** the kiwix-tools programs must sit under
-   `runtime/kiwix-tools/win` (or `mac`/`linux`) on your drive — see
-   [`troubleshooting.md`](troubleshooting.md) “The panel says kiwix-tools are
-   missing” while the installer step is still manual.
+1. **One-time setup:** the kiwix-tools programs (kiwix-serve, kiwix-manage) must be on your
+   drive. The first time, the panel offers to install them — a dialog states the size, the
+   GPL-3.0-or-later license and the source, and asks you to accept the license; or place them
+   yourself, see Troubleshooting → [“The panel says kiwix-tools are
+   missing”](troubleshooting.md#the-panel-says-kiwix-tools-are-missing).
 2. **Add packs:** copy `.zim` files into the drive’s `zim/` folder (found when you
    unlock, and on Refresh), or use *Documents → Knowledge packs → Add packs…* for files
    stored elsewhere. Files are used in place — nothing is copied. The list updates
@@ -1009,10 +1011,11 @@ skill's figures.
 ## 10. Privacy & offline
 
 Open **Settings → Privacy & data** (or click the **🔒 Local · Offline** status in the chat header)
-to see where your data lives and confirm the app's network state. Internet access is used **only**
-for optional model/engine downloads — it is on by default so you can fetch a model out of the
-box, including on a prepared commercial drive; every download is explicit and
-confirmed, and the core app — chat, documents, search — never goes online. (A link you confirm
+to see where your data lives and confirm the app's network state. The only things the app ever
+downloads are AI models, the AI engine and the optional knowledge-pack tools — each one only
+after you confirm it, each one verified before use. That setting is on by default so you can
+fetch a model out of the box, including on a prepared commercial drive; every download is
+explicit and confirmed, and the core app — chat, documents, search — never goes online. (A link you confirm
 in the dialog described in §6 is opened by your *browser*, not by the app.) Logs are stored
 **locally** on the drive (encrypted on an encrypted workspace) and never uploaded.
 

--- a/model-manifests/README.md
+++ b/model-manifests/README.md
@@ -16,8 +16,10 @@ Each YAML file here describes one model. Manifests are committed to git; **model
 - `translation/` — document-translation models (TranslateGemma 12B Instruct Q4_K_M; drives the
   Translate screen's sidecar)
 - `vision/` — vision models (Qwen2.5-VL 3B Instruct Q4; GGUF + mmproj projector)
-- `runtime-sources.yaml` — the `llama-server` sidecar download manifest (Phase 12). **Not a model
-  manifest** (it is excluded from model discovery); validated by `shared/runtime-sources.ts`.
+- `runtime-sources.yaml` — the sidecar/asset download manifest (Phase 12): the `llama-server`
+  (`llama_cpp`), `whisper_cpp`, and optional `kiwix_tools` sidecar families, plus the OCR
+  language-file block. **Not a model manifest** (it is excluded from model discovery); validated
+  by `shared/runtime-sources.ts`.
 
 Manifests are **YAML**, discovered recursively and validated at startup (invalid files are skipped
 and logged, not fatal). See [`../docs/model-policy.md`](../docs/model-policy.md) for the field


### PR DESCRIPTION
Refs #339 — P8-5, stacked on the P8-2 consent PR (retarget to master once it merges).

The app's privacy prose said the only thing it ever downloads is models (+ the AI engine); P8-2 makes a third, optional, separately-consented download reachable. This PR moves every claim: `PRIVACY.md` (the inventory sentence, the renamed downloads section, the three preconditions, the manifest sentence, the packs paragraph naming where the binaries come from), `README.md` (the packs bullet that said "the app downloads nothing", "two more downloads" → a third optional one, the runtime-sources description, and a new **native-sidecar licence class** paragraph in License with the B19 wording: "A commercial build that cannot carry these source archives must not ship kiwix-tools; the app then shows the panel's tools-missing hint and the user installs the family in-app (their download, their consent)."), `docs/user-guide.md`, `docs/security-model.md` (the ceiling prose, the gate formula note that kiwix reuses `allowModelDownloads` — decided 2026-09-06 — the `assertSafeDownloadUrl` seam list, the byte cap, the tamper posture), `SECURITY.md` (kiwix-serve / kiwix-manage in the re-hashed-before-spawn enumeration), `docs/drive-layout.md`, `docs/packaging.md` (manual install → a last-resort fallback), `docs/model-policy.md` (P8-2 recorded; the licence review stays PENDING), `docs/known-limitations.md` (the "no user-reachable install" bullet retired), `docs/rag-design.md` "Deliberately not built", `model-manifests/README.md`, and the i18n copy `settings.network.hint` / `privacy.*` EN+DE.

**The pre-existing contradiction (facts open question 20):** the code says the network setting is ON by default (`DEFAULT_SETTINGS.allowNetwork: true`, `DEFAULT_POLICY` / `STANDALONE_POLICY` allow downloads; only `STRICT_POLICY` — the fail-closed fallback for a provisioned drive whose policy file is corrupt — is off). PRIVACY.md and the user guide were right; the UI hint said "Off by default" and now agrees with the code. `settings.network.allow`'s label is unchanged (quoted verbatim in tests and reused by P8-2).

**Pin:** `repo-hygiene.test.ts` "the network-inventory sentence is stated identically wherever it lives (#339 P8-5)" — one verbatim sentence in PRIVACY.md, README.md, user-guide.md, security-model.md and `en.ts` `privacy.network.hint` (red against the old files, green now).

Note for the merge: `docs/troubleshooting.md` "The panel says kiwix-tools are missing" is also rewritten by #359 — the rebase onto master will need that section reconciled by hand (this PR's version keeps #359's script-first fallback and adds the in-app path).

Suites: repo-hygiene 35, i18n + unused-keys 35, ModelsScreen 89, KnowledgePacks 44 — green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)