### PR TITLE
feat(chat): save a code block from an answer as a file (#286)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,12 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-07 — **Save a code block from an answer (#286, `feat/286-save-code-block`):** every
+fenced code block in a persisted assistant answer gets its own Copy/Save toolbar; Save writes
+verbatim bytes (no BOM, via `saveBinaryExport`) — renderer-supplied content over the new
+`chat:saveCodeBlock` channel, mapped through a fixed extension allowlist, persisted turns only;
+audit records ids/bytes/extension only, never the text or path. Record: `security-model.md`
+"Code-block save boundary"; docs: user-guide §6, `data-contracts.md`, `design-guidelines.md`, `PRIVACY.md`, `CHANGELOG.md`._
 _2026-09-06 — **Follow-up wave on `feat/performance-screen` (#303), one commit per issue, ledger `tmp/followups-303-ledger.md`:**
 #325 closed `4293f95f` (GPU-off tile never falls back to a recorded card; Copy report carries the live pick; "Running on the graphics card right now." line — visual unverified);
 #323 closed `b0b26eec` (a completed chat-engine install re-runs the probe refresh when this machine's eligible probe is empty); #335 closed `6f1bcde1` (the harness records and removes every suite's temp root; ~2,500 leaked roots per run → 0); #322 closed — `speedIdentity` + the one-directional gate in `speedSignalFor` (a sample counts for a next start no faster than the measured path; §6.5 2026-09-06 amendment, owner-confirmed on review of the first draft)._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,11 @@ from its first public `1.0.0` release onward.
   in `runtime/kiwix-tools/source/`, with a `SOURCES.md` record. Nothing changes if you build your
   own drive and install the knowledge-pack family yourself.
 
+- **Save just one code block from an answer, not the whole conversation.** Every code block in
+  a finished assistant answer now has its own small **Copy** and **Save** buttons. Save writes
+  only that block, byte-for-byte, as `code.<ext>` — the extension follows the block's language,
+  or `.txt` when none is recognized (#286).
+
 ### Changed
 
 - **The Linux/macOS install step for knowledge-pack tools is documented.** The panel's

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -176,8 +176,8 @@ every control that bounds it — is in [`docs/local-api.md`](docs/local-api.md).
 Your data lives in your workspace directory. **In-app deletion** is available for individual items:
 you can delete documents, conversations, and image analyses from within the app — on an encrypted
 workspace this **shreds** the stored encrypted copy. You can also **export** outputs (document
-summaries/translations, chat transcripts) through an explicit save dialog. To delete **everything**
-at once, delete the `workspace/` folder (and, if you want, the `models/` and `logs/` folders) on
+summaries/translations, chat transcripts, a code block from an assistant answer) through an
+explicit save dialog. To delete **everything** at once, delete the `workspace/` folder (and, if you want, the `models/` and `logs/` folders) on
 your drive or app-data location.
 
 ## Encryption

--- a/apps/desktop/src/main/ipc/registerChatIpc.ts
+++ b/apps/desktop/src/main/ipc/registerChatIpc.ts
@@ -40,7 +40,8 @@ import { workspaceAdmitsWork } from '../services/workspace-vault'
 import { log } from '../services/logging'
 import { inFlightStreams, streamBuffers } from './inflight'
 import { assertChatStreamReady, withChatStream, withRegenerateGuard } from './chat-stream'
-import { saveTextExport } from './save-export'
+import { saveBinaryExport, saveTextExport } from './save-export'
+import { codeBlockDefaultFileName, codeBlockExtension } from '../../shared/code-block-export'
 import { tableToCsv } from '../services/tables'
 import { loadResultTable } from '../services/tables/store'
 
@@ -60,6 +61,9 @@ import { loadResultTable } from '../services/tables/store'
 // renderer can show the "start a model" empty state. Starting the real llama.cpp
 // sidecar is heavy and is an explicit user action — keeping it explicit keeps the
 // service boundary clean.
+
+/** #286: the shape a persisted message id may take (UUID alphabet, bounded) — see saveCodeBlock. */
+const MESSAGE_ID_SHAPE = /^[A-Za-z0-9_-]{1,64}$/
 
 export function registerChatIpc(ctx: AppContext): void {
   const ipcHandle = guardedHandleFor(ctx)
@@ -413,4 +417,50 @@ export function registerChatIpc(ctx: AppContext): void {
     })
     return filePath
   })
+
+  // #286: save ONE fenced code block of an assistant reply as a file. Unlike the two exports
+  // above, the bytes are RENDERER-SUPPLIED (the parsed block content + the fence info string, as
+  // `copyToClipboard` sends text), not re-derived from the DB — the block is what the user sees.
+  // Posture: the #252 sender guard + `requireUnlocked` gate the call, the native save dialog is
+  // the consent, and nothing about the content is logged. The fence info string is MODEL OUTPUT:
+  // it never reaches a filename, a filter or an audit row un-mapped — only its allowlisted
+  // extension does (shared/code-block-export.ts, D6). Written VERBATIM through
+  // `saveBinaryExport` — no BOM even for a .txt/.md/.csv destination (D1; see the `bomFor`
+  // note) — because the issue requires byte identity (a BOM breaks a shebang). Returns the saved
+  // path, or null when the user cancelled or an argument has the wrong shape (no dialog then).
+  // `messageId` is the answer the block came from, for the audit row; it must LOOK like an id
+  // (the persisted-id alphabet) so a renderer-supplied string can never smuggle content into
+  // the audit log through that slot.
+  ipcHandle(
+    IPC.saveCodeBlock,
+    async (_e, messageId: string, content: string, language: string): Promise<string | null> => {
+      requireUnlocked()
+      if (typeof content !== 'string') return null
+      if (typeof messageId !== 'string' || !MESSAGE_ID_SHAPE.test(messageId)) return null
+      const info = typeof language === 'string' ? language : ''
+      const extension = codeBlockExtension(info)
+      const bytes = Buffer.from(content, 'utf8')
+      const filePath = await saveBinaryExport(
+        {
+          title: tMain('main.dialog.exportCodeBlock'),
+          defaultPath: codeBlockDefaultFileName(info),
+          filters: [
+            { name: extension.toUpperCase(), extensions: [extension] },
+            { name: tMain('main.dialog.filterAll'), extensions: ['*'] }
+          ]
+        },
+        bytes
+      )
+      if (!filePath) return null
+      log.info('Code block saved', { messageId, extension, bytes: bytes.length })
+      // Audit privacy rule: id + byte count + the ALLOWLISTED extension only — the block text, the
+      // raw info string and the chosen path are content.
+      ctx.audit?.('code_block_exported', 'A code block from an answer was saved to a file', {
+        messageId,
+        bytes: bytes.length,
+        extension
+      })
+      return filePath
+    }
+  )
 }

