### PR TITLE
chore(issues): a knowledge-pack report form, and a chooser that keeps blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# A blank issue stays one click away: most issues here are filed by maintainers in a terse
+# house style, and a form must never stand between someone and a report they can already write.
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability — report privately
+    url: https://github.com/HilbertraumAI/HilbertRaum/security/advisories/new
+    about: Do not open a public issue for an undisclosed vulnerability. See SECURITY.md — security@hilbertraum.ai is the other channel.
+  - name: Knowledge packs — the documentation
+    url: https://github.com/HilbertraumAI/HilbertRaum/blob/master/docs/knowledge-packs.md
+    about: Setup, the privacy posture, and every measured limit of the ZIM / offline-Wikipedia support.
+  - name: Troubleshooting
+    url: https://github.com/HilbertraumAI/HilbertRaum/blob/master/docs/troubleshooting.md
+    about: The common problems and their fixes — SmartScreen/Gatekeeper, models, the engine, packs, OCR.
+  - name: Accepted limitations
+    url: https://github.com/HilbertraumAI/HilbertRaum/blob/master/docs/known-limitations.md
+    about: The gaps we know about and have consciously accepted, each with the reasoning.

--- a/.github/ISSUE_TEMPLATE/knowledge-pack-problem.yml
+++ b/.github/ISSUE_TEMPLATE/knowledge-pack-problem.yml
@@ -1,0 +1,134 @@
+name: Knowledge pack problem (ZIM / offline Wikipedia)
+description: A ZIM archive will not register, cannot be ticked, is not searched, or an article will not open.
+title: "Knowledge packs: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Knowledge packs sit on top of two upstream programs
+        (`kiwix-serve` / `kiwix-manage`) and a file we did not build, so the answer is often in
+        one of the measured limits already written down:
+        [`docs/knowledge-packs.md` §7](https://github.com/HilbertraumAI/HilbertRaum/blob/master/docs/knowledge-packs.md#7-edges-worth-knowing)
+        and the Knowledge-packs section of
+        [`docs/known-limitations.md`](https://github.com/HilbertraumAI/HilbertRaum/blob/master/docs/known-limitations.md).
+        If one of them matches, you do not need to file — but a limit that is wrong, or worse
+        than documented, is very much worth an issue.
+
+        **Please keep your data out of the report.** We do not want your document text, your
+        chat content, or a path with your name in it. The details below are enough.
+
+  - type: dropdown
+    id: symptom
+    attributes:
+      label: What happens?
+      options:
+        - The panel says the kiwix-tools are missing, or installing them fails
+        - Adding the pack fails (it never appears in the list)
+        - The pack is listed but cannot be ticked in a chat (greyed out)
+        - The pack is ticked but the answer says it was not searched
+        - The pack is searched but finds nothing it should have found
+        - An article will not open, is cut short, or shows the wrong text
+        - The panel or the list shows something wrong
+        - Something else
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What did you do, and what happened instead of what you expected?
+      description: |
+        Two or three sentences is plenty. Two things help more than anything else if you have
+        them: the exact reason text shown on the greyed-out pack in the sources picker, and the
+        "Knowledge packs:" line printed under the answer.
+      placeholder: |
+        I ticked the German Wikipedia pack and asked a question. The answer said the pack was
+        not searched. The picker shows it greyed out with "…".
+    validations:
+      required: true
+
+  - type: input
+    id: pack
+    attributes:
+      label: Which pack?
+      description: The file name, and where you got it (the library.kiwix.org title is ideal).
+      placeholder: wikipedia_de_all_nopic_2026-04.zim — library.kiwix.org
+    validations:
+      required: true
+
+  - type: input
+    id: size
+    attributes:
+      label: How big is the file?
+      placeholder: 14 GB
+    validations:
+      required: true
+
+  - type: dropdown
+    id: location
+    attributes:
+      label: Where does the file live?
+      options:
+        - In the drive's zim/ folder
+        - Somewhere else on the same drive
+        - On another drive, or elsewhere on the computer
+        - On a network share or a virtual/cloud-synced folder
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: HilbertRaum version
+      description: Settings → Diagnostics (advanced) → App & runtime shows it; "built from source at <commit>" is also fine.
+      placeholder: 0.1.59
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tools
+    attributes:
+      label: How did the kiwix-tools get onto the drive?
+      options:
+        - The app installed them (Knowledge packs panel or AI Model screen)
+        - The fetch-runtime script (--family kiwix_tools)
+        - I unzipped the release by hand
+        - I do not know
+        - They are not installed
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: known-edges
+    attributes:
+      label: The usual suspects
+      description: Tick what you have confirmed. An unticked box is a fine answer — it just tells us where to look.
+      options:
+        - label: The archive is a single `.zim` file (not a multipart `.zimaa` / `.zimab` set)
+        - label: The path to the file contains only ASCII characters (no umlaut, accent or other non-ASCII character anywhere in it) — this one matters on Windows
+        - label: The pack does not show a "No full-text index" badge in the panel
+        - label: No other pack on this drive has the same file name in a different folder
+        - label: I checked the Knowledge-packs entries in `docs/known-limitations.md` and none of them describes this
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: |
+        Optional. A screenshot of the panel or the sources picker is welcome — please crop out
+        anything private first. The Copy button on Settings → Diagnostics (advanced) → App &
+        runtime is safe to paste: it carries version, model and runtime facts, not your documents.

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -36,7 +36,9 @@ R-9 and the network-inventory sentence VERBATIM, §7 the measured edges as a tab
 "Knowledge packs — an offline Wikipedia" section, ToC row, Documentation-table row, the hero line, and the bullet rewritten
 to link it. No code, no behaviour change. The rest of the GitHub-presence review is owner-side and tracked nowhere else:
 repo About text + `zim`/`kiwix`/`wikipedia`/`offline` topics, a v0.1.60 release (the packs entries sit in CHANGELOG
-`[Unreleased]`; v0.1.59 predates the wave), a first screenshot, a pack-problem issue template, the org profile README._
+`[Unreleased]`; v0.1.59 predates the wave), a first screenshot, the org profile README. The follow-up PR #441 adds the repo's
+first `.github/ISSUE_TEMPLATE/`: a knowledge-pack report form asking for the facts that decide those reports, and a `config.yml`
+that keeps blank issues one click away and routes vulnerabilities to the private advisory channel._
 _2026-09-09 — **#333 CLOSED — measured, no cache** (instrumented on `perf/333-manifest-read-instrumentation`, PR #431; record
 `benchmark.md` §4 **I5** + Perf marks "`discover_manifests` / `performance_get` — the #333 pair"; evidence
 `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-333-measurement.txt`): on the drive, cold (eject/replug ×3:


### PR DESCRIPTION
> **Stacked on #440** (base is that branch, so the diff stays clean — GitHub retargets this to `master` once #440 merges). The form links `docs/knowledge-packs.md`, which #440 adds.

## Why

Knowledge packs are the first feature that will bring bug reports from people who did not build the app, and its failure modes are unusually specific: the tools missing, a non-ASCII path on Windows, a pack with no full-text index, two archives sharing a basename, the 12-pack cap, the upstream large-article truncation. Every one of those is decided by a fact the reporter has and we cannot guess — which pack, how big, where it sits, how the tools got there. Without them a report costs three round-trips; with them most are answerable on sight, and a good share are answered by the docs before anyone types.

The repo has no issue templates at all today, so this also sets the pattern for the next one.

## What is in it

`.github/ISSUE_TEMPLATE/knowledge-pack-problem.yml` — a form asking for the symptom (a dropdown covering the seven real classes), what happened, the pack and its size, where the file lives, OS, app version, and how the kiwix-tools were installed. Then a "usual suspects" checklist that doubles as triage: single-file `.zim`, ASCII-only path, no "No full-text index" badge, no duplicate basename, `known-limitations.md` checked. UI paths are the real ones (Settings → Diagnostics (advanced) → App & runtime for the version and its Copy button).

Two touches worth naming: the form opens by pointing at `docs/knowledge-packs.md` §7 and the known-limitations entries, because for this feature the honest outcome of many reports is "documented limit" — and it asks people **not** to paste document text, chat content, or a path with their name in it. A project that does not upload your data should not collect it in an issue either.

`.github/ISSUE_TEMPLATE/config.yml` — blank issues stay **enabled** (maintainers file terse issues here and a form must not get in the way), plus contact links to the private security advisory channel per SECURITY.md, the knowledge-packs doc, troubleshooting, and known-limitations.

## Checks

Both files parse as YAML and match the issue-forms schema. No code, no docs prose, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
