### PR TITLE
perf(benchmark): instrument performance:get's manifest scan (#333)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,13 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-08 — **#333 instrumented (`perf/333-manifest-read-instrumentation`), record `benchmark.md` §4 **I5** + Perf marks
+"`discover_manifests` / `performance_get` — the #333 pair":** two opt-in marks (the scan's walk / read / parse+validate split; the
+IPC handler end to end) + `scripts/measure-manifest-read.mjs` for both halves; `perfEnabled()` keeps the disabled path free.
+Two corrections: the original ~100 ms was measured on the INTERNAL disk, but the launchers point `HILBERTRAUM_MANIFESTS_DIR` at the
+drive's copy; and ~80 % of the WARM repeat cost is parse+validate CPU (18.9 ms median on the E: stick), so the cache question is not media-bound as framed. OPEN:
+the eject/re-insert cold run, the end-to-end `--log` run, then the decision — which would touch 13 call sites and reverse PF-4's
+recorded "deliberately NO stateful module cache"._
 _2026-09-08 — **#339 Range-first article reads (`fix/339-range-first-article-read`), record `rag-design.md` §17 **D-Z22**:**
 every `/raw` article request (and the redirect hop) now carries `Range: bytes=0-`, which libkiwix serves through its 16 KiB
 callback reader instead of the one-buffer path that carries the win-x86_64 cut-short defect — so the app stops TRIGGERING an

--- a/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
+++ b/apps/desktop/src/main/ipc/registerBenchmarkIpc.ts
@@ -44,6 +44,7 @@ import { workspaceAdmitsWork } from '../services/workspace-vault'
 import type { Db } from '../services/db'
 import { modelBusyLane, modelBusyMessageKey, type ModelBusyLane } from './model-busy'
 import { log } from '../services/logging'
+import { perfEnabled, perfMark, perfMs } from '../services/perf'
 
 // IPC for the hardware benchmark + model recommendation (spec §9.1, §11).
 //
@@ -1272,7 +1273,21 @@ export function registerBenchmarkIpc(ctx: AppContext): void {
   })
   ipcHandle(IPC.getPerformance, (): PerformanceSnapshot => {
     requireUnlocked()
-    return buildPerformanceSnapshot(ctx)
+    // #333: the END-TO-END cost of one snapshot read, marked HERE rather than inside
+    // `buildPerformanceSnapshot` so it spans exactly what the renderer awaits — the settings
+    // read, `detectSystem`, the manifest scan and the pure composition over them. The scan's
+    // own share is the `discover_manifests` line immediately before this one (they are
+    // synchronous and adjacent; `scripts/measure-manifest-read.mjs --log` pairs them on that
+    // adjacency and reports any unpaired scan as another caller's).
+    //
+    // The screen is pushed, not polled, but the pushes include one per finished chat answer
+    // and one per model start — so the figure that matters is the repeat cost while the screen
+    // sits open, not the cost of opening it once.
+    const timed = perfEnabled()
+    const startedAt = timed ? performance.now() : 0
+    const snapshot = buildPerformanceSnapshot(ctx)
+    if (timed) perfMark('performance_get', { ms: perfMs(startedAt) })
+    return snapshot
   })
   // §5 item 22 (a). Session state only — no DB read, nothing persisted, and `movedDriveNotice`
   // itself fail-closes to null on a locked workspace, so this stays a pure getter that a Home

--- a/apps/desktop/src/main/services/models.ts
+++ b/apps/desktop/src/main/services/models.ts
@@ -20,7 +20,7 @@ import type {
 } from '../../shared/types'
 import { tMain } from './i18n'
 import { log } from './logging'
-import { perfMark, perfMs } from './perf'
+import { perfEnabled, perfMark, perfMs } from './perf'
 import { recordChecksumRead } from './read-speed'
 import type { Db } from './db'
 import { getSettings, updateSettings } from './settings'
@@ -115,16 +115,51 @@ function extname(name: string): string {
   return i < 0 ? '' : name.slice(i).toLowerCase()
 }
 
