### PR TITLE
fix(build-state): the preamble is back inside its 200-line budget

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -191,10 +191,9 @@ ledger `docs/architecture.md` §52), and the five 2026-09-04 Phase F entries (PR
 entries of the #290/#291 wave (PRs #295/#300/#297/#299) and Phase F PR 6 + close-out (#293, #292) on
 2026-09-05 at ZIM Phase 3a (preamble budget), and the ten ZIM knowledge-packs wave entries
 (Phases 0–6 + the 2026-09-04 MVP entry, PRs #304–#336) on 2026-09-06 at the P7 close-out (preamble
-budget), and the 2026-09-03 audit-2026-09-02 Phase 9b close-out entry (PR #282), the 2026-09-05
-Model library UX wave entry (PR #302) and the 2026-09-07 #286 save-a-code-block entry on 2026-09-09
-(preamble budget, making room for the knowledge-packs docs entry and the #331 HW3-acceptance
-entry) —
+budget), and the Phase 9b close-out (PR #282), Model library UX (PR #302) and #286 save-a-code-block
+entries on 2026-09-09 (preamble budget, making room for the knowledge-packs docs and #331
+HW3-acceptance entries) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 


### PR DESCRIPTION
`master` is red: `repo-hygiene.test.ts` reports `preamble: 201 lines > 200`.

## How it got there

#439 and #441 landed a minute apart. Each drained exactly the lines its own new entry
needed, and each was green against a master that did not yet carry the other — the
required check never ran on the combination. Together they left the preamble one line over.

## The fix

No entry is retired for this. The single overflowing line is in the `_Older dated entries_`
retirement pointer, which #439 grew from three lines to four while recording the third drain.
Rewrapped to three lines carrying the same facts: the same three entries retired on 2026-09-09
(PR #282, PR #302, #286), making room for the same two (knowledge-packs docs, #331 HW3-acceptance).

Docs-only, one paragraph reflowed. `repo-hygiene.test.ts`: 35 passed.

## Worth knowing

This leaves the preamble at exactly **200/200**. The next dated entry has to drain one first —
and, as this PR shows, two entry-adding PRs in flight at once each need to drain for *both*,
or master goes red again the moment the second lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)