### PR TITLE
docs(knowledge-packs): give the ZIM feature a public page and a README section

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,15 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-09 — **Knowledge packs get a public face (`docs/knowledge-packs.md` + README section; docs-only,
+`docs/knowledge-packs-readme-and-page`):** the feature shipped but the repo did not say so — one README bullet (#5 of 10,
+linking nowhere) and user-guide §7b, reachable only through "walkthrough of every screen". New canonical page
+`docs/knowledge-packs.md` (§1 why, §2 choosing packs + sizing a drive, §3 the tools, §4 adding, §5 asking, §6 privacy —
+R-9 and the network-inventory sentence VERBATIM, §7 the measured edges as a table, §8 maintainer pointers), plus a README
+"Knowledge packs — an offline Wikipedia" section, ToC row, Documentation-table row, the hero line, and the bullet rewritten
+to link it. No code, no behaviour change. The rest of the GitHub-presence review is owner-side and tracked nowhere else:
+repo About text + `zim`/`kiwix`/`wikipedia`/`offline` topics, a v0.1.60 release (the packs entries sit in CHANGELOG
+`[Unreleased]`; v0.1.59 predates the wave), a first screenshot, a pack-problem issue template, the org profile README._
 _2026-09-09 — **#333 CLOSED — measured, no cache** (instrumented on `perf/333-manifest-read-instrumentation`, PR #431; record
 `benchmark.md` §4 **I5** + Perf marks "`discover_manifests` / `performance_get` — the #333 pair"; evidence
 `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-333-measurement.txt`): on the drive, cold (eject/replug ×3:
@@ -163,18 +172,6 @@ only, tracked as follow-ups #310/#311/#312 (shards, Flash-Next landing, GPU ladd
 #313/#314 (family filter, renderer-reload recovery) and #315 (review residuals). Final head =
 the PR #302 tip (CI green on every phase); 379 / 5,784 passed, 74 skipped locally._
 
-_2026-09-03 — **Audit 2026-09-02 Phase 9b — round close-out (PR #282): the durable ledger
-`docs/architecture.md` §52 (every finding ID → issue, disposition, PR and the facts as fixed; the 46
-non-findings; containment items 1–8; the 14 decisions on their defaults; B1..B9 ports; a §-anchor
-legend for the deleted working papers); §5 item 19 → ROUND COMPLETE with the open residuals; the
-round's eleven dated entries archived verbatim to `docs/build-log.md`; containment items 4 and 7
-promoted verbatim to `known-limitations.md` (decisions #221/#222/#226 still unanswered); the three
-Phase 0 doc lines that still carried audit IDs now cite issues; decision issues #218–#231 and
-#262/#263/#264 closed "default stands — re-open on request" / "accepted — §52"; #217 closed after the
-merge; the five `tmp/` working papers deleted after the merge.**_ Open Phase F: #236, #240, #243, #247,
-#248, #250, #274 (each self-sufficient — its plan detail was copied to the issue). Docs-only, no launch
-smoke. Suite: 371 / 5,570 / 74 excluding the Electron smoke (raw 372 / 5,576 / 74; the smoke ran).
-
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -193,7 +190,8 @@ ledger `docs/architecture.md` §52), and the five 2026-09-04 Phase F entries (PR
 entries of the #290/#291 wave (PRs #295/#300/#297/#299) and Phase F PR 6 + close-out (#293, #292) on
 2026-09-05 at ZIM Phase 3a (preamble budget), and the ten ZIM knowledge-packs wave entries
 (Phases 0–6 + the 2026-09-04 MVP entry, PRs #304–#336) on 2026-09-06 at the P7 close-out (preamble
-budget) —
+budget), and the 2026-09-03 audit-2026-09-02 Phase 9b close-out entry (PR #282) on 2026-09-09
+(preamble budget, making room for the knowledge-packs docs entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Your private AI workspace, fully offline
 
-> Chat with a local AI, ask questions about your private documents, and keep everything on your own computer.
+> Chat with a local AI, ask questions about your private documents and an offline Wikipedia, and keep everything on your own computer.
 
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](LICENSE)
 [![Platform: Windows · macOS · Linux](https://img.shields.io/badge/Platform-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux-informational.svg)](#what-you-need)
@@ -36,10 +36,11 @@
   answers grounded in your files. Retrieval combines vector and keyword search with a reranker
   and can be scoped to your library, a project, a section, specific documents, or the files
   attached to a chat.
-- 📚 **Knowledge packs (optional).** Register ZIM archives — such as an offline Wikipedia — as
-  per-chat sources searched alongside your documents. Needs the kiwix-tools binaries (GPL-3.0-or-later)
-  on the drive — the app offers to install them in-app with your consent, the first time you need
-  them, or you can place them yourself.
+- 📚 **Knowledge packs — an offline Wikipedia (optional).** Register ZIM archives — Wikipedia in ~100 languages,
+  Wiktionary, Wikivoyage — as per-chat sources searched and cited alongside your documents, with
+  the article readable offline in the app. Needs the kiwix-tools binaries (GPL-3.0-or-later) on
+  the drive — the app offers to install them with your consent, the first time you need them, or
+  you can place them yourself. See [Knowledge packs](#knowledge-packs--an-offline-wikipedia).
 - 🖼️ **Image understanding.** Ask questions about a picture with a local vision model. The analysis
   history is encrypted at rest and can be deleted.
 - 🎙️ **Audio and voice.** Transcribe audio files with Whisper, dictate prompts, and OCR scanned pages.
@@ -64,6 +65,7 @@
 - [What you need](#what-you-need)
 - [Getting started (DIY / from source)](#getting-started-diy--from-source)
 - [Supported models](#supported-models)
+- [Knowledge packs — an offline Wikipedia](#knowledge-packs--an-offline-wikipedia)
 - [Two distribution paths](#two-distribution-paths)
 - [Documentation](#documentation)
 - [For developers](#for-developers)
@@ -292,6 +294,43 @@ Document Q&A needs the embeddings model; chat needs one of the chat models. Bigg
 models are smarter but slower on CPU, so pick by your RAM. Benchmark methodology and measured
 numbers are in [`docs/model-benchmarks.md`](docs/model-benchmarks.md).
 
+## Knowledge packs — an offline Wikipedia
+
+HilbertRaum can answer from **ZIM archives**: compressed, self-contained offline copies of
+reference sites. The [Kiwix](https://kiwix.org) project publishes thousands at
+[`library.kiwix.org`](https://library.kiwix.org) — Wikipedia in about a hundred languages, plus
+Wiktionary, Wikivoyage, Stack Exchange, Project Gutenberg. Download one once, and the model can
+search and cite it forever, with no network.
+
+A pack is a **source**, not a bigger model: the app searches the archive, hands the model the
+passages it found, and the answer cites the articles it used — and *Open article* shows the
+article text, offline, in the app. Packs are per chat and off by default (up to 12 in one chat),
+and unticking **Search my documents** answers from the packs alone.
+
+1. **Get the tools once.** `kiwix-serve` and `kiwix-manage` are not bundled (GPL-3.0-or-later).
+   The **Knowledge packs** panel offers to install them — size, license and source stated, your
+   consent required, SHA-256 verified — or provision them yourself against the drive with
+   `scripts/fetch-runtime.sh --target <drive> --family kiwix_tools`
+   (`.\scripts\fetch-runtime.ps1 -Target E:\ -Family kiwix_tools` on Windows).
+2. **Add packs.** Copy `.zim` files into the drive's `zim/` folder, or use *Documents →
+   Knowledge packs → Add packs…*. Files are used in place; nothing is copied.
+3. **Ask.** Open a documents chat's sources picker ("Answering from…") and tick the packs.
+
+**Sizing a drive:** a `nopic` Simple English Wikipedia is a few hundred megabytes, a language
+Wikipedia without images a few to some tens of gigabytes, full English with images roughly a
+hundred. The library lists every file's exact size, and the `nopic` / `mini` variants are
+usually the right trade for a portable drive. Take a single-file `.zim` (multipart `.zimaa`
+sets are not read) and prefer a build with a full-text index.
+
+Asking never leaves your machine: the pack server binds to loopback only. One limit belongs in
+plain sight: While the workspace is unlocked and a knowledge pack has been used in a chat, other
+programs running under your own user account on this computer can read the enabled packs through
+the pack server, which has no password of its own; locking or quitting stops it.
+
+Full detail — choosing packs, the setup paths, the privacy posture and every measured limit —
+is in [`docs/knowledge-packs.md`](docs/knowledge-packs.md); the step-by-step walkthrough is
+[user guide §7b](docs/user-guide.md#7b-knowledge-packs--ask-an-offline-wikipedia).
+
 ## Two distribution paths
 
 - **Open-source DIY toolkit.** Clone this repo, prepare your own drive, and download supported
@@ -308,6 +347,7 @@ numbers are in [`docs/model-benchmarks.md`](docs/model-benchmarks.md).
 |---|---|
 | [`docs/product-vision.md`](docs/product-vision.md) | Product intent: thesis, target user, commercial model, positioning guardrails, scope, roadmap |
 | [`docs/user-guide.md`](docs/user-guide.md) | End-user walkthrough of every screen and feature |
+| [`docs/knowledge-packs.md`](docs/knowledge-packs.md) | Knowledge packs (ZIM / offline Wikipedia): choosing packs, setup, asking, privacy posture, the measured limits |
 | [`docs/architecture.md`](docs/architecture.md) | System design, services, IPC, runtimes, design records |
 | [`docs/rag-design.md`](docs/rag-design.md) | Retrieval pipeline: ingestion, chunking, hybrid search, rerank |
 | [`docs/security-model.md`](docs/security-model.md) | Threat model, encrypted vault, offline guard, audit log |

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,24 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-09 — the audit 2026-09-02 Phase 9b close-out entry retired verbatim (PR #282)
+
+_Retired from `BUILD_STATE.md` on 2026-09-09 for the preamble budget, making room for the
+knowledge-packs docs entry. The round it closes is long done; its durable ledger is
+`docs/architecture.md` §52._
+
+_2026-09-03 — **Audit 2026-09-02 Phase 9b — round close-out (PR #282): the durable ledger
+`docs/architecture.md` §52 (every finding ID → issue, disposition, PR and the facts as fixed; the 46
+non-findings; containment items 1–8; the 14 decisions on their defaults; B1..B9 ports; a §-anchor
+legend for the deleted working papers); §5 item 19 → ROUND COMPLETE with the open residuals; the
+round's eleven dated entries archived verbatim to `docs/build-log.md`; containment items 4 and 7
+promoted verbatim to `known-limitations.md` (decisions #221/#222/#226 still unanswered); the three
+Phase 0 doc lines that still carried audit IDs now cite issues; decision issues #218–#231 and
+#262/#263/#264 closed "default stands — re-open on request" / "accepted — §52"; #217 closed after the
+merge; the five `tmp/` working papers deleted after the merge.**_ Open Phase F: #236, #240, #243, #247,
+#248, #250, #274 (each self-sufficient — its plan detail was copied to the issue). Docs-only, no launch
+smoke. Suite: 371 / 5,570 / 74 excluding the Electron smoke (raw 372 / 5,576 / 74; the smoke ran).
+
 ## 2026-09-08 — the three closed ZIM knowledge-pack wave entries retired verbatim (#301 / #339 / #340)
 
 Retired from the BUILD_STATE preamble when the #339 Range-first read (D-Z22) landed: all three waves are

--- a/docs/knowledge-packs.md
+++ b/docs/knowledge-packs.md
@@ -1,0 +1,172 @@
+# Knowledge packs — an offline Wikipedia inside HilbertRaum
+
+HilbertRaum can answer from **ZIM archives**: compressed, self-contained offline copies of
+reference sites. The [Kiwix](https://kiwix.org) project publishes thousands of them —
+Wikipedia in about a hundred languages, plus Wiktionary, Wikivoyage, Stack Exchange,
+Project Gutenberg and more — at [`library.kiwix.org`](https://library.kiwix.org). Download
+one once, and the model can search and cite it forever, with no network.
+
+A pack behaves like a source, not like a bigger model: the app searches the archive, hands the
+model the passages it found, and the answer cites the articles it used. You can open any cited
+article and read it, offline, in the app.
+
+> **One sentence for the impatient:** put a `.zim` file in the drive's `zim/` folder, tick it
+> under *Knowledge packs* in a chat's sources picker, and ask.
+
+**Audience.** §1–§5 are for anyone using the app; §6 is the privacy and security posture;
+§7 collects the edges worth knowing before you plan a drive; §8 points maintainers at the
+design records. The step-by-step walkthrough with screenshots-in-words lives in the
+[user guide](user-guide.md#7b-knowledge-packs--ask-an-offline-wikipedia) — this page is the
+overview you can link to from outside the repo.
+
+## Table of contents
+
+- [§1 Why an offline encyclopedia](#1-why-an-offline-encyclopedia)
+- [§2 Getting packs](#2-getting-packs)
+- [§3 One-time setup: the kiwix-tools](#3-one-time-setup-the-kiwix-tools)
+- [§4 Adding packs](#4-adding-packs)
+- [§5 Asking](#5-asking)
+- [§6 Privacy and security](#6-privacy-and-security)
+- [§7 Edges worth knowing](#7-edges-worth-knowing)
+- [§8 For maintainers](#8-for-maintainers)
+
+## 1. Why an offline encyclopedia
+
+A local model knows a lot and remembers it imperfectly. Documents you import are yours, but
+they only cover what you happen to have. A knowledge pack closes the gap in the direction the
+rest of HilbertRaum already points: general knowledge that is **on your drive**, searched
+**on your machine**, quoted **with a citation you can open**. Nothing about it needs the
+internet after the download, which makes it the piece that turns a laptop with no connection —
+a field site, a flight, an air-gapped room, a place where the network is not trustworthy —
+into a workspace that can still answer a general question and show its source.
+
+It is also the honest answer to a local model's weakest habit. An answer built from a pack's
+passages is grounded in text you can read, so a claim it makes is checkable in one click
+instead of taken on faith.
+
+## 2. Getting packs
+
+Browse [`library.kiwix.org`](https://library.kiwix.org), pick a file, download it, and put it
+on the drive. Nothing else registers it with anyone; the file is the whole product.
+
+Sizes vary enormously, and this is the number to plan a drive around: a "no pictures" Simple
+English Wikipedia is a few hundred megabytes, a full-text language Wikipedia without images is
+a few to some tens of gigabytes, and full English Wikipedia with images runs to roughly a
+hundred. The library lists the exact size of every file, and the Wikipedia titles come in `nopic`
+(no images) and `mini` (lead sections only) variants — for a portable drive those are usually
+the right trade.
+
+Two things to check while you pick:
+
+- **Take a single-file `.zim`.** Multipart archives (`.zimaa`, `.zimab`, …) are not read by
+  this app.
+- **Prefer a build with a full-text index.** Most library files have one. A pack without one
+  can still be read article by article, but the app cannot search it, and it will show a
+  **No full-text index** badge and stay unavailable in the sources picker.
+
+## 3. One-time setup: the kiwix-tools
+
+Packs are served by two small programs from the Kiwix project, `kiwix-serve` and `kiwix-manage`.
+They are **not** bundled: they are GPL-3.0-or-later, and shipping them carries obligations the
+app takes seriously (see the licensing section of the [README](../README.md#license)).
+
+The first time you need them, the **Knowledge packs** panel offers to install them — a dialog
+states the download size, the license and the source (`download.kiwix.org`), and asks you to
+accept the license before it fetches and SHA-256-verifies the pinned kiwix-tools 3.8.1 build
+for your platform. A mirror of that offer sits on the **AI Model** screen. The install needs
+**Settings → Allow internet access for model downloads and updates** to be on (it is on by
+default) and a drive policy that permits downloads.
+
+From the repository you can provision them up front instead, without the app:
+
+```powershell
+# Windows
+.\scripts\fetch-runtime.ps1 -Target E:\ -Family kiwix_tools
+```
+```bash
+# macOS / Linux
+scripts/fetch-runtime.sh --target /Volumes/HILBERTRAUM --family kiwix_tools
+```
+
+Both paths write an install marker that hashes every file, so the binaries are verified before
+every spawn. Unzipping the release under `runtime/kiwix-tools/<os>/` by hand still works as a
+last resort, but leaves no marker and no integrity check. If the panel says the tools are
+missing, [`troubleshooting.md`](troubleshooting.md#the-panel-says-kiwix-tools-are-missing) has
+the full recovery path.
+
+## 4. Adding packs
+
+- **The simple way:** copy `.zim` files into the drive's `zim/` folder. They are found when you
+  unlock, and on **Refresh** under *Documents → Knowledge packs*.
+- **From anywhere else:** *Documents → Knowledge packs → Add packs…*.
+
+Files are **used in place** — nothing is copied, nothing is re-encoded, and a pack is never
+written to. Removing a pack's registration forgets it; the file itself is never deleted.
+
+On Windows, add packs from a path made of ASCII characters only: the pinned `kiwix-manage`
+refuses a file whose folder or name contains an umlaut or an accent. The drive's own `zim/`
+folder always works. See [§7](#7-edges-worth-knowing).
+
+## 5. Asking
+
+Packs are **per chat and off by default**. In a documents chat, open the sources picker
+("Answering from…") and tick the packs you want under *Knowledge packs*; up to 12 in one chat.
+
+- **Answer from packs alone** by unticking **Search my documents** at the top of the picker.
+  Files you attached directly to that chat are still used either way.
+- **Read the source:** answers cite pack articles the way they cite documents, and *Open
+  article* shows the article text offline — including from an evidence review's archive row.
+- **See what each pack did:** a "Knowledge packs:" line under the answer names every ticked
+  pack — searched (and how much it contributed), or not searched, with a short reason.
+- **A pack you cannot tick always says why** — file missing, a different archive at that
+  location, disabled, or no full-text index.
+
+Whole-document reads and document comparisons never consult knowledge packs; the answer says
+so. Packs are a retrieval source, not a second brain bolted onto every feature.
+
+## 6. Privacy and security
+
+Everything stays on this computer. The pack server binds to `127.0.0.1` only, asking never
+leaves the machine, and registering a pack tells nobody anything. The app's whole network
+footprint is unchanged by this feature except for the tools download itself: The only things
+the app ever downloads are AI models, the AI engine and the optional knowledge-pack tools —
+each one only after you confirm it, each one verified before use.
+
+One limit belongs in plain sight rather than in a footnote, because it is the single place
+where knowledge packs are weaker than the rest of the workspace: While the workspace is
+unlocked and a knowledge pack has been used in a chat, other programs running under your own
+user account on this computer can read the enabled packs through the pack server, which has no
+password of its own; locking or quitting stops it.
+
+That is accepted residual **R-9**. The reasoning — why `kiwix-serve` is the one sidecar without
+the per-spawn key every other one carries, and what contains it — is recorded in
+[`security-model.md`](security-model.md) under "kiwix-serve — the one unauthenticated sidecar",
+and mirrored in [`PRIVACY.md`](../PRIVACY.md) and
+[`known-limitations.md`](known-limitations.md).
+
+## 7. Edges worth knowing
+
+Every one of these is a measured, recorded limit rather than a rough edge we have not looked
+at; [`known-limitations.md`](known-limitations.md) carries the full entry for each.
+
+| Edge | What it means for you |
+|---|---|
+| **Multipart archives (R-2)** | A `.zim` split into `.zimaa`/`.zimab`/… parts is not read. Take the single-file build. |
+| **Windows, non-ASCII paths** | The pinned `kiwix-manage` refuses a path containing an umlaut or accent. Keep packs in the drive's `zim/` folder. Serving is unaffected once registered. |
+| **Windows, large articles** | The pinned `kiwix-serve` occasionally cuts a read of an article over ~80 KB short. An upstream defect, reported upstream, mitigated in the app. |
+| **No full-text index** | Such a pack is skipped when searching but still readable via *Open article*. The badge appears on its own, shortly after you add or enable the pack. |
+| **Two files with the same name** | Two archives whose file names differ only by folder cannot both be served; the panel marks the later one "Not served" and names the winner. Rename one. |
+| **Redirects** | A redirect entry opens its target within the same pack, one hop. A chain, or a hop to another pack, shows an honest "article unavailable" instead of the wrong text. |
+| **12 packs per chat** | A hard cap. Packs over it are listed as not searched, with that as the reason. |
+
+## 8. For maintainers
+
+| Where | What it holds |
+|---|---|
+| [`rag-design.md`](rag-design.md) §17 | The design record: session and lock model, retrieval arms, identity and discovery, the honesty rules behind the "Knowledge packs:" line, the real-tools acceptance findings |
+| [`security-model.md`](security-model.md) | The `kiwix-serve` access boundary and residual R-9 |
+| [`architecture.md`](architecture.md) | The `kiwix_tools` runtime family and how it differs from `llama_cpp` / `whisper_cpp` |
+| [`drive-layout.md`](drive-layout.md) | Where `zim/` and `runtime/kiwix-tools/` live on the drive |
+| [`packaging.md`](packaging.md) | Provisioning the tools onto a drive, and the source-bundle rule a shipping Kit must satisfy |
+| [`data-contracts.md`](data-contracts.md) | The IPC surface and persisted shapes |
+| [`user-guide.md`](user-guide.md#7b-knowledge-packs--ask-an-offline-wikipedia) | The end-user walkthrough |


### PR DESCRIPTION
## Why

Knowledge packs shipped, but the repo does not say so. Today the feature is one README bullet — #5 of ten, linking nowhere — plus `user-guide.md` §7b, which is only reachable through a Documentation row that reads "walkthrough of every screen and feature". Someone landing on the repo page cannot tell that HilbertRaum reads an offline Wikipedia, which is the most legible thing the product does for a stranger: it explains the whole thesis in two words.

This is the first slice of a wider GitHub-presence pass (see BUILD_STATE's dated entry for the rest, all owner-side).

## What changed

**New `docs/knowledge-packs.md`** — the canonical public page, in the shape of `local-api.md`:

- §1 why an offline encyclopedia — the grounding argument, not a feature list
- §2 choosing packs and **sizing a drive** (the number people actually need before they buy one), single-file `.zim`, full-text index
- §3 the kiwix-tools, both provisioning paths, the license/consent dialog
- §4 adding packs, §5 asking (per chat, 12 cap, *Search my documents*, citations, *Open article*, the "Knowledge packs:" line)
- §6 privacy — the **R-9** and network-inventory sentences quoted **verbatim**, so this page cannot drift from `PRIVACY.md` / `security-model.md` / `known-limitations.md` / `user-guide.md`
- §7 the measured edges as a table (multipart R-2, Windows non-ASCII paths, the upstream large-article truncation, no-FTS packs, duplicate basenames, redirects, the 12-pack cap)
- §8 maintainer pointers into `rag-design.md` §17 and the rest

**README** — a `Knowledge packs — an offline Wikipedia` section after Supported models, a ToC row, a Documentation-table row, the hero line, and the feature bullet rewritten to link the section.

**BUILD_STATE** — the dated entry. Its preamble was exactly at the 200-line budget, so per the retention rule the closed 2026-09-03 Phase 9b close-out entry (PR #282) retires **verbatim** to the top of `docs/build-log.md`, and the trailer note records the move. MOVE, not raise.

## Checks

Docs-only, no code and no behaviour change. `repo-hygiene.test.ts` green (35/35) — that is the suite that owns the pinned sentences, the docs link net (AUD-21) and the BUILD_STATE budgets.

## Not in this PR (owner-side)

Repo About text and `zim` / `kiwix` / `wikipedia` / `offline` topics; a v0.1.60 release carrying the packs entries that already sit in CHANGELOG `[Unreleased]` (v0.1.59 predates the wave, so nothing public shows the feature); a first screenshot; a pack-problem issue template; the org profile README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