-/** Discover + parse + validate every manifest under `manifestsDir`. */
+/**
+ * Discover + parse + validate every manifest under `manifestsDir`.
+ *
+ * **Instrumented for issue #333** (`discover_manifests`, opt-in — `HILBERTRAUM_PERF_LOG=1`).
+ * This runs on 13 call sites, `performance:get` among them, and the drive launchers point
+ * `HILBERTRAUM_MANIFESTS_DIR` at the removable drive's own copy — so on the shipped path every
+ * call is a real read off slow media, and nothing measured it there. The mark splits the cost
+ * three ways so the media half and the CPU half can be told apart:
+ *
+ *   - `walkMs`  — `collectManifestFiles`: the recursive `readdirSync` (directory metadata),
+ *   - `readMs`  — the `readFileSync` calls only (the file bytes),
+ *   - the remainder (`ms − walkMs − readMs`) — YAML parse + `validateManifest`, pure CPU.
+ *
+ * The split matters because the OS page cache serves every call after the first from RAM,
+ * which leaves the REPEAT cost — what the Performance screen's push-driven refetch actually
+ * pays — floored by CPU that a faster drive never moves. A media-only measurement would
+ * therefore not settle the cache question #333 asks; both halves have to be on record.
+ *
+ * All of it is gated on `perfEnabled()`: with the log off (every normal user) this costs one
+ * env-var read and nothing else. Content rule holds — counts and durations, never a path.
+ */
 export function discoverManifests(manifestsDir: string): DiscoveryResult {
   const manifests: DiscoveredManifest[] = []
   const errors: string[] = []
   const seenIds = new Map<string, string>()
+  const timed = perfEnabled()
+  const startedAt = timed ? performance.now() : 0
+  let readMs = 0
+  let bytes = 0
 
-  for (const file of collectManifestFiles(manifestsDir)) {
+  // Hoisted out of the `for` head so the walk can be timed apart from the per-file work; an
+  // unreadable directory still throws from exactly here, which every caller already handles.
+  const files = collectManifestFiles(manifestsDir)
+  const walkMs = timed ? performance.now() - startedAt : 0
+
+  for (const file of files) {
     let raw: unknown
     try {
-      raw = parseYaml(readFileSync(file, 'utf8'))
+      const readAt = timed ? performance.now() : 0
+      const text = readFileSync(file, 'utf8')
+      if (timed) {
+        readMs += performance.now() - readAt
+        bytes += Buffer.byteLength(text, 'utf8')
+      }
+      raw = parseYaml(text)
     } catch (err) {
       errors.push(`${file}: YAML parse error — ${String(err)}`)
       continue
@@ -141,6 +176,16 @@ export function discoverManifests(manifestsDir: string): DiscoveryResult {
     }
     seenIds.set(result.manifest.id, file)
     manifests.push({ manifest: result.manifest, sourceFile: file })
+  }
+  if (timed) {
+    perfMark('discover_manifests', {
+      files: files.length,
+      ok: manifests.length,
+      bytes,
+      ms: perfMs(startedAt),
+      walkMs: Math.round(walkMs),
+      readMs: Math.round(readMs)
+    })
   }
   return { manifests, errors }
 }

--- a/apps/desktop/src/main/services/perf.ts
+++ b/apps/desktop/src/main/services/perf.ts
@@ -36,6 +36,19 @@ function enabled(): boolean {
   return process.env.HILBERTRAUM_PERF_LOG === '1'
 }
 
+/**
+ * Whether marks are being recorded at all — for the rare call site that has to do WORK to
+ * produce a mark's fields (issue #333: `discoverManifests` splits its walk / read /
+ * parse+validate phases with extra `performance.now()` calls and a byte count). `perfMark`
+ * itself is already a no-op when disabled; this predicate lets the measurement code around it
+ * be one too, so an instrumented hot path costs a single env-var read for a normal user.
+ *
+ * Never gate a mark's SEMANTICS on this — only the cost of computing its fields.
+ */
+export function perfEnabled(): boolean {
+  return enabled()
+}
+
 function safeJson(v: unknown): string {
   try {
     return JSON.stringify(v)

--- a/apps/desktop/tests/integration/models.test.ts
+++ b/apps/desktop/tests/integration/models.test.ts
@@ -1755,6 +1755,37 @@ describe('discoverManifests', () => {
     const res = discoverManifests(dir)
     expect(res.manifests.length).toBe(1)
   })
+
+  // #333: the walk/read/parse phase split feeding the opt-in `discover_manifests` mark runs on
+  // a second code path (the `timed` branch — extra clocks, a byte count, and the file list
+  // hoisted out of the `for` head). Discovery is the §7.4 install gate's own source of truth, so
+  // the instrumentation must be provably semantics-free: same manifests, same errors, same
+  // order, with the perf log on and off. The mark's CONTENT is not asserted here — perf.ts
+  // buffers pre-`initPerf` marks in memory by design and exposes no reader.
+  it('returns an identical result with the perf log enabled (#333 instrumentation)', () => {
+    const dir = tempDir('hilbertraum-manifests-')
+    writeManifest(dir, 'good.yaml', manifestObj())
+    mkdirSync(join(dir, 'chat'), { recursive: true })
+    writeManifest(join(dir, 'chat'), 'nested.yml', manifestObj({ id: 'nested' }))
+    writeManifest(dir, 'bad.yaml', { id: 'broken' })
+
+    const before = process.env.HILBERTRAUM_PERF_LOG
+    const off = discoverManifests(dir)
+    process.env.HILBERTRAUM_PERF_LOG = '1'
+    let on: ReturnType<typeof discoverManifests>
+    try {
+      on = discoverManifests(dir)
+    } finally {
+      if (before === undefined) delete process.env.HILBERTRAUM_PERF_LOG
+      else process.env.HILBERTRAUM_PERF_LOG = before
+    }
+
+    expect(on.manifests.map((m) => m.manifest.id)).toEqual(off.manifests.map((m) => m.manifest.id))
+    expect(on.manifests.map((m) => m.sourceFile)).toEqual(off.manifests.map((m) => m.sourceFile))
+    expect(on.errors).toEqual(off.errors)
+    expect(off.manifests.length).toBe(2)
+    expect(off.errors.length).toBe(1)
+  })
 })
 
 // full-audit 2026-07-10 BE-5: launchContextTokens is the ONE spelling of the launch-window

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1122,8 +1122,32 @@ line, visible without the perf log), `sidecar_healthy`, `runtime_selected`,
 the load window — `started`/`skipped`, then the settle outcome `done`/`aborted`/`failed`;
 `started` → settle times the window), `runtime_ready`, `first_token`, `stream_done`,
 `embedder_selected`, `drive_benchmark`,
