### PR TITLE
docs(benchmark): #331 — the four blocked HW3 acceptance legs performed

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,22 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-09 — **#331 CLOSED — the four blocked HW3 acceptance legs performed** (`docs/331-hardware-acceptance-legs`;
+record `benchmark.md` §2 row HW3 + §4 HW3; evidence `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md`).
+A workspace created on a SECOND computer with the 14B active made leg 2 a real moved-drive `new-machine` run behind a 66 s model
+start — the review box's ~120 ms first run reproduced here first, and a FRESH workspace would not have helped either
+(`activeModelId` starts null, so nothing precedes the check). **Passed:** the moved-drive check observed window-open → completion
+(13.7 s), transitioning with no navigation; a foreground chat inside a benchmark span (both M1 halves — a chat never masquerades as
+a span nor hides one; the ~130–270 ms overlap is structural, `modelBusy` is re-checked inside the speed leg); a model load
+(120.3 MB/s) and a full file verification (85.5 s forced re-hash, 242 s cold `#382`/`#420` pass) each refreshing rows and tiles in
+place, matching what persisted. **Three defects filed:** under Narrator — against a positive control proving live regions DO work in
+the app's window — NEITHER live region is announced. **#436** is the serious one: `ErrorBanner`'s always-mounted `role="alert"` is
+defeated by the `Banner` nested inside it, whose `role="status"` is itself a live region mounted WITH its text (M-U1 one level
+down), affecting 11 screens + the gate's #145 wrong-password banner; a control fixed the remedy — inner `aria-live="off"` does NOT
+work, the inner role must go. **#437** the step region (inserted with content AND progress carried only by a CSS class +
+`aria-hidden` icon). **#438** an automatic run's step list never advances (progress is addressed to the invoking window; the screen
+renders the list for any held span, correct per M1). Lesson to keep: `role="status"` and `role="alert"` are both live regions —
+nesting one inside the other silences the outer. Docs: `benchmark.md`, `known-limitations.md` (Performance + Accessibility)._
 _2026-09-09 — **Knowledge packs get a public face (`docs/knowledge-packs.md` + README section; docs-only,
 `docs/knowledge-packs-readme-and-page`):** the feature shipped but the repo did not say so — one README bullet (#5 of 10,
 linking nowhere) and user-guide §7b, reachable only through "walkthrough of every screen". New canonical page
@@ -78,12 +94,6 @@ MODEL (nothing persisted, `runtime:notice` names it), a CPU rung starting persis
 follow view + task, a kept selection is marked, family-only reset; #314 `downloads:list`/`downloads:dismiss` re-attach a download after
 a renderer reload, dismissal lives in main memory; #315 findBy assertions, baseline staleness test, 17 dead keys deleted. Owner rulings
 taken on the plan defaults (PR body). Suite: master 421 files / 6,815 tests → 422 / 6,930 (85 skipped); typecheck + build green; the zim-packs T14 case flaked once under full load (green alone, untouched here). Residuals: §5 item 23._
