### PR TITLE
fix(zim): derive the serving name from a native path, and report a total route disagreement (#429)

### DIFF
--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -1,6 +1,7 @@
 import type { KnowledgePackOutcome } from '../../../shared/types'
 import type { ExternalRetrievalOutput, RetrievedChunk } from '../rag'
 import { CHUNK_DEFAULTS, chunkSegments } from '../ingestion/chunker'
+import { log } from '../logging'
 import { fetchArticleHtml, searchPack, searchPackTotal, suggestTitles, type KiwixSearchHit } from './client'
 import type { QueryExpander } from './expand'
 import { zimArticleToSegmentsAsync } from './html'
@@ -383,6 +384,9 @@ export async function collectPackCandidates(
     let expansionChunks = 0
     let attempted = 0
     let read = 0
+    /** Plain hits skipped because the response's `urlId` was not the name we serve this pack
+     *  under (#429) — a route disagreement, never "nothing relevant". */
+    let mismatched = 0
     for (const { hit, fromExpansion } of queue) {
       // Article requests are DERIVED FROM NEED (plan §9.21 (c)3): once the pack holds its
       // provisional quota, the remaining hits are not fetched at all.
@@ -395,7 +399,14 @@ export async function collectPackCandidates(
       // disagreeing link would mean the response describes a book we did not ask about, and
       // fetching it would label another archive's text with this pack's title.
       const expected = names?.get(pack.id)
-      if (expected !== undefined && hit.urlId !== expected) continue
+      if (expected !== undefined && hit.urlId !== expected) {
+        // #429: this used to `continue` silently, and a pack whose EVERY hit disagreed then
+        // settled `searched` with nothing found — "this archive had nothing to say", the one
+        // reading a user cannot act on and a developer cannot diagnose. Counted instead, and
+        // the settlement below treats an all-disagreement pack as unreadable, which it is.
+        if (!fromExpansion) mismatched++
+        continue
+      }
       if (!fromExpansion) attempted++
       let html: string | null
       try {
@@ -447,9 +458,22 @@ export async function collectPackCandidates(
         })
       }
     }
-    // Hits existed and every single fetch of them failed: a materially different state from
+    // Hits existed and none of them could be read: a materially different state from
     // "searched, nothing relevant" — the pack IS searchable, its articles were not readable.
-    item.settlement = attempted > 0 && read === 0 ? 'read-failed' : 'searched'
+    // Two ways to get there, one verdict (#429): every fetch failed or 404'd (`attempted > 0 &&
+    // read === 0`), or every hit was refused before the fetch because the served library and the
+    // search response disagree about this pack's name (`attempted === 0 && mismatched > 0`).
+    // The second is a defect on our side, not the archive's, so it is also logged — with the
+    // pack id and the two NAMES, which are route identifiers, never a path (the sentinel rule).
+    if (attempted === 0 && mismatched > 0) {
+      log.warn('Knowledge pack served under a name its own search results do not use', {
+        packId: pack.id,
+        servedAs: names?.get(pack.id) ?? null,
+        hitsSkipped: mismatched
+      })
+    }
+    item.settlement =
+      (attempted > 0 && read === 0) || (attempted === 0 && mismatched > 0) ? 'read-failed' : 'searched'
     item.settled = true
   }
 

--- a/apps/desktop/src/main/services/zim/identity.ts
+++ b/apps/desktop/src/main/services/zim/identity.ts
@@ -131,6 +131,28 @@ export function servingNameFor(path: string, platform: NodeJS.Platform = process
   return name
 }
 
+/**
+ * An archive path in the platform's own separator convention — the form every consumer of a
+ * pack path must be given (#429).
+ *
+ * WHY THIS EXISTS AND NOT A FIX IN `servingNameFor`. Step 2 above is a faithful mirror of
+ * libkiwix's `#ifdef _WIN32` branch, which strips a run up to the last BACKSLASH and nothing
+ * else (`book.cpp` `getHumanReadableIdFromPath`, verified against the 14.1.1 corresponding
+ * source bundle on the Kit drive). Windows itself accepts `K:/zim/x.zim` everywhere, so such a
+ * path reaches us intact — and then BOTH libkiwix and this mirror derive the serving name
+ * `k:/zim/x` from it. They AGREE; the name is simply unroutable, because it carries the `/`
+ * that separates `/raw/<book>/<action>/<path>`, so every article request 404s while `/search`
+ * (asked with `books.id`) keeps working. Teaching `servingNameFor` to strip both separators
+ * would end that agreement and mis-serve wherever libkiwix kept the whole path — the failure
+ * would move, not go away. The input is what has to be native, not the rule.
+ *
+ * On a POSIX platform a backslash is an ordinary filename character, so this is win32-only and
+ * `platform` is injected (the L9 posture) so both branches are pinned on either host.
+ */
+export function nativeArchivePath(path: string, platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? path.replace(/\//g, '\\') : path
+}
+
 /** One pack excluded from the served library because an earlier book already owns its name
  *  (`collidesWith` KEEPS it — the smaller UUID, libkiwix's own first-wins rule). The shared
  *  shape since #340 (D-Z16): `packs:status.excluded` carries it to the panel. */

--- a/apps/desktop/src/main/services/zim/index.ts
+++ b/apps/desktop/src/main/services/zim/index.ts
@@ -493,6 +493,9 @@ export class ZimService {
       this.deps.manageSpawn ?? this.deps.spawn ?? ((cmd, args, o) => nodeSpawn(cmd, args, o))
     return {
       zimDir: this.zimDir,
+      // #429: the same injected platform the manager argv normalization uses, so a registration
+      // stores a native `recorded_path` and the serving name derived from it stays routable.
+      platform: this.opts.platform,
       // The registration throwaway lives in the owned transient dir, under a name taken from
       // the ONE generation allocator, and is tracked on the operation BEFORE it is written
       // (plan §9.17 (c)1) so the lock/quit sweep can shred it if the operation cannot cancel.

--- a/apps/desktop/src/main/services/zim/packs.ts
+++ b/apps/desktop/src/main/services/zim/packs.ts
@@ -399,12 +399,7 @@ export function servedCandidates(db: Db, zimDir: string): Array<{ id: string; pa
  * and its `id` must EQUAL the header UUID, or the registration fails: a manager that disagrees
  * with the header is not trusted to name the archive we just identified.
  */
-export async function registerPack(db: Db, deps: PackDeps, rawZimPath: string): Promise<KnowledgePack> {
-  // #429: normalize the separator ONCE, at the boundary, so `recorded_path` — and therefore the
-  // serving name every later request is routed by — is native from the first write. The native
-  // form was already applied to `kiwix-manage`'s argv (`tools.ts`, finding L9), which is why a
-  // forward-slash path registered cleanly and then 404'd on every article read.
-  const zimPath = nativeArchivePath(rawZimPath, deps.platform)
+export async function registerPack(db: Db, deps: PackDeps, zimPath: string): Promise<KnowledgePack> {
   const { uuid } = readZimHeader(zimPath)
   const book = await readZimMetadata(deps, zimPath)
   if (book.id !== uuid) {
@@ -415,6 +410,13 @@ export async function registerPack(db: Db, deps: PackDeps, rawZimPath: string): 
   // into the session's database (nor into the NEXT session's, after a lock + unlock).
   deps.assert?.()
   const leaf = basename(zimPath)
+  // #429: what gets STORED is native, so the serving name derived from it downstream is routable.
+  // Only the stored form — every read above (the header, the metadata) and `fileSize` below stay
+  // on the path the caller gave, which the OS accepts as it is; normalizing before the I/O would
+  // invent a filename that need not exist. `kiwix-manage`'s argv is normalized inside
+  // `kiwixManageAdd` itself (finding L9); that half existing alone is exactly why such a path
+  // registered cleanly and only then 404'd on every article read.
+  const recordedPath = nativeArchivePath(zimPath, deps.platform)
   const now = nowIso()
   const existing = prepareCached(db, 'SELECT added_at FROM knowledge_packs WHERE id = ?').get(uuid) as
     | { added_at: string }
@@ -445,7 +447,7 @@ export async function registerPack(db: Db, deps: PackDeps, rawZimPath: string): 
     book.mediaCount,
     fileSize(zimPath),
     leaf,
-    zimPath,
+    recordedPath,
     // The archive's own `_ftindex` tag — a HINT, never a verdict (#301 P4, M7). `searchable`
     // and `searchable_key` are deliberately NOT written here: only the reconcile's key pass and
     // the /suggest probe touch them, so a re-add can never invent a capability.

--- a/apps/desktop/src/main/services/zim/packs.ts
+++ b/apps/desktop/src/main/services/zim/packs.ts
@@ -6,7 +6,7 @@ import { MAX_SELECTED_PACKS } from '../../../shared/types'
 import { type Db, prepareCached } from '../db'
 import { log } from '../logging'
 import { ftIndexHint, parseLibraryXml, type KiwixBook } from './client'
-import { ZimHeaderError, readZimHeader } from './identity'
+import { ZimHeaderError, nativeArchivePath, readZimHeader } from './identity'
 import { KiwixManageError } from './tools'
 
 // Knowledge-pack registry (ZIM wave): CRUD + disk reconciliation over the
@@ -43,6 +43,13 @@ export type ManageAddFn = (libraryXmlPath: string, zimPath: string, signal?: Abo
 export interface PackDeps {
   /** The drive's `zim/` folder (canonical pack home; may not exist). */
   zimDir: string
+  /**
+   * Which native path-separator convention an incoming archive path is normalized to (#429),
+   * the same injected-platform posture `kiwixManageAdd` uses for its argv (finding L9).
+   * Defaults to `process.platform` so production is unchanged and partial test contexts need
+   * not set it; tests pin both branches on one host.
+   */
+  platform?: NodeJS.Platform
   manageAdd: ManageAddFn
   /**
    * Where the registration throwaway `library.xml` goes (#301 P3b, findings L3/M4). Production
@@ -157,13 +164,23 @@ export type PackResolution =
  * No candidate existed at all ⇒ `'missing'`. One existed but none carried this identity ⇒
  * `'identity-mismatch'`, which is a materially different state for the user: the file is
  * there, it is simply not their archive any more.
+ *
+ * #429: the recorded path is normalized to the native separator here as well as at
+ * registration. `join()` already gives the drive-relative candidate a native path, but a
+ * `recorded_path` row written before that fix (or edited by hand) can still carry forward
+ * slashes on Windows — and a non-native path resolves and reads perfectly while producing an
+ * unroutable serving name downstream (`identity.ts` `nativeArchivePath`). Normalizing at THIS
+ * funnel means every consumer of `PackResolution.path` — the served set, the library build,
+ * the availability write — sees one convention, with no migration.
  */
 export function resolvePack(
   zimDir: string,
-  row: Pick<PackRow, 'id' | 'leaf' | 'recorded_path'>
+  row: Pick<PackRow, 'id' | 'leaf' | 'recorded_path'>,
+  platform: NodeJS.Platform = process.platform
 ): PackResolution {
   const candidates: string[] = [join(zimDir, row.leaf)]
-  if (row.recorded_path && row.recorded_path !== candidates[0]) candidates.push(row.recorded_path)
+  const recorded = row.recorded_path ? nativeArchivePath(row.recorded_path, platform) : ''
+  if (recorded && recorded !== candidates[0]) candidates.push(recorded)
   let sawCandidate = false
   let unreadable: string | null = null
   for (const candidate of candidates) {
@@ -382,7 +399,12 @@ export function servedCandidates(db: Db, zimDir: string): Array<{ id: string; pa
  * and its `id` must EQUAL the header UUID, or the registration fails: a manager that disagrees
  * with the header is not trusted to name the archive we just identified.
  */
-export async function registerPack(db: Db, deps: PackDeps, zimPath: string): Promise<KnowledgePack> {
+export async function registerPack(db: Db, deps: PackDeps, rawZimPath: string): Promise<KnowledgePack> {
+  // #429: normalize the separator ONCE, at the boundary, so `recorded_path` — and therefore the
+  // serving name every later request is routed by — is native from the first write. The native
+  // form was already applied to `kiwix-manage`'s argv (`tools.ts`, finding L9), which is why a
+  // forward-slash path registered cleanly and then 404'd on every article read.
+  const zimPath = nativeArchivePath(rawZimPath, deps.platform)
   const { uuid } = readZimHeader(zimPath)
   const book = await readZimMetadata(deps, zimPath)
   if (book.id !== uuid) {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1981,8 +1981,10 @@ export type KnowledgePackOutcomeStatus = 'searched' | 'skipped' | 'failed'
  * (`ServedLibrary.excluded`) · `not-searchable`: confirmed no full-text index · `tools-missing`
  * · `mode`: a whole-document / compare answer, which reads the document only and never queries
  * packs · `search-failed`: `/search` answered non-200 (a 404 is ambiguous — never persisted as a
- * capability) or the request failed · `read-failed`: every article fetch of a pack with hits
- * failed · `timeout`: the pack's request was cut by the per-ask deadline mid-flight · `deadline`:
+ * capability) or the request failed · `read-failed`: a pack with hits yielded no readable
+ * article — every fetch failed or 404'd, or (#429) every hit was refused by the route guard
+ * because the served library and the search response disagree about this pack's name
+ * · `timeout`: the pack's request was cut by the per-ask deadline mid-flight · `deadline`:
  * the pack was never started before the per-ask deadline · `server-restarted`: the request guard
  * discarded both attempts (`StaleServerError`).
  */

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -1214,3 +1214,38 @@ describe('the shipped per-pack article cap (#340 L2, revisited 2026-09-08 on #41
     expect(EXPANSION_ARTICLES_PER_PACK).toBeLessThan(ARTICLES_PER_PACK)
   })
 })
+
+// #429 — the served library and the search response can disagree about a pack's name (a
+// non-native separator in the recorded path used to produce an unroutable whole-path serving
+// name). The L4 guard already refused every such hit; what it did NOT do was say so, and the
+// pack settled `searched` with nothing found — "this archive had nothing to say", which is both
+// wrong and undiagnosable. Same guard, honest verdict.
+describe('#429 — a pack whose every hit is refused by the route guard is read-failed, not empty', () => {
+  const packs = [{ id: 'pack-climate', title: 'Klimawandel von Wikipedia' }]
+  const question = 'Wie entsteht Treibhausgas in der Landwirtschaft?'
+
+  it('settles read-failed and produces nothing when the published name is not the one the hits carry', async () => {
+    const wrong = new Map([['pack-climate', 'k:/zim/klimawandel']]) // the #429 shape, verbatim
+    const { candidates, outcomes } = await collectPackCandidates(port, packs, question, undefined, wrong)
+
+    expect(candidates).toEqual([])
+    expect(outcomes).toHaveLength(1)
+    expect(outcomes[0]).toMatchObject({
+      packId: 'pack-climate',
+      status: 'failed',
+      reason: 'read-failed',
+      found: 0,
+      admitted: 0
+    })
+  })
+
+  it('the SAME pack with the name its hits carry produces candidates and settles searched', async () => {
+    // The control: without it the assertion above would also pass if the fixture were simply
+    // broken, which is the failure mode the tautological serving-name check had.
+    const right = new Map([['pack-climate', 'book-pack-climate']])
+    const { candidates, outcomes } = await collectPackCandidates(port, packs, question, undefined, right)
+
+    expect(candidates.length).toBeGreaterThan(0)
+    expect(outcomes[0]).toMatchObject({ status: 'searched', reason: null })
+  })
+})

--- a/apps/desktop/tests/integration/zim-ipc-session.test.ts
+++ b/apps/desktop/tests/integration/zim-ipc-session.test.ts
@@ -2258,14 +2258,20 @@ describe('T16 — per-ask knowledge-pack outcomes end to end (#301 P4, M6/M7)', 
         h.hooks.beforeRespond = async () => undefined
 
         expect(shape(msgA.packOutcomes)).toEqual([{ packId: alpha, status: 'searched', reason: null }])
-        expect(shape(msgB.packOutcomes)).toEqual([{ packId: bravo, status: 'searched', reason: null }])
+        // bravo reads read-failed, not searched (#429): this fixture SEARCH_XML carries the same
+        // urlId (`alpha`) for every book, so every one of bravo's hits is a cross-book link the
+        // L4 route guard refuses — a pack with hits and no readable article. It used to settle
+        // `searched` with nothing found, indistinguishable from "this archive had nothing to
+        // say". The two sets now differ, which makes this leg's real subject — that one ask's
+        // outcomes never cross-write another's — visible rather than merely consistent.
+        expect(shape(msgB.packOutcomes)).toEqual([{ packId: bravo, status: 'failed', reason: 'read-failed' }])
         // …and on RELOAD each conversation reads back its own set, keyed to its own message.
         expect(listMessages(db, convA.id).at(-1)).toMatchObject({ id: msgA.id })
         expect(shape(listMessages(db, convA.id).at(-1)?.packOutcomes)).toEqual([
           { packId: alpha, status: 'searched', reason: null }
         ])
         expect(shape(listMessages(db, convB.id).at(-1)?.packOutcomes)).toEqual([
-          { packId: bravo, status: 'searched', reason: null }
+          { packId: bravo, status: 'failed', reason: 'read-failed' }
         ])
       }
       // ---- (10) SCOPE CHANGED MID-ASK: the persisted set is the ASK-TIME one ------------------

--- a/apps/desktop/tests/manual/zim-real.test.ts
+++ b/apps/desktop/tests/manual/zim-real.test.ts
@@ -5,7 +5,7 @@ import { afterAll, describe, expect, it } from 'vitest'
 import { openDatabase, type Db } from '../../src/main/services/db'
 import { ZimService } from '../../src/main/services/zim'
 import { searchPackTotal } from '../../src/main/services/zim/client'
-import { readZimHeader, servingNameFor } from '../../src/main/services/zim/identity'
+import { nativeArchivePath, readZimHeader, servingNameFor } from '../../src/main/services/zim/identity'
 import { kiwixServeBinaryName, kiwixToolsDir } from '../../src/main/services/zim/tools'
 import { zimSmokeEnv } from '../helpers/zim-smoke-env'
 import { spawn, type ChildProcess } from 'node:child_process'
@@ -175,7 +175,19 @@ describe.runIf(gate.requested)('ZIM knowledge packs against real kiwix-tools', (
       // slug rule for the path we registered it under, never the filename stem.
       const library = await svc.ensureServer(db)
       expect(library).not.toBeNull()
-      expect(library!.names.get(pack.id)).toBe(servingNameFor(zimFile, process.platform))
+      const servedName = library!.names.get(pack.id)
+      expect(servedName).toBe(servingNameFor(nativeArchivePath(zimFile), process.platform))
+      // …and the REAL server answers to it (#429). The assertion above compares our value with
+      // the function that produced it, so it holds for any input — including one that 404s on
+      // every article, which is exactly how a whole-path serving name went unnoticed until the
+      // arm reported an empty pack twenty lines later. This one asks the running kiwix-serve,
+      // through `/raw/<name>/meta/Title`: it needs no entry key, so it tests the ROUTE alone.
+      const routeProbe = await fetch(`http://127.0.0.1:${library!.port}/raw/${servedName}/meta/Title`)
+      expect(
+        routeProbe.status,
+        `kiwix-serve does not route /raw/${servedName}/… — our serving name and libkiwix's disagree`
+      ).toBe(200)
+      expect((await routeProbe.text()).trim()).toBe(pack.title)
 
       // The arm: real sidecar start + Xapian search + article fetch + chunking — through the
       // #340 L3-b expansion when the operator named a model (D-Z20), plain otherwise.

--- a/apps/desktop/tests/unit/zim-identity.test.ts
+++ b/apps/desktop/tests/unit/zim-identity.test.ts
@@ -7,6 +7,7 @@ import {
   computeServedSet,
   formatZimUuid,
   readZimHeader,
+  nativeArchivePath,
   servingNameFor
 } from '../../src/main/services/zim/identity'
 import { malformedZimFixture, uuidBytes, writeZimFixture } from '../helpers/zim-header'
@@ -102,6 +103,30 @@ describe('servingNameFor — libkiwix 14.1 Book::getHumanReadableIdFromPath', ()
     )
   })
 
+  it("#429 — a non-native separator makes the WHOLE path the name, and nativeArchivePath is the fix", () => {
+    // The forward-slash path Windows itself accepts survives step 2 intact, so the serving name
+    // carries the / that separates /raw/<book>/<action>/<path> and no URL can express it. This is
+    // NOT a divergence from libkiwix — it derives the same name from the same path (book.cpp
+    // getHumanReadableIdFromPath, #ifdef _WIN32). The input is normalized instead of the rule, so
+    // the two stay in agreement.
+    expect(servingNameFor("K:/zim/atlas.zim", "win32")).toBe("k:/zim/atlas")
+    expect(servingNameFor(nativeArchivePath("K:/zim/atlas.zim", "win32"), "win32")).toBe("atlas")
+    // Mixed separators too — the shape a config or env value most often arrives in.
+    expect(servingNameFor(nativeArchivePath('K:\\zim/sub/atlas.zim', 'win32'), 'win32')).toBe('atlas')
+  })
+
+  it("nativeArchivePath leaves a POSIX path alone — a backslash is a filename character there", () => {
+    expect(nativeArchivePath("/media/drive/zim/atlas.zim", "linux")).toBe("/media/drive/zim/atlas.zim")
+    // A literal backslash in a Linux filename must survive; converting it would rename the file.
+    expect(nativeArchivePath('/media/drive/zim/odd\\name.zim', 'linux')).toBe('/media/drive/zim/odd\\name.zim')
+    expect(servingNameFor(nativeArchivePath("/media/drive/zim/atlas.zim", "linux"), "linux")).toBe("atlas")
+  })
+
+  it("nativeArchivePath is idempotent on an already-native path", () => {
+    const once = nativeArchivePath("K:/zim/atlas.zim", "win32")
+    expect(nativeArchivePath(once, "win32")).toBe(once)
+    expect(once).toBe('K:\\zim\\atlas.zim')
+  })
   it('strips the directory with the PLATFORM separator, so both branches are pinned on one OS', () => {
     // win32 strips at the LAST backslash and leaves a forward slash alone…
     expect(servingNameFor('C:\\packs\\a\\b.zim', 'win32')).toBe('b')

--- a/apps/desktop/tests/unit/zim-packs.test.ts
+++ b/apps/desktop/tests/unit/zim-packs.test.ts
@@ -181,6 +181,39 @@ describe('knowledge-pack registry', () => {
     expect(resolvePack(zimDir, row)).toEqual({ path: canonical, uuid: U.alpha })
   })
 
+  it('#429 — a recorded path with a foreign separator still resolves, in the native form', async () => {
+    // A row written before the registration boundary normalized separators (or edited by hand)
+    // can carry forward slashes on Windows. Such a path OPENS fine on Windows — which is why
+    // this went unseen — but the serving name derived from it downstream carries the whole path
+    // and no /raw/<book>/... URL can express it. `resolvePack` hands out the native form so the
+    // one funnel every consumer reads from has one convention.
+    const { db, deps, root, zimDir } = makeHarness()
+    const elsewhere = join(root, 'elsewhere-slashes')
+    mkdirSync(elsewhere)
+    const external = addZimFile(elsewhere, 'ext.zim', U.alpha)
+    await registerPack(db, deps, external)
+    const row = (recorded: string): { id: string; leaf: string; recorded_path: string } => ({
+      id: U.alpha,
+      leaf: 'never-on-drive.zim', // forces the RECORDED candidate to be the one that resolves
+      recorded_path: recorded
+    })
+
+    // The `platform` argument only changes the separator, so this test cannot assert the win32
+    // branch on a POSIX host: the normalized path would have to EXIST for the resolve to reach
+    // the header, and `/tmp/x\ext.zim` is a different (absent) file on Linux. `nativeArchivePath`
+    // itself is pinned on BOTH branches, host-independently, in `zim-identity.test.ts`; what is
+    // asserted here is the part that needs a real file — that the funnel resolves and normalizes.
+    if (process.platform === 'win32') {
+      const foreign = external.split('\\').join('/')
+      expect(foreign).not.toBe(external) // the leg is meaningless if nothing was swapped
+      expect(resolvePack(zimDir, row(foreign), 'win32')).toEqual({ path: external, uuid: U.alpha })
+    }
+
+    // On POSIX a backslash is an ordinary filename character, so nothing is rewritten and a
+    // native path resolves exactly as before — the contract this fix must not break.
+    expect(resolvePack(zimDir, row(external), 'linux')).toEqual({ path: external, uuid: U.alpha })
+  })
+
   it('remove and enable/disable behave and report row existence', async () => {
     const { db, deps, zimDir } = makeHarness()
     const file = addZimFile(zimDir, 'a.zim', U.alpha)

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -2611,6 +2611,37 @@ offline article viewer. Files are registered in place, never copied.
   session's reconcile. A confirmed-`'no'` pack is skipped by the ask (outcome
   `not-searchable`) but stays fully readable in the article viewer, which never consults
   `searchable`.
+  **#429 amendment (2026-09-08) — the serving name is derived from a NATIVE path, and a total
+  route disagreement is `read-failed`.** `servingNameFor` mirrors libkiwix's
+  `Book::getHumanReadableIdFromPath` including its `#ifdef _WIN32` branch, which strips a run up
+  to the last BACKSLASH and nothing else (re-verified against the 14.1.1 corresponding-source
+  bundle the Kit ships, P8-4). Windows accepts a forward-slash path everywhere, so one can reach
+  us intact — and then libkiwix and the mirror AGREE on the serving name `k:/zim/<stem>`, which
+  is simply unroutable: it carries the `/` that separates `/raw/<book>/<action>/<path>`. `/search`
+  is asked with `books.id` and keeps working, so the pack searched normally and every article
+  404'd. **The fix normalizes the INPUT, never the rule** — teaching the mirror to strip both
+  separators would end the agreement and mis-serve wherever libkiwix kept the whole path, moving
+  the failure rather than removing it. `identity.ts` `nativeArchivePath(path, platform)` (win32:
+  `/` → `\`; POSIX: unchanged, where a backslash is an ordinary filename character) is applied at
+  the registration boundary, so `recorded_path` is native from the first write, and again in
+  `resolvePack`, the one funnel every consumer of a pack path reads from — so a row written by an
+  older build, or edited by hand, is covered with no migration. This is the same injected-platform
+  normalization `kiwixManageAdd` already applied to the manager's ARGV (finding L9): that half
+  existed, which is exactly why such a path registered cleanly and then failed downstream.
+  Second half, in `arm.ts`: the L4 route guard (a hit whose `urlId` is not the name we serve the
+  pack under is refused) used to `continue` silently, so a pack whose EVERY hit disagreed settled
+  `searched` with nothing found — indistinguishable from "this archive had nothing to say", and
+  undiagnosable. Those refusals are now counted, a pack with hits and no readable article settles
+  **`read-failed`** whether every fetch failed or every hit was refused before the fetch (the
+  existing code and copy, "failed: no article could be read", is true of both), and the
+  disagreement is logged once with the pack id and the two NAMES — route identifiers, never a
+  path (D-Z1's sentinel rule). No shape changes: `KnowledgePackOutcomeReason`'s 14 codes,
+  `ServedLibrary`, the IPC and the persisted rows are untouched. Tests: `zim-identity.test.ts`
+  pins `nativeArchivePath` on both platform branches and the whole-path name it prevents;
+  `zim-packs.test.ts` pins the resolve funnel; `zim-arm.test.ts` pins the `read-failed` verdict
+  with a positive control; and the manual smoke's serving-name assertion — which compared our
+  value against the function that produced it and therefore held for any input — now also asks
+  the RUNNING kiwix-serve, via `/raw/<name>/meta/Title`, which needs no entry key.
 - **D-Z12 — scope (P4, 2026-09-06; review M10, ruling D4).** The user's intent to answer
   without the document corpus is an explicit, additive `DocumentScope.documentsOff?: true`
   — persisted by BOTH scope owners (`serializeDocumentScope` in `chat.ts`,


### PR DESCRIPTION
Closes #429.

## The issue's own suggested fix was wrong, and this does not take it

#429 proposed teaching `servingNameFor` to strip both separators on win32. Checked against the **libkiwix 14.1.1 corresponding-source bundle the Kit ships** (P8-4), `src/book.cpp`:

```cpp
std::string Book::getHumanReadableIdFromPath() const
{
  std::string id = m_path;
  if (!id.empty()) {
    id = kiwix::removeAccents(id);
#ifdef _WIN32
    id = replaceRegex(id, "", "^.*\\\\");
#else
    id = replaceRegex(id, "", "^.*/");
#endif
    …
```

libkiwix strips **only backslashes** on Windows. `servingNameFor` is a faithful mirror of that, and the two **agree** on the name `k:/zim/<stem>` for a forward-slash path. The name is not wrong — it is *unroutable*, because it carries the `/` that separates `/raw/<book>/<action>/<path>`. Stripping both separators in the mirror would end that agreement and mis-serve wherever libkiwix kept the whole path: the failure would move, not go away.

So the **input** is normalized, never the rule.

## The fix

`identity.ts` gains `nativeArchivePath(path, platform)` — win32 `/` → `\`, POSIX unchanged (a backslash is an ordinary filename character there, and rewriting it would name a different file). Applied at two points:

- **the registration boundary**, so `recorded_path` is native from the first write;
- **`resolvePack`**, the one funnel every consumer of a pack path reads from — so a row written by an older build, or edited by hand, is covered with no migration.

This is the same injected-platform normalization `kiwixManageAdd` already applied to the **manager's argv** (finding L9). That half existing is precisely why such a path registered cleanly — every assertion up to and including the identity check passed — and then failed on every article read.

## Second half: the symptom was undiagnosable, and that is also fixed

The L4 route guard already refused every disagreeing hit — correctly — but with a silent `continue`. A pack whose *every* hit disagreed then settled `searched` with nothing found: **"this archive had nothing to say"**, which a user cannot act on and a developer cannot diagnose. I had to instrument the test to find it.

Those refusals are counted now, and a pack with hits and no readable article settles the existing **`read-failed`** — whether every fetch failed or 404'd, or every hit was refused before the fetch. The shipped copy already covers both readings: *"failed: no article could be read"* / *"fehlgeschlagen: kein Artikel konnte gelesen werden"*. The disagreement is also logged once with the pack id and the two **names** — route identifiers, never a path (the sentinel rule).

**No shape changes**: the 14 `KnowledgePackOutcomeReason` codes, `ServedLibrary`, the IPC and the persisted rows are untouched, so `docs/data-contracts.md` needs no edit — only the code's own prose is amended.

## The test that should have caught it

```ts
expect(library!.names.get(pack.id)).toBe(servingNameFor(zimFile, process.platform))
```

Both sides are the same function, so it holds for *any* input — including one that 404s on every article. The smoke then failed twenty lines later on `expect(candidates.length).toBeGreaterThan(0)`, one misleading symptom away from the cause. It now also asks the **running** kiwix-serve, via `/raw/<name>/meta/Title`, which needs no entry key and so tests the route alone.

## One existing expectation changed rather than the code

T16 leg 9 asserted `searched` for `bravo`, a pack whose fixture hits all carry another book's `urlId` (`SEARCH_XML` hardcodes `alpha`). That was exactly the misleading state this fixes, so it now reads `read-failed`. The leg's real subject is that one ask's outcomes never cross-write another's — with the two sets now *differing*, that is visible rather than merely consistent.

## Verification

On the real K: Kit drive, kiwix-tools 3.8.1, the climate pack, the default 4B at `-ngl 0` — the issue's **exact reproduction**, forward slashes in `HILBERTRAUM_ZIM_FILE`:

```
[zim-real] wikipedia_de_climate-change_nopic_2026-07.zim: 24 candidates in 3587 ms
list group 5/6 · D-Z18 core 9/9 · Test Files 1 passed | Tests 2 passed
```

Identical to the backslash run, which used to be the only one that worked. Before this branch the same command gave `expected 0 to be greater than 0` in ~700 ms.

`npm run typecheck` clean; `npm test` 423 files / 7 118 passed / 85 skipped.

## Not claimed

No user-facing defect is fixed. Today's callers pass Windows-native paths — the *Add packs…* dialog returns backslashes and discovery builds paths with `node:path.join` — so this closes a latent trap on an input shape the rest of the platform accepts, on the one function whose output is a URL. It gets more live if a path ever arrives from somewhere other than a dialog, which is what #417's acquisition flow would add.

Record: `docs/rag-design.md` §17 D-Z11 "#429 amendment".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