--- a/apps/desktop/src/main/ipc/save-export.ts
+++ b/apps/desktop/src/main/ipc/save-export.ts
@@ -30,6 +30,13 @@ export interface SaveExportDialogOptions {
  * Re-import is safe: the app's own CSV parser (papaparse) strips a leading BOM itself. NEVER on
  * other extensions: a BOM breaks strict JSON parsers (the audit-log export) and is wrong for .log
  * tooling.
+ *
+ * #286 (owner decision D1): the CODE-BLOCK save (`chat:saveCodeBlock`) is the deliberate
+ * exception and goes through `saveBinaryExport` instead — even when the user picks a `.txt`,
+ * `.md` or `.csv` destination. The issue requires the file to be byte-identical to the block
+ * (a BOM breaks a shebang, a `<!doctype html>` sniff and strict parsers alike), and the block's
+ * bytes are the user's own model output, not an app-authored transcript. The BOM rule above
+ * stays as recorded for transcripts, summaries and CSV exports.
  */
 export function bomFor(filePath: string): string {
   return /\.(?:md|txt|csv)$/i.test(filePath) ? '\ufeff' : ''

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -373,6 +373,14 @@ const api = {
   /** Save one message's attached result table as CSV (result-tables §4); path, or null on cancel. */
   exportMessageTable: (messageId: string): Promise<string | null> =>
     ipcRenderer.invoke(IPC.exportMessageTable, messageId),
+  /** #286: save one fenced code block of the answer `messageId` as a file. `content` is the
+   *  block's parsed text (written byte-for-byte as UTF-8, no BOM); `language` is the raw fence
+   *  info string, which MAIN maps through a fixed allowlist to pick the suggested `code.<ext>`
+   *  name + filter (the id, byte count and that extension are all the audit row records).
+   *  Resolves with the saved path, or null when the user cancelled. Persisted turns only —
+   *  never the live bubble. */
+  saveCodeBlock: (messageId: string, content: string, language: string): Promise<string | null> =>
+    ipcRenderer.invoke(IPC.saveCodeBlock, messageId, content, language),
   /** Full-text search across all conversations. Results group hits per
    *  conversation, best match first; snippets carry SEARCH_MARK_* highlight markers. */
   searchConversations: (query: string): Promise<ConversationSearchResult[]> =>

--- a/apps/desktop/src/renderer/chat/AssistantMarkdown.tsx
+++ b/apps/desktop/src/renderer/chat/AssistantMarkdown.tsx
@@ -1,6 +1,9 @@
-import { memo, type ReactNode } from 'react'
-import { Streamdown, defaultRehypePlugins } from 'streamdown'
+import { cloneElement, isValidElement, memo, type ReactElement, type ReactNode } from 'react'
+import { Streamdown, defaultRehypePlugins, useIsCodeFenceIncomplete } from 'streamdown'
 import { math } from '@streamdown/math'
+import { codeBlockExtension } from '@shared/code-block-export'
+import { useCodeBlockActions, type CodeBlockActions } from './CodeBlockActionsContext'
+import { useT } from '../i18n'
 // katex is already in the bundle via @streamdown/math → rehype-katex; imported directly only
 // to VALIDATE partially-streamed TeX before typesetting it (completePartialTex below).
 import katex from 'katex'
@@ -145,10 +148,117 @@ const mdRemend = {
 // this list, so math is unaffected. Module-level for a stable reference (memoization).
 const mdRehypePlugins = [defaultRehypePlugins.sanitize]
 
+// ---------------------------------------------------------------------------------------------
+// #286 — the per-code-block Copy / Save toolbar.
+//
+// WHY `pre` AND NOT `code`: Streamdown's default `pre` is literally
+// `({children}) => isValidElement(children) ? cloneElement(children, {'data-block':'true'}) : children`
+// — it exists only to STAMP the child <code> as a block; the default `code` component then reads
+// that stamp and renders the whole `<div data-streamdown="code-block">` (header row with the
+// language + `<pre><code>` body), and renders `<code data-streamdown="inline-code">` without it.
+// Overriding `code` would therefore mean re-implementing Streamdown's block chrome (and would have
+// to re-handle inline code); overriding `pre` lets us keep every pixel of it and merely wrap.
+//
+// `controls={false}` STAYS (owner decision D4): Streamdown's own download control is a
+// blob + `<a download>` in the renderer, which bypasses the main-process write boundary (the
+// native save dialog IS the consent). Ours goes through `window.api.saveCodeBlock`.
+
+/** The block's exact code value + its fence language token, read off the child <code> element. */
+function readCodeChild(child: ReactElement): { content: string; language: string } {
+  const props = child.props as { className?: string; children?: unknown }
+  // Mirror Streamdown's own extraction: the highlighted body may be a string or a single
+  // element wrapping one.
+  const inner = props.children
+  let raw = ''
+  if (typeof inner === 'string') {
+    raw = inner
+  } else if (isValidElement(inner)) {
+    const nested = (inner.props as { children?: unknown }).children
+    if (typeof nested === 'string') raw = nested
+  }
+  // mdast-util-to-hast appends ONE '\n' to every code node's value (`value ? value + '\n' : ''`).
+  // D1 says "verbatim" = the code value AS PARSED, so strip exactly that one newline — otherwise
+  // every saved file would gain a byte the markdown never contained.
+  const content = raw.endsWith('\n') ? raw.slice(0, -1) : raw
+  const language = /language-([^\s]+)/.exec(props.className ?? '')?.[1] ?? ''
+  return { content, language }
+}
+
+/**
+ * The hover/focus toolbar over one fenced block. Mounted ONLY when the transcript provided
+ * CodeBlockActions — which is also why it may use the i18n hook: AssistantMarkdown itself renders
+ * in contexts with no I18nProvider (unit tests, other screens) and the bare `pre` path below must
+ * stay hook-free for them.
+ */
+function CodeBlockToolbar({
+  actions,
+  content,
+  language
+}: {
+  actions: CodeBlockActions
+  content: string
+  language: string
+}): JSX.Element | null {
+  const { t } = useT()
+  // Mid-stream the closing fence may not have arrived, so the "code" so far is a partial the user
+  // should not be saving. (Belt-and-braces: the live bubble is never given a provider at all.)
+  const incomplete = useIsCodeFenceIncomplete()
+  if (incomplete) return null
+  // Distinct accessible names per block: the extension comes from the SHARED allowlist, so the
+  // label can never promise an extension main would not use.
+  const saveTitle = t('chat.code.saveTitle', { ext: codeBlockExtension(language) })
+  const copyTitle = t('chat.code.copyTitle')
+  return (
+    <div className="code-block-actions">
+      <button
+        type="button"
+        className="msg-action"
+        title={copyTitle}
+        aria-label={copyTitle}
+        onClick={() => actions.onCopy(content)}
+      >
+        {t('chat.code.copy')}
+      </button>
+      <button
+        type="button"
+        className="msg-action"
+        title={saveTitle}
+        aria-label={saveTitle}
+        onClick={() => actions.onSave(content, language)}
+      >
+        {t('chat.code.save')}
+      </button>
+    </div>
+  )
+}
+
+/**
+ * `pre` override. With NO CodeBlockActions in context this is byte-for-byte Streamdown's default
+ * (clone the child with the `data-block` stamp) — so every non-transcript consumer, inline code,
+ * and the live streaming bubble keep the exact DOM they had before #286.
+ */
+function CodeBlockPre({ children }: { children?: ReactNode }): JSX.Element {
+  const actions = useCodeBlockActions()
+  if (!isValidElement(children)) return <>{children}</>
+  const child = cloneElement(children as ReactElement<Record<string, unknown>>, {
+    'data-block': 'true'
+  })
+  if (actions === null) return <>{child}</>
+  const { content, language } = readCodeChild(children)
+  return (
+    <div className="code-block">
+      {child}
+      <CodeBlockToolbar actions={actions} content={content} language={language} />
+    </div>
+  )
+}
+
 // Module-level so the reference is stable across every render — defining this inline in JSX would
 // hand Streamdown a fresh `components` object on each ~40 ms flush, busting the block memoization
 // that makes the live bubble O(n) instead of O(n²) (the whole point of FE-1 revisited).
 const mdComponents = {
+  // #286: the Copy/Save toolbar wrapper (a no-op passthrough without the transcript's context).
+  pre: CodeBlockPre,
   // Streamdown renders `**bold**` as a Tailwind-classed <span> (font-semibold). This app ships
   // no Tailwind, so that span would be UNSTYLED — map it back to a semantic <strong> the
   // existing `.md strong` CSS styles (and screen readers announce as emphasis). Every other

--- a/apps/desktop/src/renderer/chat/CodeBlockActionsContext.tsx
+++ b/apps/desktop/src/renderer/chat/CodeBlockActionsContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext } from 'react'
+
+// #286 — "save a code block from an assistant reply as a file", renderer half.
+//
+// The per-code-block toolbar (Copy / Save) is opt-in via CONTEXT rather than a prop on
+// AssistantMarkdown, because the block that needs it is rendered several layers down inside
+// Streamdown's own component tree (our `pre` override), not by the caller.
+//
+// Scope (owner decision D3): the chat transcript's PERSISTED assistant turns only. Every other
+// consumer of AssistantMarkdown (images AnswerThread, ReviewScreen, TranslateScreen, documents
+// PreviewModal) and the live streaming bubble render WITHOUT a provider, so the default `null`
+// keeps their DOM byte-identical to before this feature existed.
+//
+// This module deliberately imports nothing but React: Transcript.tsx (in the main renderer
+// chunk) imports it to provide the value, and AssistantMarkdown (the lazily-loaded
+// streamdown/katex chunk, FE-1 code-split) imports it to consume — pulling streamdown in here
+// would drag that ~2 MB chunk back into the initial bundle.
+
+export interface CodeBlockActions {
+  /** Copy the block's exact code value to the clipboard (the transcript's own copy path). */
+  onCopy: (content: string) => void
+  /**
+   * Save the block as a file. `language` is the fence language token (the info string's first
+   * word, as remark keeps it in `language-<token>`; model output) — main maps it through the
+   * fixed allowlist in `@shared/code-block-export`; the renderer never derives a filename from
+   * it. The message id is bound by the provider.
+   */
+  onSave: (content: string, language: string) => void
+}
+
+/** Null (the default) ⇒ no toolbar: the code block renders exactly as Streamdown's default. */
+export const CodeBlockActionsContext = createContext<CodeBlockActions | null>(null)
+
+/** The block actions for the surrounding transcript turn, or null when there are none. */
+export function useCodeBlockActions(): CodeBlockActions | null {
+  return useContext(CodeBlockActionsContext)
+}

--- a/apps/desktop/src/renderer/chat/Transcript.tsx
+++ b/apps/desktop/src/renderer/chat/Transcript.tsx
@@ -7,6 +7,7 @@ import { isReviewEligible } from '@shared/evidence-review'
 import { formatAnswerSpeed } from './answerSpeed'
 import { MessageActions } from './MessageActions'
 import { SourcesDisclosure } from './SourcesDisclosure'
+import { CodeBlockActionsContext } from './CodeBlockActionsContext'
 import { PackOutcomesNotice } from './PackOutcomesNotice'
 import { CoverageMeter, Icon, Spinner } from '../components'
 import { localizeServerCopy } from '../lib/displayMap'
@@ -73,6 +74,13 @@ interface TranscriptProps {
   onCopy: (content: string) => void
   onSave: () => void
   /**
+   * #286: save ONE fenced code block out of a persisted assistant reply as a file. Absent => no
+   * per-block toolbar renders anywhere (the affordance is opt-in, D3) and the markdown DOM is
+   * unchanged. `language` is the fence language token (model output); main maps it through the
+   * shared extension allowlist. Never wired on the live streaming bubble.
+   */
+  onSaveCodeBlock?: (messageId: string, content: string, language: string) => void
+  /**
    * Save one answer's attached RESULT TABLE as CSV (result-tables §4, Phase 2). Rendered only on
    * messages with `hasResultTable`; the MAIN side re-serializes the persisted table and opens the
    * save dialog. Absent ⇒ the affordance never renders.
@@ -136,6 +144,7 @@ export const Transcript = memo(function Transcript({
   isSkillOfferAvailable,
   onCopy,
   onSave,
+  onSaveCodeBlock,
   onExportTable,
   onOpenReview,
   onOpenArticle,
@@ -218,6 +227,7 @@ export const Transcript = memo(function Transcript({
               isSkillOfferAvailable={isSkillOfferAvailable}
               onCopy={onCopy}
               onSave={onSave}
+              onSaveCodeBlock={onSaveCodeBlock}
               onExportTable={onExportTable}
               onOpenReview={onOpenReview}
               onOpenArticle={onOpenArticle}
@@ -329,6 +339,7 @@ const MessageBlock = memo(function MessageBlock({
   isSkillOfferAvailable,
   onCopy,
   onSave,
+  onSaveCodeBlock,
   onExportTable,
   onOpenReview,
   onOpenArticle,
@@ -352,6 +363,7 @@ const MessageBlock = memo(function MessageBlock({
   isSkillOfferAvailable?: (installId: string) => boolean
   onCopy: (content: string) => void
   onSave: () => void
+  onSaveCodeBlock?: (messageId: string, content: string, language: string) => void
   onExportTable?: (messageId: string) => void
   onOpenReview?: (messageId: string) => void
   onOpenArticle?: (citation: Citation) => void
@@ -370,6 +382,20 @@ const MessageBlock = memo(function MessageBlock({
   // narrowing holds inside the handler closures below.
   const skillOffer =
     m.role === 'assistant' && isLast && onRunWithSkill != null ? m.skillOffer : undefined
+  // #286: the per-code-block Copy/Save actions for THIS persisted turn. null (no handler wired)
+  // means AssistantMarkdown renders exactly the DOM it rendered before the feature existed — the
+  // provider is inert. Memoized on the message id + the two (stable, useEventCallback'd) handlers
+  // so a re-render never hands Streamdown a fresh context value and re-renders every block (FE-3).
+  const codeBlockActions = useMemo(
+    () =>
+      onSaveCodeBlock
+        ? {
+            onCopy,
+            onSave: (content: string, language: string) => onSaveCodeBlock(m.id, content, language)
+          }
+        : null,
+    [m.id, onCopy, onSaveCodeBlock]
+  )
   return (
     <div className={`msg-block ${m.role}`}>
       <div className={`msg ${m.role}`}>
@@ -379,7 +405,11 @@ const MessageBlock = memo(function MessageBlock({
             {/* The fixed RAG answers (no-context / reindex-needed) are persisted
                 canonical English; the D-L4 display map translates them at render
                 — exact match only, real model output passes through untouched. */}
-            <AssistantMarkdown text={localizeServerCopy(t, m.content)} />
+            {/* #286: PERSISTED assistant turns only — the live streaming bubble below renders
+                AssistantMarkdown with no provider, so a half-streamed fence has no Save button. */}
+            <CodeBlockActionsContext.Provider value={codeBlockActions}>
+              <AssistantMarkdown text={localizeServerCopy(t, m.content)} />
+            </CodeBlockActionsContext.Provider>
           </div>
         ) : (
           <div className="msg-content">{m.content}</div>

--- a/apps/desktop/src/renderer/screens/ChatScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ChatScreen.tsx
@@ -1097,6 +1097,7 @@ export function ChatScreen({
   const handleCopyMessage = useEventCallback(onCopyMessage)
   const handleSaveConversation = useEventCallback(onSaveConversation)
   const handleExportMessageTable = useEventCallback(onExportMessageTable)
+  const handleSaveCodeBlock = useEventCallback(onSaveCodeBlock)
   // EP-1 plan §7.2: hand off to the review workspace — an existing review by id, a first
   // review by message id (main's create is idempotent either way).
   const handleOpenReviewMessage = useEventCallback((messageId: string) => {
@@ -1876,6 +1877,19 @@ export function ChatScreen({
     }
   }
 
+  // #286: save ONE fenced code block out of an assistant reply. MAIN validates the arguments,
+  // maps the fence info string through the fixed extension allowlist and writes the bytes behind
+  // the native save dialog (the dialog IS the consent — the onSaveConversation posture); null =
+  // the user cancelled, a calm non-outcome with no toast and no banner.
+  async function onSaveCodeBlock(messageId: string, content: string, language: string): Promise<void> {
+    try {
+      const saved = await window.api.saveCodeBlock(messageId, content, language)
+      if (saved) showToast(t('chat.savedTo', { path: saved }))
+    } catch (e) {
+      setError(friendlyIpcError(e))
+    }
+  }
+
   async function onNewChat(): Promise<void> {
     // full-audit 2026-07-11 CODE-30: this entry point used to skip the SKA-18 carry+delete (a
     // composer pick vanished, then resurrected on the next empty composer) AND discarded its
@@ -2396,6 +2410,9 @@ export function ChatScreen({
           onCopy={handleCopyMessage}
           onSave={handleSaveConversation}
           onExportTable={handleExportMessageTable}
+          // #286: the per-code-block Save (Copy reuses onCopy above). Placement — persisted
+          // assistant turns only, never the streaming bubble — lives in Transcript.
+          onSaveCodeBlock={handleSaveCodeBlock}
           // EP-1 plan §7.2: the review entry points (action row + sources footer). Only wired
           // when App provides the handoff (onOpenReview); per-message eligibility + labels are
           // resolved inside Transcript via the shared isReviewEligible + reviewSummaries.

--- a/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
+++ b/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
@@ -49,6 +49,7 @@ const AUDIT_TYPE_LABELS: Record<AuditEventType, MessageKey> = {
   conversation_deleted: 'diag.audit.conversation_deleted',
   conversation_exported: 'diag.audit.conversation_exported',
   message_table_exported: 'diag.audit.message_table_exported',
+  code_block_exported: 'diag.audit.code_block_exported',
   workspace_created: 'diag.audit.workspace_created',
   workspace_unlocked: 'diag.audit.workspace_unlocked',
   workspace_locked: 'diag.audit.workspace_locked',

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -843,6 +843,27 @@ code, pre, kbd { font-family: var(--font-mono); }
 .msg-action:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }
 .msg-action:disabled { opacity: 0.5; cursor: default; }
 
+/* #286 — the per-code-block Copy/Save toolbar inside a persisted assistant answer. Same
+   reveal grammar as .msg-actions (hover or keyboard focus, never permanent chrome), parked
+   over the right end of Streamdown's code-block header row so it never covers code. The
+   surface fill keeps the labels legible where a block has no header (bare ``` fences). */
+.code-block { position: relative; }
+.code-block-actions {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+  display: flex;
+  gap: 2px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease);
+}
+.code-block:hover .code-block-actions,
+.code-block-actions:focus-within { opacity: 1; }
+
 /* Composer footer affordances: quiet text-style menu/popover triggers. */
 .footer-menu-btn {
   display: inline-flex;

--- a/apps/desktop/src/shared/code-block-export.ts
+++ b/apps/desktop/src/shared/code-block-export.ts
@@ -1,0 +1,68 @@
+// #286 — saving one fenced code block from an assistant reply as a file. This module is the
+// PURE, shared part: the fence info string → file extension map. It runs in MAIN (the save
+// dialog's default name + filter) and is unit-tested on its own; the renderer never derives a
+// filename from it (it only forwards the raw info string over IPC).
+//
+// SECURITY (D2/D6, owner decisions): the fence info string is MODEL OUTPUT — i.e. content. It
+// is never used as-is for a filename, a dialog filter or an audit row. Only the first
+// whitespace-separated token, lower-cased and stripped to [a-z0-9+#.-], is looked up in the FIXED
+// allowlist below; anything unknown (including an empty string) falls back to `txt`. The result
+// is therefore a closed set of extensions, which is why the audit event may carry it.
+
+/** The fixed fence-language → extension allowlist (D6). Keys are the normalized info tokens. */
+const EXTENSION_BY_LANGUAGE: Readonly<Record<string, string>> = {
+  html: 'html',
+  js: 'js',
+  javascript: 'js',
+  ts: 'ts',
+  typescript: 'ts',
+  py: 'py',
+  python: 'py',
+  csv: 'csv',
+  json: 'json',
+  md: 'md',
+  markdown: 'md',
+  sh: 'sh',
+  bash: 'sh',
+  zsh: 'sh',
+  css: 'css',
+  xml: 'xml',
+  yaml: 'yml',
+  yml: 'yml',
+  sql: 'sql',
+  ps1: 'ps1',
+  powershell: 'ps1',
+  bat: 'bat',
+  cmd: 'bat',
+  svg: 'svg',
+  toml: 'toml',
+  txt: 'txt',
+  text: 'txt'
+}
+
+/** The fallback for an unknown or empty language. */
+export const DEFAULT_CODE_BLOCK_EXTENSION = 'txt'
+
+/**
+ * Normalize a fence info string to its language token: the first whitespace-separated token
+ * (CommonMark's "info string" may carry attributes such as `html title="x"`), lower-cased, with
+ * everything outside `[a-z0-9+#.-]` removed. Returns '' for an empty/blank info string.
+ */
+export function codeBlockLanguageToken(info: string): string {
+  const first = info.trim().split(/\s+/, 1)[0] ?? ''
+  return first.toLowerCase().replace(/[^a-z0-9+#.-]/g, '')
+}
+
+/**
+ * The file extension (without the dot) for a fence info string — one of the allowlist values,
+ * or `txt` for anything else. Pure; safe to call with arbitrary model output.
+ */
+export function codeBlockExtension(info: string): string {
+  const token = codeBlockLanguageToken(info)
+  return (Object.hasOwn(EXTENSION_BY_LANGUAGE, token) && EXTENSION_BY_LANGUAGE[token]) || DEFAULT_CODE_BLOCK_EXTENSION
+}
+
+/** The fixed default file name offered in the save dialog — never derived from content. */
+export function codeBlockDefaultFileName(info: string): string {
+  return `code.${codeBlockExtension(info)}`
+}

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -407,6 +407,11 @@ export const de: Record<keyof typeof en, string> = {
   // Result-Tables §4 (Phase 2): nur bei Antworten mit angehängter Ergebnistabelle sichtbar.
   'chat.actions.exportCsv': 'Als CSV exportieren',
   'chat.actions.exportCsvTitle': 'Die Tabelle dieser Antwort als CSV-Datei speichern (bleibt lokal)',
+  // #286: die Werkzeugleiste pro Codeblock in einer Antwort (Kopieren + Speichern).
+  'chat.code.copy': 'Kopieren',
+  'chat.code.copyTitle': 'Diesen Codeblock in die Zwischenablage kopieren',
+  'chat.code.save': 'Speichern',
+  'chat.code.saveTitle': 'Diesen Codeblock als .{ext}-Datei speichern (bleibt lokal)',
 
   // ---- Chat: Kontext-Komprimierung (context-compaction plan §5.1–§5.3) ----
   'chat.compaction.inProgress': 'Frühere Nachrichten werden zusammengefasst, um Platz zu schaffen…',
@@ -1745,6 +1750,7 @@ export const de: Record<keyof typeof en, string> = {
   'diag.audit.conversation_deleted': 'Unterhaltung gelöscht',
   'diag.audit.conversation_exported': 'Unterhaltung exportiert',
   'diag.audit.message_table_exported': 'Antwort-Tabelle exportiert',
+  'diag.audit.code_block_exported': 'Codeblock als Datei gespeichert',
   'diag.audit.workspace_created': 'Arbeitsbereich erstellt',
   'diag.audit.workspace_unlocked': 'Arbeitsbereich entsperrt',
   'diag.audit.workspace_locked': 'Arbeitsbereich gesperrt',
@@ -2547,6 +2553,7 @@ export const de: Record<keyof typeof en, string> = {
   'main.dialog.exportSummary': 'Zusammenfassung exportieren',
   'main.dialog.exportChat': 'Chat-Verlauf exportieren',
   'main.dialog.exportTableCsv': 'Tabelle als CSV exportieren',
+  'main.dialog.exportCodeBlock': 'Codeblock als Datei speichern',
   'main.dialog.exportAudit': 'Aktivitätslog exportieren',
   'main.dialog.exportEvidencePack': 'Nachweispaket exportieren',
   'main.dialog.exportLog': 'Diagnose-Logs speichern',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -374,6 +374,12 @@ export const en = {
   // Result-tables §4 (Phase 2): shown only on answers carrying a structured result table.
   'chat.actions.exportCsv': 'Export CSV',
   'chat.actions.exportCsvTitle': 'Save this answer’s table as a CSV file (stays local)',
+  // #286: the per-code-block toolbar inside an answer (Copy + Save). The titles double as the
+  // accessible names, so blocks of different languages in one answer stay distinguishable.
+  'chat.code.copy': 'Copy',
+  'chat.code.copyTitle': 'Copy this code block to the clipboard',
+  'chat.code.save': 'Save',
+  'chat.code.saveTitle': 'Save this code block as a .{ext} file (stays local)',
 
   // ---- Chat: context compaction (context-compaction plan §5.1–§5.3) ----
   // The one-shot "summarizing…" status above the streaming bubble (§5.2).
@@ -1703,6 +1709,7 @@ export const en = {
   'diag.audit.conversation_deleted': 'Conversation deleted',
   'diag.audit.conversation_exported': 'Conversation exported',
   'diag.audit.message_table_exported': 'Answer table exported',
+  'diag.audit.code_block_exported': 'Code block saved as a file',
   'diag.audit.workspace_created': 'Workspace created',
   'diag.audit.workspace_unlocked': 'Workspace unlocked',
   'diag.audit.workspace_locked': 'Workspace locked',
@@ -2516,6 +2523,7 @@ export const en = {
   'main.dialog.exportSummary': 'Export summary',
   'main.dialog.exportChat': 'Export chat transcript',
   'main.dialog.exportTableCsv': 'Export table as CSV',
+  'main.dialog.exportCodeBlock': 'Save code block as a file',
   'main.dialog.exportAudit': 'Export activity log',
   'main.dialog.exportEvidencePack': 'Export evidence pack',
   'main.dialog.exportLog': 'Save diagnostic logs',

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -81,6 +81,11 @@ export const IPC = {
   exportConversation: 'chat:export',
   /** Save one message's attached RESULT TABLE as CSV to a user-chosen file (result-tables §4). */
   exportMessageTable: 'chat:exportMessageTable',
+  /** #286: save ONE fenced code block of an assistant reply to a user-chosen file. The bytes are
+   *  renderer-supplied (the parsed block content + fence info string), not DB-derived: main only
+   *  validates the types, maps the info string through the fixed extension allowlist
+   *  (`shared/code-block-export.ts`) and writes verbatim (no BOM) behind the native save dialog. */
+  saveCodeBlock: 'chat:saveCodeBlock',
   /** Full-text search across conversations. Queries are content: never logged/audited. */
   searchConversations: 'chat:search',
   /**

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -3014,6 +3014,11 @@ export type AuditEventType =
   // privacy rule as conversation_exported: metadata = { messageId, rows } only — the table's
   // columns/rows and the chosen path are content.
   | 'message_table_exported'
+  // #286: one fenced code block of an assistant reply saved as a file. Same privacy rule:
+  // metadata = { messageId, bytes, extension } only — the block's text, the raw fence info string
+  // and the chosen path are content. `extension` is safe because it comes from the FIXED
+  // allowlist in shared/code-block-export.ts (a closed set), never from the info string itself.
+  | 'code_block_exported'
   // Document-organization (plan §17): collection/membership/lifecycle changes. Metadata is
   // id + type + COUNT ONLY — never the collection/project NAME (a project name like
   // "Divorce" is content — exactly like a document title/filename, which S1 now withholds too).

--- a/apps/desktop/tests/integration/audit-ipc.test.ts
+++ b/apps/desktop/tests/integration/audit-ipc.test.ts
@@ -106,6 +106,13 @@ const REVIEW_EXPORT_PATH_SENTINEL = 'XREVPATH_SENTINEL_private-client-folder'
 // #90: the original-bytes export's chosen destination is user-private (a path can reveal
 // private workstation structure); `document_exported` records the documentId ONLY.
 const DOC_EXPORT_PATH_SENTINEL = 'XDOCPATH_SENTINEL_private-desktop-folder'
+// #286: a fenced code block saved as a file — the block's TEXT, its raw fence INFO STRING (both
+// model output = content) and the sentinel-named destination must never reach runtime_events;
+// the event carries { messageId, bytes, extension } only (the allowlisted extension, not the
+// info string).
+const CODE_BLOCK_SENTINEL = 'XCODEBLOCK_SENTINEL_password = "hunter2"'
+const CODE_INFO_SENTINEL = 'XCODEINFO_SENTINEL_secret_project'
+const CODE_EXPORT_PATH_SENTINEL = 'XCODEPATH_SENTINEL_private-scripts-folder'
 const SENTINELS = [
   CHAT_SENTINEL,
   DOC_SENTINEL,
@@ -116,6 +123,9 @@ const SENTINELS = [
   PROJECT_SENTINEL,
   FILENAME_SENTINEL,
   DOC_EXPORT_PATH_SENTINEL,
+  CODE_BLOCK_SENTINEL,
+  CODE_INFO_SENTINEL,
+  CODE_EXPORT_PATH_SENTINEL,
   REVIEW_TITLE_SENTINEL,
   REVIEWER_SENTINEL,
   REVIEW_NOTE_SENTINEL,
@@ -315,6 +325,25 @@ describe('audit wiring across the IPC layer (privacy sentinel grep)', () => {
     ipcState.saveDialog.canceled = false
     ipcState.saveDialog.filePath = join(rootPath, 'transcript.md')
     await invoke(handlers, IPC.exportConversation, conv.id)
+    // -- #286: save a fenced code block of the reply through the real handler. The bytes are
+    // renderer-supplied: the block text AND the fence info string are model output, the
+    // destination is user-private — the sweep below proves none of the three reached
+    // runtime_events, and the metadata pin further down proves the event carries
+    // { messageId, bytes, extension } only.
+    const reply = replyRaw as Message
+    ipcState.saveDialog.canceled = false
+    ipcState.saveDialog.filePath = join(rootPath, `${CODE_EXPORT_PATH_SENTINEL}.py`)
+    const { result: codeBlockPath } = await invoke(
+      handlers,
+      IPC.saveCodeBlock,
+      reply.id,
+      `print("hi")\n${CODE_BLOCK_SENTINEL}\n`,
+      `python title="${CODE_INFO_SENTINEL}"`
+    )
+    expect(codeBlockPath).toBeTruthy()
+    expect(readFileSync(join(rootPath, `${CODE_EXPORT_PATH_SENTINEL}.py`), 'utf8')).toContain(
+      CODE_BLOCK_SENTINEL
+    ) // the flow really carried it
     await invoke(handlers, IPC.deleteConversation, conv.id)
 
     // -- documents: sentinel text inside the file body AND in the filename — both are
@@ -596,7 +625,8 @@ describe('audit wiring across the IPC layer (privacy sentinel grep)', () => {
       'evidence_review_created',
       'evidence_review_ready',
       'evidence_review_deleted',
-      'evidence_pack_exported'
+      'evidence_pack_exported',
+      'code_block_exported'
     ]) {
       expect(types, `missing audit event: ${expected}`).toContain(expected)
     }
@@ -613,6 +643,18 @@ describe('audit wiring across the IPC layer (privacy sentinel grep)', () => {
       (e) => e.type === 'settings_changed'
     )
     expect(settingsEvent?.metadata).toEqual({ allowNetwork: true })
+
+    // #286: the code-block save records the message id, the byte count and the ALLOWLISTED
+    // extension ('py' — mapped from the info string, never the info string itself) and nothing else.
+    const codeBlockEvent = listAuditEvents(db, { limit: 5000 }).find(
+      (e) => e.type === 'code_block_exported'
+    )
+    expect(codeBlockEvent?.metadata).toEqual({
+      messageId: reply.id,
+      bytes: Buffer.byteLength(`print("hi")\n${CODE_BLOCK_SENTINEL}\n`, 'utf8'),
+      extension: 'py'
+    })
+    expect(codeBlockEvent?.message).not.toContain(CODE_INFO_SENTINEL)
 
     // S1: the document_imported event records the documentId + status + chunkCount ONLY —
     // a fixed message string with NO title (the conversation_exported precedent).

--- a/apps/desktop/tests/integration/chat-ipc.test.ts
+++ b/apps/desktop/tests/integration/chat-ipc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -34,6 +34,7 @@ vi.mock('electron', () => ({
 }))
 
 import { registerChatIpc } from '../../src/main/ipc/registerChatIpc'
+import { log } from '../../src/main/services/logging'
 import { registerBenchmarkIpc } from '../../src/main/ipc/registerBenchmarkIpc'
 import { inFlightStreams } from '../../src/main/ipc/inflight'
 import { IPC, STREAM } from '../../src/shared/ipc'
@@ -659,5 +660,187 @@ describe('chat export handlers (T-8)', () => {
     const none = (await invoke(handlers, IPC.exportMessageTable, noTable.id)).result as string | null
     expect(none).toBeNull()
     expect(dialogState.lastSaveOptions).toBeUndefined() // returned before the save dialog
+  })
+})
+
+// #286: save ONE fenced code block as a file. The first export whose bytes are RENDERER-supplied
+// (the parsed block + fence info string) rather than DB-derived — so these pin the D1 byte
+// identity (no BOM even on a .txt/.csv destination), the D2 type gate, the D6 allowlist reaching
+// the dialog, cancel = null with nothing written/audited, and the audit/log privacy posture.
+describe('chat:saveCodeBlock (#286)', () => {
+  function ctxWithAudit(db: Db): { ctx: AppContext; audit: ReturnType<typeof vi.fn> } {
+    const audit = vi.fn()
+    const ctx = {
+      trustedSenders: ANY_SENDER,
+      db,
+      workspace: { isUnlocked: () => true },
+      runtime: { active: () => null, activeModelId: () => null },
+      audit
+    } as unknown as AppContext
+    return { ctx, audit }
+  }
+  const MSG_ID = '0f5a1c2e-9b7d-4e3a-8c6f-1234567890ab'
+  const CONTENT_SENTINEL = 'XCODE_SENTINEL_api_key_hunter2'
+  const INFO_SENTINEL = 'XINFO_SENTINEL_private_project'
+  const SENTINELS = [CONTENT_SENTINEL, INFO_SENTINEL]
+  const BOM = Buffer.from([0xef, 0xbb, 0xbf])
+  // Read through a function: TS narrows the hoisted state to never after an = undefined reset.
+  const lastSave = (): SaveDialogOptions | undefined => dialogState.lastSaveOptions
+
+  it('offers code.html + an HTML-first filter for an html fence, code.txt for an unknown language', async () => {
+    const { ctx } = ctxWithAudit(freshDb())
+    registerChatIpc(ctx)
+    dialogState.saveResult = { canceled: true }
+
+    await invoke(handlers, IPC.saveCodeBlock, MSG_ID, '<b>x</b>', 'html title="x"')
+    expect(lastSave()?.defaultPath).toBe('code.html')
+    expect(lastSave()?.title).toBe('Save code block as a file')
+    expect(lastSave()?.filters).toEqual([
+      { name: 'HTML', extensions: ['html'] },
+      { name: 'All files', extensions: ['*'] }
+    ])
+
+    dialogState.lastSaveOptions = undefined
+    await invoke(handlers, IPC.saveCodeBlock, MSG_ID, 'fn main() {}', 'rust')
+    expect(lastSave()?.defaultPath).toBe('code.txt')
+    expect(lastSave()?.filters).toEqual([
+      { name: 'TXT', extensions: ['txt'] },
+      { name: 'All files', extensions: ['*'] }
+    ])
+
+    // No language at all (a bare fence) → txt too.
+    dialogState.lastSaveOptions = undefined
+    await invoke(handlers, IPC.saveCodeBlock, MSG_ID, 'plain', '')
+    expect(lastSave()?.defaultPath).toBe('code.txt')
+  })
+
+  it('cancel → null, nothing written, nothing audited', async () => {
+    const { ctx, audit } = ctxWithAudit(freshDb())
+    registerChatIpc(ctx)
+    const dir = mkdtempSync(join(tmpdir(), 'hilbertraum-codeblock-'))
+    dialogState.saveResult = { canceled: true, filePath: join(dir, 'code.html') }
+
+    const result = (await invoke(handlers, IPC.saveCodeBlock, MSG_ID, '<b>x</b>', 'html')).result
+    expect(result).toBeNull()
+    expect(readdirSync(dir)).toEqual([]) // no destination, no leftover tmp sibling
+    expect(audit).not.toHaveBeenCalled()
+  })
+
+  it('writes the bytes VERBATIM — no BOM — to a .txt and to a .csv destination (D1)', async () => {
+    const db = freshDb()
+    const { ctx } = ctxWithAudit(db)
+    registerChatIpc(ctx)
+    const dir = mkdtempSync(join(tmpdir(), 'hilbertraum-codeblock-'))
+    // A shebang (a BOM would break it), umlauts (UTF-8 multi-byte), CRLF + a bare CR + a trailing
+    // newline (line endings "as generated") and an astral-plane emoji.
+    const content = '#!/bin/sh\necho "Grüße"\r\nprintf ß\rtail 🎉\n'
+
+    for (const name of ['out.txt', 'out.csv', 'out.sh']) {
+      const dest = join(dir, name)
+      dialogState.saveResult = { canceled: false, filePath: dest }
+      const saved = (await invoke(handlers, IPC.saveCodeBlock, MSG_ID, content, 'sh')).result
+      expect(saved).toBe(dest)
+      const onDisk = readFileSync(dest)
+      expect(onDisk.equals(Buffer.from(content, 'utf8')), name).toBe(true)
+      expect(onDisk.subarray(0, 3).equals(BOM), name).toBe(false)
+    }
+    // The transcript export DOES prefix a BOM on .txt (the recorded bomFor decision) — pin the
+    // contrast so a refactor that routes the code block through saveTextExport is caught.
+    const conv = createConversation(db, { title: 'BOM contrast' })
+    appendMessage(db, { conversationId: conv.id, role: 'user', content: 'hi' })
+    const transcriptDest = join(dir, 'transcript.txt')
+    dialogState.saveResult = { canceled: false, filePath: transcriptDest }
+    await invoke(handlers, IPC.exportConversation, conv.id)
+    expect(readFileSync(transcriptDest).subarray(0, 3).equals(BOM)).toBe(true)
+  })
+
+  it('writes an empty block as an empty file', async () => {
+    const { ctx } = ctxWithAudit(freshDb())
+    registerChatIpc(ctx)
+    const dir = mkdtempSync(join(tmpdir(), 'hilbertraum-codeblock-'))
+    const dest = join(dir, 'empty.txt')
+    dialogState.saveResult = { canceled: false, filePath: dest }
+    expect((await invoke(handlers, IPC.saveCodeBlock, MSG_ID, '', '')).result).toBe(dest)
+    expect(readFileSync(dest).length).toBe(0)
+  })
+
+  it('rejects non-string content and a malformed message id WITHOUT opening the dialog', async () => {
+    const { ctx, audit } = ctxWithAudit(freshDb())
+    registerChatIpc(ctx)
+    dialogState.saveResult = { canceled: false, filePath: join(tmpdir(), 'never-written.txt') }
+    dialogState.lastSaveOptions = undefined
+
+    for (const bad of [undefined, null, 42, { toString: () => 'x' }, ['a'], Buffer.from('a')]) {
+      const r = (await invoke(handlers, IPC.saveCodeBlock, MSG_ID, bad, 'html')).result
+      expect(r, `content=${String(bad)}`).toBeNull()
+    }
+    for (const badId of [undefined, null, 7, '', 'has space', 'a/b', 'x'.repeat(65), CONTENT_SENTINEL + ' ']) {
+      const r = (await invoke(handlers, IPC.saveCodeBlock, badId, 'text', 'html')).result
+      expect(r, `messageId=${String(badId)}`).toBeNull()
+    }
+    expect(dialogState.lastSaveOptions).toBeUndefined()
+    expect(audit).not.toHaveBeenCalled()
+
+    // A non-string language is tolerated (treated as no language → txt); the content still wins.
+    const dir = mkdtempSync(join(tmpdir(), 'hilbertraum-codeblock-'))
+    dialogState.saveResult = { canceled: false, filePath: join(dir, 'x.txt') }
+    const r = (await invoke(handlers, IPC.saveCodeBlock, MSG_ID, 'ok', 12 as unknown as string)).result
+    expect(r).toBe(join(dir, 'x.txt'))
+    expect(lastSave()?.defaultPath).toBe('code.txt')
+  })
+
+  it('refuses when the workspace is locked (requireUnlocked), before any dialog', async () => {
+    const { ctx } = ctxWithAudit(freshDb())
+    ;(ctx as unknown as { workspace: { isUnlocked: () => boolean } }).workspace = {
+      isUnlocked: () => false
+    }
+    registerChatIpc(ctx)
+    dialogState.lastSaveOptions = undefined
+    await expect(invoke(handlers, IPC.saveCodeBlock, MSG_ID, 'x', 'html')).rejects.toThrow()
+    expect(dialogState.lastSaveOptions).toBeUndefined()
+  })
+
+  it('audits { messageId, bytes, extension } ONLY; no audit row or log line carries the content, the info string or the path', async () => {
+    const { ctx, audit } = ctxWithAudit(freshDb())
+    registerChatIpc(ctx)
+    const logSpy = {
+      info: vi.spyOn(log, 'info'),
+      warn: vi.spyOn(log, 'warn'),
+      error: vi.spyOn(log, 'error')
+    }
+    try {
+      const dir = mkdtempSync(join(tmpdir(), 'hilbertraum-codeblock-'))
+      const dest = join(dir, 'code.html')
+      dialogState.saveResult = { canceled: false, filePath: dest }
+      const content = `<!doctype html>\n<p>${CONTENT_SENTINEL}</p>\n`
+      const info = `html title="${INFO_SENTINEL}"`
+      const saved = (await invoke(handlers, IPC.saveCodeBlock, MSG_ID, content, info)).result
+      expect(saved).toBe(dest)
+      expect(readFileSync(dest, 'utf8')).toContain(CONTENT_SENTINEL) // the flow really carried it
+
+      expect(audit).toHaveBeenCalledTimes(1)
+      const [type, message, meta] = audit.mock.calls[0]!
+      expect(type).toBe('code_block_exported')
+      expect(meta).toEqual({
+        messageId: MSG_ID,
+        bytes: Buffer.byteLength(content, 'utf8'),
+        extension: 'html'
+      })
+      const recordedAudit = JSON.stringify([type, message, meta])
+      const recordedLog = JSON.stringify(
+        [logSpy.info, logSpy.warn, logSpy.error].flatMap((s) => s.mock.calls)
+      )
+      for (const sentinel of SENTINELS) {
+        expect(recordedAudit, `audit leaked ${sentinel}`).not.toContain(sentinel)
+        expect(recordedLog, `log leaked ${sentinel}`).not.toContain(sentinel)
+      }
+      expect(recordedAudit).not.toContain(dest) // the chosen path is user-private
+      expect(recordedLog).not.toContain(dest)
+      expect(recordedLog).not.toContain('title=') // the raw info string never reaches the log
+    } finally {
+      logSpy.info.mockRestore()
+      logSpy.warn.mockRestore()
+      logSpy.error.mockRestore()
+    }
   })
 })

--- a/apps/desktop/tests/renderer/CodeBlockActions.test.tsx
+++ b/apps/desktop/tests/renderer/CodeBlockActions.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { Transcript } from '../../src/renderer/chat/Transcript'
+import { AssistantMarkdown } from '../../src/renderer/chat/AssistantMarkdown'
+import { I18nProvider } from '../../src/renderer/i18n'
+import { stubApi } from '../helpers/renderer'
+import type { Message } from '../../src/shared/types'
+
+// #286 renderer half — the per-code-block Copy/Save toolbar on PERSISTED assistant turns.
+//
+// The invariants worth pinning:
+//  • D3 scope: transcript, persisted turns only. Never the live streaming bubble; never any other
+//    AssistantMarkdown consumer (images AnswerThread, ReviewScreen, TranslateScreen, documents
+//    PreviewModal) — those render with no CodeBlockActions context and must be unchanged.
+//  • D1 verbatim: what reaches Save/Copy is the code value AS PARSED — mdast-util-to-hast appends
+//    one '\n' to every code node, and shipping that would add a byte the markdown never had.
+//  • Distinct accessible names per block (the ext comes from the shared allowlist), so a keyboard
+//    user picking from a list of "Save" buttons can tell the html one from the python one.
+
+afterEach(cleanup)
+
+// jsdom does not implement Element.scrollTo (Transcript scrolls to newest content).
+beforeAll(() => {
+  Element.prototype.scrollTo = (() => undefined) as Element['scrollTo']
+})
+
+function noop(): void {}
+
+const HTML_BLOCK = '<b>hi</b>'
+const PY_BLOCK = 'print("hi")'
+const TWO_BLOCKS = `Here you go:\n\n\`\`\`html\n${HTML_BLOCK}\n\`\`\`\n\nand in python:\n\n\`\`\`python\n${PY_BLOCK}\n\`\`\`\n`
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: 'a1',
+    conversationId: 'c1',
+    role: 'assistant',
+    content: TWO_BLOCKS,
+    createdAt: '2026-09-06T10:00:00.000Z',
+    ...over
+  }
+}
+
+function renderTranscript(props: {
+  messages?: Message[]
+  streamingHere?: boolean
+  streamText?: string
+  onCopy?: (content: string) => void
+  onSaveCodeBlock?: (messageId: string, content: string, language: string) => void
+}): void {
+  render(
+    <I18nProvider>
+      <Transcript
+        messages={props.messages ?? [msg()]}
+        streamingHere={props.streamingHere ?? false}
+        streamText={props.streamText ?? ''}
+        streamThinking=""
+        thinkingOpen={false}
+        onThinkingOpenChange={noop}
+        emptyState={null}
+        onCopy={props.onCopy ?? noop}
+        onSave={noop}
+        onSaveCodeBlock={props.onSaveCodeBlock}
+        actionsDisabled={false}
+      />
+    </I18nProvider>
+  )
+}
+
+// Transcript renders AssistantMarkdown through the LAZY (Suspense) wrapper — every assertion
+// about markdown output has to wait for that chunk to resolve.
+const SAVE_HTML = 'Save this code block as a .html file (stays local)'
+const SAVE_PY = 'Save this code block as a .py file (stays local)'
+const COPY_TITLE = 'Copy this code block to the clipboard'
+
+describe('#286 per-code-block toolbar in the transcript', () => {
+  it('renders a Copy + Save pair per block, with DISTINCT per-language Save names', async () => {
+    renderTranscript({ onSaveCodeBlock: vi.fn() })
+    const copies = await screen.findAllByRole('button', { name: COPY_TITLE })
+    expect(copies).toHaveLength(2)
+    // Two Save buttons, and the accessible names differ by the ALLOWLIST extension.
+    expect(await screen.findByRole('button', { name: SAVE_HTML })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: SAVE_PY })).toBeInTheDocument()
+    // Visible labels stay short (sentence case); the long form is the accessible name/tooltip.
+    expect(screen.getAllByRole('button', { name: SAVE_HTML })[0]).toHaveTextContent('Save')
+    expect(copies[0]).toHaveTextContent('Copy')
+  })
+
+  it('saves the block VERBATIM — the code value with no trailing newline — plus its language', async () => {
+    const onSaveCodeBlock = vi.fn()
+    renderTranscript({ messages: [msg({ id: 'answer-7' })], onSaveCodeBlock })
+    fireEvent.click(await screen.findByRole('button', { name: SAVE_HTML }))
+    expect(onSaveCodeBlock).toHaveBeenCalledTimes(1)
+    expect(onSaveCodeBlock).toHaveBeenCalledWith('answer-7', HTML_BLOCK, 'html')
+    fireEvent.click(await screen.findByRole('button', { name: SAVE_PY }))
+    expect(onSaveCodeBlock).toHaveBeenLastCalledWith('answer-7', PY_BLOCK, 'python')
+  })
+
+  it('copies the same verbatim content through the transcript copy path', async () => {
+    const onCopy = vi.fn()
+    renderTranscript({ onCopy, onSaveCodeBlock: vi.fn() })
+    const copies = await screen.findAllByRole('button', { name: COPY_TITLE })
+    fireEvent.click(copies[0])
+    expect(onCopy).toHaveBeenCalledWith(HTML_BLOCK)
+  })
+
+  it('reaches window.api.saveCodeBlock end-to-end when the handler forwards to the bridge', async () => {
+    // The ChatScreen wiring in miniature: the Transcript prop forwards to the preload bridge,
+    // which is the ONLY write path (Streamdown's own blob download control stays disabled).
+    const saveCodeBlock = vi.fn().mockResolvedValue('C:/x/code.html')
+    stubApi({ saveCodeBlock })
+    renderTranscript({
+      messages: [msg({ id: 'answer-9' })],
+      onSaveCodeBlock: (id, content, language) => void window.api.saveCodeBlock(id, content, language)
+    })
+    fireEvent.click(await screen.findByRole('button', { name: SAVE_HTML }))
+    await waitFor(() => expect(saveCodeBlock).toHaveBeenCalledWith('answer-9', HTML_BLOCK, 'html'))
+  })
+
+  it('renders NO toolbar on the live streaming bubble (D3 — persisted turns only)', async () => {
+    renderTranscript({
+      messages: [],
+      streamingHere: true,
+      streamText: TWO_BLOCKS,
+      onSaveCodeBlock: vi.fn()
+    })
+    // Wait for the lazy markdown chunk to actually paint the block before asserting absence.
+    await waitFor(() => expect(document.querySelector('code')).not.toBeNull())
+    expect(screen.queryByRole('button', { name: SAVE_HTML })).toBeNull()
+    expect(screen.queryByRole('button', { name: COPY_TITLE })).toBeNull()
+    expect(document.querySelector('.code-block-actions')).toBeNull()
+  })
+
+  it('renders no toolbar for INLINE code', async () => {
+    renderTranscript({
+      messages: [msg({ content: 'some `inline` text' })],
+      onSaveCodeBlock: vi.fn()
+    })
+    await waitFor(() => expect(document.querySelector('code')).not.toBeNull())
+    expect(document.querySelector('.code-block-actions')).toBeNull()
+    expect(screen.queryByRole('button', { name: COPY_TITLE })).toBeNull()
+  })
+
+  it('renders no toolbar when the onSaveCodeBlock prop is absent', async () => {
+    renderTranscript({})
+    await waitFor(() => expect(document.querySelector('code')).not.toBeNull())
+    expect(document.querySelector('.code-block-actions')).toBeNull()
+    expect(screen.queryByRole('button', { name: COPY_TITLE })).toBeNull()
+    expect(screen.queryByRole('button', { name: SAVE_HTML })).toBeNull()
+  })
+})
+
+describe('#286 AssistantMarkdown outside the transcript', () => {
+  it('renders a fenced block with NO buttons and still a <code> element', () => {
+    // The other consumers (images AnswerThread, ReviewScreen, TranslateScreen, documents
+    // PreviewModal) render AssistantMarkdown with neither the actions context NOR an
+    // I18nProvider — the `pre` override must stay a hook-free passthrough there.
+    const { container } = render(<AssistantMarkdown text={'```js\nx\n```'} />)
+    expect(container.querySelector('button')).toBeNull()
+    expect(container.querySelector('.code-block-actions')).toBeNull()
+    expect(container.querySelector('code')?.textContent).toContain('x')
+  })
+})

--- a/apps/desktop/tests/unit/assistant-markdown.test.tsx
+++ b/apps/desktop/tests/unit/assistant-markdown.test.tsx
@@ -51,6 +51,19 @@ describe('AssistantMarkdown security posture', () => {
     expect(container.textContent).toContain('<img src="x.png">')
   })
 
+  it('a fenced code block ships NO Streamdown download control (controls={false} stays off)', () => {
+    // #286 D4: the ONLY save path for a code block is window.api.saveCodeBlock — main writes the
+    // bytes behind the native dialog. Streamdown's own code-block controls are a renderer-side
+    // blob + <a download> (and a navigator.clipboard copy), which bypass that write boundary
+    // entirely. Turning `controls` on would mint them here — this pin fails if anyone does.
+    // Without the transcript's CodeBlockActions context (this render has none) the block carries
+    // no interactive chrome of ours either, so ZERO buttons is the correct assertion.
+    const { container } = render(<AssistantMarkdown text={'```js\nconst a = 1\n```'} />)
+    expect(container.querySelector('a[download]'), 'no blob download anchor').toBeNull()
+    expect(container.querySelector('button'), 'no Streamdown code-block control buttons').toBeNull()
+    expect(container.querySelector('code')?.textContent).toContain('const a = 1')
+  })
+
   it('renders a ```mermaid fence as a plain code block — the mermaid plugin stays absent', () => {
     // DEP-3 (2026-08-09) judged the mermaid/DOMPurify Dependabot alerts unreachable because no
     // mermaid plugin is passed (mdPlugins = { math }); wiring one in makes that chain a live

--- a/apps/desktop/tests/unit/code-block-export.test.ts
+++ b/apps/desktop/tests/unit/code-block-export.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_CODE_BLOCK_EXTENSION,
+  codeBlockDefaultFileName,
+  codeBlockExtension,
+  codeBlockLanguageToken
+} from '../../src/shared/code-block-export'
+
+// #286 (owner decision D6): the fence info string → extension map is a FIXED allowlist. The info
+// string is model output, so this is the only step between it and a filename/filter/audit row —
+// every alias, the fallback and the token/strip rule are pinned here.
+
+describe('codeBlockExtension (#286 D6 allowlist)', () => {
+  it.each([
+    ['html', 'html'],
+    ['js', 'js'],
+    ['javascript', 'js'],
+    ['ts', 'ts'],
+    ['typescript', 'ts'],
+    ['py', 'py'],
+    ['python', 'py'],
+    ['csv', 'csv'],
+    ['json', 'json'],
+    ['md', 'md'],
+    ['markdown', 'md'],
+    ['sh', 'sh'],
+    ['bash', 'sh'],
+    ['zsh', 'sh'],
+    ['css', 'css'],
+    ['xml', 'xml'],
+    ['yaml', 'yml'],
+    ['yml', 'yml'],
+    ['sql', 'sql'],
+    ['ps1', 'ps1'],
+    ['powershell', 'ps1'],
+    ['bat', 'bat'],
+    ['cmd', 'bat'],
+    ['svg', 'svg'],
+    ['toml', 'toml'],
+    ['txt', 'txt'],
+    ['text', 'txt']
+  ])('maps %s → .%s', (info, ext) => {
+    expect(codeBlockExtension(info)).toBe(ext)
+  })
+
+  it('falls back to txt for an unknown language, an empty string and whitespace', () => {
+    expect(DEFAULT_CODE_BLOCK_EXTENSION).toBe('txt')
+    expect(codeBlockExtension('rust')).toBe('txt')
+    expect(codeBlockExtension('')).toBe('txt')
+    expect(codeBlockExtension('   ')).toBe('txt')
+    expect(codeBlockExtension('\n')).toBe('txt')
+  })
+
+  it('takes only the first whitespace-separated token — an info string with attributes', () => {
+    expect(codeBlockExtension('html title="x"')).toBe('html')
+    expect(codeBlockExtension('  python   {.numberLines}')).toBe('py')
+    expect(codeBlockExtension('js\tfilename=app.js')).toBe('js')
+  })
+
+  it('is case-insensitive', () => {
+    expect(codeBlockExtension('HTML')).toBe('html')
+    expect(codeBlockExtension('Python')).toBe('py')
+    expect(codeBlockExtension('PowerShell')).toBe('ps1')
+  })
+
+  it('strips everything outside [a-z0-9+#.-] before the lookup', () => {
+    expect(codeBlockLanguageToken('h!t@m$l')).toBe('html')
+    expect(codeBlockExtension('h!t@m$l')).toBe('html')
+    // The kept punctuation is a language alphabet (c++, c#, objective-c, d.ts) — still not in
+    // the allowlist, so it falls back rather than becoming a filename.
+    expect(codeBlockLanguageToken('C++')).toBe('c++')
+    expect(codeBlockExtension('c++')).toBe('txt')
+    expect(codeBlockExtension('c#')).toBe('txt')
+  })
+
+  it('never lets garbage, path characters or prototype names through', () => {
+    expect(codeBlockExtension('../../etc/passwd')).toBe('txt')
+    expect(codeBlockExtension('..\\..\\x.exe')).toBe('txt')
+    expect(codeBlockExtension('html/../x')).toBe('txt')
+    expect(codeBlockExtension('<script>')).toBe('txt')
+    expect(codeBlockExtension('\u0000html')).toBe('html') // control char stripped, token kept
+    expect(codeBlockExtension('__proto__')).toBe('txt')
+    expect(codeBlockExtension('constructor')).toBe('txt')
+    expect(codeBlockExtension('toString')).toBe('txt')
+    expect(codeBlockExtension('hasOwnProperty')).toBe('txt')
+  })
+
+  it('the default file name is fixed and never derived from content', () => {
+    expect(codeBlockDefaultFileName('html')).toBe('code.html')
+    expect(codeBlockDefaultFileName('html title="Secret plan"')).toBe('code.html')
+    expect(codeBlockDefaultFileName('')).toBe('code.txt')
+    expect(codeBlockDefaultFileName('anything-secret')).toBe('code.txt')
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -46,6 +46,9 @@ the in-app model downloader, async-with-polling) +
 the Diagnostics Activity panel, newest-first paging + save-dialog export) +
 `searchConversations` (`chat:search`, Phase 31) + `changeWorkspacePassword`
 (`workspace:changePassword`, Phase 32) +
+`saveCodeBlock(messageId, content, language)` (`chat:saveCodeBlock`, issue #286 — save one
+fenced code block from a persisted assistant answer as its own file; renderer-supplied bytes,
+verbatim, no BOM; resolves with the path or null on cancel) +
 `startDocTask`/`getDocTask`/`cancelDocTask` (`doctasks:start/get/cancel`, Phases 33–35 —
 document tasks, async-with-polling; `cancelDocTask()` with no jobId cancels the active task;
 shapes `StartDocTaskRequest`/`DocTaskStatus`/`DocumentSummary` in `shared/types.ts`, and
@@ -1665,7 +1668,9 @@ whole renderer-visible surface.
 - **Smaller members** (owned here so the index is complete): `exportMessageTable(messageId)`
   (result-table CSV via save dialog), `previewDocument`/`previewDocumentPage` (bounded pages),
   `exportSummary(documentId)`, `exportDocumentOriginal(documentId)` (#90 — stored original
-  bytes via save dialog), `exportLog()`/`getLogTail()`, `getDroppedFilePath(file)` (the
+  bytes via save dialog), `saveCodeBlock(messageId, content, language)` (#286 — one fenced
+  code block from a persisted assistant answer, renderer-supplied bytes, via save dialog),
+  `exportLog()`/`getLogTail()`, `getDroppedFilePath(file)` (the
   Electron-37 `webUtils.getPathForFile` bridge — drag-drop path resolution), `perfMark(event)`
   (one-way, allowlisted timing mark for opt-in measurement runs — no data channel),
   `onModelVerifyProgress(cb)` (cold-hash progress stream), `onScopeNotice(conversationId, cb)`

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -134,6 +134,7 @@ Where each existing control goes:
 | Thinking block | Single inline collapsed "Thinking…" line while generating (expand → the live reasoning text); auto-collapses when the answer streams. Stop stays available. ARIA live region for streaming. |
 | Citations | Inline, attached to the answer: "▸ Sources (3)" → source cards (name + page + snippet). No separate panel. |
 | Regenerate / Copy / Export | **Per-message action row** on hover/focus of an assistant answer ("Try again", "Copy", "Save"). Whole-conversation export → chat-header "⋯" overflow. |
+| Code-block Copy / Save | Same quiet action style, but **per code block**: revealed on hover or keyboard focus of the block itself (not shown while the answer is streaming), each with an accessible name that names the file type it saves as ("Save this code block as a .html file"). |
 | Errors / notices | Inline, in context, dismissible, rare. Never stacked at the top. |
 
 **Empty state that teaches:** one friendly line ("Ask a question, or ask about your

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -533,7 +533,8 @@ exposed to logging via `WorkspaceController.encryptionKey()` (the same data key 
 families (`AuditEventType` in `shared/types.ts`) span model starts/stops and downloads; document
 imports/deletes and lifecycle/collection changes (`document_lifecycle_changed`, `collection_*`);
 document tasks and exports (`document_task_*`, `document_exported`/`summary_exported`); conversation
-lifecycle (`conversation_*`); skill management and runs (`skill_imported`/`deleted`/`enabled`/
+lifecycle (`conversation_*`) and the per-answer exports (`message_table_exported`,
+`code_block_exported`); skill management and runs (`skill_imported`/`deleted`/`enabled`/
 `disabled`, `skill_run_*`); workspace lock/unlock; privacy-relevant settings changes; policy
 warnings; and offline-guard detections. (`shared/types.ts` is the authoritative enum.) Its data
 class is defined by a **hard privacy rule**:
@@ -541,7 +542,10 @@ class is defined by a **hard privacy rule**:
 - Events carry **ids, model ids, and counts only** — NEVER chat content, document text,
   passwords, **or user-chosen names**. A chat transcript export records only the conversation
   id (even the chosen filename is excluded — it derives from the conversation title, which is
-  chat content); `settings_changed` records the **privacy-relevant keys** (`allowNetwork`,
+  chat content); a code-block save (#286) records `{ messageId, bytes, extension }` — the
+  extension is safe only because it comes from the fixed allowlist in
+  `shared/code-block-export.ts` (a closed set), never from the fence info string, which is
+  model output; `settings_changed` records the **privacy-relevant keys** (`allowNetwork`,
   `gpuMode`, `developerMode`) and their boolean/enum values, never any other setting's value.
   **Document titles/filenames are content (S1, full-audit-2026-06-30).** `document_imported` /
   `document_reindexed` (incl. the doc-task *materialize* path) record `documentId` + `status` +
@@ -677,6 +681,36 @@ same posture applies:
   sentinel-named source file.
 - **Scope:** one document per invocation (the save dialog is the per-file consent);
   bulk/multi-select export is deliberately deferred.
+
+## Code-block save boundary (issue #286)
+
+`chat:saveCodeBlock` writes ONE fenced code block of a persisted assistant answer to a
+user-chosen file. It is the first export whose bytes are **renderer-supplied** — the parsed
+block text plus the fence info string travel over IPC exactly as `copyToClipboard` sends
+text — rather than re-derived from the database in main. The posture is otherwise the
+transcript export's:
+
+- **Gate + consent:** the #252 sender guard and `requireUnlocked` gate the call; the native
+  save dialog (main only, `saveBinaryExport`) is the consent — the renderer never touches
+  fs, and Streamdown's own download control (a blob + `<a download>` in the renderer, which
+  would bypass this boundary) stays disabled (`controls={false}`, pinned in
+  `assistant-markdown.test.tsx`). Persisted turns only; the live streaming bubble has no
+  toolbar.
+- **Untrusted inputs:** `content` must be a string (anything else returns null before a
+  dialog); the fence info string is **model output** and never reaches a filename, a dialog
+  filter or an audit row un-mapped — only its allowlisted extension does
+  (`shared/code-block-export.ts`: first token, lower-cased, stripped to `[a-z0-9+#.-]`,
+  looked up in a fixed map, else `txt`; the suggested name is the fixed `code.<ext>`). The
+  message id must match the persisted-id alphabet so that slot cannot smuggle content into
+  the audit log either.
+- **Verbatim bytes, no BOM:** the block is written byte-for-byte as UTF-8 through
+  `saveBinaryExport` (the same atomic tmp-sibling → fsync → rename tail), deliberately NOT
+  `saveTextExport`, whose `bomFor` prefixes a BOM on `.md`/`.txt`/`.csv` — a BOM breaks a
+  shebang and the issue requires byte identity. The BOM decision stays for transcripts and CSV.
+- **Nothing content-bearing is recorded:** the log line carries the id, byte count and
+  extension; the audit row is `{ messageId, bytes, extension }`. Sentinel-swept in
+  `chat-ipc.test.ts` (content + info-string sentinels against every audit and log call) and in
+  `audit-ipc.test.ts` (a sentinel-named destination as well).
 
 ## Workspace modes (Phase 9)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -329,6 +329,9 @@ with sources (see §7).
 3. Hover over (or tab to) any answer for its actions: **Try again** regenerates the latest
    answer (plain Chat only — not in *Ask my documents*), **Copy** copies it, and **Save** saves the
    conversation to a file of your choice. A small *"Copied"* / *"Saved to …"* note confirms each one.
+   A finished answer's own code blocks each get the same small **Copy** / **Save** pair, right on
+   the block: **Save** writes just that block, byte-for-byte, as `code.<ext>` (the extension comes
+   from the block's language — an unrecognized or missing language saves as `.txt`).
 4. **Save this conversation** is also in the **⋯** menu at the top right of the chat. The
    file is written wherever you choose — nothing leaves the device otherwise.
 5. To remove a conversation, hover over it in the list and open its **⋯** menu (or


### PR DESCRIPTION
## Summary

Every fenced code block inside a **persisted** assistant answer gets a small hover/focus toolbar with **Copy** and **Save**. Save opens the OS save dialog (main process) and writes **only that block's bytes**, verbatim, to the chosen file. Nothing new is logged; the audit row carries ids, a byte count and the allowlisted extension only.

Closes #286

## Owner decisions implemented

- **D1 Verbatim bytes, no BOM** — written through `saveBinaryExport` with `Buffer.from(content, 'utf8')`, never `saveTextExport` (its `bomFor` BOM rule stays for transcripts/CSV; the exception is recorded next to it). "Verbatim" = the CommonMark code value as parsed: the renderer strips the single trailing `\n` that mdast-util-to-hast appends.
- **D2 Content source** — the renderer sends the block content + language over `chat:saveCodeBlock`. Main validates `typeof content === 'string'`, maps the language through the fixed allowlist before it touches a filename, filter or audit row, and requires the message id to match the persisted-id alphabet so that slot cannot carry content either.
- **D3 Scope** — chat transcript, persisted turns only; the streaming bubble never gets the context. Other `AssistantMarkdown` consumers (images, review, translate, document preview) render byte-identically (see the implementation note below).
- **D4** — both Copy (existing `copyToClipboard` path + `chat.copied`/`chat.copyFailed`) and Save. `controls={false}` stays; a test pins that no Streamdown download control / `a[download]` / foreign button ever renders.
- **D5** — failed write → `friendlyIpcError` → error banner; success → `chat.savedTo` toast; cancel → silent.
- **D6** — allowlist exactly as specified (`shared/code-block-export.ts`), first whitespace token, lower-cased, stripped to `[a-z0-9+#.-]`, fallback `txt`; fixed default name `code.<ext>`; filters = mapped type first, then `main.dialog.filterAll`.

## Implementation notes (deviations from the brief, with reasons)

- **`pre` override instead of a `code` override.** Streamdown 2.5's default `pre` is only `cloneElement(child, {'data-block': 'true'})`; the default `code` then renders the whole `<div data-streamdown="code-block">` (header row + `<pre><code>`), which is what every screen renders today. A `code` override would have had to re-implement that chrome (and inline code) and would have changed the other screens. The `pre` override is byte-identical to the default when the context is absent and merely wraps the block in the toolbar when present. `mdComponents` stays module-level (FE-1).
- **The bridge takes the message id**: `saveCodeBlock(messageId, content, language)` — the audit metadata `{ messageId, bytes, extension }` needs it, and the two-argument signature in the brief could not supply it.
- The Copy button's accessible name is not per-language (the brief's `chat.code.copyTitle` has no `{ext}`); the Save names are distinct per language (".html" vs ".py").

## Tests

- `tests/unit/code-block-export.test.ts` — every alias, fallback, token/strip rule, attributes, upper-case, empty, garbage/path/prototype names, fixed default name (33 cases).
- `tests/integration/chat-ipc.test.ts` — dialog title/defaultPath/filters for html and unknown; cancel → null, nothing written, nothing audited; verbatim bytes to `.txt`, `.csv`, `.sh` with a BOM-contrast leg against the transcript export; empty block; non-string content / malformed id rejected before any dialog; locked workspace refuses; audit `{ messageId, bytes, extension }` only, with content + info-string + path sentinels grepped against every audit and log call.
- `tests/integration/audit-ipc.test.ts` — the sentinel sweep now drives `chat:saveCodeBlock` with content, info-string and destination sentinels and pins the event metadata.
- `tests/renderer/CodeBlockActions.test.tsx` — two blocks → two Copy + two Save with distinct names; Save/Copy receive exactly the block content (no trailing newline) and language; the bridge is reached end-to-end; no toolbar on the streaming bubble, on inline code, without the prop, or on bare `AssistantMarkdown`.
- `tests/unit/assistant-markdown.test.tsx` — security pin: no `a[download]`, no button (fails if `controls` is turned on; verified by flipping it).
- Full `npm test`: 418 files passed, 25 skipped (pre-existing). `npm run typecheck` clean. `npm run build` ok.

## Manual smoke (done, Windows 11, built app in demo mode)

Drove the built app over CDP against a scratch drive root (the main-process save dialog was monkeypatched through the inspector to return a fixed path, because a native dialog cannot be automated). With the mock runtime echoing a message containing an ```html fence: the persisted answer showed one block with Copy/Save (German labels, focus reveal works), the dialog received title "Codeblock als Datei speichern", `code.html`, filters HTML then "Alle Dateien"; the toast read "Gespeichert unter …"; the written file was byte-identical to `<!doctype html>\n<p>Grüße 🎉</p>` with no BOM. Copy showed "Kopiert"; cancel produced no toast and no banner; the Activity panel showed "Codeblock als Datei gespeichert" with no content or path.

## Observed, out of scope

Pre-existing, not introduced here: multi-line code blocks in the chat render their lines run together (Streamdown's per-line `span.block` relies on Tailwind, which the app does not load). The saved file is correct; only the on-screen display is affected. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
