### PR TITLE
feat(zim): "Save article to my documents" in the article viewer (#340 Tier-2, D-Z21)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -697,12 +697,12 @@ open round's item stays the last block of §5.)
     P8-2 consent **PR #363**, P8-4 source bundle **PR #365**, P8-5 prose **PR #364** — OPEN (2026-09-06 open-issues
     wave; rulings 1–6 on #339). Still the owner's: P8-6 filing the upstream `/raw` report (after humaniser's Linux
     probe), P8-7 R-4 mac/linux signatures + the T20-a/T20-d real Kit runs on K:.
-    (b) **Tier 2** (persistent import of selected articles) — #340; **ruled 2026-09-06: C3 (a) a "Save article to my
-    documents" button in the article viewer first**, not built yet. Other #340 rulings of 2026-09-06: L2 keep 5, L1
-    keep "not searched: no full-text index", C2 not until the upstream `/raw` fix, C4 later; (b) → `'path-unsupported'`
-    (PR #360), (c) → normalise (PR #361); L3-b measured (PR #362; 0/6 raw, 2/6 through the arm) then **ruled (a) ALWAYS on 2026-09-07 and
-    built** (`feat/340-l3b-query-expansion`, record rag-design D-Z20): one local-model call per pack ask, the list
-    group 5/6 through the arm with the default 4B model on a CPU (2.4–5.3 s per call), the D-Z18 nine still 9/9.
+    (b) **Tier 2** (persistent import of selected articles) — #340; **ruled 2026-09-06: C3 (a) a "Save article to my documents" button in the
+    article viewer first**, **built 2026-09-07** (`feat/340-tier2-save-article`, record rag-design D-Z21) — the citation-card shortcut stays
+    the owner's "later". Other #340 rulings of 2026-09-06: L2 keep 5, L1 keep "not searched: no full-text index", C2 not until the upstream
+    `/raw` fix, C4 later; (b) → `'path-unsupported'` (PR #360), (c) → normalise (PR #361); L3-b measured (PR #362; 0/6 raw, 2/6 through
+    the arm) then **ruled (a) ALWAYS on 2026-09-07 and built** (`feat/340-l3b-query-expansion`, record rag-design D-Z20): one local-model
+    call per pack ask, the list group 5/6 through the arm with the default 4B model on a CPU (2.4–5.3 s per call), the D-Z18 nine still 9/9.
     (c) **Evidence identity for archive citations — CLOSED.** Identity resolution: P2, record rag-design D-Z5; the "Open article from a review" residual: closed P6, record design-guidelines §11.15.
     (d) **Manual acceptance leg — CLOSED 2026-09-06:** the airplane-mode demo (the real K: drive, `wikipedia_de_*` packs + kiwix-tools 3.8.1, network off) passed as T19 (viii); record rag-design §17 "Real acceptance".
     (e) Observation for item 1b's matrix, measured 2026-09-04 on the i7-8550U + UHD 620: GPU auto-offload gains nothing on pp (56 vs 57 t/s) and LOSES 45 percent on tg (11 vs 19.6) — on this iGPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,11 @@ from its first public `1.0.0` release onward.
   ships the knowledge-pack tools already installed now also carries their complete source code
   in `runtime/kiwix-tools/source/`, with a `SOURCES.md` record. Nothing changes if you build your
   own drive and install the knowledge-pack family yourself.
+- **Save a knowledge-pack article to your documents.** The article viewer now has a "Save to my
+  documents" button, so a page you found in an offline archive becomes a real, searchable
+  document in your own library — it stays findable and citable even if you later remove the
+  pack or unplug its drive. Saving the same article again just points back to the copy you
+  already made.
 
 ### Changed
 

--- a/apps/desktop/src/main/ipc/registerDocsIpc.ts
+++ b/apps/desktop/src/main/ipc/registerDocsIpc.ts
@@ -165,7 +165,7 @@ export function registerDocsIpc(ctx: AppContext): void {
   // module is mid-import/re-indexing — the mirror of `requireNoActiveTask` below. Doc-task
   // ingestions themselves run OUTSIDE this set (DB-3), so the guard can never refuse a start
   // because of another task (the manager's own one-at-a-time lane covers that).
-  ctx.docIngestionActive = (documentId) => processing.has(documentId)
+  ctx.docIngestionActive = (documentId) => processing.has(documentId) || ctx.articleSaveActive?.(documentId) === true
 
   // DB-backed handlers require an unlocked workspace; surface a clean message instead of
   // the raw "Workspace is locked" the `ctx.db` getter would throw mid-operation.
@@ -218,7 +218,8 @@ export function registerDocsIpc(ctx: AppContext): void {
   }
 
   const requireNotProcessing = (documentId: string): void => {
-    if (processing.has(documentId)) {
+    // A knowledge-pack article mid-save (#340 Tier-2) is an import in flight like any other.
+    if (processing.has(documentId) || ctx.articleSaveActive?.(documentId)) {
       throw new Error(tMain('main.docs.processing'))
     }
   }
@@ -967,7 +968,7 @@ export function registerDocsIpc(ctx: AppContext): void {
           // worked on by a live SKILL run (GAP-5): re-indexing under either would lose the race
           // (see requireNoActiveTask / requireNoActiveSkillRun). Count as failed so total still
           // adds up and the user sees it didn't complete.
-          if (processing.has(id) || ctx.docTasks?.isDocumentBusy(id) || ctx.skillRunActive?.(id)) {
+          if (processing.has(id) || ctx.articleSaveActive?.(id) || ctx.docTasks?.isDocumentBusy(id) || ctx.skillRunActive?.(id)) {
             job.failed += 1
             continue
           }

--- a/apps/desktop/src/main/ipc/registerZimIpc.ts
+++ b/apps/desktop/src/main/ipc/registerZimIpc.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, dialog } from 'electron'
 import { guardedHandleFor } from './guarded-handle'
 import { IPC } from '../../shared/ipc'
 import type { AppContext } from '../services/context'
+import type { PackArticleSaveResult } from '../../shared/types'
 import type {
   KnowledgePack,
   KnowledgePackAddFailureReason,
@@ -9,6 +10,8 @@ import type {
   KnowledgePackStatus
 } from '../../shared/types'
 import type { PackArticle } from '../services/zim'
+import { findSavedArticle, saveArticleAsDocument } from '../services/zim/save-article'
+import { documentsDir } from '../services/ingestion'
 import { ArticlePathError } from '../services/zim/client'
 import { KiwixManageError } from '../services/zim/tools'
 import { ZimHeaderError } from '../services/zim/identity'
@@ -218,4 +221,87 @@ export function registerZimIpc(ctx: AppContext, opts: { platform?: NodeJS.Platfo
       }
     }
   )
+
+  // #340 Tier-2 (D-Z21): save the article as a document. Only ids cross the bridge — the text
+  // is re-read main-side through the same `getArticle` the viewer used, so the renderer is
+  // never a content source. A duplicate (same pack + entry, already indexed) is answered with the
+  // existing document; an unreadable article is a friendly failure, never a half-born row.
+  // One save per pack entry at a time: `beginDocumentWork` is a refcount, not a mutex, and the
+  // duplicate check reads the DB before the import runs — two overlapping invokes for the same
+  // entry would both miss it and file two copies. A second invoke joins the first's promise.
+  const inFlight = new Map<string, Promise<PackArticleSaveResult>>()
+  // The rows being imported right now, exposed so the docs IPC delete / re-index guards hold
+  // them busy (the `skillRunActive` pattern; the precedent pushes its id on the task status).
+  const savingDocs = new Set<string>()
+  ctx.articleSaveActive = (documentId) => savingDocs.has(documentId)
+  ipcHandle(
+    IPC.savePackArticle,
+    async (_e, packId: string, articlePath: string): Promise<PackArticleSaveResult> => {
+      requireUnlocked()
+      if (typeof packId !== 'string' || typeof articlePath !== 'string') {
+        throw new Error(tMain('main.zim.articleUnavailable'))
+      }
+      const key = `${packId}\u0000${articlePath}`
+      const running = inFlight.get(key)
+      if (running) return { ...(await running), alreadySaved: true, chunkCount: 0 }
+      const existing = findSavedArticle(ctx.db, packId, articlePath)
+      if (existing) return { documentId: existing.id, title: existing.title, alreadySaved: true, chunkCount: 0 }
+      const run = saveOne(packId, articlePath)
+      inFlight.set(key, run)
+      try {
+        return await run
+      } finally {
+        inFlight.delete(key)
+      }
+    }
+  )
+
+  async function saveOne(packId: string, articlePath: string): Promise<PackArticleSaveResult> {
+    let article: PackArticle | null = null
+    try {
+      article = await zim().getArticle(ctx.db, packId, articlePath)
+    } catch (err) {
+      log.warn('Pack article read failed', {
+        error: err instanceof Error ? err.constructor.name : 'UnknownError',
+        reason: err instanceof ArticlePathError ? err.reason : undefined
+      })
+    }
+    if (!article) throw new Error(tMain('main.zim.articleUnavailable'))
+    const pack = zim().listPacks(ctx.db).find((p) => p.id === packId)
+    let queuedId: string | null = null
+    let result: PackArticleSaveResult
+    try {
+      result = await saveArticleAsDocument(
+        {
+          db: ctx.db,
+          storeDir: documentsDir(ctx.paths.workspacePath),
+          ingestion: {
+            embedder: ctx.embedder,
+            cipher: ctx.workspace.documentCipher(),
+            transcriber: ctx.transcriber,
+            ocrEngine: ctx.ocrEngine,
+            plaintextOps: ctx.plaintextOps
+          },
+          beginDocumentWork: () => ctx.workspace.beginDocumentWork(),
+          onQueued: (id) => {
+            queuedId = id
+            savingDocs.add(id)
+          }
+        },
+        article,
+        { packId, articlePath, archiveTitle: pack?.title ?? null }
+      )
+    } finally {
+      if (queuedId) savingDocs.delete(queuedId)
+    }
+    // Ids and counts only (S1): the pack id is already audited; the entry path and both
+    // titles are content and never ride the audit.
+    ctx.audit?.('knowledge_pack_article_saved', 'Knowledge-pack article saved as a document', {
+      packId,
+      documentId: result.documentId,
+      status: 'indexed',
+      chunkCount: result.chunkCount
+    })
+    return result
+  }
 }

--- a/apps/desktop/src/main/services/context.ts
+++ b/apps/desktop/src/main/services/context.ts
@@ -121,6 +121,13 @@ export interface AppContext {
    */
   docIngestionActive?: (documentId: string) => boolean
   /**
+   * In-flight knowledge-pack article save (#340 Tier-2): true while `packs:saveArticle` is
+   * driving this document's row through the import path (registerZimIpc assigns it). The docs
+   * IPC guards treat it exactly like their own `processing` set — a delete or re-index under
+   * the import would race it. Optional so partial test contexts stay valid.
+   */
+  articleSaveActive?: (documentId: string) => boolean
+  /**
    * Skill registry (skills plan §8): the uniform disk-reconcile + state cache over the plain
    * app-skills/ + user-skills/ folders. Optional so partial test contexts stay valid. `reconcile`
    * needs an unlocked DB, so the live wiring reconciles best-effort at startup (plaintext_dev) and

--- a/apps/desktop/src/main/services/ingestion/index.ts
+++ b/apps/desktop/src/main/services/ingestion/index.ts
@@ -239,7 +239,7 @@ function parseSummary(json: string | null | undefined): DocumentSummary | null {
 }
 
 /** The valid `GeneratedProvenance.kind` values (used to narrow a parsed string). */
-const GENERATED_KINDS = ['summary', 'translation', 'compare', 'transcript', 'other'] as const
+const GENERATED_KINDS = ['summary', 'translation', 'compare', 'transcript', 'other', 'article'] as const
 
 /** Parse a stored origin (generated-document provenance); malformed JSON reads as null. */
 function parseOrigin(json: string | null | undefined): DocumentOrigin | null {
@@ -271,6 +271,18 @@ function parseOrigin(json: string | null | undefined): DocumentOrigin | null {
       }
       if (typeof v.modelId === 'string' && v.modelId.length > 0) out.modelId = v.modelId
       return out
+    }
+    // A saved knowledge-pack article (#340 Tier-2, D-Z21): the archive + entry it came from.
+    if (v.type === 'archive') {
+      if (typeof v.packId !== 'string' || v.packId.length === 0) return null
+      if (typeof v.articlePath !== 'string' || v.articlePath.length === 0) return null
+      return {
+        type: 'archive',
+        packId: v.packId,
+        articlePath: v.articlePath,
+        archiveTitle: typeof v.archiveTitle === 'string' && v.archiveTitle.length > 0 ? v.archiveTitle : null,
+        createdAt: typeof v.createdAt === 'string' ? v.createdAt : ''
+      }
     }
     // Comparison provenance: both source ids, A/B order.
     if (v.type === 'compare') {

--- a/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
+++ b/apps/desktop/src/main/services/ingestion/plaintext-ops.ts
@@ -22,6 +22,8 @@ export type PlaintextOpKind =
   | 'export'
   /** A doc-task's own transient (the OCR source PDF, a materialised output's `.parse.md`). */
   | 'doc-task'
+  /** A knowledge-pack article being saved as a document (#340 Tier-2): its `.parse.md`. */
+  | 'article-save'
   // Knowledge packs (#301, finding H4). These run on a SECOND instance of this registry
   // (`ctx.zimOps`), so the ZIM settle/sweep is its own bounded lock step and the paths it
   // tracks are only ZIM transients (`library.<n>.xml` / `meta-<n>/library.xml` under the

--- a/apps/desktop/src/main/services/zim/save-article.ts
+++ b/apps/desktop/src/main/services/zim/save-article.ts
@@ -1,0 +1,179 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { ArchiveOrigin, PackArticleSaveResult } from '../../../shared/types'
+import { fileDocumentByDestination } from '../collections'
+import type { Db } from '../db'
+import { prepareCached } from '../db'
+import { tMain } from '../i18n'
+import {
+  createQueuedDocument,
+  deleteDocument,
+  processDocument,
+  setDocumentOrigin,
+  type IngestionDeps
+} from '../ingestion'
+import { log } from '../logging'
+import { shredFile } from '../workspace-vault'
+import type { PackArticle } from './index'
+
+// Tier-2 — "Save article to my documents" (#340, owner ruling C3 (a) 2026-09-06; rag-design §17
+// D-Z21). A knowledge-pack article the user is reading becomes a REAL document in the corpus:
+// the converted plain text (the same sectioned text the viewer shows — never raw archive HTML)
+// is written as Markdown and run through the ONE import path (`createQueuedDocument` →
+// `processDocument`), exactly as a translation or comparison output is
+// (`doctasks/handlers/shared.ts` `materializeDocument`, the precedent this mirrors step for
+// step). So the copy is chunked, embedded, FTS-indexed, encrypted at rest and citable like any
+// upload — searchable offline without the pack server, alive after the pack is removed, and a
+// resolvable identity in evidence reviews (an archive citation resolves as honest `unresolved`,
+// D-Z5; a saved copy resolves with a real sha256).
+//
+// Provenance rides `documents.origin_json` as an `ArchiveOrigin` (the pack UUID, the entry
+// path, the archive title, the save time) — stamped at QUEUE time (DM-2) so a crash between
+// `indexed` and a later write can never let the Library backfill file the copy as an upload.
+// The same three fields are what the duplicate check reads: saving an article twice returns
+// the existing document instead of a second copy (the app has no other import-time dedup).
+// Unlike a translation or comparison (a generated work-product that deliberately gets NO
+// collection membership, D3/N1), a saved article is a user-chosen IMPORT: it is filed into the
+// Library once indexed, so the default documents chat — whose scope IS the Library — finds it.
+//
+// Content rules: the article title and the archive title are CONTENT (S1) — they go into the
+// document and its title, never into a log line or an audit row.
+
+/** A saved copy's document title: `<article> (<archive>).md` — the `.md` extension selects the
+ *  Markdown parser (headings → chunk sections), as `translatedDocumentTitle` forces it. */
+export const ARTICLE_TITLE_MAX_CHARS = 180
+
+export function articleDocumentTitle(articleTitle: string, archiveTitle: string | null): string {
+  const clean = (s: string): string => s.replace(/\s+/g, ' ').trim()
+  // Cut by code point, never by UTF-16 unit — a lone surrogate is not a title character.
+  const cut = (s: string, n: number): string => Array.from(s).slice(0, Math.max(n, 1)).join('').trimEnd()
+  const base = clean(articleTitle) || 'Article'
+  let archive = archiveTitle ? clean(archiveTitle) : ''
+  if (archive.length > ARTICLE_TITLE_MAX_CHARS / 2) archive = cut(archive, ARTICLE_TITLE_MAX_CHARS / 2)
+  // The parenthetical stays whole; an over-long ARTICLE title is what gets shortened.
+  const room = ARTICLE_TITLE_MAX_CHARS - (archive ? archive.length + 3 : 0)
+  const head = base.length > room ? cut(base, room) : base
+  return `${archive ? `${head} (${archive})` : head}.md`
+}
+
+/**
+ * The Markdown the import path parses: `# title`, an attribution block-quote, an honest notice
+ * when the converter stopped short, then one `## label` section per viewer section (the
+ * label-less lead stays plain). `MarkdownParser` turns each heading into a chunk
+ * `section_label`, so a citation into the saved copy names the same section the viewer showed.
+ */
+export function renderArticleMarkdown(
+  article: PackArticle,
+  meta: { archiveTitle: string | null; savedAt: string }
+): string {
+  const title = article.title.replace(/\s+/g, ' ').trim() || 'Article'
+  const lines: string[] = [`# ${title}`, '']
+  const from = meta.archiveTitle ? ` from the knowledge pack "${meta.archiveTitle.replace(/\s+/g, ' ').trim()}"` : ''
+  lines.push(`> Offline copy of the article "${title}"${from}, saved with HilbertRaum on ${meta.savedAt.slice(0, 10)}.`)
+  if (article.partial) {
+    lines.push('>', '> Only the first part of the article could be copied: the converter stopped short of the whole text.')
+  }
+  lines.push('')
+  for (const section of article.sections) {
+    const text = section.text.trim()
+    if (section.label) {
+      const label = section.label.replace(/\s+/g, ' ').trim()
+      lines.push(`## ${label}`, '')
+    }
+    if (text.length > 0) lines.push(text, '')
+  }
+  return lines.join('\n')
+}
+
+/** The INDEXED copy of this exact pack entry, if one exists. `deleteDocument` is a hard delete,
+ *  so a copy the user removed can be saved again; a crash-interrupted save that the startup
+ *  reconciliation flipped to `failed` (its transient already shredded) must not block a fresh
+ *  save either — hence the status filter, not a "not deleted" one. */
+export function findSavedArticle(
+  db: Db,
+  packId: string,
+  articlePath: string
+): { id: string; title: string } | null {
+  const row = prepareCached(
+    db,
+    `SELECT id, title FROM documents
+      WHERE status = 'indexed'
+        AND origin_json IS NOT NULL
+        AND json_extract(origin_json, '$.type') = 'archive'
+        AND json_extract(origin_json, '$.packId') = ?
+        AND json_extract(origin_json, '$.articlePath') = ?
+      ORDER BY created_at DESC LIMIT 1`
+  ).get(packId, articlePath) as { id: string; title: string } | undefined
+  return row ? { id: row.id, title: row.title } : null
+}
+
+export interface SaveArticleDeps {
+  db: Db
+  /** `documentsDir(workspacePath)` — where the stored copies and the `.parse` transient live. */
+  storeDir: string
+  ingestion: IngestionDeps
+  /** The vault lease (`WorkspaceController.beginDocumentWork`) — held for exactly this step. */
+  beginDocumentWork: () => () => void
+  /** Called with the new row's id as soon as it exists, so the caller can hold it as busy
+   *  (the docs IPC delete / re-index guards) for the seconds the import runs. */
+  onQueued?: (documentId: string) => void
+  now?: () => string
+}
+
+/**
+ * Materialise one article as a document. Mirrors `materializeDocument`: the lease, the
+ * `.parse.md` transient registered on the documents' plaintext registry (a lock/quit sweeps
+ * it), the queue-time provenance stamp, the roll-back with `deleteDocument` unless the import
+ * reached `indexed`, the shred in `finally`. Returns the new document; a duplicate is answered
+ * by the caller BEFORE this runs (`findSavedArticle`).
+ */
+export async function saveArticleAsDocument(
+  deps: SaveArticleDeps,
+  article: PackArticle,
+  source: { packId: string; articlePath: string; archiveTitle: string | null }
+): Promise<PackArticleSaveResult> {
+  const release = deps.beginDocumentWork()
+  const savedAt = (deps.now ?? (() => new Date().toISOString()))()
+  const tempPath = join(deps.storeDir, `${randomUUID()}.parse.md`)
+  const op = deps.ingestion.plaintextOps?.register('article-save')
+  op?.track(tempPath)
+  let newDocId: string | null = null
+  try {
+    mkdirSync(deps.storeDir, { recursive: true })
+    writeFileSync(tempPath, renderArticleMarkdown(article, { archiveTitle: source.archiveTitle, savedAt }), 'utf8')
+    const origin: ArchiveOrigin = {
+      type: 'archive',
+      packId: source.packId,
+      articlePath: source.articlePath,
+      archiveTitle: source.archiveTitle,
+      createdAt: savedAt
+    }
+    const title = articleDocumentTitle(article.title, source.archiveTitle)
+    const info = createQueuedDocument(deps.db, tempPath, { displayTitle: title, origin })
+    newDocId = info.id
+    deps.onQueued?.(info.id)
+    const result = await processDocument(deps.db, deps.storeDir, info.id, deps.ingestion)
+    if (result.status !== 'indexed') {
+      // Never a half-born row: the import failed, so nothing persists. Only the status and
+      // the error CLASS reach the log — the title and path are content.
+      log.error('Saving a knowledge-pack article as a document failed', {
+        status: result.status,
+        error: result.errorMessage ? result.errorMessage.split(':')[0] : null
+      })
+      throw new Error(tMain('main.zim.saveFailed'))
+    }
+    setDocumentOrigin(deps.db, info.id, origin)
+    // A user-chosen import, not a generated work-product: file it into the Library (the
+    // default chat scope) — `fileFromPendingDestination` skips every row that carries an origin.
+    fileDocumentByDestination(deps.db, info.id, { kind: 'library' })
+    return { documentId: info.id, title, alreadySaved: false, chunkCount: result.chunkCount }
+  } catch (err) {
+    if (newDocId) deleteDocument(deps.db, deps.storeDir, newDocId)
+    throw err
+  } finally {
+    shredFile(tempPath)
+    op?.release()
+    release()
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -19,6 +19,7 @@ import type {
   KnowledgePack,
   KnowledgePackAddResult,
   KnowledgePackStatus,
+  PackArticleSaveResult,
   KnowledgePacksChangedEvent,
   ContextUsage,
   Conversation,
@@ -581,6 +582,9 @@ const api = {
     partial: boolean
   } | null> =>
     ipcRenderer.invoke(IPC.getPackArticle, packId, articlePath),
+  /** Save one pack article as a document (#340 Tier-2); the main side re-reads the text. */
+  savePackArticle: (packId: string, articlePath: string): Promise<PackArticleSaveResult> =>
+    ipcRenderer.invoke(IPC.savePackArticle, packId, articlePath),
   listCollections: (): Promise<Collection[]> => ipcRenderer.invoke(IPC.listCollections),
   /** Create a project. */
   createCollection: (

--- a/apps/desktop/src/renderer/chat/ArticleModal.tsx
+++ b/apps/desktop/src/renderer/chat/ArticleModal.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useId, useState } from 'react'
-import { Modal, Spinner } from '../components'
+import { useEffect, useId, useRef, useState } from 'react'
+import type { PackArticleSaveResult } from '@shared/types'
+import { Button, Modal, Spinner } from '../components'
+import { friendlyIpcError } from '../lib/errors'
 import { useT } from '../i18n'
 
 // Offline article viewer (knowledge packs, ZIM wave): the read-only view a citation's
@@ -8,6 +10,12 @@ import { useT } from '../i18n'
 // converter retrieval uses — never raw archive HTML, never innerHTML, no loopback fetch
 // from the renderer (the CSP forbids it; window-security.ts). SourceContextModal is the
 // pattern (main-resolved read-only source view with honest states).
+//
+// #340 Tier-2 (D-Z21, the owner's ruling C3 (a)): the viewer is ALSO where an article becomes
+// a document — "Save to my documents" sends the same two ids over `packs:saveArticle`; the main
+// side re-reads the text and runs it through the normal import path. The button carries the
+// article title in its accessible name (design-guidelines §11.15 item 3) and reports its own
+// state inline: saving, saved (with the filed title), already saved, or the friendly failure.
 
 export interface ArticleTarget {
   packId: string
@@ -25,24 +33,39 @@ interface PackArticleView {
   partial: boolean
 }
 
+type SaveState =
+  | { phase: 'idle' }
+  | { phase: 'saving' }
+  | { phase: 'saved'; result: PackArticleSaveResult }
+  | { phase: 'failed'; message: string }
+
 export function ArticleModal({
   target,
-  onClose
+  onClose,
+  canSave = true
 }: {
   /** Null = closed. */
   target: ArticleTarget | null
   onClose: () => void
+  /** False on read-only surfaces (an evidence review): the viewer shows no save action. */
+  canSave?: boolean
 }): JSX.Element {
   const { t } = useT()
   const sourceLineId = useId()
   const [article, setArticle] = useState<PackArticleView | null>(null)
   const [phase, setPhase] = useState<'loading' | 'ready' | 'failed'>('loading')
+  const [save, setSave] = useState<SaveState>({ phase: 'idle' })
+  // Bumped whenever the viewer moves to another article (or closes): a save that resolves for a
+  // PREVIOUS article must not announce itself on the current one.
+  const saveGeneration = useRef(0)
 
   useEffect(() => {
+    saveGeneration.current += 1
     if (!target) return
     let cancelled = false
     setPhase('loading')
     setArticle(null)
+    setSave({ phase: 'idle' })
     void (async () => {
       try {
         const result = await window.api.getPackArticle(target.packId, target.articlePath)
@@ -57,6 +80,18 @@ export function ArticleModal({
       cancelled = true
     }
   }, [target])
+
+  async function onSave(): Promise<void> {
+    if (!target || save.phase === 'saving') return
+    const generation = saveGeneration.current
+    setSave({ phase: 'saving' })
+    try {
+      const result = await window.api.savePackArticle(target.packId, target.articlePath)
+      if (generation === saveGeneration.current) setSave({ phase: 'saved', result })
+    } catch (e) {
+      if (generation === saveGeneration.current) setSave({ phase: 'failed', message: friendlyIpcError(e) })
+    }
+  }
 
   return (
     <Modal
@@ -89,6 +124,38 @@ export function ArticleModal({
         )}
         {phase === 'ready' && article?.partial && (
           <p className="hint pack-article-source">{t('chat.article.partial')}</p>
+        )}
+        {phase === 'ready' && article && canSave && (
+          <div className="pack-article-save">
+            {save.phase === 'saved' ? (
+              <p className="hint" role="status">
+                {save.result.alreadySaved
+                  ? t('chat.article.alreadySaved', { title: save.result.title })
+                  : t('chat.article.saved', { title: save.result.title })}
+              </p>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  disabled={save.phase === 'saving'}
+                  aria-label={t('chat.article.saveAria', { title: article.title })}
+                  onClick={() => void onSave()}
+                >
+                  {save.phase === 'saving' ? t('chat.article.saving') : t('chat.article.save')}
+                </Button>
+                {save.phase === 'saving' && (
+                  <span className="hint" role="status">
+                    <Spinner />
+                  </span>
+                )}
+                {save.phase === 'failed' && (
+                  <p className="hint">
+                    <span aria-hidden="true">⚠</span> {save.message}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
         )}
         {phase === 'ready' && article && (
           <div className="pack-article-body">

--- a/apps/desktop/src/renderer/screens/ReviewScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ReviewScreen.tsx
@@ -479,8 +479,10 @@ export function ReviewScreen({
       {/* #301 P6 (plan §9.23 (c)2): the SAME offline article viewer the chat uses, mounted
           beside the source-in-context modal. It reads through `packs:getArticle` with the
           frozen snapshot's pack id + article path; a removed / disabled / unplugged pack
-          resolves to null and the viewer says so — the review itself never changes. */}
-      <ArticleModal target={articleTarget} onClose={() => setArticleTarget(null)} />
+          resolves to null and the viewer says so — the review itself never changes. No save
+          action here (#340 Tier-2): a review is a read-only surface whose bridge is evidence-only;
+          saving an article to the documents is the chat viewer's job. */}
+      <ArticleModal target={articleTarget} onClose={() => setArticleTarget(null)} canSave={false} />
 
       <ConfirmDialog
         open={confirmClear}

--- a/apps/desktop/src/renderer/screens/documents/format.tsx
+++ b/apps/desktop/src/renderer/screens/documents/format.tsx
@@ -97,6 +97,15 @@ function titleOf(id: string, sourcesById: ReadonlyMap<string, DocumentInfo>, t: 
  */
 export function provenanceLine(d: DocumentInfo, sourcesById: ReadonlyMap<string, DocumentInfo>, t: I18n['t']): ReactNode {
   if (!d.origin) return null
+  // A saved knowledge-pack article (#340 Tier-2): the archive is the source, not a document.
+  if ('type' in d.origin && d.origin.type === 'archive') {
+    return (
+      <>
+        {t('docs.provenance.articleBefore')}
+        <b>{d.origin.archiveTitle ?? t('docs.provenance.articleUnknownArchive')}</b>
+      </>
+    )
+  }
   const { kind, sourceDocumentIds } = provenanceView(d.origin)
   if (kind === 'compare') {
     const [a, b] = sourceDocumentIds

--- a/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
+++ b/apps/desktop/src/renderer/screens/settings/DiagnosticsTab.tsx
@@ -80,7 +80,8 @@ const AUDIT_TYPE_LABELS: Record<AuditEventType, MessageKey> = {
   evidence_review_deleted: 'diag.audit.evidence_review_deleted',
   evidence_pack_exported: 'diag.audit.evidence_pack_exported',
   knowledge_pack_added: 'diag.audit.knowledge_pack_added',
-  knowledge_pack_removed: 'diag.audit.knowledge_pack_removed'
+  knowledge_pack_removed: 'diag.audit.knowledge_pack_removed',
+  knowledge_pack_article_saved: 'diag.audit.knowledge_pack_article_saved'
 }
 
 function auditLabel(type: AuditEventType, t: I18n['t']): string {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2676,6 +2676,9 @@ code, pre, kbd { font-family: var(--font-mono); }
 /* Offline article viewer: readable measure inside the wide modal; scrolls in the modal. */
 .pack-article { display: flex; flex-direction: column; gap: 8px; }
 .pack-article-source { margin: 0; }
+/* #340 Tier-2: the save action row — button, inline spinner or the failure line beside it. */
+.pack-article-save { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.pack-article-save .hint { margin: 0; }
 .pack-article-body { max-width: 68ch; }
 .pack-article-heading { font-size: var(--text-md); margin: 14px 0 4px; }
 .pack-article-para { margin: 0 0 10px; white-space: pre-wrap; }

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -505,6 +505,9 @@ export const de: Record<keyof typeof en, string> = {
   // German provenance copy reviewed in the D-L7 pass (2026-06-14).
   'docs.provenance.summaryBefore': 'Zusammenfassung von ',
   'docs.provenance.generatedBefore': 'Erzeugt aus ',
+  // #340 Tier-2: ein aus einem Wissenspaket gespeicherter Artikel — die Quelle ist das Archiv.
+  'docs.provenance.articleBefore': 'Gespeichert aus dem Wissenspaket ',
+  'docs.provenance.articleUnknownArchive': 'einem Wissenspaket',
   'docs.import.busy': 'Wird importiert…',
   'docs.import.files': 'Dateien importieren',
   'docs.import.folder': 'Ordner importieren',
@@ -1775,6 +1778,7 @@ export const de: Record<keyof typeof en, string> = {
   'diag.audit.evidence_pack_exported': 'Nachweispaket exportiert',
   'diag.audit.knowledge_pack_added': 'Wissenspaket hinzugefügt',
   'diag.audit.knowledge_pack_removed': 'Wissenspaket entfernt',
+  'diag.audit.knowledge_pack_article_saved': 'Wissenspaket-Artikel als Dokument gespeichert',
   'diag.accel.gpuFallbackName': 'Grafikkarte',
   'diag.accel.gpu': '{name} (GPU)',
   'diag.accel.mock': 'Eingebauter Demo-Modus',
@@ -2553,6 +2557,9 @@ export const de: Record<keyof typeof en, string> = {
   'main.dialog.filterDocuments': 'Dokumente',
   'main.dialog.filterAll': 'Alle Dateien',
   'main.zim.unavailable': 'Wissenspakete sind in dieser Sitzung nicht verfügbar.',
+  // #340 Tier-2: die beiden freundlichen Fehler des Speicherpfads.
+  'main.zim.articleUnavailable': 'Dieser Artikel ist gerade nicht verfügbar und konnte deshalb nicht gespeichert werden. Das Paket ist womöglich deaktiviert, entfernt oder sein Laufwerk abgezogen.',
+  'main.zim.saveFailed': 'Der Artikel konnte nicht zu deinen Dokumenten hinzugefügt werden. Bitte versuch es noch einmal.',
   'main.zim.dialogTitle': 'Wissenspakete hinzufügen',
   'main.zim.filterZim': 'ZIM-Archive',
   'main.dialog.chooseImage': 'Bild auswählen',
@@ -2734,6 +2741,12 @@ export const de: Record<keyof typeof en, string> = {
   'chat.article.loading': 'Artikel wird geladen…',
   'chat.article.unavailable': 'Dieser Artikel ist gerade nicht verfügbar. Das Paket ist möglicherweise deaktiviert, entfernt oder das Laufwerk nicht angeschlossen.',
   'chat.article.partial': 'Nur der erste Teil dieses Artikels konnte angezeigt werden.',
+  // #340 Tier-2 (D-Z21): die Aktion „In meine Dokumente speichern“ im Artikelfenster.
+  'chat.article.save': 'In meine Dokumente speichern',
+  'chat.article.saveAria': 'In meine Dokumente speichern: {title}',
+  'chat.article.saving': 'Wird in deine Dokumente gespeichert …',
+  'chat.article.saved': 'In deinen Dokumenten gespeichert als „{title}“. Er bleibt auch ohne das Paket durchsuchbar.',
+  'chat.article.alreadySaved': 'Dieser Artikel ist bereits in deinen Dokumenten als „{title}“.',
   // ---- #301 P6 (a11y pass; plan §9.23 (b)4/(b)6 and decision (c)5) — BEGIN -----------------
   'chat.scope.packMissing': 'Datei fehlt',
   'chat.scope.packMismatch': 'anderes Archiv an diesem Ort',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -484,6 +484,9 @@ export const en = {
   'docs.provenance.translatedBefore': 'Translated from ',
   'docs.provenance.summaryBefore': 'Summary of ',
   'docs.provenance.generatedBefore': 'Generated from ',
+  // #340 Tier-2: a knowledge-pack article saved as a document — the archive is the source.
+  'docs.provenance.articleBefore': 'Saved from the knowledge pack ',
+  'docs.provenance.articleUnknownArchive': 'a knowledge pack',
   'docs.import.busy': 'Importing…',
   'docs.import.files': 'Import files',
   'docs.import.folder': 'Import folder',
@@ -1733,6 +1736,7 @@ export const en = {
   'diag.audit.evidence_pack_exported': 'Evidence pack exported',
   'diag.audit.knowledge_pack_added': 'Knowledge pack added',
   'diag.audit.knowledge_pack_removed': 'Knowledge pack removed',
+  'diag.audit.knowledge_pack_article_saved': 'Knowledge-pack article saved as a document',
   'diag.accel.gpuFallbackName': 'Graphics card',
   'diag.accel.gpu': '{name} (GPU)',
   'diag.accel.mock': 'Built-in demo mode',
@@ -2522,6 +2526,9 @@ export const en = {
   'main.dialog.filterDocuments': 'Documents',
   'main.dialog.filterAll': 'All files',
   'main.zim.unavailable': 'Knowledge packs are not available in this session.',
+  // #340 Tier-2: the save-as-document path's two friendly failures.
+  'main.zim.articleUnavailable': 'This article is not available right now, so it could not be saved. The pack may be disabled, removed, or its drive unplugged.',
+  'main.zim.saveFailed': 'The article could not be added to your documents. Please try again.',
   'main.zim.dialogTitle': 'Add knowledge packs',
   'main.zim.filterZim': 'ZIM archives',
   'main.dialog.chooseImage': 'Choose an image',
@@ -2703,6 +2710,12 @@ export const en = {
   'chat.article.loading': 'Loading the article…',
   'chat.article.unavailable': 'This article is not available right now. The pack may be disabled, removed, or its drive unplugged.',
   'chat.article.partial': 'Only the first part of this article could be shown.',
+  // #340 Tier-2 (D-Z21): the viewer's "Save to my documents" action and its states.
+  'chat.article.save': 'Save to my documents',
+  'chat.article.saveAria': 'Save to my documents: {title}',
+  'chat.article.saving': 'Saving to your documents…',
+  'chat.article.saved': 'Saved to your documents as “{title}”. It stays searchable even without the pack.',
+  'chat.article.alreadySaved': 'This article is already in your documents as “{title}”.',
   // ---- #301 P6 (a11y pass; plan §9.23 (b)4/(b)6 and decision (c)5) — BEGIN -----------------
   // Reason-specific popover hints. The picker greys an ineligible pack with the SAME reason the
   // arm's `classifyPackSelection` records, so the row and the per-answer outcome can never tell

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -273,6 +273,11 @@ export const IPC = {
   /** Read one article from a pack for the citation viewer — plain sectioned TEXT
    *  (`PackArticle`), resolved MAIN-side over the loopback sidecar; null when unavailable. */
   getPackArticle: 'packs:getArticle',
+  /** Save one pack article as a REAL document in the corpus (#340 Tier-2, D-Z21): the text is
+   *  re-read MAIN-side (only `packId` + `articlePath` cross the bridge) and run through the one
+   *  import path; resolves `PackArticleSaveResult`. A second save of the same entry returns the
+   *  existing document (`alreadySaved`). Locked ⇒ the friendly locked copy. */
+  savePackArticle: 'packs:saveArticle',
   // Document organization — collections (projects + built-ins). Handlers in
   // registerCollectionsIpc.ts; membership/lifecycle live on the docs: namespace above.
   /** All collections (built-ins first, then projects by name). */

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1288,7 +1288,7 @@ export interface CompareOrigin {
 }
 
 /** The kind of generation a `GeneratedProvenance` records. */
-export type GeneratedKind = 'summary' | 'translation' | 'compare' | 'transcript' | 'other'
+export type GeneratedKind = 'summary' | 'translation' | 'compare' | 'transcript' | 'other' | 'article'
 
 /**
  * Structured provenance for a document the app GENERATED from other documents
@@ -1312,7 +1312,35 @@ export interface GeneratedProvenance {
   createdAt: string
 }
 
-export type DocumentOrigin = TranslationOrigin | CompareOrigin | GeneratedProvenance
+export type DocumentOrigin = TranslationOrigin | CompareOrigin | GeneratedProvenance | ArchiveOrigin
+
+/**
+ * Provenance of a document SAVED from a knowledge-pack article (#340 Tier-2, rag-design §17
+ * D-Z21): the archive it came from and the entry inside it. No source DOCUMENT — the copy was
+ * derived from a ZIM entry, so staleness never fires for it and the duplicate check keys on
+ * (`packId`, `articlePath`). `archiveTitle` is the pack's title as it read at save time (display
+ * only; the pack may be renamed or removed later). Stored in `documents.origin_json`.
+ */
+export interface ArchiveOrigin {
+  type: 'archive'
+  /** knowledge_packs.id — the ZIM UUID. */
+  packId: string
+  /** The entry key inside the archive (the viewer's `articlePath`). */
+  articlePath: string
+  archiveTitle: string | null
+  createdAt: string
+}
+
+/** The result of `packs:saveArticle` (#340 Tier-2). `alreadySaved` = an earlier copy of this exact
+ *  entry exists and was returned instead of a second one. */
+export interface PackArticleSaveResult {
+  documentId: string
+  /** The document's title as filed (`<article> (<archive>).md`). */
+  title: string
+  alreadySaved: boolean
+  /** Chunks the copy was indexed into (0 when `alreadySaved` — not re-counted). */
+  chunkCount: number
+}
 
 /**
  * Normalize any stored provenance into the uniform view the UI renders: the generation
@@ -1327,6 +1355,10 @@ export function provenanceView(origin: DocumentOrigin): {
 } {
   if ('kind' in origin) {
     return { kind: origin.kind, sourceDocumentIds: origin.sourceDocumentIds }
+  }
+  // A saved knowledge-pack article (D-Z21): no source document — the archive is the source.
+  if (origin.type === 'archive') {
+    return { kind: 'article', sourceDocumentIds: [] }
   }
   if (origin.type === 'compare') {
     return { kind: 'compare', sourceDocumentIds: [...origin.comparedFrom] }
@@ -3066,6 +3098,9 @@ export type AuditEventType =
   // filenames — never in message or metadata.
   | 'knowledge_pack_added'
   | 'knowledge_pack_removed'
+  /** A pack article saved as a document (#340 Tier-2): ids + counts only — the pack id, the new
+   *  document id, status, chunkCount. Never the entry path or either title. */
+  | 'knowledge_pack_article_saved'
 
 /** One audit-log entry (a `runtime_events` row), newest-first over the IPC surface. */
 export interface AuditEvent {

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -2520,7 +2520,7 @@ describe('#340 Tier-2 — packs:saveArticle files the article as a real document
       // rows with an origin are otherwise never filed, D3/N1.)
       const library = getBuiltinCollection(h.db(), 'library')!
       const listed = listDocuments(h.db()).find((d) => d.id === saved.documentId)!
-      expect(listed.collections.map((c) => c.id)).toContain(library.id)
+      expect((listed.collections ?? []).map((c) => c.id)).toContain(library.id)
       // A conversation with no scope of its own resolves to the Library — the default that finds it.
       expect(resolveScope(h.db(), 'conversation-without-a-scope').collectionIds).toContain(library.id)
       // The stored copy is the converter's text, never HTML: a chunk carries the article body.

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -72,7 +72,7 @@ import {
   restoreMessage,
   setScope
 } from '../../src/main/services/chat'
-import { resolveScope } from '../../src/main/services/collections'
+import { getBuiltinCollection, resolveScope } from '../../src/main/services/collections'
 import { MockEmbedder, encodeVector } from '../../src/main/services/embeddings'
 import { createMockRuntime } from '../../src/main/services/runtime/mock'
 import type { ModelRuntime } from '../../src/main/services/runtime'
@@ -100,6 +100,7 @@ import type { AppContext } from '../../src/main/services/context'
 import type { Db } from '../../src/main/services/db'
 import { seedSettings } from '../../src/main/services/settings'
 import { createPlaintextOps, type PlaintextOpsRegistry } from '../../src/main/services/ingestion/plaintext-ops'
+import { getDocument, listDocuments } from '../../src/main/services/ingestion'
 import { registeredSidecarPids, type SpawnFn } from '../../src/main/services/runtime/sidecar'
 import { ZimService, type ServedLibrary, type ZimPacksChangedNotice } from '../../src/main/services/zim'
 import { readZimHeader, servingNameFor } from '../../src/main/services/zim/identity'
@@ -1240,6 +1241,15 @@ describe('knowledge packs across the session boundary (#301 P3b, H4/M4)', () => 
       // packId + articlePath, and nothing else may cross the bridge.
       expect(
         bridge
+          .split(',')
+          .map((p) => p.trim())
+          .filter(Boolean)
+      ).toEqual(['packId: string', 'articlePath: string'])
+      // #340 Tier-2: the save bridge carries the identical invariant — the same two ids, no hint.
+      const saveBridge = /savePackArticle: \(([\s\S]*?)\):/.exec(src('src/preload/index.ts'))![1]!
+      expect(saveBridge).not.toMatch(/urlId/i)
+      expect(
+        saveBridge
           .split(',')
           .map((p) => p.trim())
           .filter(Boolean)
@@ -2472,4 +2482,88 @@ describe('#340 — searchability is confirmed right after Add packs… / Enable 
       await h.close()
     }
   }, 60_000)
+})
+
+// ---- #340 Tier-2 (D-Z21): "Save article to my documents" -----------------------------------
+describe('#340 Tier-2 — packs:saveArticle files the article as a real document (D-Z21)', () => {
+  it('#340 Tier-2 a saved article is indexed with its sections and an archive origin, a second save returns the same document, the copy outlives the pack, and the audit carries ids and counts only', async () => {
+    const h = await sessionHarness()
+    try {
+      const alpha = await h.registerPack('alpha-save.zim')
+      // The harness's embedder stub answers no vectors; the import path needs real ones.
+      h.ctx.embedder = new MockEmbedder()
+      const before = listDocuments(h.db()).length
+      const packTitle = h.svc.listPacks(h.db()).find((p) => p.id === alpha)!.title
+
+      // Two overlapping saves of the same entry (a double-click that beat the button's disabled
+      // state, two windows): the second joins the first's import — ONE copy, the same id.
+      type Saved = { documentId: string; title: string; alreadySaved: boolean; chunkCount: number }
+      const [first, second] = (await Promise.all([
+        invoke(handlers, IPC.savePackArticle, alpha, 'A/Alpha'),
+        invoke(handlers, IPC.savePackArticle, alpha, 'A/Alpha')
+      ])).map((r) => r.result as Saved)
+      expect(first.alreadySaved).toBe(false)
+      expect(second).toMatchObject({ documentId: first.documentId, title: first.title, alreadySaved: true })
+      const saved = first
+      expect(saved.title).toBe(`Alpha and the climate (${packTitle}).md`)
+      expect(saved.chunkCount).toBeGreaterThan(0)
+      const doc = getDocument(h.db(), saved.documentId)
+      expect(doc).not.toBeNull()
+      expect(doc!.status).toBe('indexed')
+      expect(doc!.chunkCount).toBe(saved.chunkCount)
+      expect(doc!.mimeType).toBe('text/markdown')
+      // The provenance reads back as the ARCHIVE origin — pack id, entry path, the pack's title.
+      expect(doc!.origin).toMatchObject({ type: 'archive', packId: alpha, articlePath: 'A/Alpha', archiveTitle: packTitle })
+      expect(listDocuments(h.db()).length).toBe(before + 1)
+      // A user-chosen import, not a generated work-product: the copy is filed into the Library,
+      // so the default documents chat — whose scope IS the Library — can find it. (Generated
+      // rows with an origin are otherwise never filed, D3/N1.)
+      const library = getBuiltinCollection(h.db(), 'library')!
+      const listed = listDocuments(h.db()).find((d) => d.id === saved.documentId)!
+      expect(listed.collections.map((c) => c.id)).toContain(library.id)
+      // A conversation with no scope of its own resolves to the Library — the default that finds it.
+      expect(resolveScope(h.db(), 'conversation-without-a-scope').collectionIds).toContain(library.id)
+      // The stored copy is the converter's text, never HTML: a chunk carries the article body.
+      const chunk = h.db().prepare('SELECT text, section_label FROM chunks WHERE document_id = ? ORDER BY chunk_index LIMIT 1').get(saved.documentId) as { text: string; section_label: string | null }
+      expect(chunk.text).toContain('Alpha is a test archive article about the climate.')
+      expect(chunk.text).not.toMatch(/<[a-z][a-z0-9-]*[\s>]/i)
+
+      // A second save of the same entry: the existing document, no second copy.
+      const again = (await invoke(handlers, IPC.savePackArticle, alpha, 'A/Alpha')).result as typeof saved
+      expect(again).toMatchObject({ documentId: saved.documentId, title: saved.title, alreadySaved: true })
+      expect(listDocuments(h.db()).length).toBe(before + 1)
+
+      // A hazardous entry key in a LIVE pack is refused before any write (no half-born row).
+      await expect(invoke(handlers, IPC.savePackArticle, alpha, 'A/../Alpha')).rejects.toThrow(/could not be saved/)
+      expect(listDocuments(h.db()).length).toBe(before + 1)
+
+      // A crash-interrupted save (the startup reconciliation flips its row to `failed`, the
+      // transient is already shredded) must not block a fresh save of the same entry forever:
+      // the duplicate check only honours an INDEXED copy.
+      h.db().prepare("UPDATE documents SET status = 'failed' WHERE id = ?").run(saved.documentId)
+      const fresh = (await invoke(handlers, IPC.savePackArticle, alpha, 'A/Alpha')).result as Saved
+      expect(fresh.alreadySaved).toBe(false)
+      expect(fresh.documentId).not.toBe(saved.documentId)
+      expect(listDocuments(h.db()).length).toBe(before + 2)
+
+      // The copy outlives the pack: remove it, and the document is still indexed and intact.
+      await invoke(handlers, IPC.removeKnowledgePack, alpha)
+      expect(getDocument(h.db(), fresh.documentId)?.status).toBe('indexed')
+
+      // Audit: ids and counts only — never the entry path, the article title or the pack title.
+      const audit = h.auditCalls.find((c) => c.type === 'knowledge_pack_article_saved')
+      expect(audit).toBeDefined()
+      expect(audit!.metadata).toEqual({ packId: alpha, documentId: saved.documentId, status: 'indexed', chunkCount: saved.chunkCount })
+      const auditText = JSON.stringify(h.auditCalls)
+      expect(auditText).not.toContain('A/Alpha')
+      expect(auditText).not.toContain('Alpha and the climate')
+      expect(auditText).not.toContain(packTitle)
+
+      // An entry of a REMOVED pack is a friendly failure and leaves no half-born row.
+      await expect(invoke(handlers, IPC.savePackArticle, alpha, 'A/Missing')).rejects.toThrow(/could not be saved/)
+      expect(listDocuments(h.db()).length).toBe(before + 2)
+    } finally {
+      await h.close()
+    }
+  })
 })

--- a/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
+++ b/apps/desktop/tests/renderer/KnowledgePacks.test.tsx
@@ -1955,3 +1955,111 @@ describe('T18 — knowledge-pack UI acceptance (#301 P6, plan §9.23)', () => {
     120_000
   )
 })
+
+// ---- #340 Tier-2 (D-Z21): "Save to my documents" in the article viewer ---------------------
+describe('ArticleModal — save to my documents (#340 Tier-2)', () => {
+  const article = {
+    title: 'Treibhausgas',
+    sections: [{ label: null, text: 'Treibhausgase sind Spurengase.' }],
+    partial: false
+  }
+  const target = { packId: 'uuid-climate', articlePath: 'Treibhausgas', archiveTitle: 'Klimawandel von Wikipedia' }
+
+  it('offers the save action once the article is ready, sends only the two ids, and reports the filed title', async () => {
+    const savePackArticle = vi.fn(async () => ({
+      documentId: 'doc-1',
+      title: 'Treibhausgas (Klimawandel von Wikipedia).md',
+      alreadySaved: false,
+      chunkCount: 3
+    }))
+    stubApi({ getPackArticle: async () => article, savePackArticle })
+    render(
+      <I18nProvider>
+        <ArticleModal target={target} onClose={() => {}} />
+      </I18nProvider>
+    )
+    const button = await screen.findByRole('button', { name: 'Save to my documents: Treibhausgas' })
+    await userEvent.click(button)
+    expect(savePackArticle).toHaveBeenCalledWith('uuid-climate', 'Treibhausgas')
+    expect(await screen.findByText(/Saved to your documents as “Treibhausgas \(Klimawandel von Wikipedia\)\.md”/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Save to my documents/ })).not.toBeInTheDocument()
+  })
+
+  it('says so when the article was already saved, naming the existing document', async () => {
+    stubApi({
+      getPackArticle: async () => article,
+      savePackArticle: vi.fn(async () => ({ documentId: 'doc-1', title: 'Treibhausgas (Klimawandel von Wikipedia).md', alreadySaved: true, chunkCount: 0 }))
+    })
+    render(
+      <I18nProvider>
+        <ArticleModal target={target} onClose={() => {}} />
+      </I18nProvider>
+    )
+    await userEvent.click(await screen.findByRole('button', { name: /Save to my documents/ }))
+    expect(await screen.findByText(/already in your documents as “Treibhausgas/)).toBeInTheDocument()
+  })
+
+  it('shows the friendly failure and keeps the action available when the save is refused', async () => {
+    stubApi({
+      getPackArticle: async () => article,
+      savePackArticle: vi.fn(async () => {
+        throw new Error("Error invoking remote method 'packs:saveArticle': Error: This article is not available right now, so it could not be saved.")
+      })
+    })
+    render(
+      <I18nProvider>
+        <ArticleModal target={target} onClose={() => {}} />
+      </I18nProvider>
+    )
+    await userEvent.click(await screen.findByRole('button', { name: /Save to my documents/ }))
+    // The main-side reason is a whole sentence already — shown alone, no stacked prefix.
+    expect(await screen.findByText(/This article is not available right now, so it could not be saved/)).toBeInTheDocument()
+    expect(screen.queryByText(/The article could not be saved\./)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Save to my documents/ })).toBeEnabled()
+  })
+
+  it('discards a save that resolves after the viewer moved on to another article', async () => {
+    type Saved = { documentId: string; title: string; alreadySaved: boolean; chunkCount: number }
+    let resolveSave: (r: Saved) => void = () => {}
+    stubApi({
+      getPackArticle: async () => article,
+      savePackArticle: () => new Promise<Saved>((r) => (resolveSave = r))
+    })
+    const { rerender } = render(
+      <I18nProvider>
+        <ArticleModal target={target} onClose={() => {}} />
+      </I18nProvider>
+    )
+    await userEvent.click(await screen.findByRole('button', { name: /Save to my documents/ }))
+    expect(screen.getByText(/Saving to your documents/)).toBeInTheDocument()
+    // The viewer moves to another article while the first save is still running.
+    rerender(
+      <I18nProvider>
+        <ArticleModal target={{ ...target, articlePath: 'Methan' }} onClose={() => {}} />
+      </I18nProvider>
+    )
+    expect(await screen.findByRole('button', { name: /Save to my documents/ })).toBeEnabled()
+    await act(async () => resolveSave({ documentId: 'doc-1', title: 'Treibhausgas (Klimawandel von Wikipedia).md', alreadySaved: false, chunkCount: 3 }))
+    // The stale result never lands on the new article: no "saved" line, the action still offered.
+    expect(screen.queryByText(/Saved to your documents/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Save to my documents/ })).toBeEnabled()
+  })
+
+  it('has no save action while the article is loading or when it is unavailable', async () => {
+    let resolveArticle: (a: typeof article | null) => void = () => {}
+    stubApi({
+      getPackArticle: () => new Promise<typeof article | null>((r) => (resolveArticle = r)),
+      savePackArticle: vi.fn()
+    })
+    render(
+      <I18nProvider>
+        <ArticleModal target={target} onClose={() => {}} />
+      </I18nProvider>
+    )
+    expect(await screen.findByText(/Loading the article/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Save to my documents/ })).not.toBeInTheDocument()
+    await act(async () => resolveArticle(null))
+    expect(await screen.findByText(/not available right now/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Save to my documents/ })).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/tests/renderer/ReviewScreen.test.tsx
+++ b/apps/desktop/tests/renderer/ReviewScreen.test.tsx
@@ -979,6 +979,9 @@ describe('ReviewScreen — "Open article" from an archive evidence row (#301 P6,
     // EXACT call args — the frozen locator, not a live lookup.
     expect(getPackArticle).toHaveBeenCalledTimes(1)
     expect(getPackArticle).toHaveBeenCalledWith('uuid-climate', 'A/Treibhausgas')
+    // #340 Tier-2: the review's viewer is read-only — no "Save to my documents" here, so the
+    // evidence-only bridge rule above stays whole (`packs:saveArticle` is never reachable).
+    expect(within(dialog).queryByRole('button', { name: /Save to my documents/ })).not.toBeInTheDocument()
     // The attribution names the snapshot's archive title…
     expect(
       within(dialog).getByText(

--- a/apps/desktop/tests/unit/zim-save-article.test.ts
+++ b/apps/desktop/tests/unit/zim-save-article.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ARTICLE_TITLE_MAX_CHARS,
+  articleDocumentTitle,
+  renderArticleMarkdown
+} from '../../src/main/services/zim/save-article'
+
+// #340 Tier-2 (D-Z21): the pure halves of "Save article to my documents" — the document title
+// rule and the Markdown the import path parses. The materialise flow itself is exercised end to
+// end in zim-ipc-session.test.ts (a real DB, the real handler, the real import pipeline).
+
+describe('articleDocumentTitle', () => {
+  it('files the copy as "<article> (<archive>).md" — the .md picks the Markdown parser', () => {
+    expect(articleDocumentTitle('Treibhausgas', 'Klimawandel von Wikipedia')).toBe('Treibhausgas (Klimawandel von Wikipedia).md')
+  })
+
+  it('collapses whitespace, tolerates a missing archive title and an empty article title', () => {
+    expect(articleDocumentTitle('  Liste der   Länder  ', null)).toBe('Liste der Länder.md')
+    expect(articleDocumentTitle('', 'Pack')).toBe('Article (Pack).md')
+    expect(articleDocumentTitle('   ', null)).toBe('Article.md')
+  })
+
+  it('caps an absurd title without ever dropping the extension, splitting a surrogate pair or unbalancing the parenthetical', () => {
+    const long = articleDocumentTitle('x'.repeat(400), 'y'.repeat(100))
+    expect(long.endsWith('.md')).toBe(true)
+    expect(long.length).toBeLessThanOrEqual(ARTICLE_TITLE_MAX_CHARS + 3)
+    // The archive parenthetical stays whole (itself capped at half the budget); the article
+    // title is what gets shortened.
+    expect(long).toMatch(/^x+ \(y{90}\)\.md$/)
+    const smiley = String.fromCodePoint(0x1f600)
+    const astral = articleDocumentTitle(`a${smiley}`.repeat(200), null)
+    expect(astral.endsWith('.md')).toBe(true)
+    const lone = Array.from(astral).some((ch) => {
+      const cp = ch.codePointAt(0)!
+      return cp >= 0xd800 && cp <= 0xdfff
+    })
+    expect(lone).toBe(false)
+  })
+})
+
+describe('renderArticleMarkdown', () => {
+  const article = {
+    title: 'Treibhausgas',
+    sections: [
+      { label: null, text: 'Treibhausgase sind Spurengase.\n\nSie wirken auf die Strahlung.' },
+      { label: 'Landwirtschaft', text: 'Methan entsteht in der Landwirtschaft.' },
+      { label: 'Leer', text: '   ' }
+    ],
+    partial: false
+  }
+
+  it('writes an H1, an attribution quote naming the archive and the date, then one H2 per labelled section', () => {
+    const md = renderArticleMarkdown(article, { archiveTitle: 'Klimawandel von Wikipedia', savedAt: '2026-09-07T10:00:00.000Z' })
+    const lines = md.split('\n')
+    expect(lines[0]).toBe('# Treibhausgas')
+    expect(lines[2]).toBe('> Offline copy of the article "Treibhausgas" from the knowledge pack "Klimawandel von Wikipedia", saved with HilbertRaum on 2026-09-07.')
+    expect(md).toContain('\nTreibhausgase sind Spurengase.\n\nSie wirken auf die Strahlung.\n')
+    expect(md).toContain('\n## Landwirtschaft\n\nMethan entsteht in der Landwirtschaft.\n')
+    // An empty section still gets its heading (the viewer showed it) but no blank body line.
+    expect(md).toContain('## Leer\n')
+    expect(md).not.toContain('Only the first part')
+    // The lead (label-less) section never gets a heading of its own.
+    expect(md).not.toContain('## intro')
+  })
+
+  it('states honestly when the converter stopped short, and copes with no archive title', () => {
+    const md = renderArticleMarkdown({ ...article, partial: true }, { archiveTitle: null, savedAt: '2026-09-07T10:00:00.000Z' })
+    expect(md).toContain('> Offline copy of the article "Treibhausgas", saved with HilbertRaum on 2026-09-07.')
+    expect(md).toContain('> Only the first part of the article could be copied')
+  })
+
+  it('collapses whitespace inside titles and labels so headings stay single-line', () => {
+    const md = renderArticleMarkdown(
+      { title: ' Zwei\n Zeilen ', sections: [{ label: 'Ab\nschnitt', text: 'x' }], partial: false },
+      { archiveTitle: 'P\nack', savedAt: '2026-09-07' }
+    )
+    expect(md.split('\n')[0]).toBe('# Zwei Zeilen')
+    expect(md).toContain('## Ab schnitt\n')
+    expect(md).toContain('"Zwei Zeilen" from the knowledge pack "P ack"')
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1675,7 +1675,7 @@ whole renderer-visible surface.
 ### Channel-surface completion sweep (2026-08-20, docs/code audit E-1)
 
 The #138 backfill above closed the *feature* gaps. A mechanical pass over every key in
-`shared/ipc.ts` (145 channels — the keys of its `IPC` constant (138 at the time of this
+`shared/ipc.ts` (147 channels since #340 Tier-2 added `packs:saveArticle` — the keys of its `IPC` constant (138 at the time of this
 sweep, +7 `packs:*` keys added by #301 P7); the `STREAM` builders, `OCR_RASTER` and `EVENTS`
 (now 3, `packs:changed` added) are separate constants, #259) against this file then found **16** that
 appeared under neither their method name nor their channel string — mostly siblings of documented
@@ -1792,7 +1792,13 @@ Phase 1, PR #294 review H1; the modal shows a hint line instead of presenting th
 text as complete; a refused entry key (empty, > 2048 chars, a control character, a `.`/`..`
 segment, a lone surrogate — validated inside the one encoder `client.ts`
 `encodeArticlePath`, #301 P5 finding L5) → null, no request issued; URL-shaped and
-empty-segment keys stay accepted).
+empty-segment keys stay accepted) · `packs:saveArticle` (`(packId, articlePath) →
+PackArticleSaveResult { documentId, title, alreadySaved, chunkCount }` — "Save to my
+documents" in the article viewer, #340 Tier-2, D-Z21; `requireUnlocked`; the same locked
+copy as every other pack-touching channel when a lock lands mid-save; two friendly
+failures, never a half-born document — `main.zim.articleUnavailable` when the entry can no
+longer be re-read main-side, `main.zim.saveFailed` when the import itself does not reach
+`indexed`).
 
 **Event `EVENTS.knowledgePacksChanged`** (`packs:changed`, #301 P3b, finding L7) — an
 EVENT, not an invoke (the `EVENTS.modelVerifyProgress` shape above, but broadcast to
@@ -1929,7 +1935,30 @@ matrix (the `zim-real` row) for the full input table.
 **Lock-channel inventory:** `ipc-lock-coverage.test.ts`'s `registerZimIpc` group gained
 `packs:refresh` as a DB-touching (non-exempt) channel; `packs:status` remains the sole
 exempt channel (in-memory service state only — its `excluded` field, #340, is the service's
-cached list, never a query). The IPC surface is unchanged by the follow-up wave: 145 channels.
+cached list, never a query). The IPC surface was unchanged by the follow-up wave, then gained
+one channel with #340 Tier-2 (`packs:saveArticle`): 147 channels. (The earlier "145" figure was one
+short of the constant by the time it was recorded; 147 is counted from the `IPC` keys on this branch.)
 
 **#340 L3-b (D-Z20):** no shape change — `makeArm` gains an optional `{ expand }` (main-side
 only), the outcome union, the per-answer note, IPC and preload are unchanged.
+
+**#340 Tier-2 (D-Z21) shapes:** `ArchiveOrigin` (`shared/types.ts`) is a new `DocumentOrigin`
+member — `{ type: 'archive', packId, articlePath, archiveTitle: string | null, createdAt }`,
+parsed by `parseOrigin`'s archive branch (`services/ingestion/index.ts`) alongside the legacy
+and `GeneratedProvenance` shapes. `GeneratedKind` gains `'article'`; `provenanceView` maps an
+`ArchiveOrigin` to `{ kind: 'article', sourceDocumentIds: [] }` — no source DOCUMENT, since the
+copy was derived from a ZIM entry, not another document (staleness never fires for it).
+`PackArticleSaveResult = { documentId, title, alreadySaved, chunkCount }` is `packs:saveArticle`'s
+return shape (above); `chunkCount` is 0 when `alreadySaved`. A second invoke for the same
+entry while the first is still importing joins that import (`alreadySaved: true`, the same
+`documentId`) — the duplicate check reads the DB before the import runs, so the in-flight map is
+what keeps two copies from being filed. The saved row is filed into the Library once indexed
+(a user-chosen import, unlike the D3/N1 work-products that carry an origin and never get a
+membership), so the default documents chat scope finds it. `ServiceContext.articleSaveActive`
+(`services/context.ts`) is the in-flight probe the docs IPC delete / re-index guards consult
+beside their own `processing` set and `skillRunActive`. New audit type
+`'knowledge_pack_article_saved'` carries `{ packId, documentId, status: 'indexed', chunkCount }`
+only — the entry path and both titles are content and never ride it. New plaintext op kind
+`'article-save'` (`services/ingestion/plaintext-ops.ts`) tracks the `.parse.md` transient the
+save writes before handing it to `createQueuedDocument` → `processDocument`, so a lock/quit
+mid-save sweeps it like any other in-flight plaintext.

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1192,6 +1192,28 @@ secondary. `lib/useKnowledgePackToolsInstall.ts` is the shared poll/cancel/remem
 already installed makes neither call. Tests: `KnowledgePacks.test.tsx` ("#339 P8-2: …" legs),
 `ModelsScreen.test.tsx` ("ModelsScreen — knowledge-pack tools row" describe block).
 
+**Tier-2 save action (2026-09-07, #340, D-Z21):** "Save to my documents" lives inside
+`ArticleModal` itself — under the attribution line (`chat.article.from`, decision 1140's
+description) and above the article body, never in a footer, since `Modal` has no footer slot.
+The button's accessible name carries the article title (decision 3's rule for a pack-named
+action in a list — `chat.article.saveAria`, "Save to my documents: {title}"), not a bare
+"Save", so a screen reader announces which article a repeated action targets; the visible label
+is the exact prefix of that name (WCAG 2.5.3, label in name), so speech input saying the label
+still activates it. Four states, one
+region: idle (the button, label `chat.article.save`), saving (the button disabled, a `Spinner`
+beside it, `role="status"`), saved (the button is replaced by a `role="status"` line naming the
+filed title — `chat.article.saved` / `chat.article.alreadySaved` when a prior save is found —
+so there is nothing left to click), and failed (the button stays, re-enabled, with the friendly
+reason inline beside it — the main-side sentence alone via `friendlyIpcError`, no stacked
+"could not be saved" prefix in front of a reason that already says so). A save that resolves
+after the viewer moved on to another article is discarded (a generation counter), so a result
+never lands on the wrong article. The evidence review's copy of the viewer passes
+`canSave={false}`: a review is read-only and its bridge is evidence-only, so the action exists
+only where the chat opens the viewer. No undo affordance: the saved copy is a real document, and removing it is
+the Documents screen's job (delete), not the viewer's — the viewer only ever adds. No "Open in
+Documents" jump yet either; the saved state names the filed title so the user can find it, and a
+direct jump is deferred with the citation-card shortcut (rag-design §17 D-Z21).
+
 ---
 
 ## 12. Chat-UI polish pass — design record (IMPLEMENTED 2026-06-13)

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2507,6 +2507,14 @@ reports and phase plans were working papers; their full text lives in git histor
   currently-unplugged pack says the article is unavailable, same as chat. Evidence reviews created on a pre-release knowledge-pack
   build that cite an archive may carry a wrongly resolved document identity and must be
   re-run; the app never rewrites a frozen review.
+- **A saved article ("Save to my documents" in the article viewer, #340 Tier-2, D-Z21) is a
+  snapshot, not a live link.** It is titled with the pack's title as it read AT SAVE TIME —
+  renaming or re-adding the pack afterward does not retitle a copy already made — and it is
+  never updated when the underlying archive changes; a newer edition of the same article needs
+  a fresh save. The Documents screen groups it under Generated with a provenance line naming the
+  archive it came from (it also sits in the Library like any import, so a default chat finds it), and it never goes stale the way a summary or translation can, because it
+  has no source document to fall behind. Not built: a citation-card shortcut that saves directly
+  without opening the viewer, and an "Open in Documents" jump from the viewer's saved state.
 - **Serving names are computed, not read back from the running server.** Every enabled
   pack's serving name follows the pinned libkiwix 14.1 `getHumanReadableIdFromPath` rule
   exactly (`identity.ts`); when two packs would compute the SAME name, the smaller UUID

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2712,8 +2712,9 @@ offline article viewer. Files are registered in place, never copied.
   (authoritative), and reset to null by `suspend()` so a locked workspace's list never outlives
   it on the exempt channel. The panel shows a "Not served" badge plus a visible line naming the
   pack that keeps the name (or a generic line when the list no longer knows it) on the LOSER's
-  row only; the picker keeps relying on the per-answer `not-served` outcome. No new channel (the
-  145-channel count stands), no preload change. Tests: `zim-ipc-session` "#340 packs:status.excluded
+  row only; the picker keeps relying on the per-answer `not-served` outcome. No new channel here
+  (the recorded count was 145 at D-Z16; 147 since #340 Tier-2 added `packs:saveArticle`, D-Z21), no
+  preload change. Tests: `zim-ipc-session` "#340 packs:status.excluded
   …" (null → [] → the larger UUID after a same-leaf registration → cleared by disabling → the build
   agrees → null after a lock → recomputed by the next session), `KnowledgePacks.test.tsx` (badge +
   winner named; stale winner; null / absent status show nothing), `zim-ipc` (the fake reports
@@ -2906,6 +2907,61 @@ offline article viewer. Files are registered in place, never copied.
   the L3-b legs of `zim-arm.test.ts` (the expansion-articles-first fetch order, the per-pack caps,
   the `Liste …` / `List of …` chunk-keep switch, and the ask-abort-rethrown leg at this layer).
 
+- **D-Z21 — "Save article to my documents" (#340 Tier-2, owner ruling C3 (a) 2026-09-06: the
+  save button in the article viewer first, the citation-card shortcut later).** An article the
+  user is reading in `ArticleModal` becomes a REAL document in the corpus, not a link back to
+  the pack server. Why: an archive citation only ever resolves as an honest `unresolved` in
+  evidence review (D-Z5) and disappears with the pack; a save gives the same text a durable,
+  offline, citable identity. What: `packs:saveArticle(packId, articlePath)` re-reads the article
+  main-side through the same `getArticle` the viewer used — only the two ids cross the IPC
+  bridge, the renderer is never a content source — and hands the sectioned text to
+  `services/zim/save-article.ts`. Import-path reuse: the copy is written to a `.parse.md`
+  transient and run through the ONE import path, `createQueuedDocument` → `processDocument`,
+  exactly the `materializeDocument` precedent (`doctasks/handlers/shared.ts`) a translation or
+  comparison output already takes — so it is chunked, embedded, FTS-indexed and encrypted at
+  rest like any upload. Markdown shape: `# <article title>`, an attribution block-quote naming
+  the archive and the save date, an honest notice appended when the viewer's own `partial` flag
+  says the converter stopped short, then one `## <label>` per viewer section (the label-less
+  lead section stays plain) — `MarkdownParser` turns each heading into a chunk `section_label`,
+  so a citation into the saved copy names the section the viewer showed. Title rule: `<article>
+  (<archive>).md`, whitespace-collapsed, capped at `ARTICLE_TITLE_MAX_CHARS = 180` without ever
+  dropping the extension — the `.md` is what selects the Markdown parser. Provenance + dedup: an
+  `ArchiveOrigin` (`{ type: 'archive', packId, articlePath, archiveTitle, createdAt }`) is
+  stamped on `documents.origin_json` at QUEUE time (`createQueuedDocument` takes the origin, and
+  `setDocumentOrigin` re-asserts it after `indexed`, the DM-2 precedent), so a crash between `indexed` and a later
+  write can never let the Library backfill misfile the copy as an upload; `findSavedArticle`
+  reads the same three fields BEFORE any import runs, so saving the same pack+entry twice
+  returns the existing document (`alreadySaved: true`, `chunkCount: 0`) instead of a second copy
+  — the app's only import-time duplicate check. It honours an INDEXED copy only: `deleteDocument`
+  is a hard delete (a copy the user removed can be saved again), and a crash-interrupted save
+  that the startup reconciliation flipped to `failed` must not block a fresh one. Two overlapping
+  invokes for the same entry (`beginDocumentWork` is a refcount, not a mutex) are collapsed by an
+  in-flight map in the registrar: the second joins the first's import. Filing: unlike a
+  translation or comparison — a generated work-product that deliberately gets NO collection
+  membership (D3/N1) — the saved article is a user-chosen import and is filed into the Library
+  after `indexed`, because the default documents chat resolves its scope to exactly that
+  collection; without the filing the copy would be invisible to every default chat. While the
+  import runs, the row is held busy for the docs IPC delete / re-index guards
+  (`ctx.articleSaveActive`, the `skillRunActive` pattern) — the precedent's `documentIds` push. Fallback/rollback: an entry that can no longer
+  be read main-side (pack disabled, removed, drive unplugged) fails with
+  `main.zim.articleUnavailable` before any write; an import that does not reach `indexed` fails
+  with `main.zim.saveFailed` and `deleteDocument` rolls the row back in the `catch` — never a
+  half-born document — and the `.parse.md` transient is shredded in a `finally` regardless.
+  Evidence behaviour: the saved copy is a normal document from evidence review's point of view —
+  a real sha256, searchable without the pack server, alive after the pack is removed (the
+  `zim-ipc-session` leg proves this by removing the pack mid-test and re-reading the document).
+  Audit: `knowledge_pack_article_saved` carries `{ packId, documentId, status: 'indexed',
+  chunkCount }` only — ids and counts, never the entry path or either title (S1; both are
+  content). What stays unbuilt: the citation-card shortcut (save straight from a citation without
+  opening the viewer, the owner's "later"), full enumeration/import of a whole archive (D-Z1),
+  and an "Open in Documents" jump from the saved state — the Documents screen is the only way
+  back to it this wave. The evidence review's viewer (`ReviewScreen`) mounts the same modal with
+  `canSave={false}`: a review is read-only and its bridge is evidence-only. Tests: `zim-save-article.test.ts` (`articleDocumentTitle`,
+  `renderArticleMarkdown`, pure), the "#340 Tier-2 — packs:saveArticle files the article as a
+  real document (D-Z21)" describe in `zim-ipc-session.test.ts` (a real DB, the real handler, the
+  real import pipeline), and the "ArticleModal — save to my documents (#340 Tier-2)" describe in
+  `KnowledgePacks.test.tsx` (the four UI states).
+
 ### Module map
 
 `services/zim/`: `html.ts` (article HTML → segments; linear forward scanner with a work
@@ -2928,7 +2984,8 @@ searchability columns + key, `classifyPackSelection` and `packTitles`, D-Z11/D-Z
 `session.ts` (the post-unlock reconciliation kickoff, the `maybeStartLocalApi` shape,
 D-Z11), `arm.ts` (allocation, bounded concurrency, the per-ask deadline and per-pack
 outcomes — D-Z4, P4), `expand.ts` (question → concept expansion for the pack arm — D-Z20,
-#340 L3-b), `index.ts` (`ZimService` facade on
+#340 L3-b), `save-article.ts` ("Save article to my documents" — the title rule, the Markdown
+render, the import-path materialise, the duplicate lookup — D-Z21, #340 Tier-2), `index.ts` (`ZimService` facade on
 `AppContext.zim` — the revision/generation allocator, the FIFO build/teardown/start chain
 and the published tuple, D-Z10; the operation registry and admission-epoch checks, the
 `packs:changed` notify hook, D-Z11; `withServer` — the alive/generation request guard with
@@ -3013,7 +3070,8 @@ Provisioning of the `kiwix_tools` family: the family contract landed (#339 P8-1,
 reach the installer (P8-2), the drive scripts' `fetch-runtime`/`prepare-drive` support (P8-3),
 and the network-inventory prose in PRIVACY/README/user-guide/security-model (P8-5) have since
 landed too. Still open: the on-drive corresponding-source bundle (P8-4), in flight as a sibling
-PR. Also not built: persistent article import (Tier 2); an
+PR. Also not built: full enumeration / import of a whole archive (a saved article, D-Z21, is
+the built half of Tier-2); an
 in-app ZIM catalog/downloader; evidence review
 over archive citations (they resolve as honest 'unresolved'); packs on the whole-document
 / compare paths (disclosed per answer as `mode`, not queried — P4); quality guarantees
@@ -3036,7 +3094,8 @@ concept expansion through a model call: ruled (a) "always" on 2026-09-07 and bui
 (above). *C2* — link expansion not
 until the upstream `/raw` cut-short fix ships (it doubles traffic on the defect route). *C3* —
 Tier-2 import: ruled (a), a "Save article to my documents" button in the article viewer FIRST,
-the citation card later; not built in this wave. *C4* — acquisition from Kiwix catalogs: ruled
+the citation card later; the button shipped as **D-Z21** (above, `feat/340-tier2-save-article`),
+the citation-card shortcut still the owner's "later". *C4* — acquisition from Kiwix catalogs: ruled
 later, after the consent surface (D-Z19) has settled. *#339 items 3–6* — readiness never depends
 on `kiwix_tools` and `kiwix-search` stays installed-but-unused, both as built (D-Z17); the
 upstream report is the owner's to file (a Linux stall probe was asked of humaniser first);


### PR DESCRIPTION
Refs #340 — Tier-2 of the knowledge-pack capability ladder, per the owner ruling C3 (a) of 2026-09-06: **"Save article to my documents"** in the article viewer. Design record: `docs/rag-design.md` §17 **D-Z21**.

## What the user gets
- A **Save to my documents** button in the offline article viewer (shown once the article is ready). One click files the article as a real document: chunked, embedded, FTS-indexed, encrypted at rest, citable like any upload.
- The copy is searchable **without the pack server**, survives removing the pack, and resolves in evidence reviews with a real sha256 (an archive citation resolves as honest `unresolved`, D-Z5).
- Saving the same article twice returns the existing document ("already in your documents as …") instead of a second copy.
- The Documents screen groups it under **Generated** with the provenance line "Saved from the knowledge pack <archive>".

## How
- New channel `packs:saveArticle(packId, articlePath) → PackArticleSaveResult` (`requireUnlocked`). Only the two ids cross the bridge; main re-reads the text through the same converter the viewer uses and renders Markdown (`# title`, an attribution block-quote with archive + date, an honest partial notice, `## <section>` per viewer section → chunk `section_label`s).
- `services/zim/save-article.ts` mirrors the `materializeDocument` precedent step for step: vault lease, `.parse.md` transient on the plaintext registry (`'article-save'`), `ArchiveOrigin` stamped at queue time, roll back with `deleteDocument` unless `indexed`, shred in `finally`.
- The saved row is filed into the **Library** (a user-chosen import, unlike D3/N1 work-products that never get a membership), so the default documents chat finds it. The duplicate check honours an indexed copy only; overlapping saves of one entry join a single import; the row is held busy for the docs delete / re-index guards while it imports (`ctx.articleSaveActive`).
- Types: `ArchiveOrigin` joins `DocumentOrigin`; `GeneratedKind` gains `'article'`; audit type `'knowledge_pack_article_saved'` (ids + counts only).
- Channel count in the docs corrected to 147 (master already had 146; the recorded 145 was one short).
- The evidence review mounts the same viewer with `canSave={false}` (read-only surface, evidence-only bridge). Accessible name "Save to my documents: <title>" keeps the visible label as its prefix (WCAG 2.5.3).

## Tests
- `tests/unit/zim-save-article.test.ts` — title rule + Markdown shape (6).
- `tests/integration/zim-ipc-session.test.ts` — end to end through the real handler and import pipeline: two overlapping saves → one copy; indexed, sections, archive origin; Library membership and the default scope; hazardous key refused; a `failed` stub does not block a fresh save; outlives the pack; audit content rule; removed-pack entry leaves no half-born row. Plus the preload pin on the save bridge.
- `tests/renderer/KnowledgePacks.test.tsx` — the four button states and a stale result discarded after the viewer moved on; `ReviewScreen.test.tsx` — no save action in a review.
- Adversarial review (read-only) applied: Library filing, indexed-only dedup, in-flight join, busy guard, stale-result guard, a11y name, review suppression, CSS row, code-point title cap.
- Full suite on the branch: 419 files / 6761 tests passed (after the review fixes).

## Not built (by ruling)
The citation-card shortcut (the owner's "later"), full enumeration/import of an archive (D-Z1), an "Open in Documents" jump from the saved state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
