### PR TITLE
test(lock): prove the settle beat the bound by its own verdict, not a zero-margin wall clock (#389)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,8 @@ npm run test:watch                              # watch mode (re-runs affected t
   timeout ceiling — exemplars: `tests/integration/ocr-task.test.ts` (the `rasterizeReached`
   gate replacing a fixed `sleep(30)`), `tests/integration/vision-runtime.test.ts` (the
   injected-clock idle-teardown interlock) and `tests/integration/lock-admission-race.test.ts`
-  (the `settleOutcomes` recorder: the settle's own verdict instead of a wall clock measured
-  against the very production bound under test, #389). The rare *justified* fixed sleep — a
+  (the `settleEntered` gate plus the `settleOutcomes` recorder: the settle's own verdict instead
+  of a wall clock measured against the very production bound under test, #389). The rare *justified* fixed sleep — a
   wall-clock advance for timestamp ordering, a timeout simulation where the timer IS the semantics, a
   single-macrotask hop with no observable — must carry a comment saying so; everything else
   is a bug.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,11 @@ npm run test:watch                              # watch mode (re-runs affected t
   "the loop to probably get there" flakes under parallel-fork CPU starvation. Instead, expose a
   "reached" flag/promise from the fake seam or poll-until on observable state with a hard
   timeout ceiling — exemplars: `tests/integration/ocr-task.test.ts` (the `rasterizeReached`
-  gate replacing a fixed `sleep(30)`) and `tests/integration/vision-runtime.test.ts` (the
-  injected-clock idle-teardown interlock). The rare *justified* fixed sleep — a wall-clock
-  advance for timestamp ordering, a timeout simulation where the timer IS the semantics, a
+  gate replacing a fixed `sleep(30)`), `tests/integration/vision-runtime.test.ts` (the
+  injected-clock idle-teardown interlock) and `tests/integration/lock-admission-race.test.ts`
+  (the `settleOutcomes` recorder: the settle's own verdict instead of a wall clock measured
+  against the very production bound under test, #389). The rare *justified* fixed sleep — a
+  wall-clock advance for timestamp ordering, a timeout simulation where the timer IS the semantics, a
   single-macrotask hop with no observable — must carry a comment saying so; everything else
   is a bug.
 - **Type renderer stub payloads — don't reach for `as never`.** `stubApi(overrides)` takes

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -151,6 +151,8 @@ interface Harness {
   settleEntered: () => boolean
   /** #389: one entry per settle — the registry's own verdict (`true` settled, `false` bounded). */
   settleOutcomes: () => boolean[]
+  /** #389: one entry per settle — live operations AT ENTRY, so a `true` verdict is not vacuous. */
+  settleLive: () => number[]
 }
 
 interface HarnessOptions {
@@ -298,19 +300,28 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
 
   // The plaintext-operation registry (#237), as `main/index.ts` wires it; optionally with the
   // settle bound shortened through the seam (the constant itself stays the production value).
-  // #389: the wrapper is UNCONDITIONAL so every case records the settle — that it was entered
-  // (the window under test, reached only after `abortAll()`), and the registry's own verdict per
-  // call: `true` = every live operation released inside the bound, `false` = the bound won. That
-  // verdict is the observable for "the settle, not merely the bound"; wall-clock margin measured
-  // against the very constant under test is not one.
+  // #389: the wrapper is UNCONDITIONAL so every case records the settle — that it was entered (the
+  // window under test, reached only after `abortAll()`), how many operations were LIVE at entry,
+  // and the registry's own verdict per call: `true` = every live operation released inside the
+  // bound, `false` = the bound won. That verdict is the observable for "the settle, not merely the
+  // bound"; wall-clock margin measured against the very constant under test is not one. The live
+  // count is what keeps a `true` honest: `awaitSettled` returns `true` immediately for an empty
+  // registry (plaintext-ops.ts, `if (live.size === 0) return true`).
+  // Every registry member is named explicitly rather than spread, so a member added to
+  // `PlaintextOpsRegistry` later is a compile error here instead of a silently dropped delegate.
   const ops = createPlaintextOps()
   const bound = opts.settleBoundMs
   let settleEntered = false
   const settleOutcomes: boolean[] = []
+  const settleLive: number[] = []
   ctx.plaintextOps = {
-    ...ops,
+    register: (kind, parent) => ops.register(kind, parent),
+    size: () => ops.size(),
+    abortAll: () => ops.abortAll(),
+    sweepRegistered: () => ops.sweepRegistered(),
     awaitSettled: async (ms) => {
       settleEntered = true
+      settleLive.push(ops.size())
       const outcome = await ops.awaitSettled(bound === undefined ? ms : Math.min(ms, bound))
       settleOutcomes.push(outcome)
       return outcome
@@ -358,7 +369,8 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     suspendEntered: () => entered,
     releaseSuspend: release,
     settleEntered: () => settleEntered,
-    settleOutcomes: () => [...settleOutcomes]
+    settleOutcomes: () => [...settleOutcomes],
+    settleLive: () => [...settleLive]
   }
 }
 
@@ -934,29 +946,37 @@ describe('plaintext operations across the lock boundary (#237)', () => {
     })
     lockP.catch(() => undefined)
     // Gate on the teardown actually reaching the plaintext settle — the window under test — rather
-    // than assuming a fixed drain got there.
-    expect(await waitUntil(() => h.settleEntered(), 1_000)).toBe(true)
-    // A SHORT drain over real time: it observes that the lock does not return on its own while the
-    // parser is parked. Ten ticks is ~3 % of the bound on a slow Windows runner, where the old
-    // 50-tick drain burned ~18 % of it inside the very window it then measured (#389).
+    // than assuming a fixed drain got there. The helper's default ceiling (200 ticks, ~3 s here) is
+    // deliberate: a longer one would outlast the local `testTimeout`, so a settle that is never
+    // entered would report a vitest timeout instead of this assertion.
+    expect(await waitUntil(() => h.settleEntered())).toBe(true)
+    // A SHORT drain over real time: it observes that the lock does not return on its own, and that
+    // nothing settled early, while the parser is parked. Ten ticks is ~3 % of the bound on a slow
+    // Windows runner, where the old 50-tick drain burned ~15 % of it (≈777 ms) inside the very
+    // window it then measured (#389).
     for (let i = 0; i < 10; i++) await tick()
     expect(lockSettled).toBe(false)
     expect(h.ctrl.isUnlocked()).toBe(true)
     expect(ocr.abortSeen()).toBe(true) // it was asked to stop; it just cannot
 
     ocr.release()
-    const tRelease = Date.now()
     const { result } = await lockP
     expect(result).toMatchObject({ state: 'locked' })
-    // THE proof, and no wall clock in it: the registry's own verdict for that settle. `true` = every
+    // The parked preview's operation was LIVE when the settle was entered, so the verdict below was
+    // earned: `awaitSettled` returns `true` at once for an empty registry, which would make the
+    // proof vacuous.
+    expect(h.settleLive()).toEqual([1])
+    // THE proof, and the whole claim: the registry's own verdict for that settle. `true` = every
     // live plaintext operation released inside the bound — the RELEASE let the lock through. Had the
     // bound won it would read `false`, as the sweep-bounded sibling below asserts.
+    // No wall clock stands beside it ON PURPOSE. The release→locked interval is not microtask hops:
+    // it contains the parser's own transient shred (overwrite + `fsyncSync` + `rmSync`) and then the
+    // whole vault re-encrypt (`wal_checkpoint(TRUNCATE)`, close, scrypt + AES, another fsync-ing
+    // shred) — real synchronous disk I/O whose duration is the runner's, not ours. Reconstructing
+    // the 5132 ms CI failure of the old assertion puts that tail at ~4.3 s, so any bound here would
+    // just reintroduce the flake class. "Never returned" is already covered by vitest's own
+    // `testTimeout`.
     expect(h.settleOutcomes()).toEqual([true])
-    // Belt and braces, anchored at the RELEASE — the interval the old comment described but did not
-    // measure (its window opened before the lock was invoked and swallowed the drain). All that
-    // remains after the release is microtask hops plus the vault re-encrypt of a tiny test DB: tens
-    // of ms here, so 2 s leaves ~50x headroom on a starved runner.
-    expect(Date.now() - tRelease).toBeLessThan(2_000)
     expect(transientNames(docs)).toEqual([])
     // The parser finished with text in hand — the handler's admission re-check refuses it.
     await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))

--- a/apps/desktop/tests/integration/lock-admission-race.test.ts
+++ b/apps/desktop/tests/integration/lock-admission-race.test.ts
@@ -147,6 +147,10 @@ interface Harness {
   suspendEntered: () => boolean
   /** Let the parked teardown continue. */
   releaseSuspend: () => void
+  /** #389: the lock/quit teardown reached the plaintext-operation settle. */
+  settleEntered: () => boolean
+  /** #389: one entry per settle — the registry's own verdict (`true` settled, `false` bounded). */
+  settleOutcomes: () => boolean[]
 }
 
 interface HarnessOptions {
@@ -294,10 +298,24 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
 
   // The plaintext-operation registry (#237), as `main/index.ts` wires it; optionally with the
   // settle bound shortened through the seam (the constant itself stays the production value).
+  // #389: the wrapper is UNCONDITIONAL so every case records the settle — that it was entered
+  // (the window under test, reached only after `abortAll()`), and the registry's own verdict per
+  // call: `true` = every live operation released inside the bound, `false` = the bound won. That
+  // verdict is the observable for "the settle, not merely the bound"; wall-clock margin measured
+  // against the very constant under test is not one.
   const ops = createPlaintextOps()
   const bound = opts.settleBoundMs
-  ctx.plaintextOps =
-    bound === undefined ? ops : { ...ops, awaitSettled: (ms) => ops.awaitSettled(Math.min(ms, bound)) }
+  let settleEntered = false
+  const settleOutcomes: boolean[] = []
+  ctx.plaintextOps = {
+    ...ops,
+    awaitSettled: async (ms) => {
+      settleEntered = true
+      const outcome = await ops.awaitSettled(bound === undefined ? ms : Math.min(ms, bound))
+      settleOutcomes.push(outcome)
+      return outcome
+    }
+  }
 
   ctx.docTasks = new DocTaskManager({
     getDb: () => ctrl.requireDb(),
@@ -338,7 +356,9 @@ async function harness(opts: HarnessOptions = {}): Promise<Harness> {
     translator,
     createRuntime,
     suspendEntered: () => entered,
-    releaseSuspend: release
+    releaseSuspend: release,
+    settleEntered: () => settleEntered,
+    settleOutcomes: () => [...settleOutcomes]
   }
 }
 
@@ -902,28 +922,41 @@ describe('plaintext operations across the lock boundary (#237)', () => {
 
   it('lock waits for a parser that ignores the abort until it unwinds — the settle, not merely the bound', async () => {
     const ocr = gatedOcrEngine({ honoursSignal: false })
-    // The production bound (5 s) — the release below must be what lets the lock through.
+    // The production bound (5 s `LOCK_TASK_SETTLE_TIMEOUT_MS`) is in force; the release below must
+    // be what lets the lock through, and the registry's OWN settle verdict says which it was (#389).
     const h = await harness({ ocrEngine: ocr })
     h.releaseSuspend()
     const { previewP, docs } = await parkedPreview(h, ocr)
 
     let lockSettled = false
-    const t0 = Date.now()
     const lockP = invoke(handlers, IPC.lockWorkspace).finally(() => {
       lockSettled = true
     })
     lockP.catch(() => undefined)
-    // Parser parked, bound not elapsed: the lock is WAITING and the vault is still open.
-    for (let i = 0; i < 50; i++) await tick()
+    // Gate on the teardown actually reaching the plaintext settle — the window under test — rather
+    // than assuming a fixed drain got there.
+    expect(await waitUntil(() => h.settleEntered(), 1_000)).toBe(true)
+    // A SHORT drain over real time: it observes that the lock does not return on its own while the
+    // parser is parked. Ten ticks is ~3 % of the bound on a slow Windows runner, where the old
+    // 50-tick drain burned ~18 % of it inside the very window it then measured (#389).
+    for (let i = 0; i < 10; i++) await tick()
     expect(lockSettled).toBe(false)
     expect(h.ctrl.isUnlocked()).toBe(true)
     expect(ocr.abortSeen()).toBe(true) // it was asked to stop; it just cannot
 
     ocr.release()
+    const tRelease = Date.now()
     const { result } = await lockP
     expect(result).toMatchObject({ state: 'locked' })
-    // Well inside the 5 s `LOCK_TASK_SETTLE_TIMEOUT_MS`: the release let it through, not the bound.
-    expect(Date.now() - t0).toBeLessThan(5_000)
+    // THE proof, and no wall clock in it: the registry's own verdict for that settle. `true` = every
+    // live plaintext operation released inside the bound — the RELEASE let the lock through. Had the
+    // bound won it would read `false`, as the sweep-bounded sibling below asserts.
+    expect(h.settleOutcomes()).toEqual([true])
+    // Belt and braces, anchored at the RELEASE — the interval the old comment described but did not
+    // measure (its window opened before the lock was invoked and swallowed the drain). All that
+    // remains after the release is microtask hops plus the vault re-encrypt of a tiny test DB: tens
+    // of ms here, so 2 s leaves ~50x headroom on a starved runner.
+    expect(Date.now() - tRelease).toBeLessThan(2_000)
     expect(transientNames(docs)).toEqual([])
     // The parser finished with text in hand — the handler's admission re-check refuses it.
     await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))
@@ -942,6 +975,8 @@ describe('plaintext operations across the lock boundary (#237)', () => {
     expect(transientNames(docs)).toEqual([])
     expect(transientNames(images)).toEqual([])
     expect(storedCopies(docs)).toEqual(storedBefore)
+    // The negative control for the proof above: here the BOUND won, and the registry says so (#389).
+    expect(h.settleOutcomes()).toEqual([false])
 
     // Nothing released the parser: the lock went on at the bound. Let it finish now.
     ocr.release()
@@ -987,6 +1022,8 @@ describe('plaintext operations across the QUIT boundary (#237)', () => {
     expect(transientNames(docs)).toEqual([])
     expect(transientNames(images)).toEqual([])
     expect(storedCopies(docs)).toEqual(storedBefore)
+    // The negative control on the quit path too: `performShutdown` settles once, and the BOUND won.
+    expect(h.settleOutcomes()).toEqual([false])
 
     ocr.release()
     await expect(previewP).rejects.toThrow(t('en', 'main.docs.locked'))


### PR DESCRIPTION
## Summary

`lock-admission-race.test.ts` → "lock waits for a parser that ignores the abort until it unwinds — the settle, not merely the bound" asserted `Date.now() - t0 < 5_000` on a window that began BEFORE the lock was invoked and included a 50-tick drain (≈ 15.5 ms/tick on Windows → ~780 ms idle, unbounded under load), against exactly the production constant `LOCK_TASK_SETTLE_TIMEOUT_MS` it was proving had NOT been used. It flaked at 5132 ms on the `windows-latest 22.x` leg of PR #388 (a leg that took 42 s for this one file against ~6 s on a desk machine).

Test-file-only fix (plus one CONTRIBUTING exemplar line). No production change.

## What the analysis found beyond the issue

- **The seam the issue asked for already exists in production.** `PlaintextOpsRegistry.awaitSettled(boundMs)` returns `true` when every op settled and `false` when the bound won (`plaintext-ops.ts`), and the harness already wrapped `ctx.plaintextOps` for the `settleBoundMs` seam. So "which of the two raced promises won" is a recorder in the harness, not a new production hook or an injectable constant.
- **The two-timestamp change alone would only move the flake one line up.** If the drain overran the bound, the timer would win the race during the drain and `expect(lockSettled).toBe(false)` would fail with a message that reads like a security regression. The drain itself raced the bound; the timestamp was only the first symptom.
- **The failing CI log confirms the mechanism worked on that runner.** The target test logged "Preview document" at 00:00:57.271 and "Workspace locked" at 00:01:02.420 with no "still running at the settle bound" warning between them (the one such warning in the job belongs to the sibling sweep-bounded test). The release let the lock through; only the wall clock failed.
- **It is the only assertion in the suite whose ceiling IS the production constant it disproves** (grep of every `toBeLessThan` against a timeout constant; the others carry 12×+ margins or bound an injected seam).

## The fix

- The harness wraps `ctx.plaintextOps` unconditionally (every member named explicitly) and records `settleEntered`, `settleLive` (the registry's live count at settle entry) and `settleOutcomes` (the registry's own verdict per call).
- The target test gates on `settleEntered` (`waitUntil`, the helper's default ceiling) instead of assuming a fixed drain reached the window, keeps a 10-tick drain as the observation that nothing settled early (~3 % of the bound instead of ~15 %), then asserts the pre-release state, releases, and proves the claim with `settleLive() === [1]` (the parked op was live — the verdict was earned, not returned for an empty registry) and `settleOutcomes() === [true]`.
- **No wall clock at all.** The release→settle window contains two fsync-ing shreds and a full vault re-encrypt; on the 7×-slower runner any bound reintroduces the flake class. vitest's `testTimeout` remains the backstop for "never returned".
- The two sweep-bounded siblings (lock and quit, `settleBoundMs: 100`) assert `settleOutcomes() === [false]` — the negative control proving the recorder can produce both values (`false` is returned only from the timeout branch).

## Blast radius

- `LOCK_TASK_SETTLE_TIMEOUT_MS` is module-private with three uses in `registerWorkspaceIpc.ts`; untouched. `SHUTDOWN_TASK_SETTLE_TIMEOUT_MS` untouched.
- `ctx.plaintextOps` is referenced in this file only at the wrap; nothing asserts its identity. The QUIT tests get a recorder they may ignore; `awaitSettled` is reached exactly once per lock (`registerWorkspaceIpc.ts` → `settleAndSweepPlaintextOps`) and per quit (`shutdown.ts`).
- Docs: `security-model.md` / `architecture.md` describe the mechanism (unchanged, still true); their line-number citations into this file were already stale before this PR and are not touched. No known-limitations or BUILD_STATE entry: nothing is open afterwards and the preamble is at its budget.

## Tests

- Green: `npm test -- tests/integration/lock-admission-race.test.ts` 19/19 (target test 241–316 ms, down from ~814–887 ms — the idle drain is gone).
- Mutation proof (the new assertion is not vacuous): with `settleBoundMs: 100` on the target test's harness and the mid-drain assertions temporarily removed so execution reaches the proof, the run fails with `expected [ false ] to deeply equal [ true ]` at the `settleOutcomes` line, not with a timeout; reverted.
- Full suite: 6997 passed, 1 unrelated known Windows flake (`zim-client.test.ts` 8 MiB body, `ECONNRESET`; passes alone). `npm run typecheck` clean.

## Not verified

- A run on the starved `windows-latest 22.x` runner itself — CI on this PR is the first such run.
- Nit noted for a separate change, not touched here: `local-api-hardening.test.ts` asserts `< 5000` on a window that races its own 5 s timer; redundant after its `closedByServer` assertion.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
