### PR TITLE
feat(zim): expand every knowledge-pack question through the local model before the search — concepts + the list-article title (#340 L3-b, D-Z20)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -700,8 +700,9 @@ open round's item stays the last block of §5.)
     (b) **Tier 2** (persistent import of selected articles) — #340; **ruled 2026-09-06: C3 (a) a "Save article to my
     documents" button in the article viewer first**, not built yet. Other #340 rulings of 2026-09-06: L2 keep 5, L1
     keep "not searched: no full-text index", C2 not until the upstream `/raw` fix, C4 later; (b) → `'path-unsupported'`
-    (PR #360), (c) → normalise (PR #361); L3-b measured (PR #362; 0/6 raw, 2/6 through the arm, 4/6 concept-expanded,
-    6/6 `/suggest` + a "Liste …" prefix) — the always / shape-trigger / never question is on #340.
+    (PR #360), (c) → normalise (PR #361); L3-b measured (PR #362; 0/6 raw, 2/6 through the arm) then **ruled (a) ALWAYS on 2026-09-07 and
+    built** (`feat/340-l3b-query-expansion`, record rag-design D-Z20): one local-model call per pack ask, the list
+    group 5/6 through the arm with the default 4B model on a CPU (2.4–5.3 s per call), the D-Z18 nine still 9/9.
     (c) **Evidence identity for archive citations — CLOSED.** Identity resolution: P2, record rag-design D-Z5; the "Open article from a review" residual: closed P6, record design-guidelines §11.15.
     (d) **Manual acceptance leg — CLOSED 2026-09-06:** the airplane-mode demo (the real K: drive, `wikipedia_de_*` packs + kiwix-tools 3.8.1, network off) passed as T19 (viii); record rag-design §17 "Real acceptance".
     (e) Observation for item 1b's matrix, measured 2026-09-04 on the i7-8550U + UHD 620: GPU auto-offload gains nothing on pp (56 vs 57 t/s) and LOSES 45 percent on tg (11 vs 19.6) — on this iGPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,11 @@ from its first public `1.0.0` release onward.
 
 ### Changed
 
+- **Knowledge-pack questions that ask for a list or the largest, most or best-known items now
+  find the list article more often.** Before searching, the app asks your local model for the
+  question's key concepts and the likely title of a list article — one short extra model call
+  per pack question, which never blocks the answer for more than a few seconds; a slow or
+  unavailable model just falls back to the plain search for that question.
 - **The Linux/macOS install step for knowledge-pack tools is documented.** The panel's
   "kiwix-tools are missing" notice, and the user guide, now point at a Troubleshooting
   section that names the recommended `fetch-runtime` script command first, with the manual

--- a/apps/desktop/src/main/ipc/registerRagIpc.ts
+++ b/apps/desktop/src/main/ipc/registerRagIpc.ts
@@ -48,6 +48,7 @@ import {
   isClassificationTrigger,
   type ClassifyCandidate
 } from '../services/analysis/classify'
+import { makeQueryExpander } from '../services/zim/expand'
 import { isAggregationShaped, routeQuestion } from '../services/analysis/router'
 import { buildListingAnswer } from '../services/analysis/listing-answer'
 import { getSettings } from '../services/settings'
@@ -769,7 +770,10 @@ export function registerRagIpc(ctx: AppContext): void {
             // Knowledge packs (ZIM wave): the query-time archive arm, only when this chat's
             // scope selected packs (opt-in per chat). makeArm returns null when the tools
             // are missing or nothing is retrievable; retrieve() isolates arm failures.
-            externalArm: ctx.zim?.makeArm(ctx.db, scope.packIds) ?? null,
+            // #340 L3-b (D-Z20, owner ruling 2026-09-07 "always"): the arm expands the question
+            // through the turn's own runtime — one short, bounded, grammar-constrained call per
+            // pack-scoped ask, before the search; any failure falls back to the plain pattern.
+            externalArm: ctx.zim?.makeArm(ctx.db, scope.packIds, { expand: makeQueryExpander(runtime) }) ?? null,
             // The turn's skill: its fence rides in the grounded user turn; the assistant row is
             // stamped only when the fence fit AND chunks were found (no-context ⇒ NULL).
             skill,

--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -1,7 +1,8 @@
 import type { KnowledgePackOutcome } from '../../../shared/types'
 import type { ExternalRetrievalOutput, RetrievedChunk } from '../rag'
 import { CHUNK_DEFAULTS, chunkSegments } from '../ingestion/chunker'
-import { fetchArticleHtml, searchPack, searchPackTotal } from './client'
+import { fetchArticleHtml, searchPack, searchPackTotal, suggestTitles, type KiwixSearchHit } from './client'
+import type { QueryExpander } from './expand'
 import { zimArticleToSegmentsAsync } from './html'
 import { DF_PROBE_MAX_TERMS, narrowByFrequency, searchPattern } from './query-rewrite'
 
@@ -65,6 +66,24 @@ export const EXTERNAL_RETRIEVAL_DEADLINE_MS = 20_000
  * `PACK_SEARCH_CONCURRENCY`, so probes get a short budget of their own instead.
  */
 export const DF_PROBE_TIMEOUT_MS = 3_000
+/**
+ * #340 L3-b (D-Z20): how many articles the EXPANSION may add per pack on top of the plain
+ * search's `ARTICLES_PER_PACK` — the title-index hit and the concept query's top hit. NEW
+ * constants; `ARTICLES_PER_PACK` keeps its value and its role (the plain search's bound). The
+ * expansion's articles are fetched FIRST so the plain cap can never starve them, and the pack
+ * quota still bounds the total.
+ */
+export const EXPANSION_ARTICLES_PER_PACK = 2
+/** How many title-index rows the expansion asks `/suggest` for. */
+export const EXPANSION_TITLE_ROWS = 3
+/**
+ * Chunks kept from a LIST article (`Liste der …`, `List of …`), instead of `CHUNKS_PER_ARTICLE`:
+ * the name rows of a list carry none of the question's words, so the overlap picker would keep
+ * only the intro and trim exactly the rows a "which … are the largest" question needs. The
+ * reranker still scores every chunk against the original question.
+ */
+export const LIST_ARTICLE_CHUNKS = 8
+const LIST_TITLE_RE = /^(Liste |List of )/
 
 export interface ArmPack {
   /** knowledge_packs.id (ZIM UUID) — the books.id search filter. */
@@ -89,6 +108,13 @@ export interface CollectPackCandidatesOptions {
    * Production never sets it.
    */
   articleTimeoutMs?: number
+  /**
+   * #340 L3-b (D-Z20): the ask's query expander — ONE local-model call per ask, before any pack
+   * is searched; its concepts feed one extra `/search` and its list title one `/suggest` per
+   * pack, whose articles are fetched in ADDITION to the plain search's. Absent or resolving null
+   * ⇒ the arm runs exactly as before. Its abort is the ask's abort (rethrown).
+   */
+  expand?: QueryExpander
 }
 
 /** One pack's produced candidates, in the pack's own rank order (search hit order). */
@@ -214,6 +240,75 @@ export async function collectPackCandidates(
   //      answered honestly at zero, so the pack stays `searched` with 0 found rather than
   //      `search-failed` (`docs/rag-design.md` §17 D-Z18 amendment).
   const rewrite = searchPattern(question)
+
+  // #340 L3-b (D-Z20): ONE model call per ask, before any pack is searched, under the same
+  // signal. Null (no runtime, a non-JSON reply, the time bound, any failure) ⇒ the plain arm;
+  // the ask's own abort propagates like every other cancellation.
+  let expansion: Awaited<ReturnType<QueryExpander>> = null
+  if (opts.expand) {
+    try {
+      expansion = await opts.expand(question, signal)
+    } catch (err) {
+      if (aborted()) throw err
+      expansion = null
+    }
+  }
+
+  /**
+   * The expansion's own hits for one pack, in fetch order: the title index first (the exact
+   * list article, when the model named one), then the concept query's hits. Each source fails
+   * soft on its own (the other source and the plain search are unaffected); an abort is the
+   * caller's to classify. Only hits the plain search did NOT already return are kept.
+   */
+  async function expansionHits(pack: ArmPack, plain: readonly KiwixSearchHit[]): Promise<KiwixSearchHit[]> {
+    if (!expansion) return []
+    const seen = new Set(plain.map((h) => h.articlePath))
+    const out: KiwixSearchHit[] = []
+    const add = (rows: KiwixSearchHit[]): void => {
+      for (const row of rows) {
+        if (seen.has(row.articlePath)) continue
+        seen.add(row.articlePath)
+        out.push(row)
+      }
+    }
+    const servedName = names?.get(pack.id)
+    if (expansion.listTitle !== null && servedName !== undefined) {
+      try {
+        let rows = await suggestTitles(port, servedName, expansion.listTitle, EXPANSION_TITLE_ROWS, signal)
+        // The title index is PREFIX-only (R-6): a model title one word too long or inflected at
+        // its end ("… nach CO2-Emissionen" against "… nach CO2-Emission pro Kopf", measured
+        // 2026-09-07) matches nothing, so one shorter prefix — the title minus its last word —
+        // is tried once when the full title found nothing. One extra request, never more.
+        const words = expansion.listTitle.split(' ')
+        if (rows.length === 0 && words.length >= 3) {
+          // The shorter prefix is broader, so its rows are RANKED by how much of the dropped
+          // word they carry ("… nach Pro-Kopf-Emissionen" → the "… pro Kopf" row before "…
+          // nach Waldfläche"); a row sharing nothing keeps its index order, never dropped.
+          const tail = words[words.length - 1]!.toLowerCase().split('-').filter((t) => t.length >= 3)
+          const score = (title: string): number => {
+            const lower = title.toLowerCase()
+            return tail.filter((t) => lower.includes(t)).length
+          }
+          rows = (await suggestTitles(port, servedName, words.slice(0, -1).join(' '), EXPANSION_TITLE_ROWS * 2, signal))
+            .map((row, index) => ({ row, index, score: score(row.title) }))
+            .sort((a, b) => b.score - a.score || a.index - b.index)
+            .map((r) => r.row)
+        }
+        add(rows)
+      } catch (err) {
+        if (aborted()) throw err
+      }
+    }
+    if (expansion.concepts.length > 0) {
+      try {
+        add(await searchPack(port, pack.id, expansion.concepts.join(' '), ARTICLES_PER_PACK, signal))
+      } catch (err) {
+        if (aborted()) throw err
+      }
+    }
+    return out
+  }
+
   async function runPack(item: PackWork): Promise<void> {
     const { pack } = item
     let hits
@@ -259,13 +354,26 @@ export async function collectPackCandidates(
         }
       }
     }
+    // #340 L3-b: the expansion's articles come FIRST and count against their own small cap, so
+    // the plain search's `ARTICLES_PER_PACK` can never starve the one list article the whole
+    // stage exists to reach; the plain hits follow, bounded exactly as before.
+    let extra: KiwixSearchHit[] = []
+    try {
+      extra = await expansionHits(pack, hits)
+    } catch (err) {
+      if (aborted()) return noteAbort(err)
+    }
+    const queue: Array<{ hit: KiwixSearchHit; fromExpansion: boolean }> = [
+      ...extra.slice(0, EXPANSION_ARTICLES_PER_PACK).map((hit) => ({ hit, fromExpansion: true })),
+      ...hits.map((hit) => ({ hit, fromExpansion: false }))
+    ]
     let attempted = 0
     let read = 0
-    for (const hit of hits) {
+    for (const { hit, fromExpansion } of queue) {
       // Article requests are DERIVED FROM NEED (plan §9.21 (c)3): once the pack holds its
       // provisional quota, the remaining hits are not fetched at all.
       if (item.candidates.length >= item.quota) break
-      if (attempted >= ARTICLES_PER_PACK) break
+      if (!fromExpansion && attempted >= ARTICLES_PER_PACK) break
       // The published serving map (`Published.names`, #301 P3b/L4) is the route authority. A
       // hit whose parsed `urlId` is not the name this pack is served under is SKIPPED —
       // defensive within one generation: the search was filtered by `books.id`, so a
@@ -273,7 +381,7 @@ export async function collectPackCandidates(
       // fetching it would label another archive's text with this pack's title.
       const expected = names?.get(pack.id)
       if (expected !== undefined && hit.urlId !== expected) continue
-      attempted++
+      if (!fromExpansion) attempted++
       let html: string | null
       try {
         html = await fetchArticleHtml(port, expected ?? hit.urlId, hit.articlePath, signal, {
@@ -297,10 +405,13 @@ export async function collectPackCandidates(
         continue
       }
       const chunks = chunkSegments(article.segments, CHUNK_DEFAULTS)
+      const title = article.title ?? hit.title
+      // A LIST article keeps more chunks (D-Z20): its name rows never overlap the question.
+      const keep = LIST_TITLE_RE.test(title) ? LIST_ARTICLE_CHUNKS : CHUNKS_PER_ARTICLE
       const scored = chunks
         .map((c, i) => ({ c, i, overlap: overlapScore(c.text, terms) }))
         .sort((a, b) => b.overlap - a.overlap || a.i - b.i)
-        .slice(0, CHUNKS_PER_ARTICLE)
+        .slice(0, keep)
       for (const { c, i, overlap } of scored) {
         item.candidates.push({
           chunkId: `zim:${pack.id}:${hit.articlePath}#${i}`,

--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -249,7 +249,12 @@ export async function collectPackCandidates(
     try {
       expansion = await opts.expand(question, signal)
     } catch (err) {
-      if (aborted()) throw err
+      // The expander cannot tell the two aborts apart, so the arm does it here (review finding,
+      // 2026-09-07): the ASK's cancellation is rethrown like every other cancellation; the per-ask
+      // DEADLINE elapsing mid-expansion degrades — no expansion, the workers no-op under the
+      // fired signal, and every pack settles `deadline` exactly as it did before this stage.
+      const cancelled = opts.askSignal ? opts.askSignal.aborted : aborted()
+      if (cancelled) throw err
       expansion = null
     }
   }
@@ -274,7 +279,10 @@ export async function collectPackCandidates(
     const servedName = names?.get(pack.id)
     if (expansion.listTitle !== null && servedName !== undefined) {
       try {
-        let rows = await suggestTitles(port, servedName, expansion.listTitle, EXPANSION_TITLE_ROWS, signal)
+        // A title lookup is one small JSON: it gets the probe budget (`DF_PROBE_TIMEOUT_MS`), not
+        // the client's 15 s default — the same argument as the #353 probes.
+        const lookup = { timeoutMs: DF_PROBE_TIMEOUT_MS }
+        let rows = await suggestTitles(port, servedName, expansion.listTitle, EXPANSION_TITLE_ROWS, signal, lookup)
         // The title index is PREFIX-only (R-6): a model title one word too long or inflected at
         // its end ("… nach CO2-Emissionen" against "… nach CO2-Emission pro Kopf", measured
         // 2026-09-07) matches nothing, so one shorter prefix — the title minus its last word —
@@ -289,7 +297,7 @@ export async function collectPackCandidates(
             const lower = title.toLowerCase()
             return tail.filter((t) => lower.includes(t)).length
           }
-          rows = (await suggestTitles(port, servedName, words.slice(0, -1).join(' '), EXPANSION_TITLE_ROWS * 2, signal))
+          rows = (await suggestTitles(port, servedName, words.slice(0, -1).join(' '), EXPANSION_TITLE_ROWS * 2, signal, lookup))
             .map((row, index) => ({ row, index, score: score(row.title) }))
             .sort((a, b) => b.score - a.score || a.index - b.index)
             .map((r) => r.row)
@@ -367,6 +375,12 @@ export async function collectPackCandidates(
       ...extra.slice(0, EXPANSION_ARTICLES_PER_PACK).map((hit) => ({ hit, fromExpansion: true })),
       ...hits.map((hit) => ({ hit, fromExpansion: false }))
     ]
+    // The expansion's chunks take at most HALF the pack's quota (review finding, 2026-09-07):
+    // on a multi-pack ask the quota is small (12 for two packs, 8 for three), and one list
+    // article at `LIST_ARTICLE_CHUNKS` fetched first would otherwise fill it before a single
+    // plain hit was read. Half keeps the plain search's hits in every ask.
+    const expansionCap = Math.ceil(item.quota / 2)
+    let expansionChunks = 0
     let attempted = 0
     let read = 0
     for (const { hit, fromExpansion } of queue) {
@@ -374,6 +388,7 @@ export async function collectPackCandidates(
       // provisional quota, the remaining hits are not fetched at all.
       if (item.candidates.length >= item.quota) break
       if (!fromExpansion && attempted >= ARTICLES_PER_PACK) break
+      if (fromExpansion && expansionChunks >= expansionCap) continue
       // The published serving map (`Published.names`, #301 P3b/L4) is the route authority. A
       // hit whose parsed `urlId` is not the name this pack is served under is SKIPPED —
       // defensive within one generation: the search was filtered by `books.id`, so a
@@ -392,7 +407,9 @@ export async function collectPackCandidates(
         continue
       }
       if (html === null) continue // 404: the entry vanished between search and fetch
-      read++
+      // `attempted`/`read` describe the PLAIN hits only, so the `read-failed` verdict below keeps
+      // its meaning ("the pack's search hits were unreadable") whatever the expansion read.
+      if (!fromExpansion) read++
       // Cooperatively sliced (P1b): the main thread is handed back between slices and the
       // signal is honoured at every slice boundary. An abort here is the ask's or the
       // deadline's and is classified below; any other converter failure costs this ONE
@@ -407,11 +424,13 @@ export async function collectPackCandidates(
       const chunks = chunkSegments(article.segments, CHUNK_DEFAULTS)
       const title = article.title ?? hit.title
       // A LIST article keeps more chunks (D-Z20): its name rows never overlap the question.
-      const keep = LIST_TITLE_RE.test(title) ? LIST_ARTICLE_CHUNKS : CHUNKS_PER_ARTICLE
+      const wanted = LIST_TITLE_RE.test(title) ? LIST_ARTICLE_CHUNKS : CHUNKS_PER_ARTICLE
+      const keep = fromExpansion ? Math.min(wanted, expansionCap - expansionChunks) : wanted
       const scored = chunks
         .map((c, i) => ({ c, i, overlap: overlapScore(c.text, terms) }))
         .sort((a, b) => b.overlap - a.overlap || a.i - b.i)
         .slice(0, keep)
+      if (fromExpansion) expansionChunks += scored.length
       for (const { c, i, overlap } of scored) {
         item.candidates.push({
           chunkId: `zim:${pack.id}:${hit.articlePath}#${i}`,

--- a/apps/desktop/src/main/services/zim/client.ts
+++ b/apps/desktop/src/main/services/zim/client.ts
@@ -337,6 +337,52 @@ export async function probeSearchable(
   return hasPattern ? 'yes' : 'no'
 }
 
+/**
+ * Title-index lookup (#340 L3-b, D-Z20): the `/suggest` entries whose title starts with `term`,
+ * as search-hit-shaped rows the arm can fetch. On the pinned kiwix-serve the route answers
+ * `[{ value, label, kind: "path", path }]` — `value` is the article title, `path` the SAME entry
+ * key a search hit's link carries, so `/raw/<name>/content/<path>` serves it directly (verified
+ * on the real server 2026-09-07); the synthetic `kind: "pattern"` entry (the capability probe's
+ * signal) is skipped. Prefix-only and case-/diacritic-sensitive by nature (residual R-6) — that is
+ * why the arm only ever calls it with a title the expansion synthesised, never with the question.
+ * Same failure contract as `searchPack`: throws on a non-200 status or a timeout; a body that is
+ * not a JSON array yields no rows.
+ */
+export async function suggestTitles(
+  port: number,
+  name: string,
+  term: string,
+  count: number,
+  signal?: AbortSignal,
+  opts: { timeoutMs?: number } = {}
+): Promise<KiwixSearchHit[]> {
+  const path =
+    `/suggest?content=${encodeURIComponent(name)}` +
+    `&term=${encodeURIComponent(term)}&count=${count}`
+  const res = await kiwixGet(port, path, { signal, timeoutMs: opts.timeoutMs })
+  if (res.status !== 200) {
+    throw new Error(`kiwix-serve suggest failed (HTTP ${res.status})`)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(res.body)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const hits: KiwixSearchHit[] = []
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const e = entry as { kind?: unknown; value?: unknown; path?: unknown }
+    if (e.kind !== 'path' || typeof e.value !== 'string' || typeof e.path !== 'string') continue
+    const title = decodeEntities(e.value).trim()
+    const articlePath = safeDecodeURIComponent(e.path)
+    if (title === '' || articlePath === '') continue
+    hits.push({ title, urlId: name, articlePath, wordCount: null })
+  }
+  return hits
+}
+
 // ---- /raw article fetch --------------------------------------------------------
 
 /** The documented length bound for an archive entry key (#301 P5, finding L5, plan §9.19 (b)):

--- a/apps/desktop/src/main/services/zim/expand.ts
+++ b/apps/desktop/src/main/services/zim/expand.ts
@@ -1,0 +1,195 @@
+import type { JsonSchema } from '../../../shared/types'
+import type { ChatMessage, ModelRuntime } from '../runtime'
+import { stripThinkBlocks } from '../chat'
+import { TOKEN_RE, isContentWord, searchPattern } from './query-rewrite'
+
+// The question → concept expansion for the knowledge-pack arm (#340 L3-b; rag-design §17 D-Z20).
+//
+// WHY. Xapian ANDs the question's words, and a list or superlative question ("Welche Länder
+// stoßen am meisten CO2 aus?") names none of the words the answering article is indexed under
+// ("Liste der Länder nach CO2-Emission"). Measured on the real climate pack (2026-09-06): the
+// stripped question found the list article in 2 of 6 such questions through the arm; a
+// concept-expanded query found it in 4 of 6; the title index asked with a synthesised "Liste …"
+// prefix in 6 of 6. The only thing on the drive that can write those words is the local chat
+// model, so — the owner's ruling of 2026-09-07, option (a) — EVERY pack-scoped ask spends one
+// short call on it before the search.
+//
+// WHAT. `makeQueryExpander(runtime)` returns a function the arm calls ONCE per ask (never per
+// pack): a two-message prompt, thinking off (`mode: 'fast'`), temperature 0, a hard output cap,
+// a grammar-constrained JSON reply (`responseSchema`, the D55 machinery the skill classifier
+// uses) and its own wall-clock bound INSIDE the arm's per-ask deadline. `parseExpansion` then
+// sanitises the reply: only tokens the rewrite itself would keep (no function or frame words),
+// nothing the plain pattern already carries, a term cap and a length cap; the list title trimmed
+// and capped. Every failure — no runtime, a reply that is not JSON (the mock runtime ignores the
+// schema, so mock/dev always exercises this path), a timeout, a runaway reply — resolves null and
+// the arm searches exactly as it did before this module existed. The ONE exception is the ask's
+// own cancellation, which is rethrown: a cancellation is never a fallback (#301 P4, T09).
+//
+// The expansion only ever ADDS candidates (arm.ts): the plain pattern still runs and its hits
+// are kept; the reranker and the prompt still see the original question.
+
+/** What the model contributed for one question. */
+export interface QueryExpansion {
+  /** Extra content words for ONE additional full-text search (joined with spaces). */
+  concepts: string[]
+  /** The title a list article answering the question would carry, for the title index. */
+  listTitle: string | null
+}
+
+/** One call per ask; resolves null on any failure except the ask's own abort (rethrown). */
+export type QueryExpander = (question: string, signal?: AbortSignal) => Promise<QueryExpansion | null>
+
+/**
+ * Wall-clock bound on the expansion (ms). It runs inside the arm's `EXTERNAL_RETRIEVAL_DEADLINE_MS`
+ * BEFORE any pack is searched, so past this bound the request is aborted and the plain search
+ * proceeds — one slow model must never eat the packs' whole budget. Measured 2026-09-07 with the
+ * default 4B chat model on a CPU (an i9-14900K, no graphics card): 2.7–4.0 s per call when the
+ * system prompt is prefilled from scratch, well under that once `cache_prompt` has kept the
+ * prefix across asks (the app runtime always sets it). Six seconds leaves the packs fourteen of
+ * the arm's twenty and still admits a first, uncached call on a slower processor.
+ */
+export const EXPAND_TIMEOUT_MS = 6_000
+/** Output-token budget: six short words plus a title plus JSON framing. */
+export const EXPAND_MAX_TOKENS = 96
+/** Concept terms kept from the reply, at most. */
+export const EXPAND_MAX_TERMS = 6
+/** Longest single concept term / list title kept (chars); anything longer is dropped, not cut. */
+export const EXPAND_MAX_TERM_CHARS = 40
+export const EXPAND_MAX_TITLE_CHARS = 80
+/** Defensive char cap over the token budget: a runtime that ignores `maxTokens` is cut off. */
+const OUTPUT_CHAR_CAP = EXPAND_MAX_TOKENS * 8
+
+export const EXPAND_RESPONSE_SCHEMA: JsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['concepts', 'listTitle'],
+  properties: {
+    concepts: { type: 'array', items: { type: 'string', maxLength: EXPAND_MAX_TERM_CHARS }, maxItems: EXPAND_MAX_TERMS },
+    listTitle: { type: 'string', maxLength: EXPAND_MAX_TITLE_CHARS }
+  }
+}
+
+/**
+ * The per-call messages. English instructions (the pinned chat models follow them in either
+ * language); the question is CONTENT and rides in the user turn only — it is never logged. The
+ * prompt describes the JSON shape as well as constraining it (llama.cpp's grammar guarantees the
+ * shape, the description improves the choice of words).
+ */
+export function buildExpansionMessages(question: string): ChatMessage[] {
+  return [
+    {
+      role: 'system',
+      content:
+        'You write search terms for the full-text index of an offline encyclopedia (Wikipedia). ' +
+        'The index finds an article only when EVERY term occurs in it, so choose words that appear ' +
+        'in the article that answers the question, in the language of the question. Reply with JSON ' +
+        'only: {"concepts": [...], "listTitle": "..."}. "concepts": up to six single words — the ' +
+        'topic and the things such an article is about (nouns, names, technical terms); never ' +
+        'question words, never sentences. "listTitle": when the question asks for a list, a ranking, ' +
+        'or the largest / most / highest / best-known items of a kind, the exact title a Wikipedia ' +
+        'LIST article about it would have, in the language of the question (a German question gets a ' +
+        'German title such as "Liste der Länder nach CO2-Emission", an English one "List of tallest ' +
+        'buildings"); otherwise an empty string.'
+    },
+    { role: 'user', content: question }
+  ]
+}
+
+/**
+ * Sanitise the model's reply against the plain pattern the arm will search anyway. Pure.
+ *   - `concepts`: tokenised by the rewrite's own token rule; a token is kept only when it is a
+ *     content word by the rewrite's lists, not already in the plain pattern (case-insensitive),
+ *     unique, and at most `EXPAND_MAX_TERM_CHARS` long; at most `EXPAND_MAX_TERMS` kept in order.
+ *   - `listTitle`: trimmed, must hold a letter and fit `EXPAND_MAX_TITLE_CHARS`, else null.
+ * Null when neither survives, when the text is not a JSON object, or on any other shape.
+ */
+export function parseExpansion(text: string, question: string): QueryExpansion | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripThinkBlocks(text).trim())
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null
+  const raw = parsed as { concepts?: unknown; listTitle?: unknown }
+  const plain = new Set(searchPattern(question).terms.map((t) => t.toLowerCase()))
+  const concepts: string[] = []
+  const seen = new Set<string>()
+  if (Array.isArray(raw.concepts)) {
+    for (const item of raw.concepts) {
+      if (typeof item !== 'string') continue
+      for (const m of item.matchAll(TOKEN_RE)) {
+        const token = m[0].replace(/-+$/, '')
+        const key = token.toLowerCase()
+        if (token === '' || token.length > EXPAND_MAX_TERM_CHARS) continue
+        if (!isContentWord(token) || plain.has(key) || seen.has(key)) continue
+        seen.add(key)
+        concepts.push(token)
+        if (concepts.length >= EXPAND_MAX_TERMS) break
+      }
+      if (concepts.length >= EXPAND_MAX_TERMS) break
+    }
+  }
+  let listTitle: string | null = null
+  if (typeof raw.listTitle === 'string') {
+    const title = raw.listTitle.replace(/\s+/g, ' ').trim()
+    if (title.length > 0 && title.length <= EXPAND_MAX_TITLE_CHARS && /\p{L}/u.test(title)) listTitle = title
+  }
+  if (concepts.length === 0 && listTitle === null) return null
+  return { concepts, listTitle }
+}
+
+/**
+ * Build the expander over the turn's runtime, or null when there is no runtime (the arm then
+ * skips the step entirely — zero model calls). Single-shot, never retried: a second call would
+ * double the cost of exactly the questions this is meant to keep cheap.
+ */
+export function makeQueryExpander(
+  runtime: ModelRuntime | null | undefined,
+  opts: { timeoutMs?: number } = {}
+): QueryExpander | null {
+  if (!runtime) return null
+  return async (question, signal) => {
+    if (signal?.aborted) throw abortError()
+    // A linked inner signal: aborts on the ask's abort AND on the wall-clock bound.
+    const inner = new AbortController()
+    const onOuterAbort = (): void => inner.abort()
+    signal?.addEventListener('abort', onOuterAbort)
+    const timer = setTimeout(() => inner.abort(), opts.timeoutMs ?? EXPAND_TIMEOUT_MS)
+    try {
+      let text = ''
+      const stream = runtime.chatStream(buildExpansionMessages(question), {
+        signal: inner.signal,
+        mode: 'fast',
+        maxTokens: EXPAND_MAX_TOKENS,
+        temperature: 0,
+        responseSchema: EXPAND_RESPONSE_SCHEMA,
+        responseSchemaName: 'pack_query_expansion'
+      })
+      for await (const token of stream) {
+        if (inner.signal.aborted) break
+        text += token
+        if (text.length > OUTPUT_CHAR_CAP) return null // a runaway reply is dropped, never accumulated
+      }
+      if (signal?.aborted) throw abortError() // the ASK was cancelled: never a fallback
+      if (inner.signal.aborted) return null // the time bound: the plain search proceeds
+      return parseExpansion(text, question)
+    } catch (err) {
+      if (signal?.aborted) throw isAbortLike(err) ? err : abortError()
+      return null // a dead runtime, a transport error, anything else: silent degrade
+    } finally {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onOuterAbort)
+    }
+  }
+}
+
+function isAbortLike(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError'
+}
+
+function abortError(): Error {
+  const err = new Error('The knowledge-pack expansion was cancelled')
+  err.name = 'AbortError'
+  return err
+}

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -14,6 +14,7 @@ import type { BinaryVerifyResult } from '../binary-verifier'
 import { combineSignals, type SpawnFn } from '../runtime/sidecar'
 import type { ExternalRetrievalArm, ExternalRetrievalOutput } from '../rag'
 import { EXTERNAL_RETRIEVAL_DEADLINE_MS, collectPackCandidates } from './arm'
+import type { QueryExpander } from './expand'
 import { fetchArticleHtml, probeSearchable } from './client'
 import { zimArticleToSegmentsAsync } from './html'
 import {
@@ -1383,7 +1384,9 @@ export class ZimService {
     db: Db,
     packIds: readonly string[] | null | undefined,
     question: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    /** #340 L3-b (D-Z20): the ask's query expander (one local-model call per ask), or none. */
+    expand?: QueryExpander
   ): Promise<ExternalRetrievalOutput> {
     const ids = [...new Set(packIds ?? [])]
     if (ids.length === 0) return { candidates: [], outcomes: [] }
@@ -1445,7 +1448,7 @@ export class ZimService {
           question,
           deadline.signal,
           library.names,
-          { askSignal: op.signal, articleTimeoutMs: this.deps.articleTimeoutMs }
+          { askSignal: op.signal, articleTimeoutMs: this.deps.articleTimeoutMs, expand }
         )
         return { candidates: produced.candidates, outcomes: [...outcomes, ...produced.outcomes] }
       })
@@ -1501,9 +1504,13 @@ export class ZimService {
    * `file-missing` / `disabled` / … without waking a sidecar, so the honest arm costs no more than
    * the null did.
    */
-  makeArm(db: Db, packIds: readonly string[] | null | undefined): ExternalRetrievalArm | null {
+  makeArm(
+    db: Db,
+    packIds: readonly string[] | null | undefined,
+    opts: { expand?: QueryExpander | null } = {}
+  ): ExternalRetrievalArm | null {
     if (!packIds || packIds.length === 0) return null
-    return (question, signal) => this.runArm(db, packIds, question, signal)
+    return (question, signal) => this.runArm(db, packIds, question, signal, opts.expand ?? undefined)
   }
 
   /**

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -1410,6 +1410,13 @@ export class ZimService {
       op.signal,
       this.deps.externalDeadlineMs ?? EXTERNAL_RETRIEVAL_DEADLINE_MS
     )
+    // #340 L3-b (D-Z20): ONE model call per ask, even across the guard's single admitted retry —
+    // the callback below is re-entered once when a discarded attempt is retried, and the
+    // expansion must not be paid for twice out of the same deadline. Memoised on first use.
+    let expansionOnce: ReturnType<QueryExpander> | null = null
+    const expandOnce: QueryExpander | undefined = expand
+      ? (q, s) => (expansionOnce ??= expand(q, s))
+      : undefined
     try {
       op.assert()
       // The search + fetch batch is ONE guard window (#301 P5, finding M1; plan §9.19 (a)3):
@@ -1448,7 +1455,7 @@ export class ZimService {
           question,
           deadline.signal,
           library.names,
-          { askSignal: op.signal, articleTimeoutMs: this.deps.articleTimeoutMs, expand }
+          { askSignal: op.signal, articleTimeoutMs: this.deps.articleTimeoutMs, expand: expandOnce }
         )
         return { candidates: produced.candidates, outcomes: [...outcomes, ...produced.outcomes] }
       })

--- a/apps/desktop/src/main/services/zim/query-rewrite.ts
+++ b/apps/desktop/src/main/services/zim/query-rewrite.ts
@@ -98,7 +98,15 @@ export interface SearchRewrite {
 }
 
 /** Tokens: letters/digits with inner hyphens (`CO2-Konzentration`), no trailing hyphen. */
-const TOKEN_RE = /[\p{L}\p{N}][\p{L}\p{N}-]*/gu
+export const TOKEN_RE = /[\p{L}\p{N}][\p{L}\p{N}-]*/gu
+
+/** True for a token the rewrite would KEEP — neither a function word nor a question-frame word.
+ *  Shared with the #340 L3-b expansion (`expand.ts`), which sanitises the model's words with the
+ *  same lists so an expansion can never re-introduce a word the plain pattern strips. */
+export function isContentWord(token: string): boolean {
+  const key = token.toLowerCase()
+  return !STOP_WORDS.has(key) && !FRAME_WORDS.has(key)
+}
 
 export function searchPattern(question: string): SearchRewrite {
   const raw = question.trim()

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -18,6 +18,9 @@ import { DEFAULT_SETTINGS } from '../../src/shared/types'
 import {
   ARTICLES_PER_PACK,
   DF_PROBE_TIMEOUT_MS,
+  CHUNKS_PER_ARTICLE,
+  EXPANSION_ARTICLES_PER_PACK,
+  LIST_ARTICLE_CHUNKS,
   MAX_EXTERNAL_CANDIDATES,
   allocateCandidates,
   collectPackCandidates,
@@ -120,6 +123,24 @@ async function waitUntilTrue(cond: () => boolean, rounds = 400): Promise<boolean
 const stallOnce = new Set<string>()
 /** Every article title the fake sidecar was asked for over `/raw`, in order. */
 const rawReads: string[] = []
+/** #340 L3-b: every `/search` pattern the `pack-expand` book received, and every `/suggest` call. */
+const expandSearches: string[] = []
+const suggestRequests: Array<{ content: string; term: string }> = []
+const LIST_ARTICLE = 'Liste der größten Kohlekraftwerke der Erde'
+/** A list article long enough to chunk into more than `CHUNKS_PER_ARTICLE` pieces (500-token chunks). */
+function listArticleHtml(): string {
+  const row = (n: number): string =>
+    `Kraftwerk Nummer ${n} steht in einem Land mit vielen Kohlevorkommen und liefert ` +
+    'elektrische Energie fuer eine grosse Region mit mehreren Millionen Einwohnern, die ' +
+    'ueberwiegend in Staedten und Industriegebieten leben und deren Bedarf stetig waechst. '
+  const sections: Array<[string, string]> = []
+  for (let sIdx = 0; sIdx < 8; sIdx++) {
+    let text = ''
+    for (let r = 0; r < 12; r++) text += row(sIdx * 12 + r + 1)
+    sections.push([`Rang ${sIdx * 12 + 1} bis ${sIdx * 12 + 12}`, text])
+  }
+  return articleHtml(LIST_ARTICLE, sections)
+}
 
 function searchXml(bookUrlId: string, titles: string[]): string {
   const items = titles
@@ -202,6 +223,21 @@ beforeAll(async () => {
         res.end(searchXml(`book-${book}`, []))
         return
       }
+      // #340 L3-b (D-Z20): the plain pattern finds two ordinary articles; the expansion's
+      // CONCEPT query finds a third (plus one the plain search already had — never fetched twice);
+      // a three-hit concept query proves the `EXPANSION_ARTICLES_PER_PACK` cap.
+      if (book === 'pack-expand') {
+        expandSearches.push(pattern)
+        const titles =
+          pattern === 'Konzept Suche'
+            ? ['Kraftwerk Tuoketuo', 'Kohlekraftwerk']
+            : pattern === 'Drei Treffer'
+              ? ['Kraftwerk A', 'Kraftwerk B', 'Kraftwerk C']
+              : ['Kohlekraftwerk', 'Kohleausstieg']
+        res.writeHead(200, { 'content-type': 'application/xml' })
+        res.end(searchXml(`book-${book}`, titles))
+        return
+      }
       const titles =
         book === 'pack-climate'
           ? ['Treibhausgas', 'Treibhauspotential']
@@ -220,9 +256,61 @@ beforeAll(async () => {
       res.end(searchXml(`book-${book}`, titles))
       return
     }
+    // #340 L3-b (D-Z20): the title index the expansion's list title is looked up in — the real
+    // kiwix-serve shape (`value`, an HTML-bolded `label`, `kind: "path"`, the entry `path`),
+    // plus the synthetic `kind: "pattern"` row the capability probe reads, which must be skipped.
+    if (url.pathname === '/suggest') {
+      const content = url.searchParams.get('content') ?? ''
+      const term = url.searchParams.get('term') ?? ''
+      suggestRequests.push({ content, term })
+      if (term === 'Liste kaputt') {
+        res.writeHead(500)
+        res.end('boom')
+        return
+      }
+      // A title one word too long for the prefix index: nothing — the arm retries one word shorter.
+      if (term === 'Liste der größten Kohlekraftwerke der Erde') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end('[]')
+        return
+      }
+      // The one-word-shorter fallback is broader: two rows, the wrong one first — the arm ranks
+      // them by the dropped word ('Erde') so the right list article is fetched first.
+      if (term === 'Liste der größten Kohlekraftwerke der') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify([
+          { value: 'Liste der größten Kohlekraftwerke Europas', kind: 'path', path: 'Liste_der_größten_Kohlekraftwerke_Europas' },
+          { value: LIST_ARTICLE, kind: 'path', path: LIST_ARTICLE.replace(/ /g, '_') }
+        ]))
+        return
+      }
+      if (term === 'Liste der größten Kohlekraftwerke Welt') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end('[]')
+        return
+      }
+      if (content === 'book-pack-expand' && term.startsWith('Liste der größten')) {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify([
+            { value: LIST_ARTICLE, label: '&lt;b&gt;Liste&lt;/b&gt; der größten Kohlekraftwerke der Erde', kind: 'path', path: LIST_ARTICLE.replace(/ /g, '_') },
+            { value: term, label: term, kind: 'pattern' }
+          ])
+        )
+        return
+      }
+      res.writeHead(404)
+      res.end()
+      return
+    }
     if (url.pathname.startsWith('/raw/')) {
       const article = decodeURIComponent(url.pathname.split('/content/')[1] ?? '').replace(/_/g, ' ')
       rawReads.push(article)
+      if (article === LIST_ARTICLE) {
+        res.writeHead(200, { 'content-type': 'text/html' })
+        res.end(listArticleHtml())
+        return
+      }
       // One article whose fetch fails: the arm must skip THAT HIT and keep the others.
       if (article === 'Kaputt') {
         res.writeHead(500)
@@ -890,5 +978,130 @@ describe('retrieve() with an external arm', () => {
     // The seam is optional in both spellings: an explicitly-absent arm is the same as none.
     const explicitlyAbsent = await retrieve(db, embedder, fixture.query, SETTINGS, null, null, undefined, null)
     expect(explicitlyAbsent).toEqual(fixture.result)
+  })
+})
+
+// ---- #340 L3-b (D-Z20): the query expansion through the local model ---------------------------
+describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
+  const packs = [{ id: 'pack-expand', title: 'Klimawandel von Wikipedia' }]
+  const names = new Map([['pack-expand', 'book-pack-expand']])
+  const QUESTION = 'Welche sind die größten Kohlekraftwerke der Welt?'
+  const EXPANSION = { concepts: ['Konzept', 'Suche'], listTitle: 'Liste der größten Kohlekraftwerke' }
+  const reset = (): void => {
+    rawReads.length = 0
+    expandSearches.length = 0
+    suggestRequests.length = 0
+  }
+  const plainReads = ['Kohlekraftwerk', 'Kohleausstieg']
+
+  it('#340 L3-b: the expansion runs ONCE per ask; its title-index and concept articles are fetched FIRST and in addition to the plain hits; a duplicate is fetched once; a list article keeps more chunks', async () => {
+    reset()
+    let calls = 0
+    const expand = async (q: string): Promise<typeof EXPANSION> => {
+      calls++
+      expect(q).toBe(QUESTION)
+      return EXPANSION
+    }
+    const { candidates, outcomes } = await collectPackCandidates(port, packs, QUESTION, undefined, names, { expand })
+    expect(calls).toBe(1)
+    expect(suggestRequests).toEqual([{ content: 'book-pack-expand', term: 'Liste der größten Kohlekraftwerke' }])
+    expect(expandSearches).toEqual(['größten Kohlekraftwerke Welt', 'Konzept Suche'])
+    // The list article (title index) and the concept hit come first; the plain hits follow
+    // exactly as before; 'Kohlekraftwerk' — in both lists — is read once.
+    expect(rawReads).toEqual([LIST_ARTICLE, 'Kraftwerk Tuoketuo', ...plainReads])
+    const list = candidates.filter((c) => c.sourceTitle === LIST_ARTICLE)
+    expect(list.length).toBeGreaterThan(CHUNKS_PER_ARTICLE)
+    expect(list.length).toBeLessThanOrEqual(LIST_ARTICLE_CHUNKS)
+    expect(candidates.filter((c) => c.sourceTitle === 'Kohlekraftwerk').length).toBeLessThanOrEqual(CHUNKS_PER_ARTICLE)
+    expect(outcomes).toEqual([
+      { packId: 'pack-expand', title: 'Klimawandel von Wikipedia', status: 'searched', reason: null, found: candidates.length, admitted: candidates.length }
+    ])
+  })
+
+  it('#340 L3-b: a null expansion, a throwing expander and no expander at all produce the SAME arm — no /suggest, no concept search, the plain reads', async () => {
+    reset()
+    const none = await collectPackCandidates(port, packs, QUESTION, undefined, names)
+    expect(rawReads).toEqual(plainReads)
+    expect(suggestRequests).toEqual([])
+    expect(expandSearches).toEqual(['größten Kohlekraftwerke Welt'])
+    reset()
+    const nulled = await collectPackCandidates(port, packs, QUESTION, undefined, names, { expand: async () => null })
+    expect(rawReads).toEqual(plainReads)
+    expect(suggestRequests).toEqual([])
+    expect(nulled).toEqual(none)
+    reset()
+    const threw = await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+      expand: async () => {
+        throw new Error('runtime exploded')
+      }
+    })
+    expect(rawReads).toEqual(plainReads)
+    expect(threw).toEqual(none)
+  })
+
+  it('#340 L3-b: the ask cancelled while the expansion runs REJECTS with the abort — nothing is searched, never an empty list', async () => {
+    reset()
+    const ctrl = new AbortController()
+    const expand = async (_q: string, signal?: AbortSignal): Promise<null> => {
+      ctrl.abort()
+      const err = new Error('cancelled')
+      err.name = 'AbortError'
+      expect(signal?.aborted).toBe(true)
+      throw err
+    }
+    await expect(
+      collectPackCandidates(port, packs, QUESTION, ctrl.signal, names, { expand })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(expandSearches).toEqual([])
+    expect(rawReads).toEqual([])
+  })
+
+  it('#340 L3-b: a list title the prefix index does not know is retried once, one word shorter', async () => {
+    reset()
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+      expand: async () => ({ concepts: [], listTitle: 'Liste der größten Kohlekraftwerke Welt' })
+    })
+    expect(suggestRequests).toEqual([
+      { content: 'book-pack-expand', term: 'Liste der größten Kohlekraftwerke Welt' },
+      { content: 'book-pack-expand', term: 'Liste der größten Kohlekraftwerke' }
+    ])
+    expect(rawReads).toEqual([LIST_ARTICLE, ...plainReads])
+  })
+
+  it('#340 L3-b: the shorter fallback prefix is broader — its rows are ranked by the dropped word, the right list article first', async () => {
+    reset()
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+      expand: async () => ({ concepts: [], listTitle: 'Liste der größten Kohlekraftwerke der Erde' })
+    })
+    expect(suggestRequests.map((r) => r.term)).toEqual(['Liste der größten Kohlekraftwerke der Erde', 'Liste der größten Kohlekraftwerke der'])
+    // Both fallback rows fit the expansion cap; the 'Erde' row is fetched before 'Europas'.
+    expect(rawReads).toEqual([LIST_ARTICLE, 'Liste der größten Kohlekraftwerke Europas', ...plainReads])
+  })
+
+  it('#340 L3-b: a failing title index costs only the title hit — the concept hit and the plain hits still arrive', async () => {
+    reset()
+    const { candidates } = await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+      expand: async () => ({ concepts: ['Konzept', 'Suche'], listTitle: 'Liste kaputt' })
+    })
+    expect(suggestRequests).toEqual([{ content: 'book-pack-expand', term: 'Liste kaputt' }])
+    expect(rawReads).toEqual(['Kraftwerk Tuoketuo', ...plainReads])
+    expect(candidates.some((c) => c.sourceTitle === 'Kraftwerk Tuoketuo')).toBe(true)
+  })
+
+  it('#340 L3-b: the expansion adds at most EXPANSION_ARTICLES_PER_PACK articles, the plain ARTICLES_PER_PACK bound is untouched, and without a served name the title index is not asked', async () => {
+    reset()
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+      expand: async () => ({ concepts: ['Drei', 'Treffer'], listTitle: 'Liste der größten Kohlekraftwerke' })
+    })
+    // list article + 'Kraftwerk A' = the two expansion fetches; B and C are never read; the
+    // plain hits follow in full.
+    expect(rawReads).toEqual([LIST_ARTICLE, 'Kraftwerk A', ...plainReads])
+    expect(EXPANSION_ARTICLES_PER_PACK).toBe(2)
+    reset()
+    // No served-name map (a caller without the published library): the title index needs the
+    // served name, so only the concept query runs.
+    await collectPackCandidates(port, packs, QUESTION, undefined, undefined, { expand: async () => EXPANSION })
+    expect(suggestRequests).toEqual([])
+    expect(rawReads).toEqual(['Kraftwerk Tuoketuo', ...plainReads])
   })
 })

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -1010,12 +1010,14 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
     // exactly as before; 'Kohlekraftwerk' — in both lists — is read once.
     expect(rawReads).toEqual([LIST_ARTICLE, 'Kraftwerk Tuoketuo', ...plainReads])
     const list = candidates.filter((c) => c.sourceTitle === LIST_ARTICLE)
-    expect(list.length).toBeGreaterThan(CHUNKS_PER_ARTICLE)
-    expect(list.length).toBeLessThanOrEqual(LIST_ARTICLE_CHUNKS)
+    // The fixture list article chunks into more than LIST_ARTICLE_CHUNKS pieces, so the count
+    // pins the constant itself (one pack: the quota's half, 12, does not bind).
+    expect(list.length).toBe(LIST_ARTICLE_CHUNKS)
     expect(candidates.filter((c) => c.sourceTitle === 'Kohlekraftwerk').length).toBeLessThanOrEqual(CHUNKS_PER_ARTICLE)
-    expect(outcomes).toEqual([
-      { packId: 'pack-expand', title: 'Klimawandel von Wikipedia', status: 'searched', reason: null, found: candidates.length, admitted: candidates.length }
-    ])
+    expect(candidates.filter((c) => c.sourceTitle === 'Kohleausstieg').length).toBeGreaterThan(0)
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]).toMatchObject({ packId: 'pack-expand', status: 'searched', reason: null })
+    expect(outcomes[0]!.found).toBeGreaterThan(LIST_ARTICLE_CHUNKS)
   })
 
   it('#340 L3-b: a null expansion, a throwing expander and no expander at all produce the SAME arm — no /suggest, no concept search, the plain reads', async () => {
@@ -1103,5 +1105,54 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
     await collectPackCandidates(port, packs, QUESTION, undefined, undefined, { expand: async () => EXPANSION })
     expect(suggestRequests).toEqual([])
     expect(rawReads).toEqual(['Kraftwerk Tuoketuo', ...plainReads])
+  })
+
+  it('#340 L3-b: the per-ask DEADLINE elapsing during the expansion is an outcome, never a cancellation — every pack settles deadline, nothing is searched', async () => {
+    reset()
+    const deadline = new AbortController()
+    const ask = new AbortController() // the ask itself is NOT cancelled
+    const expand = async (_q: string, signal?: AbortSignal): Promise<null> => {
+      deadline.abort() // the arm's combined deadline fires while the model is still thinking
+      expect(signal?.aborted).toBe(true)
+      const err = new Error('deadline')
+      err.name = 'AbortError'
+      throw err
+    }
+    const { candidates, outcomes } = await collectPackCandidates(
+      port,
+      [...packs, { id: 'pack-climate', title: 'Klimawandel' }],
+      QUESTION,
+      deadline.signal,
+      names,
+      { expand, askSignal: ask.signal }
+    )
+    expect(candidates).toEqual([])
+    expect(outcomes.map((o) => [o.packId, o.status, o.reason])).toEqual([
+      ['pack-expand', 'skipped', 'deadline'],
+      ['pack-climate', 'skipped', 'deadline']
+    ])
+    expect(expandSearches).toEqual([])
+    expect(rawReads).toEqual([])
+  })
+
+  it('#340 L3-b: on a three-pack ask the expansion takes at most half the pack quota, so the plain hits are still read', async () => {
+    reset()
+    const three = [...packs, { id: 'pack-climate', title: 'Klimawandel' }, { id: 'pack-mixed', title: 'Gemischt' }]
+    const { candidates, outcomes } = await collectPackCandidates(port, three, QUESTION, undefined, names, {
+      expand: async () => EXPANSION
+    })
+    // quota per pack = floor(24 / 3) = 8 → the expansion may hold 4 of it: the list article is
+    // trimmed to 4 chunks and the concept hit is NOT fetched (the cap is reached); the other
+    // half of the quota goes to the plain hits, exactly as the quota always bounded them (the
+    // first plain article fills it here — before this stage two plain articles fitted, so a
+    // multi-pack ask trades one plain article for the expansion's list article).
+    const quota = packQuota(0, 3)
+    expect(quota).toBe(8)
+    const mine = rawReads.filter((r) => [LIST_ARTICLE, 'Kraftwerk Tuoketuo', ...plainReads].includes(r))
+    expect(mine).toEqual([LIST_ARTICLE, 'Kohlekraftwerk'])
+    const list = candidates.filter((c) => c.sourceTitle === LIST_ARTICLE)
+    expect(list.length).toBeLessThanOrEqual(Math.ceil(quota / 2))
+    expect(candidates.some((c) => c.sourceTitle === 'Kohlekraftwerk' || c.sourceTitle === 'Kohleausstieg')).toBe(true)
+    expect(outcomes.find((o) => o.packId === 'pack-expand')?.status).toBe('searched')
   })
 })

--- a/apps/desktop/tests/manual/zim-real.test.ts
+++ b/apps/desktop/tests/manual/zim-real.test.ts
@@ -8,6 +8,10 @@ import { searchPackTotal } from '../../src/main/services/zim/client'
 import { readZimHeader, servingNameFor } from '../../src/main/services/zim/identity'
 import { kiwixServeBinaryName, kiwixToolsDir } from '../../src/main/services/zim/tools'
 import { zimSmokeEnv } from '../helpers/zim-smoke-env'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { createServer } from 'node:net'
+import { makeQueryExpander, type QueryExpander } from '../../src/main/services/zim/expand'
+import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
 
 // REAL kiwix-tools + REAL ZIM end-to-end (manual smoke, the HILBERTRAUM_* convention):
 // registration via real kiwix-manage, the real kiwix-serve sidecar over a generated
@@ -20,6 +24,11 @@ import { zimSmokeEnv } from '../helpers/zim-smoke-env'
 //   HILBERTRAUM_ZIM_FILE=<path to a small .zim, e.g. wikipedia_de_climate-change_nopic>
 //   HILBERTRAUM_ZIM_QUERY=<a word the pack's index will hit, e.g. Treibhausgas>
 //   HILBERTRAUM_ZIM_EXPECT_ARTICLE=<optional — an entry key known to exist in that archive>
+//   HILBERTRAUM_ZIM_MODEL=<optional — a chat GGUF; with HILBERTRAUM_ZIM_LLAMA_SERVER=<llama-server
+//                          binary> the smoke starts it (CPU only, -ngl 0, unless
+//                          HILBERTRAUM_ZIM_MODEL_NGL says otherwise) and replays the quality
+//                          fixture THROUGH the #340 L3-b expansion (D-Z20), asserting the list
+//                          group too — the measurement of that lever on real tools + a real model>
 //
 // FAIL-CLOSED (#301 P5, finding L8, plan §9.19 (d)): CI never sets HILBERTRAUM_ZIM_SMOKE, so
 // `zimSmokeEnv` reports `{ requested: false }` and the suite below is a genuine skip — no test
@@ -30,11 +39,95 @@ import { zimSmokeEnv } from '../helpers/zim-smoke-env'
 
 const gate = zimSmokeEnv(process.env)
 
+/** The list group's hit@5 the #340 L3-b expansion reached on the real climate pack with a real
+ *  chat model at the ruling (D-Z20) — the smoke asserts it whenever a model is configured. */
+const LIST_GROUP_MIN_HITS = 4
+
 let svc: ZimService | null = null
+let llama: ChildProcess | null = null
 
 afterAll(async () => {
   await svc?.stop()
+  llama?.kill()
 })
+
+/** A free loopback port for the smoke's own llama-server. */
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as { port: number }).port
+      srv.close(() => resolve(port))
+    })
+    srv.on('error', reject)
+  })
+}
+
+/**
+ * The optional real model behind the #340 L3-b expansion (D-Z20): a llama-server started by the
+ * smoke over the GGUF the operator named, and a minimal `ModelRuntime` over its OpenAI endpoint
+ * (non-streaming; the same request body `runtime/llama.ts` sends — thinking switch, temperature,
+ * max_tokens, the grammar-constrained `response_format`). Null when the operator set no model.
+ */
+async function startExpansionModel(): Promise<ModelRuntime | null> {
+  const model = process.env.HILBERTRAUM_ZIM_MODEL ?? ''
+  const exe = process.env.HILBERTRAUM_ZIM_LLAMA_SERVER ?? ''
+  if (model === '' || exe === '') return null
+  expect(existsSync(model), 'HILBERTRAUM_ZIM_MODEL must be a file').toBe(true)
+  expect(existsSync(exe), 'HILBERTRAUM_ZIM_LLAMA_SERVER must be a file').toBe(true)
+  const port = await freePort()
+  const ngl = process.env.HILBERTRAUM_ZIM_MODEL_NGL ?? '0'
+  llama = spawn(
+    exe,
+    ['-m', model, '--host', '127.0.0.1', '--port', String(port), '-c', '4096', '-ngl', ngl, '--jinja', '--reasoning-format', 'deepseek', '-np', '1'],
+    { stdio: ['ignore', 'ignore', 'ignore'] }
+  )
+  const deadline = Date.now() + 180_000
+  for (;;) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/health`)
+      if (r.status === 200) break
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error('llama-server did not become healthy within 180 s')
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  const modelId = basename(model)
+  return {
+    modelId,
+    async start() {},
+    async stop() {},
+    async health() {
+      return { healthy: true, message: 'smoke llama-server', port }
+    },
+    async *chatStream(messages: ChatMessage[], options?: RuntimeChatOptions) {
+      const body = JSON.stringify({
+        model: modelId,
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+        stream: false,
+        cache_prompt: true, // the app runtime sets it too: the system prefix is prefilled once per session
+        chat_template_kwargs: { enable_thinking: options?.mode === 'deep' },
+        ...(options?.maxTokens != null ? { max_tokens: options.maxTokens } : {}),
+        ...(options?.temperature != null ? { temperature: options.temperature } : {}),
+        ...(options?.responseSchema
+          ? { response_format: { type: 'json_schema', json_schema: { name: options.responseSchemaName ?? 'response', schema: options.responseSchema, strict: true } } }
+          : {})
+      })
+      const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        signal: options?.signal
+      })
+      if (!res.ok) throw new Error(`llama-server ${res.status}`)
+      const json = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+      const content = json.choices?.[0]?.message?.content ?? ''
+      if (content) yield content
+      options?.onFinish?.('stop')
+    }
+  }
+}
 
 describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', () => {
   it('the requested smoke has valid inputs', () => {
@@ -84,8 +177,13 @@ describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', (
       expect(library).not.toBeNull()
       expect(library!.names.get(pack.id)).toBe(servingNameFor(zimFile, process.platform))
 
-      // The arm: real sidecar start + Xapian search + article fetch + chunking.
-      const arm = svc.makeArm(db, [pack.id])
+      // The arm: real sidecar start + Xapian search + article fetch + chunking — through the
+      // #340 L3-b expansion when the operator named a model (D-Z20), plain otherwise.
+      const expansionRuntime = await startExpansionModel()
+      const expand: QueryExpander | null = makeQueryExpander(expansionRuntime)
+      // eslint-disable-next-line no-console
+      console.info(`[zim-real] query expansion: ${expand ? `ON (${expansionRuntime!.modelId})` : 'off (no HILBERTRAUM_ZIM_MODEL)'}`)
+      const arm = svc.makeArm(db, [pack.id], { expand })
       expect(arm).not.toBeNull()
       const t0 = performance.now()
       const { candidates } = await arm!(query)
@@ -157,16 +255,27 @@ describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', (
         const measured = fixture.questions.filter((x) => x.answerable && x.measuredOnly)
         let hits = 0
         for (const q of measured) {
+          // With a model: the expansion the arm will use, logged once more here for the record
+          // (one extra call per question — a smoke, not the app path).
+          let note = ''
+          if (expand) {
+            const e0 = performance.now()
+            const ex = await expand(q.question)
+            note = ` [expansion ${(performance.now() - e0).toFixed(0)} ms: ${ex ? `concepts=${ex.concepts.join(' ')}; listTitle=${ex.listTitle ?? '—'}` : 'null'}]`
+          }
           const { candidates: found } = await arm!(q.question)
           const titles = [...new Set(found.map((c) => c.sourceTitle))].slice(0, 5)
           const hit = q.expectedTitles.some((t) => titles.includes(t))
           if (hit) hits++
           // eslint-disable-next-line no-console
-          console.info(`[zim-real] ${q.group ?? 'measured'} ${hit ? 'HIT ' : 'miss'} ${q.question} → ${titles.join(' | ')}`)
+          console.info(`[zim-real] ${q.group ?? 'measured'} ${hit ? 'HIT ' : 'miss'} ${q.question} → ${titles.join(' | ')}${note}`)
         }
         if (measured.length > 0) {
           // eslint-disable-next-line no-console
-          console.info(`[zim-real] ${measured[0]!.group ?? 'measured'} questions through the arm: ${hits}/${measured.length} hit@5 (logged, not asserted)`)
+          console.info(`[zim-real] ${measured[0]!.group ?? 'measured'} questions through the arm: ${hits}/${measured.length} hit@5${expand ? ' (with the L3-b expansion — asserted)' : ' (no model — logged, not asserted)'}`)
+          // D-Z20: with a real model the list group must reach the figure measured at the
+          // ruling (2026-09-07); without one the plain arm's 2/6 is the honest, logged state.
+          if (expand) expect(hits).toBeGreaterThanOrEqual(LIST_GROUP_MIN_HITS)
         }
       } else {
         // eslint-disable-next-line no-console
@@ -199,6 +308,7 @@ describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', (
       expect(after.candidates).toEqual([])
       expect(after.outcomes.map((o) => [o.packId, o.status, o.reason])).toEqual([[pack.id, 'skipped', 'disabled']])
     },
-    120_000
+    // A model-backed replay spends several seconds per question on a CPU (D-Z20).
+    process.env.HILBERTRAUM_ZIM_MODEL ? 600_000 : 120_000
   )
 })

--- a/apps/desktop/tests/unit/zim-expand.test.ts
+++ b/apps/desktop/tests/unit/zim-expand.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from 'vitest'
+import {
+  EXPAND_MAX_TOKENS,
+  EXPAND_MAX_TERMS,
+  EXPAND_MAX_TERM_CHARS,
+  EXPAND_RESPONSE_SCHEMA,
+  buildExpansionMessages,
+  makeQueryExpander,
+  parseExpansion
+} from '../../src/main/services/zim/expand'
+import { MockRuntime } from '../../src/main/services/runtime/mock'
+import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
+
+// #340 L3-b (D-Z20) — the question → concept expansion the knowledge-pack arm calls once per ask.
+// The contract under test: `parseExpansion` sanitises a model reply against the SAME content-word
+// / stop-word / frame-word rules `query-rewrite.ts` uses for the plain pattern (so an expansion can
+// never re-introduce a word the plain rewrite would have stripped); `makeQueryExpander` wraps ONE
+// grammar-constrained, temperature-0 call with its own wall-clock bound and degrades to null on
+// every failure except the ask's own abort, which is rethrown — mirroring `classify.ts`'s
+// `classifySkillPointer` (issue #80), the precedent module for this shape.
+
+interface ScriptedRuntime extends ModelRuntime {
+  calls: number
+  options: Array<RuntimeChatOptions | undefined>
+  messages: ChatMessage[][]
+}
+
+/** A runtime that replies with a fixed token list (default: one valid JSON expansion). */
+function scripted(replies: string[] = ['{"concepts":["Vulkanismus"],"listTitle":""}']): ScriptedRuntime {
+  const rt: ScriptedRuntime = {
+    modelId: 'scripted',
+    calls: 0,
+    options: [],
+    messages: [],
+    start: async () => {},
+    stop: async () => {},
+    health: async () => ({ healthy: true, message: 'ok', port: null }),
+    async *chatStream(msgs: ChatMessage[], options?: RuntimeChatOptions) {
+      rt.calls += 1
+      rt.options.push(options)
+      rt.messages.push(msgs)
+      for (const token of replies) {
+        if (options?.signal?.aborted) return
+        yield token
+      }
+    }
+  }
+  return rt
+}
+
+/** Collect a `ModelRuntime`'s full streamed reply for a question, so a test can feed the REAL
+ *  mock reply text into `parseExpansion` rather than a hand-typed stand-in. */
+async function collect(runtime: ModelRuntime, question: string): Promise<string> {
+  let text = ''
+  for await (const token of runtime.chatStream(buildExpansionMessages(question))) text += token
+  return text
+}
+
+describe('parseExpansion — sanitising the model reply', () => {
+  it('a well-formed reply yields concepts + listTitle', () => {
+    const result = parseExpansion(
+      '{"concepts":["Vulkanismus","Wattenmeer"],"listTitle":"Liste der Vulkane"}',
+      'Was ist das?'
+    )
+    expect(result).toEqual({ concepts: ['Vulkanismus', 'Wattenmeer'], listTitle: 'Liste der Vulkane' })
+  })
+
+  it('a <think> block before the JSON is stripped (chat.ts stripThinkBlocks)', () => {
+    const result = parseExpansion(
+      '<think>the user wants a list of volcanoes</think>{"concepts":["Vulkanismus"],"listTitle":""}',
+      'Was ist das?'
+    )
+    expect(result).toEqual({ concepts: ['Vulkanismus'], listTitle: null })
+  })
+
+  it('function and frame words never survive, standalone', () => {
+    // "die" (function word), "welche" (function word), "Rolle" (frame word) — none is a content
+    // word by query-rewrite.ts's own lists, so parseExpansion drops all three regardless of the
+    // question, leaving nothing: the whole reply degrades to null.
+    const result = parseExpansion('{"concepts":["die","welche","Rolle"],"listTitle":""}', 'Was ist das?')
+    expect(result).toBeNull()
+  })
+
+  it('a word already in the plain pattern is dropped case-insensitively; a frame word is dropped regardless', () => {
+    // Question's plain pattern (searchPattern) keeps "Länder stoßen meisten CO2" ("welche"/"am"/
+    // "aus" strip as function words). "Länder" duplicates the pattern (case-insensitive) and is
+    // dropped; "CO2-Emission" is new vocabulary and survives. "Liste" is ALSO offered by the model
+    // here, but query-rewrite.ts's FRAME_WORDS list (shared via `isContentWord`) treats "liste" as
+    // a German frame word ("zeige, liste, nenne …") — it is filtered at the content-word stage,
+    // before the pattern-overlap check ever runs, so it never survives either. See the report for
+    // this discrepancy against the task's worked example.
+    const question = 'Welche Länder stoßen am meisten CO2 aus?'
+    const result = parseExpansion('{"concepts":["Länder","CO2-Emission","Liste"],"listTitle":""}', question)
+    expect(result).toEqual({ concepts: ['CO2-Emission'], listTitle: null })
+  })
+
+  it('duplicate concepts are dropped, case-insensitively, keeping the first occurrence', () => {
+    const result = parseExpansion(
+      '{"concepts":["Vulkanismus","vulkanismus","VULKANISMUS"],"listTitle":""}',
+      'Was ist das?'
+    )
+    expect(result).toEqual({ concepts: ['Vulkanismus'], listTitle: null })
+  })
+
+  it('multi-word strings are tokenised per-word: frame and stop words inside them still drop', () => {
+    // "Liste" (frame word) and "der" (stop word) both drop out of the single multi-word item;
+    // "Länder" is a content word and, for THIS question, is not already in the plain pattern.
+    const result = parseExpansion('{"concepts":["Liste der Länder"],"listTitle":""}', 'Was sind Volkswirtschaften?')
+    expect(result).toEqual({ concepts: ['Länder'], listTitle: null })
+  })
+
+  it('the term cap keeps the first EXPAND_MAX_TERMS distinct valid words, in order', () => {
+    const eight = [
+      'Fotosynthese',
+      'Quantenmechanik',
+      'Bibliothek',
+      'Vulkanismus',
+      'Handelsabkommen',
+      'Wattenmeer',
+      'Seidenstraße',
+      'Klimaanlage'
+    ]
+    const result = parseExpansion(JSON.stringify({ concepts: eight, listTitle: '' }), 'Was ist das?')
+    expect(EXPAND_MAX_TERMS).toBe(6)
+    expect(result?.concepts).toEqual(eight.slice(0, EXPAND_MAX_TERMS))
+  })
+
+  it('a term longer than EXPAND_MAX_TERM_CHARS is dropped whole, never cut to fit', () => {
+    const tooLong = 'a'.repeat(EXPAND_MAX_TERM_CHARS + 1)
+    const result = parseExpansion(
+      JSON.stringify({ concepts: [tooLong], listTitle: 'Liste der Beispiele' }),
+      'Was ist das?'
+    )
+    expect(tooLong.length).toBe(41)
+    expect(result?.concepts).toEqual([])
+    // Not truncated to EXPAND_MAX_TERM_CHARS — dropped outright.
+    expect(result?.concepts).not.toContain(tooLong.slice(0, EXPAND_MAX_TERM_CHARS))
+    expect(result?.listTitle).toBe('Liste der Beispiele')
+  })
+
+  it('listTitle is trimmed and inner whitespace collapsed', () => {
+    const result = parseExpansion(
+      JSON.stringify({ concepts: [], listTitle: '  Liste   der   Flüsse  ' }),
+      'Was ist das?'
+    )
+    expect(result?.listTitle).toBe('Liste der Flüsse')
+  })
+
+  it('an empty listTitle yields null', () => {
+    const result = parseExpansion(
+      JSON.stringify({ concepts: ['Vulkanismus'], listTitle: '' }),
+      'Was ist das?'
+    )
+    expect(result?.listTitle).toBeNull()
+  })
+
+  it('a listTitle over EXPAND_MAX_TITLE_CHARS (81) yields null', () => {
+    const title = `${'a'.repeat(80)} b` // 82 chars total, well past the 80-char cap
+    const result = parseExpansion(JSON.stringify({ concepts: ['Vulkanismus'], listTitle: title }), 'Was ist das?')
+    expect(title.length).toBeGreaterThanOrEqual(81)
+    expect(result?.listTitle).toBeNull()
+  })
+
+  it('a digits-only listTitle yields null (no letter)', () => {
+    const result = parseExpansion(
+      JSON.stringify({ concepts: ['Vulkanismus'], listTitle: '1234567890' }),
+      'Was ist das?'
+    )
+    expect(result?.listTitle).toBeNull()
+  })
+
+  it('non-object JSON ([], "x", 42) all yield null', () => {
+    expect(parseExpansion('[]', 'Was ist das?')).toBeNull()
+    expect(parseExpansion('"x"', 'Was ist das?')).toBeNull()
+    expect(parseExpansion('42', 'Was ist das?')).toBeNull()
+  })
+
+  it('non-JSON prose — the mock runtime\'s own reply — yields null', async () => {
+    const mock = new MockRuntime({ modelId: 'mock-model', modelPath: 'x', contextTokens: 4096 })
+    await mock.start()
+    const text = await collect(mock, 'Welche Länder stoßen am meisten CO2 aus?')
+    expect(parseExpansion(text, 'Welche Länder stoßen am meisten CO2 aus?')).toBeNull()
+  })
+
+  it('an all-empty reply ({ concepts: [], listTitle: "" }) yields null', () => {
+    expect(parseExpansion('{"concepts":[],"listTitle":""}', 'Was ist das?')).toBeNull()
+  })
+
+  it('non-string concept entries are ignored; valid string entries among them still survive', () => {
+    const result = parseExpansion(
+      JSON.stringify({ concepts: [123, { a: 1 }, null, 'Vulkanismus'], listTitle: '' }),
+      'Was ist das?'
+    )
+    expect(result).toEqual({ concepts: ['Vulkanismus'], listTitle: null })
+  })
+})
+
+describe('buildExpansionMessages — the per-call prompt', () => {
+  it('is two messages: a system message naming JSON and both fields, and the question verbatim', () => {
+    const question = 'Welche Länder stoßen am meisten CO2 aus?'
+    const messages = buildExpansionMessages(question)
+    expect(messages).toHaveLength(2)
+    const [system, user] = messages
+    expect(system.role).toBe('system')
+    expect(system.content).toContain('JSON')
+    expect(system.content).toContain('concepts')
+    expect(system.content).toContain('listTitle')
+    expect(user.role).toBe('user')
+    expect(user.content).toBe(question)
+  })
+})
+
+describe('makeQueryExpander — the one bounded call', () => {
+  it('returns null (no expander) when the runtime is null or undefined', () => {
+    expect(makeQueryExpander(null)).toBeNull()
+    expect(makeQueryExpander(undefined)).toBeNull()
+  })
+
+  it('parses a JSON reply streamed in pieces and pins the call shape', async () => {
+    const rt = scripted(['{"concepts":["Vulkan', 'ismus"],"list', 'Title":""}'])
+    const expander = makeQueryExpander(rt)
+    expect(expander).not.toBeNull()
+    const result = await expander!('Was ist das?')
+    expect(result).toEqual({ concepts: ['Vulkanismus'], listTitle: null })
+    expect(rt.calls).toBe(1)
+    const o = rt.options[0]
+    expect(o?.mode).toBe('fast')
+    expect(o?.temperature).toBe(0)
+    expect(o?.maxTokens).toBe(EXPAND_MAX_TOKENS)
+    expect(o?.responseSchema).toBe(EXPAND_RESPONSE_SCHEMA)
+    expect(o?.signal).toBeDefined()
+  })
+
+  it('a prose reply (no JSON) resolves null', async () => {
+    const rt = scripted(['sorry, no structured output here'])
+    const expander = makeQueryExpander(rt)
+    expect(await expander!('Was ist das?')).toBeNull()
+  })
+
+  it('a throwing runtime resolves null', async () => {
+    const throwing: ModelRuntime = {
+      ...scripted(),
+      // eslint-disable-next-line require-yield
+      async *chatStream(): AsyncGenerator<string> {
+        throw new Error('HTTP 500: llama-server gone')
+      }
+    }
+    const expander = makeQueryExpander(throwing)
+    expect(await expander!('Was ist das?')).toBeNull()
+  })
+
+  it('a runtime that never ends is cut off by the injected timeout: null, well under 4s, its signal aborted', async () => {
+    let sawAbort = false
+    const hanging: ModelRuntime = {
+      ...scripted(),
+      async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+        await new Promise<void>((resolve) => {
+          if (options?.signal?.aborted) {
+            sawAbort = true
+            return resolve()
+          }
+          options?.signal?.addEventListener('abort', () => {
+            sawAbort = true
+            resolve()
+          })
+        })
+      }
+    }
+    const expander = makeQueryExpander(hanging, { timeoutMs: 50 })
+    const t0 = Date.now()
+    const result = await expander!('Was ist das?')
+    expect(result).toBeNull()
+    expect(Date.now() - t0).toBeLessThan(3_000) // well under EXPAND_TIMEOUT_MS (6000ms)
+    expect(sawAbort).toBe(true)
+  })
+
+  it('a reply longer than EXPAND_MAX_TOKENS * 8 chars resolves null (runaway output dropped)', async () => {
+    const runaway: ModelRuntime = {
+      ...scripted(),
+      async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+        for (;;) {
+          if (options?.signal?.aborted) return
+          yield 'x'.repeat(EXPAND_MAX_TOKENS * 8 + 1)
+        }
+      }
+    }
+    const expander = makeQueryExpander(runaway)
+    expect(await expander!('Was ist das?')).toBeNull()
+  })
+
+  it('an already-aborted ask signal rejects with AbortError, with zero model calls', async () => {
+    const rt = scripted()
+    const expander = makeQueryExpander(rt)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(expander!('Was ist das?', controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+    expect(rt.calls).toBe(0)
+  })
+
+  it('the ask signal aborting mid-stream rejects with AbortError — never resolves null', async () => {
+    const ctrl = new AbortController()
+    const midAbort: ModelRuntime = {
+      ...scripted(),
+      async *chatStream(_m: ChatMessage[], options?: RuntimeChatOptions) {
+        yield '{"concepts":'
+        ctrl.abort()
+        if (options?.signal?.aborted) return
+        yield '["Vulkanismus"],"listTitle":""}'
+      }
+    }
+    const expander = makeQueryExpander(midAbort)
+    await expect(expander!('Was ist das?', ctrl.signal)).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('MOCK INVARIANT: under the real MockRuntime the expansion always degrades to null', async () => {
+    const mock = new MockRuntime({ modelId: 'mock-model', modelPath: 'x', contextTokens: 4096 })
+    await mock.start()
+    const expander = makeQueryExpander(mock)
+    expect(await expander!('Welche Länder stoßen am meisten CO2 aus?')).toBeNull()
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1930,3 +1930,6 @@ matrix (the `zim-real` row) for the full input table.
 `packs:refresh` as a DB-touching (non-exempt) channel; `packs:status` remains the sole
 exempt channel (in-memory service state only — its `excluded` field, #340, is the service's
 cached list, never a query). The IPC surface is unchanged by the follow-up wave: 145 channels.
+
+**#340 L3-b (D-Z20):** no shape change — `makeArm` gains an optional `{ expand }` (main-side
+only), the outcome union, the per-answer note, IPC and preload are unchanged.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2527,9 +2527,13 @@ reports and phase plans were working papers; their full text lives in git histor
   searched: out of time for this question"). The pack server ANDs every word of the search pattern, so the app sends only the question's content words (function and question-frame words stripped, `rag-design.md` §17 D-Z18), retries once with fewer words when nothing is found, and — when even that finds nothing — checks how common each remaining word is in that archive, drops every word that is entirely absent from it (or, if none is, just the rarest one), and tries once more (§17 D-Z18 amendment, #353); a question whose remaining content words never co-occur in one article can still miss. None of this considers language: a German question against an
   English pack simply scores poorly; the reranker sorts it out when present, and without
   one, expect occasional off-language chunks. Aggregation or superlative questions ("which
-  scientists are famous Austrians") tend to surface list or enumeration articles rather than
-  a clean answer, because no single passage carries what the question asks for — a
-  retrieval-shape limit, not a defect. Every ticked pack gets one line in the
+  scientists are famous Austrians") get one extra step before the search: the app asks the
+  local model for the concepts and the likely list-article title (one short model call per
+  pack question, roughly one to three seconds on a processor-only machine), which finds the
+  list article in the cases we measured. A question whose answer is spread across an
+  article's individual rows, rather than named on the page itself, can still miss; and on a
+  machine where that model call takes longer than six seconds, the question falls back to
+  the plain search with no list-title step. Every ticked pack gets one line in the
   "Knowledge packs:" note under the answer — searched (and how much it contributed) or
   not searched/failed with a short reason — even on an answer that cites nothing at all;
   an older answer, from before this note existed, says "outcome not recorded" instead.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2529,7 +2529,7 @@ reports and phase plans were working papers; their full text lives in git histor
   one, expect occasional off-language chunks. Aggregation or superlative questions ("which
   scientists are famous Austrians") get one extra step before the search: the app asks the
   local model for the concepts and the likely list-article title (one short model call per
-  pack question, roughly one to three seconds on a processor-only machine), which finds the
+  pack question, measured at two to five seconds on a processor-only machine), which finds the
   list article in the cases we measured. A question whose answer is spread across an
   article's individual rows, rather than named on the page itself, can still miss; and on a
   machine where that model call takes longer than six seconds, the question falls back to

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2859,7 +2859,10 @@ offline article viewer. Files are registered in place, never copied.
   (thinking off), temperature 0, `EXPAND_MAX_TOKENS = 96`, the D55 `responseSchema` (the same
   grammar-constrained-JSON machinery `classify.ts` uses), and its own `EXPAND_TIMEOUT_MS = 6_000`
   bound INSIDE `arm.ts`'s 20 s `EXTERNAL_RETRIEVAL_DEADLINE_MS` — a stuck call leaves the packs
-  fourteen seconds, never nothing (measured 2026-09-07 with the default 4B model on an i9-14900K
+  fourteen seconds, never nothing; and when the arm's DEADLINE itself elapses mid-expansion the
+  arm degrades exactly as before this stage — no expansion, every pack settles `deadline` — while
+  the ask's own cancellation is rethrown (the arm, not the expander, tells the two apart via
+  `askSignal`; measured 2026-09-07 with the default 4B model on an i9-14900K
   at -ngl 0: 2.7–4.0 s per call with the system prompt prefilled from scratch; the app runtime
   sets `cache_prompt`, so from the second ask on only the question is prefilled). When the title
   index knows nothing under the model's title, one shorter prefix — the title minus its last word
@@ -2877,9 +2880,15 @@ offline article viewer. Files are registered in place, never copied.
   trimmed, null unless it holds a letter and fits `EXPAND_MAX_TITLE_CHARS = 80`. `arm.ts`
   `collectPackCandidates` calls the expander once before any pack is searched, then per pack:
   the title (`suggestTitles`, `/suggest`, `EXPANSION_TITLE_ROWS = 3`) and the concept query
-  (`searchPack`) each add up to `EXPANSION_ARTICLES_PER_PACK = 2` NEW articles, fetched BEFORE the
-  plain search's hits so the plain `ARTICLES_PER_PACK` cap can never starve them — the plain
-  pattern still runs unchanged and every one of its hits is kept. A fetched article whose title
+  (`searchPack`) together add at most `EXPANSION_ARTICLES_PER_PACK = 2` NEW articles, fetched BEFORE the
+  plain search's hits so the plain `ARTICLES_PER_PACK` cap can never starve them, and they may
+  hold at most HALF the pack's quota (`Math.ceil(quota / 2)`) so the plain hits are always read
+  after them — the plain pattern runs unchanged; on a one-pack ask (quota 24) every plain hit is
+  still fetched, on a multi-pack ask the quota was always the bound and the expansion's list
+  article now takes the slot one plain article used to have. The expansion is memoised per ask
+  in `runArm`, so the guard's single admitted retry never pays for a second model call. Note:
+  the call enters the runtime as an in-app generation like the answer itself, so a pack-scoped
+  ask pre-empts an external (local-API) generation a few seconds earlier than before. A fetched article whose title
   matches `Liste …` / `List of …` keeps `LIST_ARTICLE_CHUNKS = 8` chunks instead of
   `CHUNKS_PER_ARTICLE`: a list's name rows carry none of the question's words, so the overlap
   picker would otherwise trim exactly the rows a "which … are the largest" question needs — the

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2847,6 +2847,56 @@ offline article viewer. Files are registered in place, never copied.
   `HILBERTRAUM_ZIM_SMOKE=1` against K:): `searchPackTotal(port, pack.id, "Treibhausgas")` → 301
   (17 ms), the invented word `"qzxvwtrkp"` → 0 (15 ms); the quality fixture still hit 9/9.
 
+- **D-Z20 — question → concept expansion (#340 L3-b, owner ruling 2026-09-07, option (a)
+  "always").** L3-b was left MEASURED-not-built at the open-issues wave close (see "Deliberately
+  not built" below, K: climate pack, 2026-09-06): raw question 0/6 of the list-shaped fixture
+  questions (`quality-questions-de.json` `group: list`), the shipped rewrite (D-Z18) 2/6, a
+  hand-written concept-expanded query 4/6, `/suggest` asked with a synthesised "Liste …" prefix
+  6/6. The owner's ruling: spend the call on EVERY pack-scoped ask, not a question-shape
+  trigger — quality wins over the ~1-3 s CPU cost, and a shape heuristic ("superlatives, `welche
+  … gibt es`") is guesswork the fixture never validated as complete. `services/zim/expand.ts`
+  `makeQueryExpander(runtime)` builds the call: ONE per ask (never per pack), `mode: 'fast'`
+  (thinking off), temperature 0, `EXPAND_MAX_TOKENS = 96`, the D55 `responseSchema` (the same
+  grammar-constrained-JSON machinery `classify.ts` uses), and its own `EXPAND_TIMEOUT_MS = 6_000`
+  bound INSIDE `arm.ts`'s 20 s `EXTERNAL_RETRIEVAL_DEADLINE_MS` — a stuck call leaves the packs
+  fourteen seconds, never nothing (measured 2026-09-07 with the default 4B model on an i9-14900K
+  at -ngl 0: 2.7–4.0 s per call with the system prompt prefilled from scratch; the app runtime
+  sets `cache_prompt`, so from the second ask on only the question is prefilled). When the title
+  index knows nothing under the model's title, one shorter prefix — the title minus its last word
+  — is tried once with twice the rows, RANKED by how much of the dropped word each carries (the
+  index is prefix-only; "… nach Pro-Kopf-Emissionen" matched nothing, "… nach" matched everything
+  and the "… pro Kopf" row is the one wanted). **Measured through the arm with the real tools and
+  the default 4B chat model on a CPU (2026-09-07, the manual smoke with HILBERTRAUM_ZIM_MODEL): the
+  list group 5/6 hit@5 (2/6 before), the D-Z18 nine still 9/9, 2.4–5.3 s per expansion call; the
+  smoke asserts the list group at LIST_GROUP_MIN_HITS = 4 whenever a model is configured.** `parseExpansion` then sanitises the reply against
+  the SAME lists `query-rewrite.ts` uses (`isContentWord`, `TOKEN_RE`): a concept survives only
+  when it is a content word (no function or frame word — "liste" itself is a German frame word
+  and never survives, even when the model offers it), not already in the plain pattern
+  case-insensitively, unique, and at most `EXPAND_MAX_TERM_CHARS = 40` chars (dropped whole, never
+  cut); at most `EXPAND_MAX_TERMS = 6` kept, in order; `listTitle` is whitespace-collapsed and
+  trimmed, null unless it holds a letter and fits `EXPAND_MAX_TITLE_CHARS = 80`. `arm.ts`
+  `collectPackCandidates` calls the expander once before any pack is searched, then per pack:
+  the title (`suggestTitles`, `/suggest`, `EXPANSION_TITLE_ROWS = 3`) and the concept query
+  (`searchPack`) each add up to `EXPANSION_ARTICLES_PER_PACK = 2` NEW articles, fetched BEFORE the
+  plain search's hits so the plain `ARTICLES_PER_PACK` cap can never starve them — the plain
+  pattern still runs unchanged and every one of its hits is kept. A fetched article whose title
+  matches `Liste …` / `List of …` keeps `LIST_ARTICLE_CHUNKS = 8` chunks instead of
+  `CHUNKS_PER_ARTICLE`: a list's name rows carry none of the question's words, so the overlap
+  picker would otherwise trim exactly the rows a "which … are the largest" question needs — the
+  reranker still scores every chunk against the ORIGINAL question. Fallback contract: no runtime,
+  a non-JSON reply, the 6 s bound, a runaway reply, or any other failure all resolve null and the
+  arm runs exactly as it did before this module existed; the ONE exception is the ask's own abort,
+  rethrown, never swallowed as a fallback. The MockRuntime ignores `responseSchema` and always
+  replies prose, so mock/dev mode always takes the degrade path — byte-identical to a build with
+  no expander (a tested invariant, mirroring `classify.ts`'s mock invariant). Unchanged: the
+  original question stays the reranker's and the prompt's query and the chunk picker's terms; no
+  D-Z4/D-Z13 constant (`ARTICLES_PER_PACK`, `CHUNKS_PER_ARTICLE`, …) changes value; no
+  `KnowledgePackOutcome`, IPC, or persisted shape changes (`docs/data-contracts.md` "Knowledge
+  packs"). Tests: `zim-expand.test.ts` (`parseExpansion`'s sanitiser rules, `buildExpansionMessages`,
+  and `makeQueryExpander`'s call shape, timeout, abort-vs-fallback split, and mock invariant) and
+  the L3-b legs of `zim-arm.test.ts` (the expansion-articles-first fetch order, the per-pack caps,
+  the `Liste …` / `List of …` chunk-keep switch, and the ask-abort-rethrown leg at this layer).
+
 ### Module map
 
 `services/zim/`: `html.ts` (article HTML → segments; linear forward scanner with a work
@@ -2868,7 +2918,8 @@ searchability columns + key, `classifyPackSelection` and `packTitles`, D-Z11/D-Z
 (the owned `zim-transient/` dir; containment-checked, link-refusing cleanup, D-Z11),
 `session.ts` (the post-unlock reconciliation kickoff, the `maybeStartLocalApi` shape,
 D-Z11), `arm.ts` (allocation, bounded concurrency, the per-ask deadline and per-pack
-outcomes — D-Z4, P4), `index.ts` (`ZimService` facade on
+outcomes — D-Z4, P4), `expand.ts` (question → concept expansion for the pack arm — D-Z20,
+#340 L3-b), `index.ts` (`ZimService` facade on
 `AppContext.zim` — the revision/generation allocator, the FIFO build/teardown/start chain
 and the published tuple, D-Z10; the operation registry and admission-epoch checks, the
 `packs:changed` notify hook, D-Z11; `withServer` — the alive/generation request guard with
@@ -2972,13 +3023,8 @@ the list shape were not helped by hits 6–10, and one selected pack already get
 *L1* — the title-index `/suggest` arm stays unbuilt and an index-less pack keeps "not searched:
 no full-text index": alone it is prefix-bound (no title match for "österreichische
 Wissenschaftler"); paired with a synthesised "Liste …" prefix it is part of L3-b. *L3-b* —
-concept expansion through a model call: MEASURED, not built (fixture `quality-questions-de.json`
-`group: list`, replayed by the smoke and logged, never asserted; K: climate pack, 2026-09-06:
-raw question 0/6, the shipped rewrite 2/6 through the arm — the failures return 13–40 wrong
-hits, so neither the zero-hit retry nor the #353 ladder fires — a hand-written concept-expanded
-query 4/6, `/suggest` with a synthesised "Liste …" prefix 6/6). The open owner question on #340:
-spend the model call on every pack-scoped ask, only on a question-SHAPE trigger (superlatives,
-"welche … gibt es"; "weak by hit count" cannot work), or not at all. *C2* — link expansion not
+concept expansion through a model call: ruled (a) "always" on 2026-09-07 and built as **D-Z20**
+(above). *C2* — link expansion not
 until the upstream `/raw` cut-short fix ships (it doubles traffic on the defect route). *C3* —
 Tier-2 import: ruled (a), a "Save article to my documents" button in the article viewer FIRST,
 the citation card later; not built in this wave. *C4* — acquisition from Kiwix catalogs: ruled


### PR DESCRIPTION
Refs #340 — owner ruling of 2026-09-07 (option (a), ALWAYS). Record: rag-design §17 **D-Z20**.

**Why.** Xapian ANDs the question's words, and a list or superlative question ("Welche Länder stoßen am meisten CO2 aus?") names none of the words the answering article is indexed under. Measured on the real climate pack: the shipped rewrite reached the list article in 2 of 6 such questions through the arm; a concept-expanded query in 4 of 6; the title index asked with a synthesised "Liste …" prefix in 6 of 6. The only thing on the drive that can write those words is the local chat model.

**What.** `services/zim/expand.ts`: ONE short call per pack-scoped ask on the turn's own runtime — thinking off, temperature 0, 96 tokens, grammar-constrained JSON `{ concepts, listTitle }` (the D55 machinery the skill classifier uses), its own 6 s bound inside the arm's 20 s deadline; the reply is sanitised with the rewrite's own word lists (no function/frame words, nothing the plain pattern already carries, six terms, length caps). The arm fetches the expansion's articles FIRST — the title index (`client.ts` `suggestTitles`, `/suggest`, with a one-word-shorter fallback ranked by the dropped word, because the index is prefix-only and a model title inflected at its end matched nothing) and the concept query — at most two per pack and at most half the pack's quota, then the plain search's hits exactly as before; a `Liste …` / `List of …` article keeps 8 chunks instead of 4 (its name rows carry no question words). `makeArm(db, ids, { expand })`; the IPC layer wires `makeQueryExpander(runtime)`. Every failure — no runtime, a non-JSON reply (the mock runtime, so mock/dev is byte-identical to no expander), the time bound, a runaway reply — falls back to the plain arm; the per-ask deadline elapsing mid-expansion degrades to `deadline` outcomes; only the ask's own cancellation is rethrown. Memoised per ask, so the guard's single admitted retry never pays a second call. No listed constant changes; no outcome, IPC, preload or persisted shape change; the original question stays the reranker's and the prompt's query.

**Measured through the arm on K: with the real kiwix-tools and the default qwen3-4b model on a CPU** (`-ngl 0`; the manual smoke gains `HILBERTRAUM_ZIM_MODEL` + `HILBERTRAUM_ZIM_LLAMA_SERVER`, spawns the server itself and asserts the list group ≥ 4): the list group **5/6** hit@5 (2/6 before), the nine D-Z18 questions still **9/9**, 2.4–5.3 s per expansion call.

**Review.** Opus adversarial review; its findings landed in the second commit: a deadline mid-expansion no longer ends the turn as a cancellation, the expansion takes at most half the quota on multi-pack asks, one call across the guard retry, `/suggest` gets the probe budget, `read-failed` keeps its meaning, the records corrected.

**Tests.** `zim-expand.test.ts` (26: the sanitiser, the prompt, the bounded call incl. timeout / runaway / abort / the real MockRuntime), `zim-arm.test.ts` L3-b legs (9: expansion articles first and bounded, duplicates once, null/throwing/absent expander identical, abort rejects, deadline degrades, failing title index, one-word-shorter and ranked fallbacks, the half-quota three-pack case, `LIST_ARTICLE_CHUNKS` pinned), the smoke's model-backed replay. Records: D-Z20, module map, "Deliberately not built", known-limitations, data-contracts (no shape change), CHANGELOG, BUILD_STATE 21(b). Typecheck clean; full suite 418 files / 6,749 passed / 89 skipped (master: 417 / 6,719 / 83).

Not covered by an automated leg: the memoisation across the guard retry (the T17 session harness is the place; it is typed and one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)