-_2026-09-07 — **Save a code block from an answer (#286, `feat/286-save-code-block`):** every
-fenced code block in a persisted assistant answer gets its own Copy/Save toolbar; Save writes
-verbatim bytes (no BOM, via `saveBinaryExport`) — renderer-supplied content over the new
-`chat:saveCodeBlock` channel, mapped through a fixed extension allowlist, persisted turns only;
-audit records ids/bytes/extension only, never the text or path. Record: `security-model.md`
-"Code-block save boundary"; docs: user-guide §6, `data-contracts.md`, `design-guidelines.md`, `PRIVACY.md`, `CHANGELOG.md`._
 _2026-09-06 — **Follow-up wave on `feat/performance-screen` (#303), one commit per issue, ledger `tmp/followups-303-ledger.md`:**
 #325 closed `4293f95f` (GPU-off tile never falls back to a recorded card; Copy report carries the live pick; "Running on the graphics card right now." line — visual unverified);
 #323 closed `b0b26eec` (a completed chat-engine install re-runs the probe refresh when this machine's eligible probe is empty); #335 closed `6f1bcde1` (the harness records and removes every suite's temp root; ~2,500 leaked roots per run → 0); #322 closed — `speedIdentity` + the one-directional gate in `speedSignalFor` (a sample counts for a next start no faster than the measured path; §6.5 2026-09-06 amendment, owner-confirmed on review of the first draft)._
@@ -161,17 +171,6 @@ check in `maybeRunFirstBenchmark` restores a known machine's result or benchmark
 `benchmark:progress` streams the run's steps. Diagnostics keeps the raw table. Records:
 `docs/benchmark.md` "History per machine" / "Performance screen", data-contracts (settings
 storage + IPC). §5 item 22 tracks the residuals._
-_2026-09-05 — **Model library UX fix wave (PR #302, `feat/model-library-ux`), ready for merge
-(owner squash-merge; keep the branch):** searchable On this drive / Browse views, task/family
-filters and expandable quantization groups (`docs/design-guidelines.md` §15, user-guide §5/§6);
-F2 keeps a failed/unverified download's named result with Retry/Dismiss; F3 keeps repair-state
-models visible and auto-expands their groups; F5 fronts a tied group with an obtainable variant;
-a catalog guard plus F7 cleanup retire dead keys/CSS and add an unused-i18n-key guard. Rebuilt
-on master as UX-only: Flash-Next (`feat/qwen38-flash-next-manifest`) split out, contained here
-only, tracked as follow-ups #310/#311/#312 (shards, Flash-Next landing, GPU ladder) plus
-#313/#314 (family filter, renderer-reload recovery) and #315 (review residuals). Final head =
-the PR #302 tip (CI green on every phase); 379 / 5,784 passed, 74 skipped locally._
-
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -190,8 +189,10 @@ ledger `docs/architecture.md` §52), and the five 2026-09-04 Phase F entries (PR
 entries of the #290/#291 wave (PRs #295/#300/#297/#299) and Phase F PR 6 + close-out (#293, #292) on
 2026-09-05 at ZIM Phase 3a (preamble budget), and the ten ZIM knowledge-packs wave entries
 (Phases 0–6 + the 2026-09-04 MVP entry, PRs #304–#336) on 2026-09-06 at the P7 close-out (preamble
-budget), and the 2026-09-03 audit-2026-09-02 Phase 9b close-out entry (PR #282) on 2026-09-09
-(preamble budget, making room for the knowledge-packs docs entry) —
+budget), and the 2026-09-03 audit-2026-09-02 Phase 9b close-out entry (PR #282), the 2026-09-05
+Model library UX wave entry (PR #302) and the 2026-09-07 #286 save-a-code-block entry on 2026-09-09
+(preamble budget, making room for the knowledge-packs docs entry and the #331 HW3-acceptance
+entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1259,7 +1259,7 @@ guess.
 | TH2 | fixed P8 `4baec2be` | `closePerformanceFixture()` tears down every DB/root/observer the performance test helper registered; a leak check showed zero growth across a targeted run. The other suites' ~2,500 leaked roots per full run (#335, 2026-09-06) are now recorded and removed by the harness itself — `tests/setup-temp-roots.ts` per file, `tests/global-temp-roots.ts` after the forks exit; design in `tests/helpers/temp-roots.ts`, rule in CONTRIBUTING.md. | `tests/helpers/performance-fixture.ts`; `tests/unit/temp-roots.test.ts` |
 | HW1 | verified 2026-09-07 (issue #330) | Physical encrypted-drive A→B→A move on two real computers (i9-14900K / RTX 3080 Ti and i7-8700 / GTX 1070 Ti, one exFAT SSD) for a fresh workspace AND an upgraded one created by 0.1.57 (keyed `lastBenchmark`, no history): new-computer background run on B, instant restore on A, the outgoing result backfilled, later samples update the headline and the matching entry only. Side findings are not persistence defects (§4). | `eval/results/hardware/330-round-trip-20260907/` (`00-protocol.md` + every report and log) |
 | HW2 | CLOSED 2026-09-08 (#329) | Same gap as T9, closed by the same capture: real partial-offload load logs from the pinned build now exist (20/33 and 18/33 on a hybrid laptop, 62/66 on an RTX 3090) and are committed as fixtures. | `apps/desktop/tests/fixtures/placement-b9849-*.txt`; `eval/results/hardware/` |
-| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the blocked legs are follow-up issue #331 | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). Not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms): announcements with assistive technology, a first-run check observed while mounted, a foreground chat during a check, a model load or file verification finishing while mounted. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run" |
+| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the four blocked legs CLOSED 2026-09-09 (issue #331) | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). The four legs not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms) were performed 2026-09-09 on the E: stick with a moved-drive workspace and a real 14B: **chat-during-a-span and mounted-screen refresh PASSED; both live regions are SILENT under a screen reader (#436, #437) and an automatic run's step list never advances (#438)**. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run"; `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md` |
 | HW4 | follow-up issue #332 | Hybrid `[iGPU, dGPU]` Vulkan order and Apple Silicon unified memory: synthetic fixtures only. | — |
 | DR1 | fixed P5 `be177a34` | Chat/translation "on the card" rows now respect `gpuMode`, `gpuAutoDisabled` and the matching observed backend, not the hardware class alone. | `performance-gpu.test.ts` "gpuMode 'off': both rows say cpu, the verdict is the processor estimate against RAM, bothOnCard is false — the hardware class is untouched"; "a matching start OBSERVED on the CPU backend puts the chat row on the processor and judges it against RAM" |
 | DR2 | fixed P5 `be177a34` | `ModelPlacement.devices` keeps every GPU row of the `device_info` block; `attributedGpuFigures` matches by device name, never the first row's. | `placement-parser.test.ts` "keeps every GPU row of a hybrid device_info block with its own compute buffer, by label (DR2)"; `performance-gpu.test.ts` "a hybrid log: the figures are the selected dGPU's, by name — never the first row's" |
@@ -1384,18 +1384,44 @@ commit references, and added the changelog entry.
   `placement-parser.test.ts` and `placement-wiring.test.ts` read them. Still unwitnessed by any
   capture, so still handwritten from ggml's naming convention: CUDA and Metal devices, a
   `<Backend>_Host` **KV** buffer (M7), and two GPUs both holding weights (HW4 / #332).
-- **HW3** (performed at P10; the blocked legs are follow-up issue #331): the live,
-  CDP-driven review at `07dd9085` passed EN/DE layout at 880/1024/1280 px in both themes, the
-  German rail label at font weight 600, the keyboard focus order and Enter activation; the
-  focus loss it found is fixed (HW3-focus). Not exercised on the review box: announcements
-  with a real screen reader, a first-run check observed while the screen is mounted, a
-  foreground chat during a check, and a model load or file verification finishing while
-  mounted.
+- **HW3** — the P10 review passed EN/DE layout at 880/1024/1280 px in both themes, the German
+  rail label at font weight 600, the keyboard focus order and Enter activation; the focus loss it
+  found is fixed (HW3-focus). Its four unexercisable legs are **CLOSED 2026-09-09** (issue #331),
+  performed on the E: stick against a workspace created on a SECOND computer with the 14B active
+  — so the check really was a moved-drive `new-machine` run behind a 66 s model start, not the
+  ~120 ms first run the review box could never observe (reproduced here: a fresh workspace would
+  not have helped either, since `activeModelId` starts null and nothing precedes the check).
+  Evidence + protocol:
+  `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md`.
+
+  **Passed.** A moved-drive check observed from window-open through completion (13.7 s), the
+  screen moving from the outgoing computer's result to this one's with no navigation. A
+  foreground chat inside a benchmark span: both halves of M1 hold — a chat never masquerades as a
+  span (1,345 samples, `running` false) and never hides a real one (`streaming` and `running`
+  both true). The overlap is only ~130–270 ms, and that is STRUCTURAL, not a defect: `modelBusy`
+  is re-checked inside the speed leg, so a chat arriving during it ends the span. A model load
+  (120.3 MB/s, 9.0 GB) and a full file verification (85.5 s forced re-hash; 242 s for the whole
+  #382/#420 pass on a cold cache) each refreshed the observed rows and the drive tile in place,
+  matching what was persisted.
+
+  **Failed — three defects, filed separately.** Under Narrator, against a positive control that
+  proved live regions DO work in this window, **neither** live region on the screen is announced.
+  The progress steps are inserted already containing their content, and progress rides only on a
+  CSS class and an `aria-hidden` icon, so there is nothing to announce even once that is fixed
+  (#437). Worse, the FAILURE BANNER is silent too (#436): `ErrorBanner`'s always-mounted
+  `role="alert"` wrapper is defeated by the `Banner` nested inside it, whose `role="status"` is
+  itself a live region mounted WITH its text — M-U1 reintroduced one level down, on a component
+  11 screens and the workspace gate's #145 fix depend on. A control isolated the fix: an inner
+  `aria-live="off"` does NOT help; the inner role has to go. And an automatic run's step list
+  never advances, because progress is addressed to the window that pressed the button while the
+  screen renders the list for any held span (#438).
 - **HW3-focus**: the keyboard-focus-after-a-run fix (`PerformanceScreen.test.tsx` "PerformanceScreen:
   focus survives the run") is pinned in jsdom and was re-verified live at P11 in the dev app
   built from `ab01e14b`: with "Check again" focused, a real Enter press ran the check (the
   "Checked" time advanced) and the active element was the "Check again" button again once the
-  idle row returned — twice in a row. Announcements were still not audible-tested (#331).
+  idle row returned — twice in a row. Announcements were audible-tested separately on
+  2026-09-09 (HW3 above, issue #331): the focus behaviour is unaffected, but neither live region
+  on the screen is announced (#436, #437).
 - **HW4** (follow-up issue #332): a hybrid `[iGPU, dGPU]` Vulkan enumeration order and Apple
   Silicon `unified` memory. P5's device-pairing logic is exercised only by synthetic
   two-device fixtures.

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,11 +27,35 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
-## 2026-09-09 — the audit 2026-09-02 Phase 9b close-out entry retired verbatim (PR #282)
+## 2026-09-09 — three closed dated entries retired verbatim (preamble budget)
 
-_Retired from `BUILD_STATE.md` on 2026-09-09 for the preamble budget, making room for the
-knowledge-packs docs entry. The round it closes is long done; its durable ledger is
-`docs/architecture.md` §52._
+Moved out of `BUILD_STATE.md` on 2026-09-09 to keep the preamble inside its 200-line budget
+(`repo-hygiene.test.ts`): the 2026-09-02 audit round's Phase 9b close-out entry (PR #282), making
+room for the knowledge-packs docs entry; the Model library UX wave entry (PR #302), making room for
+the #331 HW3-acceptance entry; and — because those two waves landed in parallel and each had drained
+only its own line's worth — the #286 save-a-code-block entry, for the four lines the merged preamble
+was still over. All three waves are closed and carry their own durable records — the code-block save
+in `docs/security-model.md` "Code-block save boundary" and user-guide §6, the Model library UX wave
+in `docs/design-guidelines.md` §15 and the user guide, the 2026-09-02 audit round in
+`docs/architecture.md` §52.
+
+_2026-09-07 — **Save a code block from an answer (#286, `feat/286-save-code-block`):** every
+fenced code block in a persisted assistant answer gets its own Copy/Save toolbar; Save writes
+verbatim bytes (no BOM, via `saveBinaryExport`) — renderer-supplied content over the new
+`chat:saveCodeBlock` channel, mapped through a fixed extension allowlist, persisted turns only;
+audit records ids/bytes/extension only, never the text or path. Record: `security-model.md`
+"Code-block save boundary"; docs: user-guide §6, `data-contracts.md`, `design-guidelines.md`, `PRIVACY.md`, `CHANGELOG.md`._
+
+_2026-09-05 — **Model library UX fix wave (PR #302, `feat/model-library-ux`), ready for merge
+(owner squash-merge; keep the branch):** searchable On this drive / Browse views, task/family
+filters and expandable quantization groups (`docs/design-guidelines.md` §15, user-guide §5/§6);
+F2 keeps a failed/unverified download's named result with Retry/Dismiss; F3 keeps repair-state
+models visible and auto-expands their groups; F5 fronts a tied group with an obtainable variant;
+a catalog guard plus F7 cleanup retire dead keys/CSS and add an unused-i18n-key guard. Rebuilt
+on master as UX-only: Flash-Next (`feat/qwen38-flash-next-manifest`) split out, contained here
+only, tracked as follow-ups #310/#311/#312 (shards, Flash-Next landing, GPU ladder) plus
+#313/#314 (family filter, renderer-reload recovery) and #315 (review residuals). Final head =
+the PR #302 tip (CI green on every phase); 379 / 5,784 passed, 74 skipped locally._
 
 _2026-09-03 — **Audit 2026-09-02 Phase 9b — round close-out (PR #282): the durable ledger
 `docs/architecture.md` §52 (every finding ID → issue, disposition, PR and the facts as fixed; the 46

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2473,6 +2473,17 @@ All of these are decided scope, not oversights; the design record's §7 carries 
 - **The silent re-check has no Home-screen notice yet.** The moved-drive re-check above runs with
   no visible sign beyond Performance itself refreshing; a Home notice while it is pending is
   tracked in BUILD_STATE §5 item 22 (a).
+- **Nothing on this screen is announced to a screen reader** (verified by ear with Narrator on
+  2026-09-09, issue #331, against a positive control proving live regions do work in the app's
+  window). Two separate defects, neither fixed yet: the progress-step list is inserted already
+  containing its content AND carries progress only in a CSS class and an `aria-hidden` icon, so
+  a check is silent from start to finish (#437); and the failure banner is silent too (#436) —
+  which is NOT specific to this screen, see the entry below.
+- **An automatic check shows a step list that never advances.** A first-run or moved-drive check
+  is run by the main process, and progress steps are addressed only to the window that pressed
+  the button — but the screen renders the list whenever the backend span is held (correct per
+  audit M1). So a moved-drive check sits frozen on step 1 for its whole duration (measured:
+  13.7 s) and then disappears. A manual check does advance. Tracked as #438.
 - **Remaining hardware acceptance not yet performed:** the hybrid iGPU+dGPU device-order check
   and Apple Silicon unified-memory behaviour. Two items left this list: the two-computer round
   trip on an encrypted drive, including an upgraded workspace with no history yet, was verified
@@ -2552,7 +2563,22 @@ identifier), added forced-colors (Windows High Contrast) rules for the custom-dr
 controls (Switch, strength meter — #151 KL-3: the inventory is now THREE, the chat context
 meter `.context-meter-track/-fill` joined later and carries no forced-colors rule; accepted
 because its value is never color-only — the numeric label carries the meaning), and verified
-the reduced-motion kill-switch. Accepted as-is, with reasons:
+the reduced-motion kill-switch.
+
+**NOT accepted — an open defect, recorded here so it is not mistaken for one of the acceptances
+below.** Verified by ear with Narrator on 2026-09-09 (issue #331), against a positive control
+that proved live regions do work in the app's own Electron window: **`ErrorBanner`'s message is
+never announced** (#436). The component exists to implement audit finding M-U1 — an always-mounted
+`role="alert" aria-live="assertive"` container whose text swaps inside it — but the `Banner`
+nested within it carries `role="status"`, which is itself a live region (implicit
+`aria-live="polite"`) and IS mounted with its text. The nearest live-region ancestor governs, so
+M-U1's anti-pattern is reintroduced one level down. This is the shared failure surface for **11
+screens**, and for `WorkspaceGate`'s wrong-password banner — the SH-2 / #145 fix — so a failed
+unlock is silent too. A control isolated the remedy: `aria-live="off"` on the inner element does
+NOT help; the inner live-region role has to go. The lesson generalises — **`role="status"` and
+`role="alert"` are both live regions, so nesting one inside the other silences the outer one.**
+
+Accepted as-is, with reasons:
 
 - **Hairline `--border` separators are ~1.3:1.** They are decorative row/card separators,
   never the sole identifier of a component (cards pair them with surface fill + shadow;

--- a/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md
+++ b/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md
@@ -1,0 +1,170 @@
+# #331 — the four blocked HW3 acceptance legs: performed 2026-09-09
+
+Closes the legs PR #303's HW3 review could not exercise on the reviewing machine
+(`docs/benchmark.md` "Audit remediation record — PR #303" §2 row HW3, §4 "Not verified here").
+This is a VERIFICATION record: the deliverable is evidence plus separately-filed defects
+(#436, #437, #438), not a fix.
+
+Machine: DESKTOPDIT — i7-8700 (6c/12t), GTX 1070 Ti 8 GB, 31.9 GB RAM, Windows 11 Pro 26200.
+Drive:   E: lite test stick (SSK USB 3.2), runtime b9849, chat weights 4B / 9B / 14B.
+App:     dev build at master `4f3c1f78` + this branch, launched with
+         `HILBERTRAUM_DRIVE_ROOT=E:\`, `HILBERTRAUM_MANIFESTS_DIR=E:\model-manifests`,
+         `HILBERTRAUM_PERF_LOG=1`, `REMOTE_DEBUGGING_PORT=9222`, `ELECTRON_RUN_AS_NODE` cleared.
+         Renderer driven over CDP; DOM sampled every 25 ms and recorded on change.
+UI language: German (the machine's locale) — labels below are quoted as they appeared.
+Raw logs stay on the drive (`E:\logs\perf.log`) and are not committed.
+
+Workspace **A** was created on a SECOND computer (Surface, i7-1185G7 / Iris Xe, 15.8 GB) with
+`qwen3-14b-instruct-q4` set active, then carried here — so unlocking it on this machine is a
+genuine moved-drive `new-machine` decision, confirmed in the log:
+`Drive is on a new computer: benchmarking it in the background once the model start settles`.
+
+## Why the reviewing machine could not do these — reproduced first
+
+Control run on this box against a scratch drive root with no runtime binary: the automatic
+first-run check took **106 ms** (`First run: …` → `Benchmark complete`) and a manual check
+**under 87 ms**; `ul.perf-steps` never appeared in a 25 ms sample at all. That is PR #303's
+blocker ("a first run that finishes in ~120 ms") reproduced exactly, and it is why a fresh
+workspace on this drive would NOT have unblocked leg 2 either — a fresh workspace has
+`activeModelId: null`, so no model start precedes the check and there is no speed leg.
+What makes the legs possible is the stick plus a real runtime: an in-run `probeAndPersistGpu`
+`--list-devices` subprocess, a USB drive probe, a 14B speed leg, and a 66 s model start.
+
+---
+
+## Leg 1 — assistive technology  ✗ BOTH REGIONS SILENT (#436, #437)
+
+Narrator (Windows built-in), app window in the foreground, owner listening. Every result below
+was taken with the app genuinely in front — an earlier pass where focus sat in the terminal was
+discarded, because Narrator announces focus changes more broadly than live-region updates and
+that difference would have produced a false negative.
+
+**Positive control, in the app's own window.** Three injected textbook live regions — two
+`role="alert" aria-live="assertive"`, one `role="status" aria-live="polite"`, each mounted EMPTY
+and filled later — were **all three announced**. Live regions therefore work in this Electron
+window under Narrator, and the silences below belong to the app.
+
+**1b — progress steps: SILENT.** Two runs, step list on screen for **14.2 s** and **14.4 s**.
+Narrator announced the button's own name on focus ("Erneut prüfen") and then said nothing for
+the entire check. Two causes, both real, both needed for a fix → **#437**:
+  1. `<ul className="perf-steps" aria-live="polite">` is built inside `steps()`, which is only
+     called from the `busy` branch — the region is INSERTED already containing its three `<li>`s
+     (the M-U1 anti-pattern). `perf-steps` is the only live region in the renderer that does this.
+  2. Even always-mounted there would be nothing to announce as it advances: the `<li>` text is
+     constant for the whole run and progress rides only on the `perf-step-{state}` class and on
+     `StepIcon`, which is `aria-hidden="true"`.
+
+**1a — failure banner: ALSO SILENT.** This was the half predicted to PASS, and it does not.
+A genuine refusal was produced with nothing broken: with a chat streaming, "Erneut prüfen" is
+refused (`BenchmarkBusyError`, `lane: 'chat'`); the text lands in the region 35 ms after the
+click and Narrator says nothing. Cause, isolated by control → **#436**:
+
+`ErrorBanner`'s always-mounted `role="alert" aria-live="assertive"` wrapper is defeated by the
+`Banner` nested inside it, which carries `role="status"` — itself a live region (implicit
+`aria-live="polite"`) — and is mounted WITH its text. The nearest live-region ancestor governs,
+so the announcement is governed by an inserted-with-content polite region: M-U1 reintroduced one
+level down. Three variants inside an identical always-mounted alert wrapper:
+
+| variant | inserted child                     | Narrator      |
+|---------|------------------------------------|---------------|
+| A       | `role="status"` (what ships today) | **silent**    |
+| B       | `role="status" aria-live="off"`    | **silent**    |
+| C       | no role at all                     | **announced** |
+
+So the fix is variant C — the role has to go on that path; `aria-live="off"` does not rescue it.
+Blast radius is the shared component: 11 screens, plus `WorkspaceGate`'s wrong-password banner,
+which is the SH-2 / #145 fix.
+
+Note on scope: two `.error-banner-region` elements are mounted on this screen — a global one in
+`.app-shell` and the Performance screen's own inside its `.card`. Both were always present and
+empty; the screen's is the one that filled. Not a defect, recorded because a naive
+`querySelector('.error-banner-region')` reads the wrong one.
+
+## Leg 2 — a moved-drive check observed live  ✓ TRANSITION / ✗ STEPS (#438)
+
+Unlock → Performance immediately → stayed there. Timeline (offsets from process start):
+
+```
++   619 ms  unlock clicked        +   708 ms  app shell up (89 ms later)
+             Home: "Arbeitsbereich Wird geprüft…"  (the moved-drive 'measuring' notice)
++  1744 ms  screen still shows the SURFACE's result: "15,8 GB RAM · i7-1185G7"
++  2361 ms  GPU probe lands: placement memoryClass cpu → discrete, 8273 MB, GTX 1070 Ti
++ 77102 ms  model load done — observed row updates IN PLACE (120.3 MB/s, 9.0 GB, 74 844 ms)
++ 79727 ms  step list APPEARS, already [active, todo, todo]
++ 93464 ms  check finishes (13.7 s) — tiles now "31,9 GB RAM · i7-8700 · GTX 1070 Ti"
++ 93514 ms  step list gone
+```
+
+**Passed:** the check was fully observable (13.7 s), the screen moved from the outgoing
+computer's result to this one's with **no navigation**, and `ipcRunning` was true for the span.
+
+**Failed:** the step list never advanced — one single state for the whole 13.7 s, sampled at
+25 ms. Cause: progress events are addressed to the window that invoked `benchmark:run`
+(`registerBenchmarkIpc.ts:1266-1272`) and the automatic scheduler passes no callback
+(`:819`), while the screen renders the list whenever the backend span is held (correct per
+audit M1). A manual check DOES advance — recorded as the contrast case. → **#438**
+
+## Leg 3 — a foreground chat during a benchmark span  ✓ PASSED
+
+Only one direction is legal: `modelBusyLane` returns `'chat'` first, so a benchmark refuses to
+start on top of a live stream; a chat is not gated by the benchmark span. So: check first, chat
+inside it. Two runs. Both halves of audit **M1** confirmed:
+
+- **A chat does not masquerade as a span.** ~86 s / 1345 samples of a live stream with no check
+  running: `running` false throughout.
+- **A chat does not hide a real span.** `streaming` and `running` both true, in both runs.
+
+The overlap is short — 273 ms (run 1) and 126 ms (run 2) — and that is **structural, not a
+defect**: `modelBusy` is re-checked inside the speed leg, so a chat arriving during it causes the
+leg to be abandoned and the span legitimately ends. A long overlap is unreachable by design in
+this direction. The chat answered normally in both runs (595 and 1347 characters).
+
+## Leg 4 — a load / verification finishing while mounted  ✓ PASSED (both halves)
+
+**4a — model load.** From leg 2 above: the 14B's start finished while Performance was mounted;
+`lastModelLoad` (120.3 MB/s, 9 001 752 960 bytes, 74 844 ms) appeared in the observed rows and in
+the drive tile with no navigation.
+
+**4b — full file verification.** Run twice, because the first attempt exposed a trap:
+
+- On workspace A, "Alle Modelldateien prüfen" **read nothing and returned instantly** — no
+  progress, no Stop button, no log line, no sample. The workspace's `checksumCache` lives in its
+  own settings (`models.ts` HashStore over `AppSettings.checksumCache`) and had travelled inside
+  the workspace from the Surface, where every file had just been hashed. Every file was a cache
+  hit. Not a defect; recorded because on a drive whose files were already verified this button
+  is a silent no-op with no visible confirmation.
+- The per-model "Prüfsumme prüfen" invalidates every file the manifest carries before re-hashing
+  ("the forced re-hash is a real full-file read", `registerModelIpc.ts`). On the 14B: **85.5 s,
+  105.3 MB/s, 9.0 GB**, landing in the observed rows while Performance stayed mounted.
+- Then, on a workspace created fresh here (COLD cache), the named `#382`/`#420` action itself:
+  the pass really ran (the "Prüfung abbrechen" Stop button was present 1.5 s in), the first
+  checksum sample landed **27.2 s** after the start while Performance was mounted with no
+  navigation, and the drive tile changed in place from "Ausstehend" to
+  "Langsam 71,5 MB/s lesen · Aus einer Dateiprüfung". Full pass: **242 s**.
+
+Displayed values matched what was persisted: all three observed rows equalled the
+`performance:get` snapshot exactly. The drive tile kept the model-load sample (120.3 MB/s) over
+the checksum one (105.3 MB/s) — correct per the documented source ranking, not a defect.
+
+---
+
+## Acceptance boxes (issue #331)
+
+- [x] 1 — assistive-technology pass. Performed with Narrator against a positive control.
+      **Both** regions silent → #437 (steps) and #436 (banner, the more serious).
+- [x] 2 — a moved-drive check observed live from window-open through completion (13.7 s).
+      Transition passed; the steps do not advance → #438.
+- [x] 3 — a foreground chat answer generated while a benchmark span is running; `running`
+      unaffected, both directions of M1 confirmed.
+- [x] 4 — a model start and a full file verification each observed finishing while Performance
+      was the active screen; rows and tiles refreshed in place and matched what was persisted.
+- [x] 5 — every defect filed separately with its own reproduction: **#436**, **#437**, **#438**.
+
+## Drive housekeeping
+
+The owner's workspaces were set aside for the session and `F` was restored in place at the end
+(`E:\_334\swap.cmd`). Workspace `A` (the moved-drive one, created on the Surface) and `P` (the
+cold-cache one created here) are left set aside beside the existing `U` / `W1`, the same way the
+#330 and #334 sessions left theirs. Every session was quit normally; `vault_lock_done` is in
+`E:\logs\perf.log` for the A session and both encrypted DBs were written at quit with no
+`-wal`/`-shm` sidecars left behind.


### PR DESCRIPTION
Closes #331.

The four PR #303 HW3 acceptance legs that could not be exercised on the reviewing machine, now
performed on real hardware. **Verification round: evidence plus separately-filed defects, no
behaviour change.** Docs + one evidence file only.

## What made leg 2 possible

The reviewing machine's blocker was a first-run check that finished in ~120 ms. I reproduced that
here first (106 ms on a scratch drive root with no runtime) — which also showed that a *fresh*
workspace on the stick would not have helped either, since `activeModelId` starts null so no
model start precedes the check and there is no speed leg.

So the workspace was created on a **second computer** (Surface, i7-1185G7) with the 14B set
active and carried over. Unlocking it here is therefore a genuine moved-drive `new-machine`
decision — confirmed in the log — with the check held behind a 66 s model start.

## Passed

- **Leg 2** — moved-drive check observed window-open → completion (**13.7 s**), the screen moving
  from the outgoing computer's result to this one's with no navigation.
- **Leg 3** — a foreground chat inside a benchmark span. Both halves of audit **M1** hold: a chat
  never masquerades as a span (1,345 samples, `running` false) and never hides a real one. The
  overlap is only ~130–270 ms and that is **structural, not a defect** — `modelBusy` is re-checked
  inside the speed leg, so a chat arriving during it ends the span.
- **Leg 4** — a model load (120.3 MB/s, 9.0 GB) and a full file verification (85.5 s forced
  re-hash; **242 s** for the whole #382/#420 pass on a cold cache) each finishing while
  Performance was mounted, refreshing rows and tiles in place and matching what was persisted.

## Failed — three defects, filed separately (acceptance box 5)

Verified **by ear** with Narrator, app window foregrounded, against a positive control that
proved live regions *do* work in this Electron window. **Neither** live region on the screen is
announced.

- **#436 — the serious one.** `ErrorBanner`'s always-mounted `role="alert"` wrapper is defeated by
  the `Banner` nested inside it, whose `role="status"` is itself a live region mounted **with** its
  text — M-U1 reintroduced one level down. This is the shared failure surface for **11 screens**
  and for `WorkspaceGate`'s wrong-password banner (the SH-2 / #145 fix), so a failed unlock is
  silent too. A control isolated the remedy: inner `aria-live="off"` does **not** work; the inner
  role has to go.
- **#437** — the progress-step region is inserted already containing its content, *and* progress
  rides only on a CSS class and an `aria-hidden` icon, so there is nothing to announce even once
  the mounting is fixed. Both causes need fixing.
- **#438** — an automatic run's step list never advances: progress is addressed to the window that
  pressed the button, while the screen renders the list for any held span (correct per M1). A
  manual check does advance — captured as the contrast case.

## Also worth knowing (not filed)

"Alle Modelldateien prüfen" **read nothing and returned instantly** on the moved-drive workspace:
`checksumCache` lives in the workspace's own settings and had travelled inside it from the
Surface, so every file was a cache hit. Confirmed by contrast on a cold-cache workspace, where
the same button really runs. Not a defect, but on a drive whose files were already verified the
button is a silent no-op with no visible confirmation — the owner may want to decide whether that
deserves its own issue.

## Housekeeping

- BUILD_STATE's preamble was at **exactly** its 200-line budget, so two closed dated entries (the
  Model library UX wave PR #302; the 2026-09-02 audit round's Phase 9b close-out PR #282) were
  retired verbatim to `docs/build-log.md` per the retention rule. Sections now 195/200 and
  500/500.
- The drive was left as found: the owner's `F` workspace restored in place, every session quit
  normally, no `-wal`/`-shm` sidecars, no raw logs committed.

Suite **423 files / 7,119 tests** green; typecheck + build green.
