### PR TITLE
fix(#399): the record was wrong on 11 of 14 models — correct it, stop evicting, stop caching what cannot be read

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,22 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-09 — **#399 CLOSED — the §6.6 record corrected and both owner decisions landed** (`fix/399-prompt-cache-restore`;
+record `model-benchmarks.md` §6.6 "2026-09-09 correction (#399)", `known-limitations.md` "The one chat slot and the prompt
+cache"; evidence PR #445). The old accepted-cost clause said "both 27B quants are hybrid/recurrent, so the restore path is
+closed to them". Measured: **11 of 14 chat models** lose llama-server's host-cache restore — the whole `qwen3.5`/`qwen3.8`
+line (recurrent state) and all four `gemma4` manifests (SWA), **including the catalog-default 4B and the 9B**; three
+positive controls (dense `qwen3`, `qwen3moe`, `mistral3`) DID restore, which makes it a measured architecture split.
+**D3(a)** — the arbiter waits 90 s after a chat turn before resuming a parked deep-index build, capped at 10 min of
+deferral per park so a document can never silently miss its index (`model-slot-arbiter.ts`; the delay is on the BUILD's
+resume, never on `acquireForChat`, which chat awaits). **D5** — `--cache-ram 0` for those three families only
+(`shared/prompt-cache-rules.ts`); unmeasured families keep cache-ON, the safe direction. **D4 deferred**: leg B showed a
+documents ask keeps only its ~227-token system prefix with or without a helper, so the length-proportional cost belongs to
+the plain-CHAT path alone and a picker warning would overstate it. Residual: a break longer than the delay still costs ONE
+slow reply, once. Follow-ups **#446** (`qwen3.6-27b` ×2 + `granite-4.1-8b` never tested — must not be read as "measured and
+fine") and **#447** (the ZIM query expander is bounded by inference, not measurement). Trap for reproducers: `forcing full
+prompt re-processing` appears only on MTP starts — the token count is the only honest read._
+
 _2026-09-09 — **#331 CLOSED — the four blocked HW3 acceptance legs performed** (`docs/331-hardware-acceptance-legs`;
 record `benchmark.md` §2 row HW3 + §4 HW3; evidence `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md`).
 A workspace created on a SECOND computer with the 14B active made leg 2 a real moved-drive `new-machine` run behind a 66 s model
@@ -156,23 +172,6 @@ hygiene in other suites), the record's issue and commit references filled, the c
 the keyboard-focus repair re-verified live in the dev app. Merge is the owner's call; the branch
 stays._
 
-_2026-09-05: **Graphics-memory-aware picker (`feat/vram-aware-picker`, stacked on #303):** the total-memory
-rule shipped here is **superseded** by the 2026-09-06 PR #308 audit amendment above (rule C on free memory; §6.6)._
-
-_2026-09-05: **Performance wave (`feat/performance-screen`): the hardware check moves from the
-third card of Settings › Diagnostics to a primary rail destination, "Performance". Rail rework in
-the same branch (owner decision): three groups (Chat · Documents · Translate · Images ‖ AI Model ·
-Performance ‖ Settings), Home behind the brand mark (lit on Home), Skills back into Settings as a
-tab (`skills` target resolves there); design-guidelines §2 rewritten.** Verdict + four rated tiles (speed, RAM, VRAM via
-`BenchmarkResult.gpuVramMb`, drive) and the "Your model" row (memory class discrete / unified /
-cpu, the chat ladder's placement parser over llama.cpp's load log, `settings.modelPlacements`,
-`placementVerdict`), the session's observed figures (last
-answer via a `chat:speed` observer, last model start / file check via per-source read-speed
-latches), and one result per computer (`settings.benchmarkHistory`, `machineKey`). The moved-drive
-check in `maybeRunFirstBenchmark` restores a known machine's result or benchmarks a new one;
-`benchmark:progress` streams the run's steps. Diagnostics keeps the raw table. Records:
-`docs/benchmark.md` "History per machine" / "Performance screen", data-contracts (settings
-storage + IPC). §5 item 22 tracks the residuals._
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,19 @@ from its first public `1.0.0` release onward.
 
 ### Changed
 
+- **Chatting while a long document is being deep-indexed no longer slows down every reply.** The
+  deep index yields the model to your message and then waits before picking its work back up, so
+  an ordinary back-and-forth is not interrupted turn after turn. On most of the models the app
+  ships, the conversation has to be re-read from the beginning whenever something else uses the
+  model in between — that is a limitation of the local engine, not something the app can undo, so
+  the fix is to interrupt you far less often. Coming back after a longer break can still cost one
+  slower reply, once; and the indexing always gets its turn, so a document can never be left
+  without its deep index.
+- **Less RAM held for nothing while you chat.** On the model families where the local engine
+  cannot reuse a saved conversation anyway, the app now tells it not to keep that copy — it could
+  grow to several gigabytes of memory that was never read back. Models that can reuse it are
+  unchanged.
+
 - **Knowledge-pack questions that ask for a list or the largest, most or best-known items now
   find the list article more often.** Before searching, the app asks your local model for the
   question's key concepts and the likely title of a list article — one short extra model call

--- a/apps/desktop/src/main/ipc/registerModelIpc.ts
+++ b/apps/desktop/src/main/ipc/registerModelIpc.ts
@@ -275,7 +275,10 @@ export async function startModelRuntime(ctx: AppContext, modelId: string): Promi
     weightPaths: manifestFiles(ctx.paths.rootPath, found.manifest).map((f) => f.path),
     // #182: the manifest's opt-in, not a decision. The ladder gates it on the hardware it
     // actually finds and silently drops it when the machine cannot benefit.
-    speculativeDecoding: found.manifest.speculativeDecoding ?? null
+    speculativeDecoding: found.manifest.speculativeDecoding ?? null,
+    // #399 D5: the prompt-cache gate's only input. The manifest states the family; the RULE
+    // (which families lost the evicted-prefix restore, and why) lives in shared/prompt-cache-rules.
+    family: found.manifest.family
   })
   perfMark('runtime_ready', {
     modelId,

--- a/apps/desktop/src/main/services/analysis/model-slot-arbiter.ts
+++ b/apps/desktop/src/main/services/analysis/model-slot-arbiter.ts
@@ -17,7 +17,8 @@
 //     `acquireForChat()`: it flags `pauseRequested` and AWAITS the builder's handoff (the
 //     builder reaching its yield point and parking). Only then does chat hold the slot.
 //   - When chat's stream ends it calls the release fn `acquireForChat()` returned, which
-//     resumes the parked builder (when the last concurrent chat is done).
+//     resumes the parked builder (when the last concurrent chat is done) — after a DELAY,
+//     see RESUME_AFTER_CHAT_DELAY_MS below.
 //
 // There is exactly one yielding build at a time (DocTaskManager runs one task), so the
 // arbiter tracks a single active build + a single parked reacquire.
@@ -28,6 +29,64 @@ export class SlotAbortedError extends Error {
     super(message)
     this.name = 'SlotAbortedError'
   }
+}
+
+/**
+ * How long a parked build waits after the LAST chat stream ends before it takes the slot back
+ * (issue #399, owner decision D3(a), 2026-09-09). Until this landed the builder resumed the
+ * instant `chatHolders` hit 0 — i.e. inside the few seconds between one reply finishing and the
+ * user typing the next one — so an ordinary conversation handed the slot away and took it back on
+ * EVERY turn.
+ *
+ * Why that is expensive, and why "not evicting" is the only available lever: on 11 of our 14 chat
+ * models an evicted chat prefix is **re-prefilled from scratch, not restored**. llama-server saves
+ * the conversation to its host-RAM prompt cache and then silently re-processes the whole prompt
+ * anyway — recurrent state (the whole `qwen3.5`/`qwen3.8` line) and a sliding window (all four
+ * `gemma4` manifests) both close the restore path, measured across fourteen models with three
+ * positive controls that DID restore. No slot arrangement fixes it (`-np 2` re-prefilled token for
+ * token, even into a slot nothing had ever touched), so the eviction itself is the only thing we
+ * control. Record + evidence: `docs/model-benchmarks.md` §6.6 "2026-09-09 correction (#399)".
+ *
+ * Why 90 s. The owner's range was 60–120 s; 90 s is its midpoint and the thing being covered is a
+ * conversation's own turn gap — reading a long answer and typing a follow-up sits comfortably
+ * inside it, while 120 s buys little more and delays the index for that much longer on every park.
+ *
+ * WHERE THE DELAY IS NOT: never on `acquireForChat()`. The chat path AWAITS that call, so a delay
+ * there would slow down every chat turn — a far worse bug than the one this fixes. A chat arriving
+ * while the resume timer is pending finds the builder still parked, cancels the timer and takes the
+ * slot immediately, exactly as before.
+ */
+export const RESUME_AFTER_CHAT_DELAY_MS = 90_000
+
+/**
+ * The starvation guarantee (#399 D3(a)). A naive "wait 90 s after every chat turn" lets a user who
+ * chats steadily every 30 s prevent the deep-index build from EVER resuming, and a document that
+ * silently never gets its deep index is a worse outcome than one slow reply.
+ *
+ * The guarantee, stated so a test can pin it: **the arbiter adds at most `MAX_PARK_DEFERRAL_MS` of
+ * delay to any single park.** The clock starts when the builder parks in `reacquire()`. While the
+ * park is younger than this cap, a release schedules the resume `RESUME_AFTER_CHAT_DELAY_MS` later
+ * and a new chat cancels it. Once the park is older, the very next release resumes the build
+ * IMMEDIATELY — exactly the pre-#399 behaviour — no matter how many deferrals preceded it.
+ *
+ * 10 minutes is ~6 consecutive deferrals at 90 s. Past that the user is in a sustained conversation
+ * rather than an ordinary turn gap, and the build's progress is worth one slow reply. So a steady
+ * chat pays a re-prefill roughly every 10 minutes instead of on every turn. Note the cap bounds the
+ * delay the ARBITER adds, not the wall clock: a chat that simply never releases the slot holds it
+ * for its own reasons, and the build physically cannot run while it does.
+ */
+export const MAX_PARK_DEFERRAL_MS = 600_000
+
+/** Opaque timer handle — the seam is injected so tests drive the delay without real sleeps. */
+type TimerHandle = unknown
+
+/** Test seams (#399): fake time in, no `setTimeout` in the unit tests. All optional. */
+export interface ModelSlotArbiterDeps {
+  resumeDelayMs?: number
+  maxParkDeferralMs?: number
+  setTimer?: (fn: () => void, ms: number) => TimerHandle
+  clearTimer?: (handle: TimerHandle) => void
+  now?: () => number
 }
 
 export class ModelSlotArbiter {
@@ -42,6 +101,24 @@ export class ModelSlotArbiter {
   private reacquireReject: ((err: Error) => void) | null = null
   /** How many chat streams currently hold the slot (resume the builder when this hits 0). */
   private chatHolders = 0
+  /** The pending post-chat resume timer, or null when none is armed (#399 D3(a)). */
+  private resumeTimer: TimerHandle | null = null
+  /** When the builder parked (`now()`), or null when it is not parked — the starvation clock. */
+  private parkedAt: number | null = null
+
+  private readonly resumeDelayMs: number
+  private readonly maxParkDeferralMs: number
+  private readonly setTimer: (fn: () => void, ms: number) => TimerHandle
+  private readonly clearTimer: (handle: TimerHandle) => void
+  private readonly now: () => number
+
+  constructor(deps: ModelSlotArbiterDeps = {}) {
+    this.resumeDelayMs = deps.resumeDelayMs ?? RESUME_AFTER_CHAT_DELAY_MS
+    this.maxParkDeferralMs = deps.maxParkDeferralMs ?? MAX_PARK_DEFERRAL_MS
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>))
+    this.now = deps.now ?? (() => Date.now())
+  }
 
   /** True while a yielding build owns the slot — chat branches on this to pause vs refuse. */
   isBuildActive(): boolean {
@@ -61,6 +138,8 @@ export class ModelSlotArbiter {
     this.handoffWaiters = []
     this.reacquireResolve = null
     this.reacquireReject = null
+    this.cancelPendingResume()
+    this.parkedAt = null
   }
 
   /**
@@ -74,6 +153,9 @@ export class ModelSlotArbiter {
     this.pauseRequested = false
     this.reacquireResolve = null
     this.reacquireReject = null
+    // The build is gone; a resume timer aimed at it must not fire into a dead handshake.
+    this.cancelPendingResume()
+    this.parkedAt = null
     this.wakeHandoffWaiters()
   }
 
@@ -85,7 +167,10 @@ export class ModelSlotArbiter {
   /**
    * The builder parks here when `shouldYield()` is true: it hands the slot to the waiting
    * chat (resolving the handoff) and returns a Promise that resolves when chat releases
-   * the slot, or rejects with `SlotAbortedError` on cancel/lock/quit/model-switch.
+   * the slot — after `RESUME_AFTER_CHAT_DELAY_MS` (#399 D3(a)) — or rejects with
+   * `SlotAbortedError` on cancel/lock/quit/model-switch. `parkedAt` is stamped here: it is the
+   * start of the `MAX_PARK_DEFERRAL_MS` starvation clock, so the cap measures how long THIS park
+   * has been deferred, not how long the process has been running.
    */
   reacquire(jobId: string): Promise<void> {
     if (this.activeBuild !== jobId) {
@@ -93,6 +178,8 @@ export class ModelSlotArbiter {
       return Promise.resolve()
     }
     this.pauseRequested = false
+    this.cancelPendingResume()
+    this.parkedAt = this.now()
     this.wakeHandoffWaiters()
     return new Promise<void>((resolve, reject) => {
       this.reacquireResolve = resolve
@@ -117,6 +204,11 @@ export class ModelSlotArbiter {
     // Already stopped before we even ask — don't request a pause or take a holder slot.
     if (signal?.aborted) throw new SlotAbortedError('Chat slot acquire aborted')
     this.chatHolders += 1
+    // #399 D3(a): a new chat turn inside the post-chat window cancels the pending resume — this is
+    // the whole point of the delay, and it is why the conversation stops handing the slot away turn
+    // after turn. It costs this call NOTHING: the builder is still parked, so the fast path below
+    // hands the slot over synchronously. The delay is never on chat's own acquisition.
+    this.cancelPendingResume()
     // If the builder is ALREADY parked (a prior chat handed the slot off and the build is
     // waiting to resume), the slot is free RIGHT NOW — a second concurrent chat must NOT
     // wait for another handoff that will never come (the builder won't reach a new node
@@ -189,17 +281,47 @@ export class ModelSlotArbiter {
     const reject = this.reacquireReject
     this.reacquireResolve = null
     this.reacquireReject = null
+    // A build being torn down must not be woken by an in-flight resume timer.
+    this.cancelPendingResume()
+    this.parkedAt = null
     if (reject) reject(err)
   }
 
+  /**
+   * The last chat holder letting go is what used to resume the builder immediately. Since #399
+   * D3(a) it instead ARMS the resume for `RESUME_AFTER_CHAT_DELAY_MS`, unless this park has
+   * already been deferred past `MAX_PARK_DEFERRAL_MS` — the starvation guarantee — in which case
+   * the build resumes right now, exactly as it did before.
+   */
   private releaseOneChat(): void {
     if (this.chatHolders > 0) this.chatHolders -= 1
-    if (this.chatHolders === 0 && this.reacquireResolve) {
-      const resolve = this.reacquireResolve
-      this.reacquireResolve = null
-      this.reacquireReject = null
-      resolve()
+    if (this.chatHolders !== 0 || !this.reacquireResolve) return
+    const deferredFor = this.parkedAt === null ? 0 : this.now() - this.parkedAt
+    if (deferredFor >= this.maxParkDeferralMs) {
+      this.resumeParkedBuild()
+      return
     }
+    this.cancelPendingResume()
+    this.resumeTimer = this.setTimer(() => {
+      this.resumeTimer = null
+      this.resumeParkedBuild()
+    }, this.resumeDelayMs)
+  }
+
+  /** Wake the parked builder, if one is still parked and the slot is still free. */
+  private resumeParkedBuild(): void {
+    if (this.chatHolders !== 0 || !this.reacquireResolve) return
+    const resolve = this.reacquireResolve
+    this.reacquireResolve = null
+    this.reacquireReject = null
+    this.parkedAt = null
+    resolve()
+  }
+
+  private cancelPendingResume(): void {
+    if (this.resumeTimer === null) return
+    this.clearTimer(this.resumeTimer)
+    this.resumeTimer = null
   }
 
   private wakeHandoffWaiters(): void {

--- a/apps/desktop/src/main/services/doctasks/context.ts
+++ b/apps/desktop/src/main/services/doctasks/context.ts
@@ -20,7 +20,7 @@ import type { IngestionDeps } from '../ingestion'
 import type { OcrEngine } from '../ocr'
 import type { RasterizePdf } from '../ocr/rasterizer'
 import type { AuditRecorder } from '../audit'
-import type { ModelSlotArbiter } from '../analysis/model-slot-arbiter'
+import type { ModelSlotArbiter, ModelSlotArbiterDeps } from '../analysis/model-slot-arbiter'
 
 /** Injected seams so the engine is testable without Electron and the IPC layer. */
 export interface DocTaskDeps {
@@ -109,6 +109,14 @@ export interface DocTaskDeps {
    * nothing else changes.
    */
   beginOccupancy?: () => () => void
+  /**
+   * Overrides for the model-slot arbiter's post-chat resume delay (#399 D3(a)) — the ONLY
+   * reason this exists is that the delay is 90 seconds of wall clock, which no test can wait
+   * out. Tests inject a fake clock + timer here so the pause/resume contract is still exercised
+   * end to end through this manager. Absent/unwired ⇒ the shipped 90 s / 10 min constants, so
+   * partial test deps stay valid. Production never sets it.
+   */
+  slotArbiterDeps?: ModelSlotArbiterDeps
   audit?: AuditRecorder
 }
 

--- a/apps/desktop/src/main/services/doctasks/manager.ts
+++ b/apps/desktop/src/main/services/doctasks/manager.ts
@@ -126,11 +126,15 @@ export class DocTaskManager {
    * The single model-slot owner for a YIELDING tree build (plan §4.1, H9/H10). Only a
    * running `tree` build registers with it; chat uses it to pause+hand-off, never to race.
    */
-  private readonly arbiter = new ModelSlotArbiter()
+  private readonly arbiter: ModelSlotArbiter
   /** The narrow orchestration handle handed to each per-kind handler (DX-1). */
   private readonly ctx: DocTaskCtx
 
   constructor(private readonly deps: DocTaskDeps) {
+    // #399 D3(a): the resume delay is a 90 s wall-clock wait in production; `slotArbiterDeps`
+    // is the test-only fake-clock seam (see DocTaskDeps). Assigned here rather than as a field
+    // initializer because it reads `deps`.
+    this.arbiter = new ModelSlotArbiter(deps.slotArbiterDeps)
     this.ctx = {
       deps,
       arbiter: this.arbiter,

--- a/apps/desktop/src/main/services/runtime/index.ts
+++ b/apps/desktop/src/main/services/runtime/index.ts
@@ -139,6 +139,15 @@ export interface RuntimeStartOptions {
    * downstream of the ladder reads it.
    */
   speculativeDecoding?: SpeculativeDecoding | null
+  /**
+   * The model manifest's `family:` (#399 D5) — e.g. `qwen3.5`, `gemma4`, `mistral3`. Supplied by
+   * `startModelRuntime` (which has the manifest). The ONLY thing that reads it is the chat argv
+   * builder's prompt-cache gate (`shared/prompt-cache-rules.ts`): a family measured to lose
+   * llama-server's evicted-prefix restore gets `--cache-ram 0`, because for it the host cache is
+   * written and never read. Absent/unknown ⇒ cache ON, i.e. exactly today's behaviour — the safe
+   * direction, and the reason this is optional rather than required.
+   */
+  family?: string | null
 }
 
 export interface HealthStatus {

--- a/apps/desktop/src/main/services/runtime/llama.ts
+++ b/apps/desktop/src/main/services/runtime/llama.ts
@@ -1,4 +1,5 @@
 import type { ChatDepthMode } from '../../../shared/types'
+import { promptCacheServerArgs } from '../../../shared/prompt-cache-rules'
 import type {
   ChatMessage,
   HealthStatus,
@@ -60,10 +61,19 @@ import { LlamaServer, type LlamaServerOptions } from './sidecar'
  * 24 GB card while keeping MTP. On the 8 GB card (leg 2) the four slots cost the 9B 440 MiB and the
  * fit missed a full offload by 133.
  *
- * Accepted cost (owner): with one slot a background job (categorisation, ZIM query expansion, a doc
- * task) evicts the chat conversation's KV prefix. llama-server's host-RAM prompt cache restores it
- * on a prefix match, so the cost is a restore, not a full re-prefill — bounded, and no in-app path
- * depends on parallel slots.
+ * Accepted cost (owner) — CORRECTED 2026-09-09 (issue #399). The original clause said the host-RAM
+ * prompt cache RESTORES an evicted prefix, so the cost was a restore rather than a full re-prefill.
+ * That measured false on 11 of our 14 chat models: recurrent state (the whole qwen3.5/qwen3.8 line)
+ * and a sliding window (all four gemma4 manifests) both close the restore path, so the server saves
+ * the conversation and then silently re-prefills it anyway. Three positive controls (dense qwen3,
+ * qwen3moe, mistral3) did restore, and `-np 2` re-prefilled token for token even into a slot nothing
+ * had ever touched — so no slot arrangement fixes it and the only lever is NOT EVICTING. The
+ * decision to run one slot still stands (nothing here is caused by `-np 1`; four slots lose the
+ * restore the same way). What changed instead: the model-slot arbiter waits before resuming a
+ * parked deep-index build (#399 D3(a)), and the unreadable cache copy is switched off for the
+ * affected families (#399 D5, `shared/prompt-cache-rules.ts`). Also measured: on a DOCUMENTS ask
+ * only the ~227-token system prefix is ever reused anyway, so the length-proportional cost belongs
+ * to the plain-chat path alone. Record: `model-benchmarks.md` §6.6 "2026-09-09 correction (#399)".
  */
 /**
  * `-lv 4` (log verbosity): the pinned build prints its load log (`load_tensors: offloaded X/Y
@@ -495,7 +505,12 @@ export class LlamaRuntime implements ModelRuntime {
       modelPath: opts.modelPath,
       contextTokens: opts.contextTokens,
       physicalBatchSize: Math.min(opts.contextTokens, CHAT_MAX_PHYSICAL_BATCH),
-      extraArgs: [...CHAT_SERVER_ARGS, ...(deps.extraArgs ?? [])],
+      // #399 D5: `--cache-ram 0`, but ONLY for the manifest families measured to lose
+      // llama-server's evicted-prefix restore — the rule and its measured basis are in
+      // `shared/prompt-cache-rules.ts`. It sits between the shared const and the ladder's rung
+      // args so a rung can still override anything it needs to (`--device none`), exactly as
+      // before; every unaffected and every unmeasured family adds nothing here.
+      extraArgs: [...CHAT_SERVER_ARGS, ...promptCacheServerArgs(opts.family), ...(deps.extraArgs ?? [])],
       onUnexpectedExit: deps.onUnexpectedExit,
       onStderrData: deps.onStderrData,
       spawn: deps.spawn,

--- a/apps/desktop/src/shared/prompt-cache-rules.ts
+++ b/apps/desktop/src/shared/prompt-cache-rules.ts
@@ -1,0 +1,63 @@
+// The ONE rule for "does llama-server's host-RAM prompt cache do this model any good?" — issue
+// #399, owner decision D5, 2026-09-09. Shared and PURE (no node:, no electron, no DB) so the
+// runtime's argv builder and its tests read the same list, and so the measured basis lives beside
+// the rule instead of as an inline literal at a call site.
+//
+// WHAT THE CACHE IS FOR. When something else takes the one chat slot (`-np 1`, issue #319), the
+// server writes the evicted conversation to a host-RAM prompt cache — 8,192 MiB of it by default —
+// so it can restore the prefix instead of re-processing it when that conversation comes back.
+//
+// WHAT WAS MEASURED. On 11 of our 14 chat models it CANNOT restore it. The server saves the
+// conversation and then silently re-prefills the whole prompt anyway: llama.cpp cannot rebuild
+// either a recurrent state or a sliding-window cache from a saved prompt (llama.cpp PR #13194).
+// A fourteen-model sweep on `i9-9900x-rtx-3090-24gb-128gb` — raw `llama-server`, the app's argv
+// shape at `--ctx-size 8192 -np 1`, no MTP, every model fully offloaded, three requests per start
+// (conversation A → an unrelated B takes the slot → back to A) — split them exactly along the
+// architecture line, with three positive controls that DID restore (a dense Qwen, a Qwen MoE and a
+// Mistral, each re-prefilling only 14–21 tokens of a ~1,470-token return prompt):
+//
+//   RE-PREFILLED, recurrent state   qwen3.5 (2b, 4b, 9b, 35b-a3b)  ·  qwen3.8 (three 27b quants)
+//   RE-PREFILLED, sliding window    gemma4 (e2b, e4b, 12b, 26b-a4b), n_swa 512 / 1024
+//   RESTORED                        qwen3 (dense + moe)  ·  mistral3
+//
+// So on those eleven the cache is pure waste: 14.86–343.59 MiB of host RAM written per eviction
+// and never read once. `--cache-ram 0` gives that back and costs nothing.
+//
+// Record + evidence: `docs/model-benchmarks.md` §6.6 "2026-09-09 correction (#399)"; PR #445,
+// `eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue399-arch-sweep-*`.
+//
+// WHY THIS IS A FAMILY LIST AND NOT AN ARCHITECTURE PROBE. The manifests already carry `family:`,
+// and the measured split maps onto it exactly. We could ask the GGUF header instead, but that
+// would be an inference from metadata we have not validated against this outcome; the list is what
+// was actually measured, and #446 tracks the entries that were not.
+
+/**
+ * Manifest `family:` values whose models CANNOT restore an evicted chat prefix, so llama-server's
+ * host prompt cache is written and never read for them. Measured, not inferred — see the module
+ * comment for the sweep and its evidence.
+ *
+ * NOT on this list, deliberately: `qwen3.6` and `granite` (#446). `qwen3.6` is almost certainly
+ * affected — same lineage as the `qwen3.8` 27Bs that failed — but its weights were broken symlinks
+ * on the test rig and it was never started, and `granite-4.1-8b-q4` was not on that rig at all.
+ * They stay off until someone measures them.
+ */
+export const PROMPT_CACHE_RESTORE_BROKEN_FAMILIES: readonly string[] = ['qwen3.5', 'qwen3.8', 'gemma4']
+
+/**
+ * The chat sidecar args this model's family needs for the prompt cache, appended to
+ * `CHAT_SERVER_ARGS`. `['--cache-ram', '0']` for a family measured to lose the restore, `[]` for
+ * everything else.
+ *
+ * THE DEFAULT IS DELIBERATELY CACHE-**ON**, including for a family nobody has measured and for a
+ * model with no manifest family at all. The asymmetry decides it: turning the cache off on a model
+ * that CAN restore costs real prompt-cache restores on every hand-back, while leaving it on for a
+ * model that cannot merely continues a waste we can already name and bound. So an unmeasured family
+ * keeps today's behaviour, and adding one here requires a measurement.
+ *
+ * `-cram, --cache-ram N` — "set the maximum cache size in MiB (default: 8192, -1 = no limit,
+ * 0 = disable)" — verified present on the pinned b9849 binary (`799fcc04a`) before this shipped.
+ */
+export function promptCacheServerArgs(family: string | null | undefined): readonly string[] {
+  if (!family) return []
+  return PROMPT_CACHE_RESTORE_BROKEN_FAMILIES.includes(family) ? ['--cache-ram', '0'] : []
+}

--- a/apps/desktop/tests/integration/core-model-ipc.test.ts
+++ b/apps/desktop/tests/integration/core-model-ipc.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { promptCacheServerArgs } from '../../src/shared/prompt-cache-rules'
 import { createHash } from 'node:crypto'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -556,6 +557,38 @@ describe('registerModelIpc', () => {
     // "did this manifest opt in?" question must never be answered by an undefined.
     await invoke(handlers, IPC.startRuntime, 'qwen3.8-27b-q6')
     expect(started[1].speculativeDecoding).toBeNull()
+  })
+
+  // Issue #399 D5: the manifest's `family:` has to REACH the runtime start options — it is the
+  // ONLY input to the prompt-cache gate (`shared/prompt-cache-rules.ts`), and a dropped field
+  // here would be invisible: the affected model would simply go on writing a host-cache copy
+  // llama-server can never read back, exactly as before the fix.
+  it('forwards the manifest family into the runtime start options (#399 D5)', async () => {
+    const started: Array<Record<string, unknown>> = []
+    const db = seededDb()
+    updateSettings(db, { developerMode: true })
+    const ctx = {
+      db,
+      manifestsDir: REPO_MANIFESTS,
+      paths: { rootPath: join(tmpdir(), 'hilbertraum-no-weights'), configPath: devPolicyConfigDir() },
+      isDev: false,
+      runtime: {
+        start: async (o: Record<string, unknown>) => {
+          started.push(o)
+          return { running: true, modelId: String(o.modelId), port: null, healthy: true, message: 'ok' }
+        },
+        activeModelId: () => null
+      }
+    } as unknown as AppContext
+    reg(ctx)
+    // An AFFECTED family (recurrent state — the sweep's 27B control) …
+    await invoke(handlers, IPC.startRuntime, 'qwen3.8-27b-q4')
+    expect(started[0].family).toBe('qwen3.8')
+    expect(promptCacheServerArgs(started[0].family as string)).toEqual(['--cache-ram', '0'])
+    // … and one that restores, which must keep today's argv exactly.
+    await invoke(handlers, IPC.startRuntime, 'qwen3-4b-instruct-q4')
+    expect(started[1].family).toBe('qwen3')
+    expect(promptCacheServerArgs(started[1].family as string)).toEqual([])
   })
 
   it('refuses the mock fallback on a PACKAGED build with no policy.json (M-4 fail-closed)', async () => {

--- a/apps/desktop/tests/integration/llama-runtime.test.ts
+++ b/apps/desktop/tests/integration/llama-runtime.test.ts
@@ -515,6 +515,82 @@ describe('answer-depth mode → request mapping (D4)', () => {
     expect(joined).toContain('--device none')
     await runtime.stop()
   })
+
+  // ---- #399 D5: the family-gated prompt-cache switch ----------------------------------
+  //
+  // On 11 of our 14 chat models llama-server writes the evicted conversation to its host-RAM
+  // prompt cache and can never read it back (recurrent state / sliding window — see
+  // shared/prompt-cache-rules.ts for the sweep). `--cache-ram 0` stops paying for a copy that is
+  // never used. CHAT_SERVER_ARGS is shared by EVERY chat model start on every machine, so these
+  // pin both halves: the flag appears for an affected family, and the argv of every other family
+  // is byte-identical to what it was before #399.
+
+  it('passes --cache-ram 0 for a family measured to lose the prompt-cache restore (#399 D5)', async () => {
+    const { spawn, calls } = fakeSpawn()
+    const runtime = new LlamaRuntime(
+      { ...startOpts, modelId: 'qwen3.5-9b-ud-q4kxl', family: 'qwen3.5' },
+      {
+        binPath: '/bin/llama-server',
+        spawn,
+        fetchImpl: chatFetch({ frames: ['data: [DONE]\n\n'] }),
+        findPort: async () => 51010,
+        healthIntervalMs: 1
+      }
+    )
+    await runtime.start()
+    const args = calls[0].args
+    expect(args.join(' ')).toContain('--cache-ram 0')
+    // Adjacent, in order, and not accidentally consuming another flag's value.
+    expect(args[args.indexOf('--cache-ram') + 1]).toBe('0')
+    // Everything the chat sidecar already got is still there, unmoved.
+    for (const a of CHAT_SERVER_ARGS) expect(args).toContain(a)
+    await runtime.stop()
+  })
+
+  it('adds nothing for an unaffected OR unmeasured family, and for a model with no family', async () => {
+    // 'qwen3' restored in the sweep; 'qwen3.6' was never started (#446) and defaults to cache-ON;
+    // no family at all is the same safe default. All three must produce the pre-#399 argv.
+    for (const family of ['qwen3', 'qwen3.6', undefined]) {
+      const { spawn, calls } = fakeSpawn()
+      const runtime = new LlamaRuntime(
+        { ...startOpts, family },
+        {
+          binPath: '/bin/llama-server',
+          spawn,
+          fetchImpl: chatFetch({ frames: ['data: [DONE]\n\n'] }),
+          findPort: async () => 51011,
+          healthIntervalMs: 1
+        }
+      )
+      await runtime.start()
+      expect(calls[0].args).not.toContain('--cache-ram')
+      expect(calls[0].args).not.toContain('-cram')
+      await runtime.stop()
+    }
+  })
+
+  it('the prompt-cache flag never displaces a ladder rung arg (--device none still wins)', async () => {
+    // The rung's extraArgs are appended AFTER the cache flag, so rung 2 can still force CPU on an
+    // affected model — the ladder contract is unchanged by #399.
+    const { spawn, calls } = fakeSpawn()
+    const runtime = new LlamaRuntime(
+      { ...startOpts, family: 'gemma4' },
+      {
+        binPath: '/bin/llama-server',
+        spawn,
+        fetchImpl: chatFetch({ frames: ['data: [DONE]\n\n'] }),
+        findPort: async () => 51012,
+        healthIntervalMs: 1,
+        extraArgs: ['--device', 'none']
+      }
+    )
+    await runtime.start()
+    const joined = calls[0].args.join(' ')
+    expect(joined).toContain('--cache-ram 0')
+    expect(joined).toContain('--device none')
+    expect(joined.indexOf('--cache-ram')).toBeLessThan(joined.indexOf('--device none'))
+    await runtime.stop()
+  })
 })
 
 // ---- Factory selector -----------------------------------------------------------

--- a/apps/desktop/tests/integration/reranker.test.ts
+++ b/apps/desktop/tests/integration/reranker.test.ts
@@ -156,6 +156,9 @@ describe('LlamaReranker', () => {
     expect(args).not.toContain('--jinja')
     expect(args).not.toContain('--reasoning-format')
     expect(args).not.toContain('-np ') // the chat server's one slot (#319) is chat-only too
+    // #399 D5: the family-gated prompt-cache switch is composed in LlamaRuntime, not here — this
+    // sidecar's host cache is untouched whatever family the rerank model belongs to.
+    expect(args).not.toContain('--cache-ram')
     await reranker.stop()
     expect(child.killed).toBe(true)
   })

--- a/apps/desktop/tests/integration/translation-runtime.test.ts
+++ b/apps/desktop/tests/integration/translation-runtime.test.ts
@@ -104,6 +104,9 @@ describe('TranslationRuntime — launch + translate', () => {
     // One slot here is TRANSLATION_SLOT_ARGS' own decision, in the long form: the chat server's
     // `-np 1` (#319) never reaches this sidecar, exactly as `--jinja` never does.
     expect(args).not.toContain('-np ')
+    // #399 D5 likewise: --cache-ram is gated on the CHAT model's family in LlamaRuntime and never
+    // reaches this sidecar (TranslateGemma is a gemma family — the one that would have matched).
+    expect(args).not.toContain('--cache-ram')
     // Issue #42: default posture = GPU auto-offload, the chat rung-1 shape — NO device args
     // (b9849 defaults ngl=auto + fit=on; on a GPU-less machine this IS CPU mode).
     expect(args).not.toContain('--device')

--- a/apps/desktop/tests/integration/whole-doc-analysis.test.ts
+++ b/apps/desktop/tests/integration/whole-doc-analysis.test.ts
@@ -17,7 +17,11 @@ import { DocTaskManager } from '../../src/main/services/doctasks'
 import { ContextOverflowError } from '../../src/main/services/doctasks/errors'
 import { ChatRequestError } from '../../src/main/services/runtime/llama'
 import { buildTree } from '../../src/main/services/analysis/tree-build'
-import { ModelSlotArbiter } from '../../src/main/services/analysis/model-slot-arbiter'
+import {
+  ModelSlotArbiter,
+  RESUME_AFTER_CHAT_DELAY_MS,
+  type ModelSlotArbiterDeps
+} from '../../src/main/services/analysis/model-slot-arbiter'
 import {
   documentChunkCount,
   documentCoverage,
@@ -107,7 +111,46 @@ function scriptedRuntime(opts: { tokenDelayMs?: number } = {}): ScriptedRuntime 
   return rt
 }
 
-function makeManager(runtime: ModelRuntime | null, contextTokens = 4096): DocTaskManager {
+// #399 D3(a): a parked build resumes RESUME_AFTER_CHAT_DELAY_MS (90 s) after the last chat lets
+// go. No test can wait that out, so the one test that needs a resume drives an injected clock —
+// `advance()` is then the only thing that can wake the builder, which is exactly the assertion.
+interface FakeClock {
+  deps: ModelSlotArbiterDeps
+  advance: (ms: number) => void
+}
+function makeClock(): FakeClock {
+  let nowMs = 0
+  let seq = 0
+  const timers = new Map<number, { at: number; fn: () => void }>()
+  return {
+    deps: {
+      now: () => nowMs,
+      setTimer: (fn, ms) => {
+        const id = ++seq
+        timers.set(id, { at: nowMs + ms, fn })
+        return id
+      },
+      clearTimer: (h) => {
+        timers.delete(h as number)
+      }
+    },
+    advance: (ms) => {
+      nowMs += ms
+      for (const [id, e] of [...timers]) {
+        if (e.at <= nowMs) {
+          timers.delete(id)
+          e.fn()
+        }
+      }
+    }
+  }
+}
+
+function makeManager(
+  runtime: ModelRuntime | null,
+  contextTokens = 4096,
+  slotArbiterDeps?: ModelSlotArbiterDeps
+): DocTaskManager {
   return new DocTaskManager({
     getDb: () => db,
     getRuntime: () => runtime,
@@ -116,7 +159,8 @@ function makeManager(runtime: ModelRuntime | null, contextTokens = 4096): DocTas
     getContextTokens: () => contextTokens,
     getStoreDir: () => storeDir,
     getIngestionDeps: () => ({}),
-    beginDocumentWork: () => () => {}
+    beginDocumentWork: () => () => {},
+    slotArbiterDeps
   })
 }
 
@@ -568,7 +612,8 @@ describe('H10 yielding build handshake', () => {
   it('a chat slot request pauses the build, which then resumes in-session to ready', async () => {
     const id = await importWords(8000)
     const runtime = scriptedRuntime({ tokenDelayMs: 15 })
-    const m = makeManager(runtime, 1024)
+    const clock = makeClock()
+    const m = makeManager(runtime, 1024, clock.deps)
     const { jobId } = m.startDocTask({ kind: 'tree', documentIds: [id] })
 
     // Wait until the build is mid-flight (at least one node committed, not finished).
@@ -580,8 +625,14 @@ describe('H10 yielding build handshake', () => {
     const atPause = m.getDocTask(jobId)
     expect(atPause.state).toBe('running') // paused, NOT done/cancelled
 
-    // Releasing resumes the SAME build in-session — it reaches ready with no restart.
+    // Releasing ARMS the resume; the build must still be parked until the #399 D3(a) delay is up.
     release()
+    await new Promise((r) => setTimeout(r, 30))
+    expect(m.getDocTask(jobId).state).toBe('running') // still parked, not resumed
+    expect(m.isYieldingBuildActive()).toBe(true)
+
+    // Once it is up, the SAME build resumes in-session — it reaches ready with no restart.
+    clock.advance(RESUME_AFTER_CHAT_DELAY_MS)
     const s = await waitTerminal(m, jobId)
     expect(s.state).toBe('done')
     expect(treeStatus(id)).toBe('ready')

--- a/apps/desktop/tests/unit/model-slot-arbiter.test.ts
+++ b/apps/desktop/tests/unit/model-slot-arbiter.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  MAX_PARK_DEFERRAL_MS,
   ModelSlotArbiter,
+  RESUME_AFTER_CHAT_DELAY_MS,
   SlotAbortedError
 } from '../../src/main/services/analysis/model-slot-arbiter'
 import { openDatabase } from '../../src/main/services/db'
@@ -21,9 +23,55 @@ import { buildTree } from '../../src/main/services/analysis/tree-build'
 
 const tick = (): Promise<void> => new Promise((r) => setImmediate(r))
 
+// #399 D3(a): the builder no longer resumes the instant chat releases — it waits
+// RESUME_AFTER_CHAT_DELAY_MS (90 s of real wall clock). Every test here drives that with an
+// injected clock: nothing sleeps, and `advance()` is the ONLY thing that fires a resume, so a
+// resume that happened too early or not at all is visible rather than merely slow.
+interface FakeClock {
+  deps: { now: () => number; setTimer: (fn: () => void, ms: number) => unknown; clearTimer: (h: unknown) => void }
+  advance: (ms: number) => void
+  pending: () => number
+}
+function makeClock(): FakeClock {
+  let nowMs = 0
+  let seq = 0
+  const timers = new Map<number, { at: number; fn: () => void }>()
+  return {
+    deps: {
+      now: () => nowMs,
+      setTimer: (fn, ms) => {
+        const id = ++seq
+        timers.set(id, { at: nowMs + ms, fn })
+        return id
+      },
+      clearTimer: (h) => {
+        timers.delete(h as number)
+      }
+    },
+    advance: (ms) => {
+      nowMs += ms
+      for (const [id, e] of [...timers]) {
+        if (e.at <= nowMs) {
+          timers.delete(id)
+          e.fn()
+        }
+      }
+    },
+    pending: () => timers.size
+  }
+}
+
 describe('ModelSlotArbiter', () => {
+  let clock: FakeClock
+  beforeEach(() => {
+    clock = makeClock()
+  })
+  /** An arbiter on the fake clock, with the SHIPPED delay + cap (never a test-only value). */
+  const mkArbiter = (): ModelSlotArbiter => new ModelSlotArbiter(clock.deps)
+  /** Let the whole post-chat resume delay elapse. */
+  const passDelay = (): void => clock.advance(RESUME_AFTER_CHAT_DELAY_MS)
   it('reports no build active by default; chat acquire is an immediate no-op', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     expect(a.isBuildActive()).toBe(false)
     const release = await a.acquireForChat()
     expect(typeof release).toBe('function')
@@ -31,7 +79,7 @@ describe('ModelSlotArbiter', () => {
   })
 
   it('hands the slot from builder to chat and resumes the builder on release', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     expect(a.isBuildActive()).toBe(true)
     expect(a.shouldYield()).toBe(false)
@@ -59,12 +107,15 @@ describe('ModelSlotArbiter', () => {
     expect(resumed).toBe(false) // builder still parked while chat streams
 
     release() // chat stream ended
+    await tick()
+    expect(resumed).toBe(false) // #399 D3(a): NOT the instant chat let go
+    passDelay()
     await parked
     expect(resumed).toBe(true) // builder resumed in-session, no restart
   })
 
   it('resumes the builder only after the LAST concurrent chat releases', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const acquire1 = a.acquireForChat()
     const acquire2 = a.acquireForChat()
@@ -78,12 +129,13 @@ describe('ModelSlotArbiter', () => {
     await tick()
     expect(resumed).toBe(false) // one chat still holds the slot
     rel2()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('a second concurrent chat does not deadlock when the build is already parked', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     // Chat A pauses the build and waits for the handoff.
     const acquireA = a.acquireForChat()
@@ -107,12 +159,13 @@ describe('ModelSlotArbiter', () => {
     await tick()
     expect(resumed).toBe(false)
     relB()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('a fresh build is not poisoned by a prior build s leftover handshake state', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     // Simulate a prior build that left chatHolders > 0 (e.g. an unbalanced release path).
     a.registerBuild('old')
     void a.acquireForChat() // chatHolders -> 1 (never released)
@@ -127,12 +180,13 @@ describe('ModelSlotArbiter', () => {
     const parked = a.reacquire('new').then(() => (resumed = true))
     const release = await acquire
     release()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('rejects a parked reacquire on abort (cancel/lock/quit) — no hung await', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const acquire = a.acquireForChat()
     await tick()
@@ -148,7 +202,7 @@ describe('ModelSlotArbiter', () => {
   // and the pause it requested is dropped, so the builder doesn't needlessly park for a chat
   // that's gone (which, with no chat left to release it, would hang the build).
   it('rejects a chat acquire when its signal aborts during the handoff wait, and unwinds cleanly (REL-3)', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const controller = new AbortController()
     const acquire = a.acquireForChat(controller.signal)
@@ -166,12 +220,13 @@ describe('ModelSlotArbiter', () => {
     const parked = a.reacquire('job1').then(() => (resumed = true))
     const rel = await acquire2
     rel()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('one chat aborting during the wait keeps the pause + handoff for a co-waiting chat (REL-3)', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const c1 = new AbortController()
     const acquire1 = a.acquireForChat(c1.signal)
@@ -189,12 +244,13 @@ describe('ModelSlotArbiter', () => {
     await tick()
     expect(resumed).toBe(false)
     rel2()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('an already-aborted signal makes a chat acquire reject without taking the slot (REL-3)', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const controller = new AbortController()
     controller.abort() // already stopped before we even ask
@@ -206,12 +262,13 @@ describe('ModelSlotArbiter', () => {
     let resumed = false
     const parked = a.reacquire('job1').then(() => (resumed = true))
     ;(await acquire)()
+    passDelay()
     await parked
     expect(resumed).toBe(true)
   })
 
   it('does not hang a chat acquire that races the build finishing', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const acquire = a.acquireForChat() // waits for a handoff that will never come
     await tick()
@@ -222,7 +279,7 @@ describe('ModelSlotArbiter', () => {
   })
 
   it('release is idempotent', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const acquire = a.acquireForChat()
     await tick()
@@ -230,6 +287,7 @@ describe('ModelSlotArbiter', () => {
     const release = await acquire
     release()
     release() // second call is a no-op, does not double-resume
+    passDelay()
     await expect(parked).resolves.toBeUndefined()
   })
 
@@ -239,7 +297,7 @@ describe('ModelSlotArbiter', () => {
   // withChatStream's `finally` later ran the returned release fn — a transient stall in which the
   // build resumed only via the OTHER chat. The fix installs the release-on-abort on BOTH paths.
   it('aborting a FAST-PATH (build-already-parked) chat holder releases its slot promptly (R2)', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     // Chat A pauses the build and is handed the slot (slow path).
     const acquireA = a.acquireForChat()
@@ -258,6 +316,7 @@ describe('ModelSlotArbiter', () => {
     await tick()
     expect(resumed).toBe(false) // A still holds the slot → build NOT resumed yet
     relA() // the surviving chat releases
+    passDelay()
     await tick()
     // FIXED: B was released by its abort, A by relA → chatHolders hit 0 → build resumes. UNFIXED:
     // B's abort installed no listener and its release fn was never called → chatHolders stuck at 1
@@ -266,7 +325,7 @@ describe('ModelSlotArbiter', () => {
   })
 
   it('a FAST-PATH holder freed by abort is idempotent with its release fn (R2 — no double-release)', async () => {
-    const a = new ModelSlotArbiter()
+    const a = mkArbiter()
     a.registerBuild('job1')
     const acquireA = a.acquireForChat()
     await tick()
@@ -287,8 +346,149 @@ describe('ModelSlotArbiter', () => {
     // while A still holds → this pins single-release.
     expect(resumed).toBe(false)
     relA()
+    passDelay()
     await tick()
     expect(resumed).toBe(true)
+  })
+
+  // ---- #399 D3(a): the post-chat resume delay -----------------------------------------
+  //
+  // Why the delay exists: on 11 of our 14 chat models an evicted chat prefix is re-prefilled
+  // from scratch, not restored (model-benchmarks.md §6.6, "2026-09-09 correction (#399)"). The
+  // builder used to take the slot back the instant chatHolders hit 0 — i.e. inside the gap
+  // between one reply ending and the user typing the next — so an ordinary conversation paid a
+  // full re-prefill on EVERY turn. Not evicting is the only lever there is.
+
+  it('does not resume the parked build until the whole post-chat delay has elapsed (#399 D3(a))', async () => {
+    const a = mkArbiter()
+    a.registerBuild('job1')
+    const acquire = a.acquireForChat()
+    await tick()
+    let resumed = false
+    const parked = a.reacquire('job1').then(() => (resumed = true))
+    const release = await acquire
+
+    release() // the chat stream ended
+    await tick()
+    expect(resumed).toBe(false) // pre-#399 this was already true at this point
+
+    clock.advance(RESUME_AFTER_CHAT_DELAY_MS - 1) // one millisecond short
+    await tick()
+    expect(resumed).toBe(false)
+
+    clock.advance(1) // …and now the delay is up
+    await parked
+    expect(resumed).toBe(true)
+  })
+
+  it('a chat turn inside the delay window cancels the resume — and waits for NOTHING itself', async () => {
+    const a = mkArbiter()
+    a.registerBuild('job1')
+    const first = a.acquireForChat()
+    await tick()
+    let resumed = false
+    const parked = a.reacquire('job1').then(() => (resumed = true))
+    ;(await first)()
+
+    // The user's next turn lands 30 s later — inside the window. THE POINT OF THE WHOLE FIX:
+    // the build must not have taken the slot back in between, so nothing was evicted.
+    clock.advance(30_000)
+    await tick()
+    expect(resumed).toBe(false)
+
+    // And this acquire resolves WITHOUT the delay: the delay is on the BUILD's resume, never on
+    // chat's acquisition (which the chat path awaits). No clock advance below — if acquiring the
+    // slot cost any fake time at all, this would hang instead of settling.
+    let acquired = false
+    const second = await a.acquireForChat().then((r) => {
+      acquired = true
+      return r
+    })
+    expect(acquired).toBe(true)
+    expect(clock.pending()).toBe(0) // the armed resume really was cancelled, not just ignored
+
+    // Only the release after the LAST turn re-arms it — so one conversation costs at most one
+    // hand-back, not one per turn.
+    second()
+    passDelay()
+    await parked
+    expect(resumed).toBe(true)
+  })
+
+  // ---- #399 D3(a): the starvation guarantee -------------------------------------------
+  //
+  // The guarantee, stated: the arbiter adds at most MAX_PARK_DEFERRAL_MS of delay to any single
+  // park. A document that silently never gets its deep index is a worse outcome than one slow
+  // reply, so past the cap the next release resumes the build immediately — pre-#399 behaviour.
+
+  it('a park already deferred past the cap resumes on the very next release, with no delay', async () => {
+    const a = mkArbiter()
+    a.registerBuild('job1')
+    const acquire = a.acquireForChat()
+    await tick()
+    let resumed = false
+    const parked = a.reacquire('job1').then(() => (resumed = true))
+    const release = await acquire
+
+    // This chat turn itself ran long enough to carry the park past the cap.
+    clock.advance(MAX_PARK_DEFERRAL_MS)
+    release()
+    await parked // NO advance: past the cap the resume is synchronous
+    expect(resumed).toBe(true)
+    expect(clock.pending()).toBe(0) // it resumed, it did not schedule
+  })
+
+  it('a user chatting steadily every 30 s cannot defer the build for ever (starvation guarantee)', async () => {
+    const a = mkArbiter()
+    a.registerBuild('job1')
+    const opening = a.acquireForChat()
+    await tick()
+    let resumed = false
+    const parked = a.reacquire('job1').then(() => (resumed = true))
+    ;(await opening)()
+
+    // Turn after turn, each landing 30 s after the last — always inside the 90 s window, which
+    // is exactly the pattern a naive "wait 90 s after every chat turn" starves on for ever.
+    let turns = 0
+    while (!resumed && turns < 1000) {
+      turns += 1
+      clock.advance(30_000)
+      await tick()
+      const rel = await a.acquireForChat()
+      rel()
+      await tick()
+    }
+    expect(resumed).toBe(true) // UNCAPPED, this loop runs out its 1000 turns instead
+    await parked
+    // And it resumed on the first release past the cap, no later: 30 s a turn, so the cap falls
+    // on turn MAX_PARK_DEFERRAL_MS / 30_000 and that turn's release is the one that wakes it.
+    expect(turns).toBe(MAX_PARK_DEFERRAL_MS / 30_000)
+  })
+
+  it('an armed resume never fires into a build that was aborted or replaced meanwhile', async () => {
+    const a = mkArbiter()
+    a.registerBuild('job1')
+    const acquire = a.acquireForChat()
+    await tick()
+    const parked = a.reacquire('job1')
+    const rejected = expect(parked).rejects.toBeInstanceOf(SlotAbortedError)
+    ;(await acquire)()
+    expect(clock.pending()).toBe(1) // the resume is armed…
+
+    a.abort() // …and a cancel / lock / quit / model-switch lands first
+    await rejected
+    expect(clock.pending()).toBe(0) // disarmed, so it cannot wake a dead handshake
+
+    // A fresh build starts clean and still gets the normal delayed resume.
+    a.registerBuild('job2')
+    const acquire2 = a.acquireForChat()
+    await tick()
+    let resumed2 = false
+    const parked2 = a.reacquire('job2').then(() => (resumed2 = true))
+    ;(await acquire2)()
+    passDelay()
+    await parked2
+    expect(resumed2).toBe(true)
   })
 })
 
@@ -334,7 +534,8 @@ describe('builder parks at the level boundary (full-audit 2026-07-10 BE-6)', () 
 
     // Real build ('real' modelId ⇒ cache misses again): chat asks for the slot DURING the
     // final level-1 generation.
-    const arbiter = new ModelSlotArbiter()
+    const clock = makeClock()
+    const arbiter = new ModelSlotArbiter(clock.deps)
     arbiter.registerBuild('job-level-yield')
     let calls = 0
     // Boxed so the outer await does NOT flatten (and thus wait on) the acquire promise.
@@ -369,8 +570,10 @@ describe('builder parks at the level boundary (full-audit 2026-07-10 BE-6)', () 
     expect(winner).toBe('chat-acquired')
     expect(calls).toBe(probeL1) // parked BEFORE the first level-2 generation
 
-    // Releasing resumes the SAME build in-session to a complete tree.
+    // Releasing resumes the SAME build in-session to a complete tree — after the #399 D3(a)
+    // post-chat delay, which this fake clock is the only thing that can advance.
     ;(await acquire)()
+    clock.advance(RESUME_AFTER_CHAT_DELAY_MS)
     const meta = await buildDone
     expect(meta.rootId).toBeTruthy()
     expect(meta.levels).toBeGreaterThan(1)

--- a/apps/desktop/tests/unit/prompt-cache-rules.test.ts
+++ b/apps/desktop/tests/unit/prompt-cache-rules.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PROMPT_CACHE_RESTORE_BROKEN_FAMILIES,
+  promptCacheServerArgs
+} from '../../src/shared/prompt-cache-rules'
+
+// Issue #399 D5. The rule is a NAMED list with a measured basis, not an inline literal at the
+// argv call site, so these tests can pin (a) the measured split, (b) that the default for
+// anything unmeasured is cache-ON, and (c) that the flag we emit is the one the pinned binary
+// takes. The families come from the fourteen-model sweep recorded in model-benchmarks.md §6.6
+// ("2026-09-09 correction (#399)"); the three RESTORED rows below are its positive controls.
+
+describe('prompt-cache family rule (#399 D5)', () => {
+  it('disables the host prompt cache for every family measured to lose the restore', () => {
+    // RE-PREFILLED in the sweep: qwen3.5 / qwen3.8 by recurrent state, gemma4 by sliding window.
+    for (const family of ['qwen3.5', 'qwen3.8', 'gemma4']) {
+      expect(promptCacheServerArgs(family)).toEqual(['--cache-ram', '0'])
+    }
+  })
+
+  it('leaves every family that DID restore alone — argv byte-identical to before #399', () => {
+    // The sweep's three positive controls, by the `family:` their manifests declare.
+    for (const family of ['qwen3', 'mistral3']) {
+      expect(promptCacheServerArgs(family)).toEqual([])
+    }
+  })
+
+  it('defaults an UNMEASURED family to cache-ON (the deliberate safe direction)', () => {
+    // qwen3.6 and granite were never started in the sweep (#446) — broken symlinks / not on the
+    // rig. Turning the cache off on a model that CAN restore costs real restores on every
+    // hand-back; leaving it on for one that cannot merely continues a waste we can bound. So an
+    // unknown family, and a model with no family at all, must add nothing to the argv.
+    for (const family of ['qwen3.6', 'granite', 'llama9', 'phi-next']) {
+      expect(promptCacheServerArgs(family)).toEqual([])
+    }
+    expect(promptCacheServerArgs(null)).toEqual([])
+    expect(promptCacheServerArgs(undefined)).toEqual([])
+    expect(promptCacheServerArgs('')).toEqual([])
+  })
+
+  it('matches the family exactly — no prefix or substring creep', () => {
+    // `qwen3` must not be caught by `qwen3.5`, and `qwen3.5` must not swallow a future
+    // `qwen3.5x`. A prefix match here would silently disable the cache on models that restore.
+    expect(promptCacheServerArgs('qwen3')).toEqual([])
+    expect(promptCacheServerArgs('qwen3.55')).toEqual([])
+    expect(promptCacheServerArgs('gemma4x')).toEqual([])
+    expect(promptCacheServerArgs('GEMMA4')).toEqual([]) // manifests are lower-case
+  })
+
+  it('emits the flag the pinned b9849 binary actually takes', () => {
+    // `-cram, --cache-ram N` — "default: 8192, -1 = no limit, 0 = disable". Verified against
+    // `llama-server.exe --help` on the pin (799fcc04a) before this shipped. A malformed arg here
+    // breaks EVERY chat model start on every machine, not just the affected families.
+    const args = promptCacheServerArgs('gemma4')
+    expect(args).toHaveLength(2)
+    expect(args[0]).toBe('--cache-ram')
+    expect(args[1]).toBe('0')
+  })
+
+  it('the exported list is exactly the three measured families', () => {
+    // A guard against quietly widening the rule: adding a family here requires a measurement.
+    expect([...PROMPT_CACHE_RESTORE_BROKEN_FAMILIES].sort()).toEqual(['gemma4', 'qwen3.5', 'qwen3.8'])
+  })
+})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3291,9 +3291,17 @@ layers at 30.4 tok/s into 66/66 at 51.0 by cutting the recurrent state from 1,79
 (#318 leg 1). It does **not** change the context window: `--ctx-size` is the total cache on both
 settings and each slot sees all of it (`n_ctx_slot = 8192` either way), so only the per-sequence
 recurrent term moved in the seven manifest cache estimates — the KV and Gemma's sliding-window
-caches are cell-sized and counted once. Accepted cost: a background job now evicts the chat
-conversation's KV prefix, which llama-server's host-RAM prompt cache restores on a prefix match.
-Record: `model-benchmarks.md` §6.6 "2026-09-07 amendment (#319)"; BUILD_STATE §5 item 22 (f)/(i).
+caches are cell-sized and counted once. Accepted cost, **corrected 2026-09-09 (#399)**: a
+background job evicts the chat conversation's KV prefix, and on 11 of the 14 chat models
+llama-server's host-RAM prompt cache does **not** restore it — recurrent state (the whole
+`qwen3.5`/`qwen3.8` line) and a sliding window (all four `gemma4` manifests) both close that path,
+so the server saves the conversation and silently re-prefills it anyway. Not caused by `-np 1`
+(four slots lose the restore the same way) and not fixable by any slot arrangement, so the fix is
+not to evict: the model-slot arbiter waits 90 s after a chat turn before resuming a parked
+deep-index build, capped at 10 minutes of deferral per park (D3(a)), and `--cache-ram 0` stops the
+unreadable copy being written for those families (D5, `shared/prompt-cache-rules.ts`).
+Record: `model-benchmarks.md` §6.6 "2026-09-07 amendment (#319)" and its "2026-09-09 correction
+(#399)"; BUILD_STATE §5 item 22 (f)/(i).
 Separately, whether `--fit` also puts layers on a hybrid laptop's iGPU — which the app
 never excludes with `--device` — was read from `common/fit.cpp` as "it spreads layers across every
 device `--list-devices` lists". **MEASURED FALSE on the pinned b9849 build (#318 leg 5, 2026-09-07;

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,34 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-09 — the two 2026-09-05 dated entries retired verbatim (preamble budget)
+
+Moved out of `BUILD_STATE.md` on 2026-09-09 to keep the preamble inside its 200-line budget
+(`repo-hygiene.test.ts`), making room for the #399 prompt-cache entry: the Graphics-memory-aware
+picker entry (whose total-memory rule was already superseded by the 2026-09-06 PR #308 audit
+amendment) and the Performance-wave entry. Both waves are closed and carry their durable records —
+`docs/model-benchmarks.md` §6.6 (rule C, the 2026-09-06 and 2026-09-07 amendments) and
+`docs/benchmark.md` "History per machine" / "Performance screen" plus its "Audit remediation
+record — PR #303"; residuals stay tracked in BUILD_STATE §5 item 22.
+
+_2026-09-05: **Graphics-memory-aware picker (`feat/vram-aware-picker`, stacked on #303):** the total-memory
+rule shipped here is **superseded** by the 2026-09-06 PR #308 audit amendment above (rule C on free memory; §6.6)._
+
+_2026-09-05: **Performance wave (`feat/performance-screen`): the hardware check moves from the
+third card of Settings › Diagnostics to a primary rail destination, "Performance". Rail rework in
+the same branch (owner decision): three groups (Chat · Documents · Translate · Images ‖ AI Model ·
+Performance ‖ Settings), Home behind the brand mark (lit on Home), Skills back into Settings as a
+tab (`skills` target resolves there); design-guidelines §2 rewritten.** Verdict + four rated tiles (speed, RAM, VRAM via
+`BenchmarkResult.gpuVramMb`, drive) and the "Your model" row (memory class discrete / unified /
+cpu, the chat ladder's placement parser over llama.cpp's load log, `settings.modelPlacements`,
+`placementVerdict`), the session's observed figures (last
+answer via a `chat:speed` observer, last model start / file check via per-source read-speed
+latches), and one result per computer (`settings.benchmarkHistory`, `machineKey`). The moved-drive
+check in `maybeRunFirstBenchmark` restores a known machine's result or benchmarks a new one;
+`benchmark:progress` streams the run's steps. Diagnostics keeps the raw table. Records:
+`docs/benchmark.md` "History per machine" / "Performance screen", data-contracts (settings
+storage + IPC). §5 item 22 tracks the residuals._
+
 ## 2026-09-09 — three closed dated entries retired verbatim (preamble budget)
 
 Moved out of `BUILD_STATE.md` on 2026-09-09 to keep the preamble inside its 200-line budget

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2493,6 +2493,52 @@ All of these are decided scope, not oversights; the design record's §7 carries 
   lands on the RTX, pinned as a fixture), so what stays open there is the SNAPSHOT's device
   pairing on a hybrid box that also has a budget device (#332).
 
+## The one chat slot and the prompt cache (#319 / #399 — [`model-benchmarks.md`](model-benchmarks.md) §6.6)
+
+The chat sidecar runs **one** server slot (`-np 1`, issue #319): the app is single-user and already
+serialises every lane that reaches it, and four slots cost card memory exactly where the fit decides
+between a full and a half offload. The consequence is that when something else takes the slot, the
+conversation's KV prefix is evicted — and on most of the models we ship, llama-server **cannot give
+it back**.
+
+- **On 11 of our 14 chat models an evicted chat prefix is re-prefilled from scratch, not restored**
+  (measured 2026-09-08/09, #399). llama-server saves the conversation to its host-RAM prompt cache
+  and then silently re-processes the whole prompt anyway. Two architectures lose the restore:
+  **recurrent state** — the whole `qwen3.5` line (`-2b`, `-4b`, `-9b`, `-35b-a3b`) and all three
+  `qwen3.8-27b` quants — and a **sliding window** — all four `gemma4` manifests (`e2b`, `e4b`,
+  `12b`, `26b-a4b`). That includes the **catalog-default 4B and the 9B**, i.e. the 8–12 GB tier
+  picks. Among ranked models only `ministral3-8b-instruct-2512-q4` keeps the restore; the dense
+  `qwen3-8b` and the `qwen3-30b-a3b` MoE keep it too, which is what makes this a measured
+  architecture split rather than an anecdote. **Not measured:** `qwen3.6-27b-q4` / `-q5` and
+  `granite-4.1-8b-q4` (#446 — almost certainly affected, treated as unaffected by the conservative
+  default), and the ZIM query expander's own call (#447). If llama.cpp PR #13194 lands
+  recurrent-state restore upstream, this whole entry becomes removable.
+- **What can actually evict a live conversation is narrower than it sounds.** `assertChatStreamReady`
+  makes categorisation, summary, translate, compare, OCR and every `modelLane` skill run **refuse**
+  a chat turn rather than take the slot from it. The one cooperative hand-back is the **yielding
+  deep-index build**, auto-enqueued when a document too large for the one-pass summary is ingested.
+  And a *documents* ask never had the history in the slot to lose: its retrieved-excerpt block
+  changes every turn, so only its ~227-token system prefix is ever reused. So the case that costs
+  real time is specific: **a long document was just added, and you are having a plain chat — not a
+  documents ask — while it indexes.**
+- **Residual after the 2026-09-09 fix: returning from a break costs ONE slow reply.** The arbiter
+  now waits 90 s after a chat turn before resuming a parked deep-index build, which removes the
+  per-turn churn — a conversation's own typing and reading gaps no longer hand the slot away turn
+  after turn. It does not remove the cost. A pause **longer** than 90 s still lets the build resume
+  and evict, so the first reply after that break re-prefills the conversation: once, not per turn.
+  Nor is the delay unbounded — a single park is deferred for at most 10 minutes, after which the
+  build resumes at the next release regardless. That cap is deliberate: a document that silently
+  never gets its deep index is a worse outcome than one slow reply. A steady chat every 30 s
+  therefore still pays a re-prefill roughly every 10 minutes.
+- **Behaviour change on affected models: llama-server's host prompt cache is switched off**
+  (`--cache-ram 0`, gated on the manifest's `family:` — `qwen3.5`, `qwen3.8`, `gemma4`). On those
+  models the cache was written on every hand-back (15–344 MiB per eviction, up to an 8 GiB host-RAM
+  default) and **never read**, so this gives that RAM back and costs nothing. Every other family —
+  **including a family nobody has measured** — keeps the cache on. That asymmetry is the point:
+  disabling it on an unaffected model would cost real restores, while leaving it on an affected one
+  merely continues a waste we can already name. Chat only; the embedder, reranker, translation and
+  vision sidecars do not inherit the chat args and are untouched.
+
 ## Speculative decoding (MTP — [`architecture.md`](architecture.md) "MTP speculative decoding" record)
 
 The measured speed-up (+38–45 % decode on the reference GPU) is deliberately narrow. All of these

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -1020,7 +1020,12 @@ build still runs. And `CHAT_SERVER_ARGS` gains `--cache-ram 0` for the affected 
 so the unreadable copy is no longer written; every other family, **including an unmeasured one**,
 keeps today's behaviour, because disabling the cache on an unaffected model would cost real restores
 while leaving it on merely continues the waste. Residual: a pause longer than the delay still lets
-the build resume and evict, so returning from a break costs ONE slow reply — once, not per turn.
+the build resume and evict, so returning from a break costs ONE slow reply — once, not per turn. Both
+sides of the D5 gate were checked on hardware before it shipped — on `i7-8700-gtx-1070-ti-8gb-32gb`
+the app spawned `qwen3.5-9b-ud-q4kxl` WITH `--cache-ram 0` and `qwen3-14b-instruct-q4` without it
+(read from the OS process list, not from our own code), and the affected model still started fully
+offloaded, its 50.25 MiB recurrent state matching the sweep's 9B row exactly:
+`eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/399-cache-ram-gate-smoke.md`.
 
 **A methodological warning for anyone reproducing this.** Do **not** grep for `forcing full prompt
 re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see llama.cpp

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -957,13 +957,82 @@ in-app path depends on parallel slots. **The restore half of that cost MEASURED 
 (#391 leg 7, evidence `leg7-app-q5km-evicted-prefix.*`); the decision stands, the cost is larger
 than stated.** Consecutive turns in one conversation do reuse the prefix in the slot (22 tokens
 re-prefilled on turn 2 of 190 cached). But once another task takes the one slot, the server saves the
-conversation to the host cache and then refuses to load it back: `forcing full prompt re-processing
-due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see llama.cpp PR #13194)`.
-Both 27B quants are hybrid/recurrent, so the restore path is closed to them. Measured: a 435-token
-conversation, evicted by one turn in another conversation, re-prefilled **305 of 452 tokens** on
-return; only the 147-token system prefix survived, because it is common to every conversation and
-stays in the slot. The cost therefore scales with conversation length rather than being constant, and
-it is paid on every hand-back. Follow-up: #399. **What it does NOT change: the context window.**
+conversation to the host cache and then refuses to load it back. Measured: a 435-token conversation,
+evicted by one turn in another conversation, re-prefilled **305 of 452 tokens** on return; only the
+147-token system prefix survived, because it is common to every conversation and stays in the slot.
+
+**2026-09-09 correction (#399): the affected set is 11 of 14 chat models, not "both 27B quants".**
+The first version of this paragraph named only the two 27B quants as hybrid/recurrent. That reading
+was far too narrow. A fourteen-model architecture sweep on `i9-9900x-rtx-3090-24gb-128gb` — raw
+`llama-server`, the app's argv shape at `--ctx-size 8192 -np 1`, **no MTP**, every model fully
+offloaded, three requests per start (long conversation A → a short unrelated B takes the slot → back
+to A) — settles which architectures lose the restore. Evidence: PR #445,
+`eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue399-arch-sweep-*`.
+
+**RE-PREFILLED — 11 models, two architectures.** The whole modern Qwen line by **recurrent state**:
+`qwen3.5-2b/-4b/-9b-ud-q4kxl`, `qwen3.5-35b-a3b-ud-q4kxl`, and all three `qwen3.8-27b` quants
+(`-q4`, `-ud-q4km`, `-ud-q5km`) — 1,488–1,492 of ~1,530–1,571 tokens re-processed on return, with
+only the 41–79-token shared system prefix surviving. And **all four Gemma 4 manifests** by **sliding
+window** (`n_swa` 512 or 1024): `gemma4-e2b`, `gemma4-e4b`, `gemma4-12b`, `gemma4-26b-a4b` — 1,471 of
+1,514, 43 kept. That includes **both 8–12 GB tier picks, the catalog-default 4B and the DIY 9B** —
+i.e. exactly the machines where re-prefilling a whole history is least affordable. The 27B Q5 control
+reproduces leg 7 token for token.
+
+**RESTORED — the three positive controls.** `qwen3-8b-instruct-q4` (arch `qwen3`),
+`qwen3-30b-a3b-q4` (`qwen3moe`) and `ministral3-8b-instruct-2512-q4` (`mistral3`) — no sliding
+window, no recurrent state — each re-prefilled only **14–21 tokens** of a ~1,470-token return prompt.
+So the restore mechanism works, the method detects it, and this is a **measured architecture split**,
+not an anecdote: recurrent state OR a sliding window closes the restore path; nothing else does.
+Among ranked models `ministral3-8b` is the only one that keeps it.
+
+**Which path actually pays the length-proportional cost — the plain CHAT path only (leg B).** A
+documents ask keeps only its **~227-token system prefix** on every turn, with or without a helper
+call: the retrieved-excerpt block changes between turns, so the prompt diverges immediately after the
+system prompt and the history was never being reused there in the first place (control, 2,371-token
+prompt, 2,144 prefilled, 227 kept, nothing touching the slot). RT-2's hoisting keeps the grounding
+rules inside that 227-token prefix, and that prefix is the whole of what in-slot reuse can save on
+that path — so an eviction's marginal cost on a documents ask is bounded by it, not by conversation
+length. `classifySkillPointer` also turns out to run only on the two trigger classes
+`services/analysis/classify.ts:65` pins, not "whenever there are skill candidates": an ordinary
+high-confidence documents ask made zero classifier calls in four attempts, and on a turn that does
+trigger it the cost is ~400 extra prefilled tokens (~1.4 s). The length-proportional cost is real but
+belongs to an ordinary **chat** conversation, where the prompt is append-only and in-slot reuse works
+(171 → 22 → 22). Neither helper runs on that path, and `assertChatStreamReady`
+(`ipc/chat-stream.ts:65-77`) makes every non-yielding lane refuse chat rather than take the slot — so
+the one thing that can evict a live chat is the **yielding deep-index build**. That is what narrowed
+the fix to D3(a).
+
+**No slot arrangement fixes this (leg C).** `-np 2` on the 27B Q5 fits (66/66, 2,676 MiB headroom
+left, so `MTP_VRAM_HEADROOM_MB` does not bite) but halves every conversation's window to 4,096
+(`--ctx-size` is the total cache) — and R3 is **identical token for token**, 1,492 of 1,571. The slot
+picker prefers prefix similarity (0.804, threshold 0.100 — the shared `BASE_SYSTEM_PROMPT`
+guarantees it) over an idle empty slot, and when A did land in the never-used slot the host-cache
+restore failed there too. On a recurrent/SWA model the state cannot be reconstructed from a saved
+prompt at all. **The only lever is not evicting**, and the saved copy is pure waste: 14.86–343.59 MiB
+written per eviction and never read.
+
+**Fixed 2026-09-09 (#399, owner decisions D3(a) + D5).** The arbiter no longer resumes a parked
+deep-index build the instant chat releases the slot — it waits `RESUME_AFTER_CHAT_DELAY_MS` (90 s,
+`services/analysis/model-slot-arbiter.ts`), so a conversation's own typing/reading gaps stop handing
+the slot away turn after turn; a `MAX_PARK_DEFERRAL_MS` (10 min) cap on a single park guarantees the
+build still runs. And `CHAT_SERVER_ARGS` gains `--cache-ram 0` for the affected families only
+(`shared/prompt-cache-rules.ts`, gated on the manifest's `family:` — `qwen3.5`, `qwen3.8`, `gemma4`),
+so the unreadable copy is no longer written; every other family, **including an unmeasured one**,
+keeps today's behaviour, because disabling the cache on an unaffected model would cost real restores
+while leaving it on merely continues the waste. Residual: a pause longer than the delay still lets
+the build resume and evict, so returning from a break costs ONE slow reply — once, not per turn.
+
+**A methodological warning for anyone reproducing this.** Do **not** grep for `forcing full prompt
+re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see llama.cpp
+PR #13194)`. That line appears only on **MTP** starts — it did not appear once in the whole
+fourteen-model sweep, not on the 27B Q5 control, not on any Gemma. Without MTP the server logs a
+confident `load: - found better prompt with f_keep = 0.990, sim = 0.983` and then silently re-prefills
+the whole prompt anyway. Grepping for `forcing full` gives the **opposite** answer; the TOKEN COUNT
+(`prompt eval time = … / N tokens` against `cached n_tokens`) is the only honest read. Still
+unmeasured: `qwen3.6-27b-q4` / `-q5` and `granite-4.1-8b-q4` (#446), and the ZIM query expander
+(#447). If llama.cpp PR #13194 lands recurrent-state restore upstream, both the delay and the D5
+switch become removable. Follow-up: #399 (closed by this work). **What it does NOT change: the
+context window.**
 `--ctx-size` is the TOTAL cache size on both settings and every slot sees all of it
 (`n_ctx_slot = 8192` either way; `kv_unified` goes true → false, `n_seq_max` 4 → 1). That is the
 whole reason only four of the seven cache terms moved — see point 4 above for the rule and the

--- a/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/399-cache-ram-gate-smoke.md
+++ b/eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/399-cache-ram-gate-smoke.md
@@ -1,0 +1,94 @@
+### #399 D5 smoke: does `--cache-ram 0` reach the right models, and does the affected one still start?
+
+Machine `i7-8700-gtx-1070-ti-8gb-32gb` (this repo's `00-preflight.md`), 2026-09-09, on the lite
+test drive `E:`. Runtime `E:\runtime\llama.cpp\win\llama-server.exe` → `version: 9849 (799fcc04a)`,
+the app pin. Branch `fix/399-prompt-cache-restore`.
+
+The question this leg answers is narrow and it is the one the unit tests cannot answer: **does the
+flag our code composes actually arrive at the process, on the model it should and only on that
+model** — and does the affected model still start with it. It is not a re-run of the #399
+architecture sweep (that is PR #445, on `i9-9900x-rtx-3090-24gb-128gb`).
+
+Both sides of the family gate exist on this drive with real weights:
+
+| manifest id | `family:` | rule says |
+|---|---|---|
+| `qwen3.5-9b-ud-q4kxl` | `qwen3.5` | AFFECTED → `--cache-ram 0` |
+| `qwen3-14b-instruct-q4` | `qwen3` | unaffected → argv unchanged |
+
+---
+
+#### Leg 1 — the flag is real on the pin, and it is what disables the cache
+
+Raw `llama-server`, no app. The server states the outcome itself, which is the honest read:
+
+```text
+# qwen3-4b-instruct-q4, --ctx-size 512 -lv 4 -np 1, NO cache flag
+srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+srv    load_model: use `--cache-ram 0` to disable the prompt cache
+srv          init: idle slots will be saved to prompt cache upon starting a new task
+
+# same model, same argv + --cache-ram 0
+srv    load_model: prompt cache is disabled - use `--cache-ram N` to enable it
+srv          init: --cache-idle-slots requires --cache-ram, disabling
+```
+
+The second `init:` line is expected and harmless: `--cache-idle-slots` defaults on and depends on
+the cache, and at `-np 1` there is no idle slot to save anyway.
+
+#### Leg 2 — the AFFECTED model starts with the flag, and it is the architecture the sweep named
+
+Raw `llama-server`, the app's full chat argv shape (`--ctx-size 8192 --batch-size 2048
+--ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1 --cache-ram 0`):
+
+```text
+load_tensors: offloaded 33/33 layers to GPU
+llama_memory_recurrent:    Vulkan0 RS buffer size =    50.25 MiB
+srv    load_model: prompt cache is disabled - use `--cache-ram N` to enable it
+```
+
+Starts clean and fully offloaded on an 8 GB card. The `llama_memory_recurrent` line is the
+independent confirmation that this really is the affected architecture — **50.25 MiB, the exact
+figure the sweep recorded for the 9B** (leg A, `issue399-arch-sweep-qwen3.5-9b-ud-q4kxl`).
+
+#### Leg 3 — IN-APP: the gate picks the right model, read from the OS, not from our code
+
+Dev build against `E:` (`HILBERTRAUM_DRIVE_ROOT`, `HILBERTRAUM_MANIFESTS_DIR`,
+`HILBERTRAUM_PERF_LOG=1`), workspace unlocked, each model started from the app. The argv below is
+`Get-CimInstance Win32_Process` — the command line **Windows** reports for the spawned child, not
+anything the app printed:
+
+```text
+# unaffected — family qwen3
+…\llama-server.exe --host 127.0.0.1 --port 65225 --model E:\models\chat\qwen3-14b-instruct-q4.gguf
+  --ctx-size 8192 --threads 6 --batch-size 2048 --ubatch-size 2048
+  --jinja --reasoning-format deepseek -lv 4 -np 1
+
+# affected — family qwen3.5
+…\llama-server.exe --host 127.0.0.1 --port 51155 --model E:\models\chat\qwen3.5-9b-ud-q4kxl.gguf
+  --ctx-size 8192 --threads 6 --batch-size 2048 --ubatch-size 2048
+  --jinja --reasoning-format deepseek -lv 4 -np 1 --cache-ram 0
+```
+
+**The unaffected model's argv is byte-identical to before #399** — the flag is appended, nothing is
+displaced, and the rung args would still follow it. Both starts reported `healthy: true`,
+`backend: gpu` (GTX 1070 Ti); the perf log records `runtime_ready` for the affected model at
+64.5 s (a 5.97 GB weight read over USB 3, not a figure about this change).
+
+Session ended by closing the window: `vault_lock_done` in `E:\logs\perf.log`, the workspace back to
+`hilbertraum.sqlite.enc` with no `-wal` sidecar, no stray `llama-server` left, and the drive's
+in-place workspace and active model unchanged.
+
+---
+
+#### What this leg does NOT show
+
+- **No token was generated in-app on the affected model.** Both starts passed the app's own health
+  round-trip, and leg 2 is a full raw start of the same weight with the same flag, but no chat turn
+  was sent (the workspace on this drive is the owner's).
+- **Nothing here re-measures the eviction.** Whether an evicted prefix is restored was settled on
+  `i9-9900x-rtx-3090-24gb-128gb` (PR #445) and is not re-derived from an 8 GB card.
+- **Only two families were exercised.** `gemma4` and `qwen3.8` are not on this drive; they are
+  covered by `prompt-cache-rules.test.ts` and `llama-runtime.test.ts`, not by hardware.
+- **The D3(a) arbiter delay was not exercised on hardware at all** — it is behavioural and pinned
+  by tests on an injected clock; a real run would take 90 s per park to observe.


### PR DESCRIPTION
Implements the #399 outcome: the record is corrected (step 2) and both owner decisions are landed (step 3). Four commits: docs correction, arbiter, argv, hardware evidence.

## Why this needed a fix at all

#386's accepted-cost clause said an evicted chat prefix is **restored** from llama-server's host-RAM prompt cache, so the cost of running one slot was "a restore, not a full re-prefill". #391 leg 7 found the counter-evidence, and the #399 measurement round (PR #445, merged) settled the shape of it:

- **11 of 14 chat models cannot restore an evicted prefix.** Two architectures lose it — **recurrent state** (the whole `qwen3.5` line and all three `qwen3.8-27b` quants) and a **sliding window** (all four `gemma4` manifests, including the catalog-default 4B and the DIY 9B, i.e. the 8–12 GB tier picks). Three positive controls — a dense Qwen, a Qwen MoE and a Mistral — *did* restore, each re-prefilling 14–21 tokens of a ~1,470-token return prompt. That is what makes this a measured architecture split rather than an anecdote. Among ranked models `ministral3-8b` is the only one that keeps the restore.
- **No slot arrangement fixes it.** `-np 2` fits on the 27B (66/66, 2,676 MiB spare) but re-prefills **token for token** — and it did so even when the conversation landed in a slot nothing had ever touched. The state cannot be rebuilt from a saved prompt at all. So the only lever is **not evicting**, and the saved copy is pure waste.
- **Leg B narrowed the fix.** A documents ask keeps only its ~227-token system prefix with or without a helper call, because the retrieved-excerpt block makes the prompt diverge right after the system prompt — nothing was being reused there to lose. The length-proportional cost belongs to the plain **chat** path, and `assertChatStreamReady` leaves exactly one thing that can evict a live conversation: the yielding deep-index build.

## Step 2 — correcting the record

- **`docs/model-benchmarks.md` §6.6** — the accepted-cost paragraph rewritten. The §-anchor is unchanged (code comments cite it) and the original clause is kept visible with its correction, rather than quietly edited away. Adds the measured split with the three positive controls, leg B's finding, leg C, and the grep trap below.
- **`docs/known-limitations.md`** — new "The one chat slot and the prompt cache": the affected family list, what can actually evict a live chat, the residual after the fix, and the D5 behaviour change.
- **`docs/architecture.md`** and the `-np 1` doc comment above `CHAT_SERVER_ARGS` both carried copies of the same false sentence; both corrected.
- **BUILD_STATE.md** dated entry. The preamble and §5 were sitting at **exactly** their caps (200/200 and 500/500), so per the retention rule the two oldest closed entries (both 2026-09-05) were drained **verbatim** to `docs/build-log.md`. No budget raised, no §5 item renumbered.
- **Follow-ups filed:** **#446** (`qwen3.6-27b` q4/q5 — broken symlinks on the rig — and `granite-4.1-8b`, never tested; almost certainly affected, safe under the conservative default, must not later read as "measured and fine") and **#447** (the ZIM query expander, bounded by inference rather than measurement).
- **PR #445** was already merged, so every citation resolves.

**D4 is deferred, as decided** — no picker warning. The warning was proposed when we believed the length-proportional cost hit every documents turn; leg B says it does not.

## Step 3 — the fix

### D3(a): the arbiter waits before resuming a parked build

The parked builder used to take the slot back the instant `chatHolders` hit 0 — inside the gap between one reply ending and the user typing the next — so an ordinary conversation paid a full re-prefill **every turn**.

**The delay is on the build's resume, never on `acquireForChat()`.** The chat path awaits that call; a delay there would slow every chat turn and be a worse bug than the one being fixed. A chat arriving inside the window finds the builder still parked, cancels the pending resume and takes the slot synchronously. One test asserts this by construction: it advances no fake time around the acquire, so if acquiring ever cost any, it would hang rather than pass.

**90 s** is the midpoint of the owner's 60–120 s range. What is being covered is a conversation's own turn gap — reading a long answer and typing a follow-up sits comfortably inside it, while 120 s buys little more and delays the index longer on every park.

**The starvation guarantee.** A naive "wait 90 s after every chat turn" lets someone chatting every 30 s stop the build resuming for ever, and a document that silently never gets its deep index is a worse outcome than one slow reply. So: **the arbiter adds at most `MAX_PARK_DEFERRAL_MS` (10 min) of delay to any single park.** The clock starts when the builder parks; past the cap the next release resumes it immediately — exactly pre-#399 behaviour. A steady conversation therefore pays a re-prefill roughly every 10 minutes instead of every turn. Two tests pin it, including one that drives turn after turn at 30 s and asserts the resume lands on the first release past the cap and no later.

### D5: `--cache-ram 0`, family-gated

The rule is a **named, tested module** with the sweep in its comment — `shared/prompt-cache-rules.ts`, following the `shared/gpu-rules.ts` / `shared/performance-rules.ts` pattern — not an inline literal at the call site.

The family was **not** reachable at argv-build time, so it is **threaded, not smuggled through a global**: `family` joins `RuntimeStartOptions` exactly as `speculativeDecoding` did (#182), supplied by `startModelRuntime`, which has the manifest. A test pins that wiring, because a dropped field would be invisible — the model would just go on writing a copy that is never read.

**The default is deliberately cache-ON**, including for an unmeasured family and for a model with no family. Disabling the cache on a model that *can* restore costs real restores on every hand-back; leaving it on for one that cannot merely continues a waste we can bound. So `qwen3.6` and `granite` stay off the list until someone measures them (#446).

## Blast-radius review — what it found

- **The arbiter's pause/resume contract survives intact.** All 13 existing handshake tests (H10, the `chatHolders` refcount, "a returning DocTask never resumes", the REL-3 abort paths, the R2 fast-path single-release latch) still drive the **shipped** path — they advance an injected clock where they expected a resume, rather than being neutered with a fire-immediately timer. A broken cancel or a resume that fires early still reddens them.
- **Every teardown path had to disarm the timer,** or a pending resume could wake a dead handshake: `abort()` (cancel/lock/quit/model-switch), `unregisterBuild()`, and `registerBuild()`'s clean-slate reset. There is a test for that.
- **`chat-stream.ts:65-77` is untouched.** Only a yielding build can take the slot; every other lane still refuses chat. Nothing here weakens that.
- **`CHAT_SERVER_ARGS` stays a frozen shared const.** The cache flag is composed **between** it and the ladder's rung args, so `--device none` still wins on rung 2 for an affected model; a test pins that ordering. No test asserted argv by exact equality, so nothing broke there, and the runtime-ladder / MTP / placement-parser paths are unaffected — the placement parser reads `-lv 4` load lines, which the new flag does not touch.
- **The reranker, translation and vision sidecars compose `LlamaServer` directly** and never see `CHAT_SERVER_ARGS`. Their tests now assert `--cache-ram` does not leak in, beside the existing `--jinja` / `-np` assertions. Worth pinning on translation in particular: TranslateGemma is a *gemma* family, the one that would have matched had the gate been applied at the wrong layer.
- **One new seam:** `slotArbiterDeps` on `DocTaskDeps`, documented as test-only. It exists because the delay is 90 s of wall clock, which no test can wait out; production never sets it.

## Hardware smoke — run, both sides of the gate

On `i7-8700-gtx-1070-ti-8gb-32gb`, pinned b9849, against the `E:` drive. Full write-up: `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/399-cache-ram-gate-smoke.md`.

The in-app leg reads the spawned child's command line **from Windows**, not from our own code:

```text
# family qwen3 (unaffected) — byte-identical to before this branch
…llama-server.exe … --jinja --reasoning-format deepseek -lv 4 -np 1

# family qwen3.5 (affected)
…llama-server.exe … --jinja --reasoning-format deepseek -lv 4 -np 1 --cache-ram 0
```

Both started `healthy: true`, `backend: gpu`. Raw-server legs confirm the flag is what disables the cache (`prompt cache is enabled, size limit: 8192 MiB` becomes `prompt cache is disabled`) and that the affected `qwen3.5-9b-ud-q4kxl` still starts **fully offloaded, 33/33 layers**, with `llama_memory_recurrent: RS buffer size = 50.25 MiB` — the exact figure the sweep recorded for the 9B, so this is independently the architecture that was measured.

Not shown, and said so in the evidence file: no token was generated in-app on the affected model; nothing here re-measures the eviction; only two of the three gated families are on this drive; and D3(a) was not exercised on hardware (it is behavioural and would take 90 s per park to observe).

## The trap, restated because it will mislead the next person

Do **not** grep for `forcing full prompt re-processing due to lack of cache data`. That line appears **only on MTP starts** — it did not appear once in the whole fourteen-model sweep, not on the 27B Q5 control, not on any Gemma. Without MTP the server logs a confident `found better prompt with f_keep = 0.990, sim = 0.983` and then silently re-prefills the whole prompt anyway. Grepping for it gives the **opposite** answer. The token count is the only honest read.

## Verification

`npm test` (448 files), `npm run typecheck` and `npm run build` all green locally. Six timeouts on the first full run were self-inflicted — a 6 GB model was loading off USB at the same time; those two files pass on an idle machine.

## Closing #399

Every item in step 2 is done, so this closes it. The two things #399 named as unfinished are filed rather than dropped: **#446** and **#447**. The tracking line for llama.cpp PR #13194 is in §6.6 — if upstream lands recurrent-state restore, both the delay and the D5 switch become removable.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