+`discover_manifests` / `performance_get` (issue #333 — see below),
 and the `ingest_*` phase marks (`start`, `copy_done`, `parse_done`, `chunks_committed`,
 `embed_done`, `indexed`).
+
+### `discover_manifests` / `performance_get` — the #333 pair
+
+`discover_manifests` fires once per `discoverManifests` call — all thirteen call sites, not just
+the Performance screen — with `{files, ok, bytes, ms, walkMs, readMs}`. The three-way split is the
+point: `walkMs` is the recursive `readdirSync` (directory metadata), `readMs` the `readFileSync`
+bytes, and the remainder (`ms − walkMs − readMs`) YAML parse + `validateManifest`, which is pure
+CPU. Computing those fields costs extra clocks, so unlike every other mark the surrounding
+measurement code is itself gated — on `perfEnabled()`, a predicate `perf.ts` exports for exactly
+this case. With the log off, an instrumented scan costs one env-var read.
+
+`performance_get` wraps the IPC handler, not `buildPerformanceSnapshot`, so it spans exactly what
+the renderer awaits. The scan's share is the `discover_manifests` line immediately before it: the
+two are synchronous and adjacent, which is how `scripts/measure-manifest-read.mjs --log` pairs
+them (a scan with anything in between is reported as another caller's).
+
+**Reading these marks honestly.** The manifests are ~90–140 KiB and stay page-cache resident once
+read, so the first mark of a run and every later one measure different things — and this project
+has three recorded cases of a warm cache corrupting a drive figure (#392, #404, and #414, where an
+external `Get-FileHash` in the protocol itself reported 1,008 MB/s for a 407.9 MB/s drive). Cold
+means the first read since the drive's cache was dropped: eject the drive, re-insert it, then run.
+The warm figure is not the lesser one — it is what the screen's push-driven refetch actually pays,
+once per finished chat answer and once per model start while the screen sits open.
 
 Content rule, stricter than `app.log`: a mark carries only phase names, model and
 backend ids, byte counts, and millisecond durations. Never file names, paths of user
@@ -1225,7 +1249,7 @@ guess.
 | N3 | fixed P5 `be177a34` | `SLOW_TOKENS_PER_SECOND`/`SLOW_READ_MBPS`/`USABLE_VRAM_MB` moved to `shared/gpu-rules.ts` and `shared/performance-rules.ts`; the renderer's own copies deleted. | `gpu-rules.test.ts`; `shared/performance-rules.ts` |
 | N4 | fixed P6 `9f703b87` | `perf.tile.drive.noneHint` reads "…or file check". | `shared/i18n/en.ts` `perf.tile.drive.noneHint`; `PerformanceScreen.test.tsx` "N4: the empty Drive tile credits a file check as well as a model start" |
 | N5 | fixed P6 `9f703b87` | `perf.step.drive` renamed "Drive speed". | `shared/i18n/en.ts` `perf.step.drive`; `PerformanceScreen.test.tsx` "N5: the drive step is \"Drive speed\", not \"Drive write speed\" beside a tile reading MB/s read" |
-| N6 | follow-up issue #333 | Not a code change; see §4 for the one measurement taken so far. | — |
+| N6 | follow-up issue #333 | Not a code change; instrumented 2026-09-08 (`discover_manifests` / `performance_get` marks + `scripts/measure-manifest-read.mjs`). See §4 for the figures so far. | — |
 | N7 | documented (this phase) | This file's "Other computers" paragraph now names `currentKey ?? here` explicitly; the field already behaved this way. | `benchmark.md` "Other computers this drive has been used on." (this file) |
 | DX1 | fixed P3 `3fbc51d0` | The "session-only, never persisted" vs. "falls back to the persisted sample" contradiction is gone; this file and `data-contracts.md` agree. | `benchmark.md` "Observed while you worked."; `data-contracts.md` |
 | DX2 | fixed P9 (this phase) | This file's "Performance screen" section is a clean four-item list; "Your model" and "Models on this computer" no longer sit between numbered items. | `benchmark.md` "Performance screen" (this file) |
@@ -1377,7 +1401,27 @@ commit references, and added the changelog entry.
   two-device fixtures.
 - **I5** (follow-up issue #333): `performance:get`'s synchronous `discoverManifests` scan measured about 100 ms in one
   dev-build launch smoke (P3); not measured on slow USB media, and no cache was built pending
-  that measurement.
+  that measurement. **Instrumented 2026-09-08** — `discover_manifests` + `performance_get` perf
+  marks (above) and `scripts/measure-manifest-read.mjs`, which runs the phase split standalone
+  (`--dir <drive>/model-manifests`, the validator imported from the app's own source) or
+  summarises a real run's `perf.log` (`--log`). Note the dev smoke measured the INTERNAL disk:
+  the launchers set `HILBERTRAUM_MANIFESTS_DIR` to the drive's copy, so the shipped path reads
+  off the stick and the original figure was taken on the wrong medium.
+  **Preliminary figures, i7-8700, idle** (`eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-20260908-preliminary.txt`
+  — read its header: none of it is a cold run under the eject/re-insert protocol). E: test stick,
+  28 manifests / 90.6 KiB: warm median **18.9 ms** (walk 0.8 / read 2.8 / parse+validate 15.1) —
+  **80 % of the warm cost is CPU**. Repo catalog on internal NVMe, 34 manifests: warm median
+  24.1 ms, 79 % CPU. The one near-cold observation, the session's first read of the stick before
+  anything had touched those files: 69.0 ms total, of which **27.4 ms of reads for 90.6 KiB across
+  28 opens** — about 1 ms per open, i.e. per-open latency, not throughput (that payload is ~3.6 ms
+  of bandwidth even at 25 MB/s). Two things follow, both against the issue's own framing: the
+  decision does not turn on media speed, because the page cache serves every repeat from RAM and
+  the floor underneath is parse + validate; and where media *does* show up it is IOPS, so a
+  catalog's FILE COUNT matters more than its size (relevant to #311, which would add manifests).
+  A same-machine control: the identical capture taken while the test suite ran doubled every
+  figure (44.5 ms warm median), which is what a CPU-bound cost looks like. **Still open:** the
+  formal cold run (eject/re-insert, `--cold-only`), the end-to-end `--log` run on a rig machine
+  with the full committed catalog, then the box-3 decision.
 - **I6** — **verified 2026-09-08** (issue #334): the P7 sequencing ran on real slow media — an
   SSK USB stick (28 MB/s cold read on the i7-8700's slow port, 133 MB/s on a Surface's; 87–91 MB/s
   as the app hashes there) carrying the 9B, moved from the #330 computer B to an i7-1185G7 /

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2461,8 +2461,15 @@ All of these are decided scope, not oversights; the design record's §7 carries 
   auto-start begins hashing (#334 perf marks, 0.4 s after `unlock_done`). It persists nothing and
   measured the same write figure as the sequenced probe after the load; noted, not sequenced.
 - **One `performance:get` read costs about 100 ms in the dev build** (a synchronous manifest scan
-  alongside settings and system detection) — measured once during development, not on slow
-  removable media; a cache is a follow-up if it proves to matter (issue #333).
+  alongside settings and system detection) — measured once during development, and on the
+  INTERNAL disk: the launchers point `HILBERTRAUM_MANIFESTS_DIR` at the drive's own copy, so the
+  shipped path reads off the removable drive. Instrumented 2026-09-08 (issue #333): the
+  `discover_manifests` / `performance_get` perf marks split the scan into walk / read /
+  parse+validate, and `scripts/measure-manifest-read.mjs` runs it standalone or against a
+  `perf.log`. Preliminary figures (`benchmark.md` §4 I5) put ~80 % of the warm repeat cost in
+  parse+validate CPU rather than in drive I/O — the page cache serves every read after the first
+  — so the cache question is not decided by media speed alone. The formal cold (eject/re-insert)
+  and end-to-end runs, and the decision, are still open.
 - **The silent re-check has no Home-screen notice yet.** The moved-drive re-check above runs with
   no visible sign beyond Performance itself refreshing; a Home notice while it is pending is
   tracked in BUILD_STATE §5 item 22 (a).

--- a/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-20260908-e-stick.json
+++ b/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-20260908-e-stick.json
@@ -1,0 +1,133 @@
+{
+  "mode": "trials",
+  "manifestsDir": "E:/model-manifests",
+  "machine": "HilbertRaum — performance:get manifest-scan read cost (issue #333)\n2026-09-08T20:30:10.064Z\nwin32 x64 · Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12 cores · 34.3 GB RAM",
+  "shape": {
+    "files": 28,
+    "ok": 28,
+    "invalid": 0,
+    "bytes": 92753
+  },
+  "runs": [
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 1.4731000000000165,
+      "readMs": 3.680499999999995,
+      "parseMs": 38.81469999999999,
+      "totalMs": 43.9683
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 1.2690999999999804,
+      "readMs": 2.863999999999919,
+      "parseMs": 16.662700000000086,
+      "totalMs": 20.795799999999986
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.949799999999982,
+      "readMs": 2.8664000000000556,
+      "parseMs": 16.93919999999997,
+      "totalMs": 20.75540000000001
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.8692000000000064,
+      "readMs": 2.7184999999999206,
+      "parseMs": 15.534600000000097,
+      "totalMs": 19.122300000000024
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.9621999999999957,
+      "readMs": 2.666099999999915,
+      "parseMs": 14.651600000000087,
+      "totalMs": 18.279899999999998
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7497999999999934,
+      "readMs": 2.9128000000000043,
+      "parseMs": 15.54159999999996,
+      "totalMs": 19.204199999999958
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7848000000000184,
+      "readMs": 2.911700000000053,
+      "parseMs": 15.394699999999943,
+      "totalMs": 19.091200000000015
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7415000000000305,
+      "readMs": 3.015799999999956,
+      "parseMs": 15.12760000000003,
+      "totalMs": 18.884900000000016
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.8079999999999927,
+      "readMs": 2.6475999999998976,
+      "parseMs": 13.50220000000013,
+      "totalMs": 16.95780000000002
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7239999999999895,
+      "readMs": 2.676400000000001,
+      "parseMs": 13.512699999999995,
+      "totalMs": 16.913099999999986
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7933000000000447,
+      "readMs": 2.675999999999931,
+      "parseMs": 14.089800000000025,
+      "totalMs": 17.5591
+    },
+    {
+      "files": 28,
+      "ok": 28,
+      "invalid": 0,
+      "bytes": 92753,
+      "walkMs": 0.7590000000000146,
+      "readMs": 2.544399999999996,
+      "parseMs": 13.568699999999978,
+      "totalMs": 16.87209999999999
+    }
+  ]
+}

--- a/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-20260908-preliminary.txt
+++ b/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-20260908-preliminary.txt
@@ -1,0 +1,85 @@
+PRELIMINARY — issue #333, 2026-09-08, DESKTOPDIT (i7-8700, 34.3 GB, the 1070 Ti leg machine).
+
+WHAT THIS IS AND IS NOT
+-----------------------
+This capture establishes the WARM repeat cost of the manifest scan and its media/CPU split. It
+does NOT contain a cold figure taken under the eject/re-insert protocol, and the formal cold run
+plus the end-to-end `--log` run from a real app launch on the drive are still owed (benchmark.md
+§4 I5). Read the trial-1 line of each block with that in mind: by the time these two blocks were
+captured the files had already been read several times in the session, so trial 1 here is warm
+too — its `read` component (3.9 ms on the stick) is cache speed, not the medium.
+
+THE ONE NEAR-COLD OBSERVATION, recorded here because it cannot be reproduced without an
+eject/re-insert. The session's FIRST read of E:/model-manifests, on an idle machine, before
+anything else had touched those files (20:19:35Z, same script, --trials 12):
+
+    total 69.0 ms   walk 1.4 ms   read 27.4 ms   parse+validate 40.2 ms
+    → 27.4 ms for 90.6 KiB across 28 opens ≈ 1.0 ms/open, i.e. per-open latency on USB, not
+      throughput (90.6 KiB at even 25 MB/s is ~3.6 ms of bandwidth). Directory metadata was
+      already warm from an `ls`, so `walk` is understated and the true cold total is higher.
+
+Both blocks below were taken on an otherwise IDLE machine. An earlier attempt at this same file
+was taken while the test suite ran and every figure came out roughly double (warm median 44.5 ms
+against 18.2 ms here) — which is itself evidence that the cost is CPU-bound rather than
+media-bound, and a warning that these figures move with whatever else the box is doing.
+
+$ node --no-warnings scripts/measure-manifest-read.mjs --dir E:/model-manifests --trials 12
+==========================================================================================
+HilbertRaum — performance:get manifest-scan read cost (issue #333)
+2026-09-08T20:30:10.061Z
+win32 x64 · Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12 cores · 34.3 GB RAM
+
+Directory     E:/model-manifests
+Catalog       28 manifest files · 90.6 KiB · 28 valid, 0 rejected
+Trials        12
+
+FIRST TRIAL (cold only if the drive's cache was dropped — eject/re-insert, then --cold-only)
+  total 44.0 ms   walk 1.5 ms (3%)   read 3.7 ms (8%)   parse+validate 38.8 ms (88%)
+  effective read 25.2 MB/s over 28 opens — compare against the drive's known sequential figure; far above it means a warm cache
+
+WARM TRIALS (trials 2..12) — what a pushed refetch pays
+  total                      median   18.9 ms   min   16.9 ms   p95   20.8 ms   max   20.8 ms   (n=11)
+  walk (readdir)             median    0.8 ms   min    0.7 ms   p95    1.3 ms   max    1.3 ms   (n=11)
+  read (readFileSync)        median    2.7 ms   min    2.5 ms   p95    3.0 ms   max    3.0 ms   (n=11)
+  parse + validate (CPU)     median   15.1 ms   min   13.5 ms   p95   16.9 ms   max   16.9 ms   (n=11)
+
+  Warm floor: 80% of the warm median is parse+validate CPU — a faster drive cannot move it.
+
+#333 acceptance — what this run answers and what it does not:
+  [~] box 1 (end-to-end performance:get cost)  → --log mode, from a real app run on the drive
+  [x] box 2 (the scan's share, isolated)       → the phase split above
+  [ ] box 3 (the decision)                     → owner call on these figures
+
+JSON written to manifest-read-20260908-e-stick.json
+
+
+$ node --no-warnings scripts/measure-manifest-read.mjs --trials 12    # repo copy, internal NVMe
+==========================================================================================
+HilbertRaum — performance:get manifest-scan read cost (issue #333)
+2026-09-08T20:30:10.611Z
+win32 x64 · Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz · 12 cores · 34.3 GB RAM
+
+Directory     C:\work\HilbertRaum\model-manifests
+Catalog       34 manifest files · 136.5 KiB · 34 valid, 0 rejected
+Trials        12
+
+  ! This is the repo's own model-manifests/ on the INTERNAL disk. The CPU half below is
+    valid; the media half is not the drive. Re-run with --dir <drive>/model-manifests.
+
+FIRST TRIAL (cold only if the drive's cache was dropped — eject/re-insert, then --cold-only)
+  total 58.6 ms   walk 2.4 ms (4%)   read 5.7 ms (10%)   parse+validate 50.5 ms (86%)
+  effective read 24.7 MB/s over 34 opens — compare against the drive's known sequential figure; far above it means a warm cache
+
+WARM TRIALS (trials 2..12) — what a pushed refetch pays
+  total                      median   24.1 ms   min   21.9 ms   p95   29.0 ms   max   29.0 ms   (n=11)
+  walk (readdir)             median    0.8 ms   min    0.8 ms   p95    0.9 ms   max    0.9 ms   (n=11)
+  read (readFileSync)        median    4.3 ms   min    4.1 ms   p95    4.9 ms   max    4.9 ms   (n=11)
+  parse + validate (CPU)     median   19.0 ms   min   17.0 ms   p95   23.3 ms   max   23.3 ms   (n=11)
+
+  Warm floor: 79% of the warm median is parse+validate CPU — a faster drive cannot move it.
+
+#333 acceptance — what this run answers and what it does not:
+  [~] box 1 (end-to-end performance:get cost)  → --log mode, from a real app run on the drive
+  [x] box 2 (the scan's share, isolated)       → the phase split above
+  [ ] box 3 (the decision)                     → owner call on these figures
+

--- a/scripts/measure-manifest-read.mjs
+++ b/scripts/measure-manifest-read.mjs
@@ -1,0 +1,394 @@
+// `performance:get`'s manifest-scan read cost — issue #333.
+//
+// The Performance screen builds every snapshot from a SYNCHRONOUS `discoverManifests` scan
+// (`apps/desktop/src/main/services/models.ts`) beside a settings read and `detectSystem()`.
+// `docs/benchmark.md` §2 row N6 / §4 row I5 record that this was measured ONCE, at ~100 ms, in a
+// dev-build launch smoke on the reviewing machine's internal disk — never on the slow removable
+// media the app is meant to run from, and the drive launchers point `HILBERTRAUM_MANIFESTS_DIR`
+// at the drive's own copy, so the shipped path reads off the stick. This script produces the
+// missing figures.
+//
+// Run (from the repo root):
+//   node --no-warnings scripts/measure-manifest-read.mjs --dir <drive>/model-manifests
+//   node --no-warnings scripts/measure-manifest-read.mjs --log <workspace>/logs/perf.log
+//
+// TWO MODES, and #333 wants both:
+//
+//   TRIALS (default) — repeats the scan against a directory and splits it three ways: the
+//     recursive `readdirSync` walk, the `readFileSync` bytes, and YAML parse + `validateManifest`.
+//     The validator is IMPORTED FROM THE APP'S OWN SOURCE (Node 24 type stripping), so the
+//     expensive half is never reimplemented here; only the file-selection rule is restated (see
+//     MANIFEST_EXTENSIONS below). No Electron, no workspace, no unlock — this is the media
+//     measurement, and it is the one that can be repeated cold.
+//
+//   LOG (--log) — reads a real app run's opt-in `perf.log` (`HILBERTRAUM_PERF_LOG=1`) and
+//     summarises the `performance_get` marks with the `discover_manifests` line each one sits
+//     behind. This is the END-TO-END half: the actual IPC the renderer awaits, on the real drive,
+//     through the real settings read. Pairing is by ADJACENCY — the two marks are synchronous and
+//     consecutive — so a `discover_manifests` with anything between it and the next
+//     `performance_get` is reported separately as another caller's scan (the §7.4 start gate, the
+//     Models screen, the downloader and nine other call sites all scan too).
+//
+// COLD VS WARM IS THE WHOLE MEASUREMENT, and it is easy to get wrong: this project has recorded
+// page-cache contamination three times (#392 a Models-screen hash, #404 a warm relaunch, #414
+// an EXTERNAL `Get-FileHash` in the test protocol itself — 1,008 MB/s reported for a 407.9 MB/s
+// drive). The manifests are ~158 KB total and stay resident indefinitely once read, so a naive
+// "open the screen and time it" measures RAM and closes #333 on a fiction.
+//
+//   Cold  = the first read of these files since the drive's cache was dropped. On Windows there
+//           is no supported way to drop it for a volume, so the protocol is: EJECT the drive,
+//           re-insert it, then run with --cold-only. A reboot works too. Trial 1 of a normal run
+//           is reported apart from the warm figures for the same reason, but it is only honestly
+//           cold if nothing touched the directory since insertion.
+//   Warm  = every later trial. This is what the Performance screen's push-driven refetch pays,
+//           and its floor is parse+validate CPU, which no drive speed moves.
+//
+// THE RIG RUN, end to end — three commands, in this order:
+//
+//   1. Media half, cold. Eject the drive, re-insert it, then WITHOUT opening anything on it:
+//        node --no-warnings scripts/measure-manifest-read.mjs --dir <drive>/model-manifests --cold-only
+//      Repeat the eject/re-insert for each cold sample; run without --cold-only for the warm set.
+//
+//   2. End-to-end half. Launch the app with the perf log on, from the drive's own launcher so
+//      HILBERTRAUM_MANIFESTS_DIR points at the drive (a two-line wrapper beside the launcher, the
+//      #334 protocol's `_334-start-perf.cmd`):
+//        @echo off
+//        set "HILBERTRAUM_PERF_LOG=1"
+//        call "%~dp0Start HilbertRaum.cmd" %*
+//      Unlock, open Performance, and LEAVE IT OPEN through a few chat answers and a model start —
+//      every one of those pushes a refetch, and that repeat cost is what the issue is about.
+//
+//   3. Summarise what the run wrote:
+//        node --no-warnings scripts/measure-manifest-read.mjs --log <workspace>/logs/perf.log
+//
+// Take both halves on an IDLE machine: parse+validate dominates the warm cost, so a build or a
+// test suite running alongside inflates the figures roughly twofold (observed while writing this).
+//
+// Flags:
+//   --dir <path>     Manifests directory. Default: $HILBERTRAUM_MANIFESTS_DIR, else the repo's
+//                    own `model-manifests/` (which measures the INTERNAL disk — fine for the CPU
+//                    half, wrong for the media half; the script says so in the header it prints).
+//   --trials <n>     Timed trials (default 10). Trial 1 is always reported separately.
+//   --cold-only      One trial, then exit — the eject/re-insert protocol above.
+//   --log <path>     LOG mode: summarise `performance_get` / `discover_manifests` from a perf.log.
+//   --json <path>    Also write the full result set as JSON (for the evidence directory).
+//
+// Exit code is always 0 — this is a report, not a test.
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { basename, dirname, extname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(__dirname)
+
+const { validateManifest } = await import(
+  pathToFileURL(join(repoRoot, 'apps/desktop/src/shared/manifest.ts')).href
+)
+
+// RESTATED from models.ts:55-61 — the only rule this script duplicates. Keep them in step; a
+// drift shows up immediately as a differing `files:` count against the app's own mark. (The
+// script also skips the app's duplicate-id dedupe, which costs nothing and cannot fire on a
+// catalog the committed-catalog test already forbids duplicates in — so `ok` here means
+// "parsed and validated", where the app's means "accepted".)
+const MANIFEST_EXTENSIONS = new Set(['.yaml', '.yml'])
+const RESERVED_MANIFEST_FILES = new Set(['runtime-sources.yaml', 'runtime-sources.yml'])
+
+// ---- args -----------------------------------------------------------------------------------
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name)
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : fallback
+}
+const has = (name) => process.argv.includes(name)
+
+const coldOnly = has('--cold-only')
+const trials = coldOnly ? 1 : Number(arg('--trials', '10'))
+const jsonOut = arg('--json')
+const logPath = arg('--log')
+const manifestsDir =
+  arg('--dir') ?? process.env.HILBERTRAUM_MANIFESTS_DIR ?? join(repoRoot, 'model-manifests')
+
+// ---- helpers --------------------------------------------------------------------------------
+
+const ms = (n) => `${n.toFixed(1)} ms`
+const pct = (part, whole) => (whole > 0 ? `${((part / whole) * 100).toFixed(0)}%` : '—')
+
+function stats(values) {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const at = (q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+  return {
+    n: sorted.length,
+    min: sorted[0],
+    median: at(0.5),
+    p95: at(0.95),
+    max: sorted[sorted.length - 1],
+    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length
+  }
+}
+
+function line(label, s) {
+  if (!s) return `  ${label.padEnd(26)} —`
+  return `  ${label.padEnd(26)} median ${ms(s.median).padStart(9)}   min ${ms(s.min).padStart(9)}   p95 ${ms(
+    s.p95
+  ).padStart(9)}   max ${ms(s.max).padStart(9)}   (n=${s.n})`
+}
+
+function machineHeader() {
+  const cpu = os.cpus()?.[0]?.model?.trim() ?? 'unknown CPU'
+  const ramGb = Math.round((os.totalmem() / 1e9) * 10) / 10
+  return [
+    `HilbertRaum — performance:get manifest-scan read cost (issue #333)`,
+    `${new Date().toISOString()}`,
+    `${os.platform()} ${os.arch()} · ${cpu} · ${os.cpus()?.length ?? 0} cores · ${ramGb} GB RAM`
+  ].join('\n')
+}
+
+// ---- TRIALS mode ------------------------------------------------------------------------------
+
+/** The walk, timed apart — mirrors `collectManifestFiles`. */
+function collectManifestFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...collectManifestFiles(full))
+    else if (
+      MANIFEST_EXTENSIONS.has(extname(entry.name).toLowerCase()) &&
+      !RESERVED_MANIFEST_FILES.has(entry.name.toLowerCase())
+    )
+      out.push(full)
+  }
+  return out
+}
+
+/** One full scan, split into the three phases `discover_manifests` marks in the app. */
+function oneScan() {
+  const t0 = performance.now()
+  const files = collectManifestFiles(manifestsDir)
+  const walkMs = performance.now() - t0
+
+  let readMs = 0
+  let bytes = 0
+  let ok = 0
+  let invalid = 0
+  for (const file of files) {
+    const readAt = performance.now()
+    const text = readFileSync(file, 'utf8')
+    readMs += performance.now() - readAt
+    bytes += Buffer.byteLength(text, 'utf8')
+    let raw
+    try {
+      raw = parseYaml(text)
+    } catch {
+      invalid++
+      continue
+    }
+    const result = validateManifest(raw)
+    if (result.ok && result.manifest) ok++
+    else invalid++
+  }
+  const totalMs = performance.now() - t0
+  return { files: files.length, ok, invalid, bytes, walkMs, readMs, parseMs: totalMs - walkMs - readMs, totalMs }
+}
+
+function runTrials() {
+  let dirOk = true
+  try {
+    dirOk = statSync(manifestsDir).isDirectory()
+  } catch {
+    dirOk = false
+  }
+  if (!dirOk) {
+    console.error(`\nNo manifests directory at: ${manifestsDir}`)
+    console.error(`Pass --dir <drive>/model-manifests (the launchers set HILBERTRAUM_MANIFESTS_DIR to it).\n`)
+    return { error: 'no-dir', manifestsDir }
+  }
+
+  const isRepoCopy = manifestsDir === join(repoRoot, 'model-manifests')
+  const runs = []
+  for (let i = 0; i < trials; i++) runs.push(oneScan())
+
+  const first = runs[0]
+  const warm = runs.slice(1)
+  const shape = { files: first.files, ok: first.ok, invalid: first.invalid, bytes: first.bytes }
+
+  const out = []
+  out.push(machineHeader())
+  out.push('')
+  out.push(`Directory     ${manifestsDir}`)
+  out.push(
+    `Catalog       ${shape.files} manifest files · ${(shape.bytes / 1024).toFixed(1)} KiB · ${shape.ok} valid, ${
+      shape.invalid
+    } rejected`
+  )
+  out.push(`Trials        ${runs.length}${coldOnly ? ' (--cold-only)' : ''}`)
+  if (isRepoCopy)
+    out.push(
+      `\n  ! This is the repo's own model-manifests/ on the INTERNAL disk. The CPU half below is\n` +
+        `    valid; the media half is not the drive. Re-run with --dir <drive>/model-manifests.`
+    )
+  out.push('')
+  out.push(`FIRST TRIAL (cold only if the drive's cache was dropped — eject/re-insert, then --cold-only)`)
+  out.push(`  total ${ms(first.totalMs)}   walk ${ms(first.walkMs)} (${pct(first.walkMs, first.totalMs)})   read ${ms(
+    first.readMs
+  )} (${pct(first.readMs, first.totalMs)})   parse+validate ${ms(first.parseMs)} (${pct(
+    first.parseMs,
+    first.totalMs
+  )})`)
+  if (first.readMs > 0)
+    out.push(
+      `  effective read ${((shape.bytes / 1e6 / first.readMs) * 1000).toFixed(1)} MB/s over ${
+        shape.files
+      } opens — compare against the drive's known sequential figure; far above it means a warm cache`
+    )
+
+  if (warm.length > 0) {
+    out.push('')
+    out.push(`WARM TRIALS (trials 2..${runs.length}) — what a pushed refetch pays`)
+    out.push(line('total', stats(warm.map((r) => r.totalMs))))
+    out.push(line('walk (readdir)', stats(warm.map((r) => r.walkMs))))
+    out.push(line('read (readFileSync)', stats(warm.map((r) => r.readMs))))
+    out.push(line('parse + validate (CPU)', stats(warm.map((r) => r.parseMs))))
+    const warmTotal = stats(warm.map((r) => r.totalMs))
+    const warmParse = stats(warm.map((r) => r.parseMs))
+    out.push('')
+    out.push(
+      `  Warm floor: ${pct(warmParse.median, warmTotal.median)} of the warm median is parse+validate CPU —` +
+        ` a faster drive cannot move it.`
+    )
+  }
+
+  out.push('')
+  out.push(`#333 acceptance — what this run answers and what it does not:`)
+  out.push(`  [~] box 1 (end-to-end performance:get cost)  → --log mode, from a real app run on the drive`)
+  out.push(`  [x] box 2 (the scan's share, isolated)       → the phase split above`)
+  out.push(`  [ ] box 3 (the decision)                     → owner call on these figures`)
+  out.push('')
+
+  console.log(out.join('\n'))
+  return { mode: 'trials', manifestsDir, machine: machineHeader(), shape, runs }
+}
+
+// ---- LOG mode ---------------------------------------------------------------------------------
+
+/** `<ISO> <monotonic> <event> <json>` — the format perf.ts writes. */
+function parsePerfLog(text) {
+  const marks = []
+  for (const raw of text.split(/\r?\n/)) {
+    const l = raw.trim()
+    if (l === '') continue
+    const m = /^(\S+)\s+(\S+)\s+(\S+)(?:\s+(.*))?$/.exec(l)
+    if (!m) continue
+    let fields = {}
+    if (m[4]) {
+      try {
+        fields = JSON.parse(m[4])
+      } catch {
+        /* a truncated final line of an interrupted run — skip its fields, keep the event */
+      }
+    }
+    marks.push({ wall: m[1], mono: Number(m[2]), event: m[3], fields })
+  }
+  return marks
+}
+
+function runLog() {
+  let text
+  try {
+    text = readFileSync(logPath, 'utf8')
+  } catch (err) {
+    console.error(`\nCould not read ${logPath}: ${String(err)}\n`)
+    return { error: 'no-log', logPath }
+  }
+  const marks = parsePerfLog(text)
+  const gets = []
+  let unpairedScans = 0
+  for (let i = 0; i < marks.length; i++) {
+    if (marks[i].event !== 'performance_get') continue
+    const prev = marks[i - 1]
+    const scan = prev && prev.event === 'discover_manifests' ? prev.fields : null
+    gets.push({ mono: marks[i].mono, totalMs: Number(marks[i].fields.ms), scan })
+  }
+  for (let i = 0; i < marks.length; i++) {
+    if (marks[i].event !== 'discover_manifests') continue
+    const next = marks[i + 1]
+    if (!next || next.event !== 'performance_get') unpairedScans++
+  }
+
+  const out = []
+  out.push(machineHeader())
+  out.push('')
+  out.push(`Log           ${logPath}`)
+  out.push(`Marks         ${marks.length} total · ${gets.length} performance_get · ${unpairedScans} scans by other callers`)
+  if (gets.length === 0) {
+    out.push('')
+    out.push(`  No performance_get marks. Launch with HILBERTRAUM_PERF_LOG=1 and open the Performance`)
+    out.push(`  screen; leave it open through a few chat answers — every finished answer and every`)
+    out.push(`  model start pushes a refetch, and that repeat cost is the figure #333 is really about.`)
+    out.push('')
+    console.log(out.join('\n'))
+    return { mode: 'log', logPath, gets: [] }
+  }
+
+  const paired = gets.filter((g) => g.scan)
+  const firstGet = gets[0]
+  out.push('')
+  out.push(`FIRST performance:get of the run (cold cache, if the app had not scanned yet)`)
+  out.push(
+    `  total ${ms(firstGet.totalMs)}` +
+      (firstGet.scan
+        ? `   scan ${ms(Number(firstGet.scan.ms))} (${pct(Number(firstGet.scan.ms), firstGet.totalMs)} of it)` +
+          `   walk ${ms(Number(firstGet.scan.walkMs))}   read ${ms(Number(firstGet.scan.readMs))}` +
+          `   parse+validate ${ms(Number(firstGet.scan.ms) - Number(firstGet.scan.walkMs) - Number(firstGet.scan.readMs))}`
+        : '   (no adjacent scan mark)')
+  )
+  if (gets.length > 1) {
+    const rest = gets.slice(1)
+    out.push('')
+    out.push(`SUBSEQUENT READS (n=${rest.length}) — the pushed refetches`)
+    out.push(line('performance:get end to end', stats(rest.map((g) => g.totalMs))))
+    const scans = rest.filter((g) => g.scan)
+    if (scans.length > 0) {
+      out.push(line('  of which: manifest scan', stats(scans.map((g) => Number(g.scan.ms)))))
+      out.push(line('  … walk (readdir)', stats(scans.map((g) => Number(g.scan.walkMs)))))
+      out.push(line('  … read (bytes)', stats(scans.map((g) => Number(g.scan.readMs)))))
+      out.push(
+        line(
+          '  … parse + validate',
+          stats(scans.map((g) => Number(g.scan.ms) - Number(g.scan.walkMs) - Number(g.scan.readMs)))
+        )
+      )
+      const t = stats(rest.map((g) => g.totalMs))
+      const s = stats(scans.map((g) => Number(g.scan.ms)))
+      out.push('')
+      out.push(`  The scan is ${pct(s.median, t.median)} of the median read — the rest is the settings`)
+      out.push(`  read and detectSystem(), which touch no manifest file.`)
+    }
+    if (paired.length < gets.length)
+      out.push(`\n  (${gets.length - paired.length} reads had no adjacent scan mark — a scan that ran under`)
+    if (paired.length < gets.length) out.push(`   another caller in between; their totals are still counted.)`)
+  }
+  out.push('')
+  out.push(`#333 acceptance — what this run answers and what it does not:`)
+  out.push(`  [x] box 1 (end-to-end performance:get cost)  → above, on the real drive`)
+  out.push(`  [x] box 2 (the scan's share, isolated)       → the split above`)
+  out.push(`  [ ] box 3 (the decision)                     → owner call on these figures`)
+  out.push('')
+  console.log(out.join('\n'))
+  return { mode: 'log', logPath, machine: machineHeader(), gets, unpairedScans }
+}
+
+// ---- main -------------------------------------------------------------------------------------
+
+const result = logPath ? runLog() : runTrials()
+if (jsonOut) {
+  try {
+    writeFileSync(jsonOut, JSON.stringify(result, null, 2) + '\n', 'utf8')
+    console.log(`JSON written to ${basename(jsonOut)}\n`)
+  } catch (err) {
+    console.error(`Could not write ${jsonOut}: ${String(err)}`)
+  }
+}


### PR DESCRIPTION
Refs #333. Lands the **instrument**, not the decision — #333 stays open.

## What it adds

Two opt-in perf marks (`HILBERTRAUM_PERF_LOG=1`) and a script, so the figure #333 asks for can be taken where it is actually paid:

- **`discover_manifests`** — `{files, ok, bytes, ms, walkMs, readMs}` on every `discoverManifests` call (all 13 sites, so the §7.4 start gate and the Models screen are measured too). The split — recursive `readdirSync`, `readFileSync` bytes, remainder as YAML parse + `validateManifest` — is what separates the media half from the CPU half, which is the whole point.
- **`performance_get`** — on the IPC handler rather than inside `buildPerformanceSnapshot`, so it spans exactly what the renderer awaits. The scan's share is the adjacent `discover_manifests` line.
- **`perfEnabled()`** in `perf.ts` — producing those fields costs work, unlike every other mark, so the measurement code around them is gated too. With the log off an instrumented scan costs one env-var read.
- **`scripts/measure-manifest-read.mjs`** — standalone trials against a manifests dir (validator imported from `shared/manifest.ts`; only the file-selection rule is restated) *or* `--log` to summarise a real run's `perf.log`. Header carries the three-command rig protocol, including the eject/re-insert rule for a cold read.

## Two corrections this turned up

1. **The ~100 ms on record was measured on the wrong medium.** All three launchers set `HILBERTRAUM_MANIFESTS_DIR` to the drive's own copy, so the shipped path reads off the stick; the dev-build smoke read the internal disk.
2. **~80% of the *warm* repeat cost is parse+validate CPU**, not I/O — 18.9 ms median on the E: stick, 24.1 ms on an internal NVMe. The page cache serves every repeat from RAM, so what the screen's push-driven refetch pays (once per finished chat answer, once per model start, while the screen sits open) has a floor no drive speed moves. **A media-only measurement would not settle the question the issue asks.** Where media does show up it is IOPS, not bandwidth: the one near-cold observation was 27.4 ms of reads for 90.6 KiB across 28 opens (~1 ms/open, against ~3.6 ms of bandwidth at 25 MB/s) — so a catalog's file *count* matters more than its size, which is worth knowing before #311 adds manifests.

A same-machine control: the identical capture taken while the test suite ran doubled every figure. That is what a CPU-bound cost looks like — and a reminder that these numbers move with whatever else the box is doing.

## Still open on #333

- The formal cold run (eject, re-insert, `--cold-only`) and the end-to-end `--log` run on a rig machine with the full committed catalog.
- Then the box-3 decision. Noted for whoever takes it: a cache would land on **13 call sites** — the §7.4 install gate, the downloader and the ship-time commercial gate among them — and would reverse the recorded **PF-4** ruling (*"deliberately NO stateful module cache"*, `build-log.md` 2026-07-10, whose chosen shape was threading the discovery instead). That is a design amendment with an invalidation surface of its own, not a memo. It would also invalidate `compose-services-discovery.test.ts`'s "the per-action caller still re-discovers" assertion.

## Verification

- Full suite **423 files / 7,113 passed**, 85 skipped; typecheck + `npm run build` green.
- New test: `models.test.ts` pins that discovery returns an identical result with the perf log on and off — the timed branch is a second code path through the install gate's own source of truth, so it has to be provably semantics-free.
- Behaviour with the log off is unchanged: the only structural edit is hoisting the file list out of the `for` head, which throws from exactly where it did.

## Docs

`benchmark.md` §2 row N6, §4 row I5 (figures + what is still owed) and a new Perf-marks subsection for the pair; `known-limitations.md`; a short `BUILD_STATE.md` entry (the size-budget test rejected the first draft for length, correctly). Preliminary evidence under `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/` — its header states plainly that none of it is a cold run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)