### PR TITLE
fix(#436, #437): the two silent live regions announce again

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,26 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-10 — **#436 + #437 CLOSED — the two silent live regions fixed** (`fix/436-437-live-region-announce`).
+**#436:** `role="status"` is a LIVE REGION (implicit `aria-live="polite"`), not a quieter label — so the `Banner` nested inside
+`ErrorBanner`'s always-mounted `role="alert"` wrapper became the nearest live-region ancestor of the message AND arrived already
+containing it: M-U1 one level down, silencing the shared failure surface of 11 screens + the gate's #145 wrong-password banner.
+`Banner`'s `role` prop now accepts `null` (render no role at all; `aria-live="off"` does NOT work, the ROLE has to go) and
+`ErrorBanner` passes it. The blast radius was one site larger than the issue said: `ModelsScreen`'s download panel keeps its own
+hand-rolled copy of the wrapper with TWO nested `role="status"` Banners — same defect, fixed the same way. **#437:** the
+Performance step list was BOTH inserted with its content and textless as it advanced (progress rode only on `perf-step-{state}`
+and an `aria-hidden` icon). The `<ul>` is now mounted unconditionally (`.perf-steps:empty` collapses it, idle layout unchanged)
+and each step carries its state IN its accessible text — the visible label is `aria-hidden` and an sr-only twin reads
+"<step>: <state>" (new `perf.step.state.*` keys, EN+DE) — so an advance is a whole-line text change WITH context, plus
+`aria-current="step"` on the active item. Guard: `tests/unit/live-region-nesting.test.ts` parses every renderer `.tsx` and fails
+on ANY live-region role nested inside another (it flags all three pre-fix sites; two fixtures pin the broken and the fixed shape).
+**Not closed by this branch: the BY-EAR leg.** Both issues require re-verification with a screen reader (#436 also on the #145
+wrong-password path, #437 during a real multi-second check) — that needs Narrator on the 1070 Ti box and is the remaining
+acceptance item on the PR. **Sequencing:** #438 (an automatic run's steps never advance) is still an open owner call on the same
+subtree; this fix is forward-compatible with either of its options — under option 2 the items render on `ownActionInFlight`
+instead of `busy`, a one-condition change, not a rework. Docs: `benchmark.md` §2 row HW3 + §4, `known-limitations.md`
+(Performance + Accessibility), `design-guidelines.md` §6 error announcements._
+
 _2026-09-09 — **#399 CLOSED — the §6.6 record corrected and both owner decisions landed** (`fix/399-prompt-cache-restore`;
 record `model-benchmarks.md` §6.6 "2026-09-09 correction (#399)", `known-limitations.md` "The one chat slot and the prompt
 cache"; evidence PR #445). The old accepted-cost clause said "both 27B quants are hybrid/recurrent, so the restore path is
@@ -112,66 +132,6 @@ MODEL (nothing persisted, `runtime:notice` names it), a CPU rung starting persis
 follow view + task, a kept selection is marked, family-only reset; #314 `downloads:list`/`downloads:dismiss` re-attach a download after
 a renderer reload, dismissal lives in main memory; #315 findBy assertions, baseline staleness test, 17 dead keys deleted. Owner rulings
 taken on the plan defaults (PR body). Suite: master 421 files / 6,815 tests → 422 / 6,930 (85 skipped); typecheck + build green; the zim-packs T14 case flaked once under full load (green alone, untouched here). Residuals: §5 item 23._
-_2026-09-06 — **Follow-up wave on `feat/performance-screen` (#303), one commit per issue, ledger `tmp/followups-303-ledger.md`:**
-#325 closed `4293f95f` (GPU-off tile never falls back to a recorded card; Copy report carries the live pick; "Running on the graphics card right now." line — visual unverified);
-#323 closed `b0b26eec` (a completed chat-engine install re-runs the probe refresh when this machine's eligible probe is empty); #335 closed `6f1bcde1` (the harness records and removes every suite's temp root; ~2,500 leaked roots per run → 0); #322 closed — `speedIdentity` + the one-directional gate in `speedSignalFor` (a sample counts for a next start no faster than the measured path; §6.5 2026-09-06 amendment, owner-confirmed on review of the first draft)._
-
-_2026-09-06 — **PR #308 audit remediation (`feat/vram-aware-picker`, stacked on #303):** R1–R6 closed —
-P1 sync (`7aae2716`), P2 budget device + next-start class (`81661c69`), P2a empty-probe persistence
-(`8cb4422d`), P3 rule C on the free-memory budget + per-model cache term (`bf9a09b0`), P4 live
-Performance recommendation (`a468f6e1`), P5 records (`e4b762e9`); base re-merged as #303 landed (the
-second merge unified #303 P5's `gpu-rules` with this wave's helper). Decisions 1–11 adopted; record
-`model-benchmarks.md` §6.6 (2026-09-06 amendment) + §6.5; **owner sign-off given 2026-09-06** in the PR
-review. #318 hardware legs (not a gate); (h)–(k) → #320 / #319 / #320 / #321 (all: keep, measure first);
-#324 omitted; #326 → strictly ranked card-path fallback; residuals #322, #323, #325; #327 fixed by #303._
-
-_2026-09-06 — **PR #303 audit remediation on `feat/performance-screen` (master `ddd704ad` merged in
-first; one commit per phase, CI green on each; working ledger `tmp/pr-303-fix-plan-ledger.md`,
-untracked; durable record → `docs/benchmark.md` at P9).** P1 pinned the M7 `_Host` and L7
-empty-reading fixes of `ce741533`, removed the `skills.title` orphan, archived §5 item 20. P2 repaired
-M2/M4/M6/L2 together (`services/benchmark-persistence.ts`: identity before source ranking under G3,
-outgoing-result backfill, commit-time re-resolution, samples to both destinations). P3 made the screen
-pushed, never polled (`performance:changed` after every mutation incl. runtime and sidecar residency;
-`running` = the held span; observed rows = session latches; honest `drive`/`speed` steps; the renderer
-splits backend running from its own action) — the dev launch smoke caught and fixed a StrictMode
-double-mount defect and measured `performance:get` ≈ 100 ms (I5). P4 validates `lastBenchmark`,
-`benchmarkHistory`, `modelPlacements` on read and write (`shared/benchmark-schema.ts`; the legacy
-profile-only record survives unkeyed), resolves the displayed context with `launchContextTokens`, and
-counts a placement as measured only when its context/backend match the configuration. P5 made one
-machine-eligible GPU source (`gpuProbe.machineKey`, `shared/gpu-rules.ts`, paired name + memory,
-configuration-aware resident rows, class-aware RAM total, free/working figures by device; a CI-only
-same-millisecond sample clash was fixed by an injectable read-speed clock). P6 carried the speed basis
-into the report and rows, fixed the first-start / per-drive / observed-unknown / N4 / N5 copy, named
-the fit margin from `shared/performance-rules.ts`, added the German smoke and the display-device labels. P7 sequenced the first-run / moved-drive
-measurement behind the auto-start (L1/SD2, G5): `prepareFirstBenchmark` does the cheap seed /
-backfill / restore before `maybeAutoStartActiveModel` (now awaitable), `scheduleFirstBenchmark` waits
-for the start to settle under a 120 s bound and otherwise keeps one continuation, re-checks admission
-/ epoch / shutdown / busy / "already current" before running, allows one automatic attempt per unlock
-epoch, and the run refuses to persist into a session that locked or re-opened meanwhile. P8 closed the test gaps (T7/T8/T11/TH1/TH2): the history-order assertion names both
-identities, a source-text + behavioural pin covers the answer-speed observer wiring, the 300 ms sleep
-became an await on P7's outcome, one shared teardown closes the fixture's DBs and removes its temp
-roots (2,683 leaked roots from earlier runs cleared), and a ladder-to-placement wiring test drives
-the real rung factory with a fake sidecar's stderr (one parser per attempt; the persister writes,
-skips while locked, and survives a throwing observer). P9 wrote the durable record — `docs/benchmark.md` "Audit remediation record — PR #303"
-§1–§5 (decisions, a 63-row disposition matrix, the design as built, what is not verified, a §-anchor
-legend) — plus user-guide §5a "Performance", the privacy inventories in `PRIVACY.md` /
-`security-model.md`, the known-limitations block, the `architecture.md` supersession notes, and the
-DR11 host-conditional assertion turned into a fixed expectation. P10 cross-reviewed the candidate `07dd9085` (Opus over the Fable phases, Fable
-over the Opus phases, both over the Sonnet docs and the P0 delta inventory): no user-facing defect;
-four low main-process items, one schema hardening gap, a keyboard focus loss after "Check again" and
-issue #327 (the Diagnostics acceleration line bypassing the eligible-probe rule, filed by the PR #308
-review against this branch) repaired with fail-before/pass-after tests; the audit probes re-run at the
-candidate pass every main-process case (22 / 2 superseded by design / 1 retired); HW3 performed live
-over CDP — EN/DE, light/dark, 880/1024/1280 px, the German rail at weight 600, a real Tab walk and
-Enter activation all passed; a synthetic moved-drive restart verified M2/M4/P7 end to end. Blocked
-legs (screen-reader announcements; a first-run, chat or model-load while mounted — no runtime here)
-carried into the follow-up issues. P11 closed the wave without a source change: follow-up
-issues #329–#334 (a real partial-offload log, the two-computer round trip, the blocked HW3 legs,
-hybrid / Apple Silicon hardware, the slow-media read cost, slow-USB sequencing) and #335 (temp-root
-hygiene in other suites), the record's issue and commit references filled, the changelog entry,
-the keyboard-focus repair re-verified live in the dev app. Merge is the owner's call; the branch
-stays._
-
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -192,7 +152,9 @@ entries of the #290/#291 wave (PRs #295/#300/#297/#299) and Phase F PR 6 + close
 (Phases 0–6 + the 2026-09-04 MVP entry, PRs #304–#336) on 2026-09-06 at the P7 close-out (preamble
 budget), and the Phase 9b close-out (PR #282), Model library UX (PR #302) and #286 save-a-code-block
 entries on 2026-09-09 (preamble budget, making room for the knowledge-packs docs and #331
-HW3-acceptance entries) —
+HW3-acceptance entries), and the three closed 2026-09-06 entries (the #303 follow-up wave, the PR #308
+audit remediation, the PR #303 audit remediation) on 2026-09-10 (preamble budget, making room for the
+#436/#437 accessibility entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/apps/desktop/src/renderer/components/Banner.tsx
+++ b/apps/desktop/src/renderer/components/Banner.tsx
@@ -5,6 +5,9 @@ import { englishTranslator, type Translator } from './translator'
 // text + optional action, optionally dismissible. Errors announce via role="alert";
 // everything else is a polite role="status". Never stacked at the top of a screen;
 // place a Banner next to the thing it talks about.
+//
+// A Banner rendered INSIDE an already-mounted live region (ErrorBanner, the ModelsScreen
+// download panel) must pass `role={null}` — see the role prop below and issue #436.
 
 export type BannerTone = 'info' | 'success' | 'warning' | 'error'
 
@@ -25,11 +28,16 @@ export interface BannerProps {
   /** Bound translate fn for the built-in dismiss label (i18n record §5 ⑤); English default. */
   t?: Translator
   /**
-   * Override the announce role. Defaults to `alert` for the error tone, `status`
-   * otherwise. ErrorBanner (audit M-U1) passes `status` so the always-mounted wrapper
-   * owns the single `role="alert"` live region instead of nesting two.
+   * Override the announce role. Defaults to `alert` for the error tone, `status` otherwise.
+   *
+   * `null` renders NO role attribute — the only correct value when this Banner is nested inside
+   * an already-mounted live region. `role="status"` is ITSELF a live region (implicit
+   * `aria-live="polite"`), so a nested `status` becomes the nearest live-region ancestor of the
+   * message AND is inserted already containing it — the very M-U1 anti-pattern the wrapper exists
+   * to prevent. Verified by ear with Narrator (#436): a nested `status` is silent, `aria-live="off"`
+   * on it does NOT rescue it, and only removing the role outright announces.
    */
-  role?: 'alert' | 'status'
+  role?: 'alert' | 'status' | null
 }
 
 export function Banner({
@@ -43,7 +51,8 @@ export function Banner({
   return (
     <div
       className={`banner banner-${tone}`}
-      role={role ?? (tone === 'error' ? 'alert' : 'status')}
+      // Prop omitted (`undefined`) ⇒ the tone default; an explicit `null` ⇒ no role at all.
+      role={role === null ? undefined : (role ?? (tone === 'error' ? 'alert' : 'status'))}
     >
       <span className="banner-icon" aria-hidden="true">
         {TONE_ICON[tone]}

--- a/apps/desktop/src/renderer/components/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/ErrorBanner.tsx
@@ -8,6 +8,15 @@ import { englishTranslator, type Translator } from './translator'
 // missed by many screen readers. So the alert container is ALWAYS mounted; the visible
 // Banner mounts/unmounts inside it, and the message text swaps within the live region.
 // Mirrors the always-mounted Toast host live region.
+//
+// ⚠ role="status" IS A LIVE REGION (implicit aria-live="polite"), not merely a quieter label.
+// The first cut of this component nested <Banner role="status"> inside the wrapper, reasoning
+// that the wrapper should own the single ALERT role — which is true, and beside the point: the
+// nested status then became the nearest live-region ancestor of the message and was inserted
+// already containing it, reintroducing M-U1 one level down. Narrator (2026-09-09, #436) heard
+// NOTHING from it. aria-live="off" on the inner element does not rescue it either; the ROLE has
+// to go. So nothing inside .error-banner-region may carry a live-region role — pinned by
+// A11yAnnounce.test.tsx "no live-region role nests inside the wrapper".
 
 export interface ErrorBannerProps {
   /** Error text to announce + show. `null`/`''` renders an empty (but mounted) region. */
@@ -33,13 +42,13 @@ export function ErrorBanner({
 }: ErrorBannerProps): JSX.Element {
   const show = message != null && message !== ''
   return (
-    // The Banner already carries role="alert" for the error tone; the outer wrapper
-    // keeps a stable element in the tree across mounts so the swap is what AT hears.
+    // The outer wrapper keeps a stable element in the tree across mounts, so what AT hears
+    // is the text swapping inside a region that was already there.
     <div className="error-banner-region" role="alert" aria-live="assertive">
       {show && (
-        // Inner Banner is role="status" (not its own alert) — the wrapper owns the
-        // single live region so AT doesn't see two competing alert roles.
-        <Banner tone="error" role="status" onDismiss={onDismiss} t={t}>
+        // Inner Banner carries NO role: the wrapper above is the one and only live region in
+        // this subtree, so the message reads as a text change inside it (#436).
+        <Banner tone="error" role={null} onDismiss={onDismiss} t={t}>
           {message}
           {children}
         </Banner>

--- a/apps/desktop/src/renderer/screens/ModelsScreen.tsx
+++ b/apps/desktop/src/renderer/screens/ModelsScreen.tsx
@@ -1415,16 +1415,18 @@ export function ModelsScreen(): JSX.Element {
           {!panelRowRendered && <strong>{panelName}</strong>}
           {/* ONE always-mounted alert node for the whole panel lifetime: empty while the download
               runs, filled on the terminal transition. Same wrapper shape as ErrorBanner (audit
-              M-U1) — a live region that only appears at failure is not reliably announced. */}
+              M-U1) — a live region that only appears at failure is not reliably announced.
+              The Banners inside pass role={null}: role="status" is itself a live region, and a
+              nested one swallows the announcement (#436). Nothing in here may carry a role. */}
           <div className="error-banner-region" role="alert" aria-live="assertive">
             {panelJob.status === 'failed' && (
-              <Banner tone="error" role="status">
+              <Banner tone="error" role={null}>
                 <p>{t('models.download.failed', { name: panelName })}</p>
                 {panelJob.error && <p>{panelJob.error}</p>}
               </Banner>
             )}
             {panelJob.status === 'done' && panelJob.unverified && (
-              <Banner tone="warning" role="status">
+              <Banner tone="warning" role={null}>
                 {t('models.download.unverifiedBefore')}
                 <code>verify-models --generate</code>
                 {t('models.download.unverifiedAfter')}

--- a/apps/desktop/src/renderer/screens/PerformanceScreen.tsx
+++ b/apps/desktop/src/renderer/screens/PerformanceScreen.tsx
@@ -943,7 +943,14 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
     )
   }
 
-  function steps(): JSX.Element {
+  /**
+   * The progress-step ITEMS. The <ul> that holds them is mounted unconditionally below — this
+   * returns only what goes inside it while a check runs (#437 cause 1: the region used to be
+   * created together with its <li>s, i.e. inserted already containing its content, which is the
+   * M-U1 anti-pattern every other live region in the renderer avoids; Narrator heard nothing
+   * across two real 14-second runs).
+   */
+  function stepItems(): JSX.Element[] {
     // The speed step only exists when a runtime is up; a run with no model shows it skipped.
     const speedLabel = runtimeModelId
       ? t('perf.step.speed', { model: modelName(runtimeModelId, models, t) })
@@ -955,19 +962,26 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
       done: ''
     }
     const firstOpen = STEP_ORDER.find((s) => !doneSteps.includes(s))
-    return (
-      <ul className="perf-steps" aria-live="polite">
-        {STEP_ORDER.map((step) => {
-          const state = doneSteps.includes(step) ? 'done' : step === firstOpen ? 'active' : 'todo'
-          return (
-            <li key={step} className={`perf-step perf-step-${state}`}>
-              <StepIcon state={state} />
-              <span>{labels[step]}</span>
-            </li>
-          )
-        })}
-      </ul>
-    )
+    return STEP_ORDER.map((step) => {
+      const state = doneSteps.includes(step) ? 'done' : step === firstOpen ? 'active' : 'todo'
+      return (
+        // #437 cause 2: progress used to be carried ONLY by the class and by StepIcon, which is
+        // aria-hidden — so even a correctly mounted region had no text change to announce. The
+        // state now lives in the accessible text. The visible label is aria-hidden and an sr-only
+        // twin carries "<step>: <state>", so the line is ONE accessible string that changes as a
+        // whole on every advance: assistive tech announces the step WITH its new state instead of
+        // a context-free "done". aria-current="step" additionally exposes the position as state.
+        <li
+          key={step}
+          className={`perf-step perf-step-${state}`}
+          aria-current={state === 'active' ? 'step' : undefined}
+        >
+          <StepIcon state={state} />
+          <span aria-hidden="true">{labels[step]}</span>
+          <span className="sr-only">{t(`perf.step.state.${state}`, { step: labels[step] })}</span>
+        </li>
+      )
+    })
   }
 
   const observed = snap?.observed
@@ -990,9 +1004,13 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
           </span>
         </div>
         {snap && bench && !snap.currentMachine && <p className="hint hint-lede">{t('perf.otherMachine')}</p>}
+        {/* The live region is mounted at all times — empty while idle (`.perf-steps:empty`
+            collapses it, so the idle layout is unchanged) and filled while a check runs, so the
+            steps arrive as a text change INSIDE a region that was already there (#437). Nothing
+            in here may carry a live-region role of its own — see #436. */}
+        <ul className="perf-steps" aria-live="polite">{busy ? stepItems() : null}</ul>
         {busy ? (
           <>
-            {steps()}
             <div className="actions perf-actions">
               <Button disabled>{t('perf.running')}</Button>
               <span className="hint">{t('perf.step.hint')}</span>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2638,6 +2638,11 @@ code, pre, kbd { font-family: var(--font-mono); }
 .perf-row-sub { grid-column: 1; grid-row: 2; font-size: var(--text-xs); line-height: var(--line-xs); color: var(--text-muted); overflow-wrap: anywhere; }
 .perf-row-side { grid-column: 2; grid-row: 1 / span 2; display: flex; align-items: center; gap: 6px; }
 .perf-steps { list-style: none; padding: 0; margin: 12px 0 0; display: flex; flex-direction: column; gap: 8px; }
+/* #437: the list is a live region and is therefore mounted even when idle (a region created
+   together with its content is not announced). Empty ⇒ no box at all, so the idle card looks
+   exactly as it did — never display:none on a non-empty one, which would drop it from the
+   accessibility tree along with the announcement. */
+.perf-steps:empty { display: none; }
 .perf-step { display: flex; align-items: flex-start; gap: 10px; font-size: var(--text-sm); line-height: var(--line-sm); }
 .perf-step-icon { width: 18px; height: 18px; flex-shrink: 0; }
 .perf-step-done .perf-step-icon { color: var(--success); }

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1999,6 +1999,10 @@ export const de: Record<keyof typeof en, string> = {
   'perf.step.speed': 'Generierungsgeschwindigkeit mit {model}',
   'perf.step.speedSkipped': 'Generierungsgeschwindigkeit (kein Modell läuft, übersprungen)',
   'perf.step.hint': 'Etwa eine halbe Minute. Du kannst die App weiter benutzen.',
+  // #437: der Schrittzustand steckt jetzt im Text, nicht nur in der CSS-Klasse.
+  'perf.step.state.done': '{step}: fertig',
+  'perf.step.state.active': '{step}: läuft',
+  'perf.step.state.todo': '{step}: wartet',
   'perf.observed.title': 'Während der Arbeit beobachtet',
   // Die Zeilen sind Sitzungs-Latches, die Lese-Messwerte dahinter werden aber zusätzlich in den
   // Benchmark-Datensätzen gespeichert (Laufwerkskachel oben) — L8.

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2000,6 +2000,14 @@ export const en = {
   'perf.step.speed': 'Generation speed with {model}',
   'perf.step.speedSkipped': 'Generation speed (no model running, skipped)',
   'perf.step.hint': 'About half a minute. You can keep using the app.',
+  // #437: a step's progress used to live ONLY in a CSS class and an aria-hidden icon, so the
+  // live region's text never changed as the check advanced and a screen reader heard nothing
+  // after the list appeared. Each step now carries its state IN ITS TEXT — the whole line is
+  // one accessible string, so an advance is a text change with its own context ("Drive speed:
+  // in progress"), not a bare "in progress" detached from the step it belongs to.
+  'perf.step.state.done': '{step}: done',
+  'perf.step.state.active': '{step}: in progress',
+  'perf.step.state.todo': '{step}: waiting',
   'perf.observed.title': 'Observed while you worked',
   // The rows are session latches, but the READ samples behind them are also persisted into the
   // benchmark records (the Drive tile above shows them with their own source and date). The

--- a/apps/desktop/tests/renderer/A11yAnnounce.test.tsx
+++ b/apps/desktop/tests/renderer/A11yAnnounce.test.tsx
@@ -44,6 +44,30 @@ describe('ErrorBanner persistent alert region (M-U1)', () => {
     expect(screen.getAllByRole('alert')).toHaveLength(1)
   })
 
+  // #436: the wrapper was defeated by what was nested in it. role="status" on the inner Banner
+  // is a live region of its own (implicit aria-live="polite"), so it became the nearest live-region
+  // ancestor of the message AND arrived already containing it — M-U1 again, one level down.
+  // Narrator confirmed the silence by ear. Nothing inside the wrapper may carry a live-region role.
+  it('nests no live-region role inside the wrapper', () => {
+    render(<ErrorBanner message="Import failed" onDismiss={() => {}} />)
+    const region = screen.getByRole('alert')
+    const nested = Array.from(region.querySelectorAll('[role], [aria-live]'))
+    expect(nested.map((el) => el.getAttribute('role') ?? el.getAttribute('aria-live'))).toEqual([])
+    // The visible Banner is still there — it just announces through the wrapper, not itself.
+    expect(region.querySelector('.banner')).not.toBeNull()
+    expect(region.querySelector('.banner')?.hasAttribute('role')).toBe(false)
+  })
+
+  // aria-live="off" on the inner node does NOT rescue it (variant B in #436 was silent too), so
+  // the guard is about the ROLE being absent, not about muting it.
+  it('the wrapper itself is the only live region, and it stays assertive', () => {
+    render(<ErrorBanner message="Import failed" />)
+    const region = screen.getByRole('alert')
+    expect(region).toHaveAttribute('aria-live', 'assertive')
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(screen.queryAllByRole('status')).toHaveLength(0)
+  })
+
   it('calls onDismiss from the inner Banner dismiss button', () => {
     const onDismiss = vi.fn()
     render(<ErrorBanner message="Something broke" onDismiss={onDismiss} />)

--- a/apps/desktop/tests/renderer/ModelsScreen.test.tsx
+++ b/apps/desktop/tests/renderer/ModelsScreen.test.tsx
@@ -1490,6 +1490,10 @@ describe('ModelsScreen — terminal download results stay visible (PR #302 F2, B
     expect(screen.getByRole('region', { name: REGION })).toBe(region)
     expect(within(region).getByRole('alert')).toBe(alert)
     await waitFor(() => expect(alert).toHaveTextContent('the connection dropped'))
+    // #436: the panel keeps its own hand-rolled copy of the ErrorBanner wrapper, and it had the
+    // same defect — a nested Banner role="status" is a live region itself, so it swallowed the
+    // announcement. Nothing inside this alert may carry a live-region role.
+    expect(alert.querySelectorAll('[role], [aria-live]')).toHaveLength(0)
   })
 
   // ---- Refresh at the terminal transition -------------------------------------------------------

--- a/apps/desktop/tests/renderer/PerformanceScreen.test.tsx
+++ b/apps/desktop/tests/renderer/PerformanceScreen.test.tsx
@@ -764,7 +764,9 @@ describe('PerformanceScreen: actions', () => {
     expect(api.runBenchmark).toHaveBeenCalledTimes(1)
     // Steps replace the tiles while the run is in flight.
     expect(screen.getByText('Hardware detected')).toBeInTheDocument()
-    expect(screen.getByText(/Generation speed with Qwen3\.5 9B/)).toBeInTheDocument()
+    // Two nodes now carry the speed label: the visible one and the sr-only twin that appends
+    // the step state (#437). Anchor the match so only the visible line satisfies it.
+    expect(screen.getByText(/Generation speed with Qwen3\.5 9B \(UD-Q4_K_XL\)$/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Running…' })).toBeDisabled()
     act(() => progress.forEach((cb) => cb('system')))
     expect(screen.getByText('Hardware detected').closest('li')?.className).toContain('perf-step-done')
@@ -1739,5 +1741,122 @@ describe('PerformanceScreen: whose recommendation the report names (#381)', () =
     )
     expect(contextAt).toBe(liveAt + 1)
     expect(contextAt).toBeLessThan(savedAt)
+  })
+})
+
+// -------------------------------------------------------------------------------------------
+// #437 — the progress steps are actually announceable.
+//
+// Verified by ear with Narrator on 2026-09-09 (issue #331, HW3 leg 1): across two real runs of
+// 14.2 s and 14.4 s the screen said NOTHING. Two independent causes, both pinned here:
+//   1. the aria-live list was created together with its <li>s, i.e. inserted already containing
+//      its content — the M-U1 anti-pattern. A region has to be present BEFORE the text arrives.
+//   2. even mounted, its text never changed: progress lived only in the `perf-step-{state}`
+//      class and in StepIcon, which is aria-hidden. Nothing to announce.
+// These tests are the DOM half of the acceptance; the by-ear half cannot be automated.
+// -------------------------------------------------------------------------------------------
+describe('PerformanceScreen: the step list is announceable (#437)', () => {
+  const stepList = (): HTMLElement | null => document.querySelector('ul.perf-steps')
+
+  it('cause 1: the live region is mounted while idle, before any run', async () => {
+    install(snapshot())
+    mountScreen()
+    await screen.findByRole('button', { name: 'Check again' })
+    const idle = stepList()
+    expect(idle).not.toBeNull()
+    expect(idle).toHaveAttribute('aria-live', 'polite')
+    // Empty, so `.perf-steps:empty` collapses it and the idle card is visually unchanged.
+    expect(idle).toBeEmptyDOMElement()
+  })
+
+  it('cause 1: the steps arrive INSIDE the same region node, not with a fresh one', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    const during = stepList()
+    // Same element instance as the idle one would be — identity is what makes it announceable.
+    expect(during).not.toBeNull()
+    expect(during?.querySelectorAll('li')).toHaveLength(3)
+    await act(async () => {
+      resolveRun(result())
+    })
+    await screen.findByRole('button', { name: 'Check again' })
+    // Back to idle: the region survives the run and empties, ready for the next one.
+    expect(stepList()).toBe(during)
+    expect(stepList()).toBeEmptyDOMElement()
+  })
+
+  it('cause 2: an advance changes the region text, not only a CSS class', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    const { progress } = install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    const before = stepList()?.textContent ?? ''
+    expect(before).toContain('Hardware detected: in progress')
+    expect(before).toContain('Drive speed: waiting')
+
+    act(() => progress.forEach((cb) => cb('system')))
+
+    const after = stepList()?.textContent ?? ''
+    expect(after).not.toBe(before)
+    expect(after).toContain('Hardware detected: done')
+    expect(after).toContain('Drive speed: in progress')
+    await act(async () => {
+      resolveRun(result())
+    })
+  })
+
+  it('cause 2: the active step exposes aria-current, and only one step does', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    const { progress } = install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    const current = (): HTMLElement[] => Array.from(document.querySelectorAll('.perf-steps [aria-current="step"]'))
+    expect(current()).toHaveLength(1)
+    expect(current()[0]?.textContent).toContain('Hardware detected')
+
+    act(() => progress.forEach((cb) => cb('system')))
+
+    expect(current()).toHaveLength(1)
+    expect(current()[0]?.textContent).toContain('Drive speed')
+    await act(async () => {
+      resolveRun(result())
+    })
+  })
+
+  it('the step line reads once: the visible label is hidden from AT, the sr-only twin carries it', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    const li = screen.getByText('Hardware detected').closest('li')
+    // Visible copy is unchanged and unduplicated on screen; only its accessible twin adds state.
+    expect(screen.getByText('Hardware detected')).toHaveAttribute('aria-hidden', 'true')
+    expect(li?.querySelector('.sr-only')?.textContent).toBe('Hardware detected: in progress')
+    await act(async () => {
+      resolveRun(result())
+    })
+  })
+
+  it('#436 applies here too: no live-region role nests inside the step region', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    expect(stepList()?.querySelectorAll('[role], [aria-live]')).toHaveLength(0)
+    await act(async () => {
+      resolveRun(result())
+    })
   })
 })

--- a/apps/desktop/tests/unit/live-region-nesting.test.ts
+++ b/apps/desktop/tests/unit/live-region-nesting.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import * as ts from 'typescript'
+
+// Nested-live-region guard (#436).
+//
+// The M-U1 discipline says a live region must be MOUNTED BEFORE its text arrives, so assistive
+// tech hears a text change inside a present region rather than a pre-filled region appearing.
+// The app grew always-mounted wrappers everywhere for exactly that — and then defeated two of
+// them by nesting `role="status"` INSIDE the wrapper. `status` is not a quiet label: it carries
+// an implicit `aria-live="polite"`, so it becomes the nearest live-region ancestor of the text
+// and is itself inserted already full. Narrator (2026-09-09) heard nothing from `ErrorBanner`
+// — the shared failure surface of 11 screens plus the workspace gate — for as long as it shipped
+// that way, and `aria-live="off"` on the inner node does NOT rescue it; the role has to go.
+//
+// So: no live-region element in the renderer may contain another one. This is a syntactic guard
+// over JSX with STRING-LITERAL attributes, which is precisely the shape both real defects had
+// (`<Banner tone="error" role="status">` inside `<div role="alert" aria-live="assertive">`).
+//
+// Known limits, stated so nobody reads more assurance into a green run than it earns:
+//   - A child COMPONENT that renders a live region internally (e.g. <Toast/>) is invisible here;
+//     the scan does not resolve component bodies.
+//   - A role supplied by a computed expression (`role={cond ? 'status' : undefined}`) is skipped.
+// Both are only reachable by ear. The by-ear leg stays the acceptance for #436/#437.
+
+const LIVE_ROLES = new Set(['alert', 'status', 'log', 'timer', 'marquee'])
+
+/** The renderer is the only tree with JSX; main/preload have none to scan. */
+function listRendererFiles(): string[] {
+  const root = join(process.cwd(), 'src', 'renderer')
+  const files: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name.endsWith('.tsx')) files.push(full)
+    }
+  }
+  walk(root)
+  return files
+}
+
+function attrs(node: ts.JsxElement | ts.JsxSelfClosingElement): ts.JsxAttributes {
+  return ts.isJsxElement(node) ? node.openingElement.attributes : node.attributes
+}
+
+/** The string-literal value of `name` on this element, or undefined (absent / computed). */
+function literalAttr(node: ts.JsxElement | ts.JsxSelfClosingElement, name: string): string | undefined {
+  for (const prop of attrs(node).properties) {
+    if (!ts.isJsxAttribute(prop) || prop.name.getText() !== name) continue
+    const init = prop.initializer
+    if (init && ts.isStringLiteral(init)) return init.text
+    // `role={'status'}` — a literal wearing braces is still a literal.
+    if (init && ts.isJsxExpression(init) && init.expression && ts.isStringLiteral(init.expression)) {
+      return init.expression.text
+    }
+    return undefined
+  }
+  return undefined
+}
+
+/** Does this element declare a live region via a literal `role` or `aria-live`? */
+function isLiveRegion(node: ts.JsxElement | ts.JsxSelfClosingElement): boolean {
+  const role = literalAttr(node, 'role')
+  if (role !== undefined && LIVE_ROLES.has(role)) return true
+  const live = literalAttr(node, 'aria-live')
+  return live === 'polite' || live === 'assertive'
+}
+
+function tagOf(node: ts.JsxElement | ts.JsxSelfClosingElement): string {
+  return (ts.isJsxElement(node) ? node.openingElement.tagName : node.tagName).getText()
+}
+
+interface Violation {
+  file: string
+  line: number
+  outer: string
+  inner: string
+}
+
+function findNestedLiveRegions(file: string): Violation[] {
+  const text = readFileSync(file, 'utf8')
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const found: Violation[] = []
+  const relative = file.replace(/[\\/]+/g, '/').split('/src/renderer/')[1] ?? file
+
+  // `outer` is the nearest enclosing live region, or null. Depth-first so the nearest one wins.
+  const walk = (node: ts.Node, outer: { tag: string } | null): void => {
+    let nextOuter = outer
+    if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+      if (isLiveRegion(node)) {
+        if (outer) {
+          found.push({
+            file: relative,
+            line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+            outer: outer.tag,
+            inner: tagOf(node)
+          })
+        }
+        nextOuter = { tag: tagOf(node) }
+      }
+    }
+    ts.forEachChild(node, (child) => walk(child, nextOuter))
+  }
+  walk(source, null)
+  return found
+}
+
+describe('no live region nests inside another (#436)', () => {
+  it('finds no nested live-region role anywhere in the renderer', () => {
+    const violations = listRendererFiles().flatMap(findNestedLiveRegions)
+    const rendered = violations.map((v) => `${v.file}:${v.line} <${v.inner}> inside <${v.outer}>`)
+    expect(rendered).toEqual([])
+  })
+
+  // The guard is worth nothing if it cannot see the shape that actually shipped. Both fixtures
+  // are the real defects, reduced: ErrorBanner's wrapper and the ModelsScreen download panel.
+  it('detects the shape that shipped (a Banner role="status" inside an alert wrapper)', () => {
+    const fixture = join(process.cwd(), 'tests', 'unit', '__live-region-fixture__.tsx')
+    const source = ts.createSourceFile(
+      fixture,
+      `export const X = () => (
+         <div className="error-banner-region" role="alert" aria-live="assertive">
+           {show && <Banner tone="error" role="status">{message}</Banner>}
+         </div>
+       )`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    )
+    // Re-run the same walk over the fixture text via the shared helper's parse path.
+    const found: string[] = []
+    const walk = (node: ts.Node, outer: string | null): void => {
+      let next = outer
+      if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+        if (isLiveRegion(node)) {
+          if (outer) found.push(`${tagOf(node)} inside ${outer}`)
+          next = tagOf(node)
+        }
+      }
+      ts.forEachChild(node, (child) => walk(child, next))
+    }
+    walk(source, null)
+    expect(found).toEqual(['Banner inside div'])
+  })
+
+  it('accepts the fixed shape (the nested Banner carries no role)', () => {
+    const source = ts.createSourceFile(
+      'ok.tsx',
+      `export const X = () => (
+         <div className="error-banner-region" role="alert" aria-live="assertive">
+           {show && <Banner tone="error" role={null}>{message}</Banner>}
+         </div>
+       )`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    )
+    const found: string[] = []
+    const walk = (node: ts.Node, outer: string | null): void => {
+      let next = outer
+      if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+        if (isLiveRegion(node)) {
+          if (outer) found.push(tagOf(node))
+          next = tagOf(node)
+        }
+      }
+      ts.forEachChild(node, (child) => walk(child, next))
+    }
+    walk(source, null)
+    expect(found).toEqual([])
+  })
+})

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1259,7 +1259,7 @@ guess.
 | TH2 | fixed P8 `4baec2be` | `closePerformanceFixture()` tears down every DB/root/observer the performance test helper registered; a leak check showed zero growth across a targeted run. The other suites' ~2,500 leaked roots per full run (#335, 2026-09-06) are now recorded and removed by the harness itself — `tests/setup-temp-roots.ts` per file, `tests/global-temp-roots.ts` after the forks exit; design in `tests/helpers/temp-roots.ts`, rule in CONTRIBUTING.md. | `tests/helpers/performance-fixture.ts`; `tests/unit/temp-roots.test.ts` |
 | HW1 | verified 2026-09-07 (issue #330) | Physical encrypted-drive A→B→A move on two real computers (i9-14900K / RTX 3080 Ti and i7-8700 / GTX 1070 Ti, one exFAT SSD) for a fresh workspace AND an upgraded one created by 0.1.57 (keyed `lastBenchmark`, no history): new-computer background run on B, instant restore on A, the outgoing result backfilled, later samples update the headline and the matching entry only. Side findings are not persistence defects (§4). | `eval/results/hardware/330-round-trip-20260907/` (`00-protocol.md` + every report and log) |
 | HW2 | CLOSED 2026-09-08 (#329) | Same gap as T9, closed by the same capture: real partial-offload load logs from the pinned build now exist (20/33 and 18/33 on a hybrid laptop, 62/66 on an RTX 3090) and are committed as fixtures. | `apps/desktop/tests/fixtures/placement-b9849-*.txt`; `eval/results/hardware/` |
-| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the four blocked legs CLOSED 2026-09-09 (issue #331) | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). The four legs not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms) were performed 2026-09-09 on the E: stick with a moved-drive workspace and a real 14B: **chat-during-a-span and mounted-screen refresh PASSED; both live regions are SILENT under a screen reader (#436, #437) and an automatic run's step list never advances (#438)**. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run"; `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md` |
+| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the four blocked legs CLOSED 2026-09-09 (issue #331) | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). The four legs not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms) were performed 2026-09-09 on the E: stick with a moved-drive workspace and a real 14B: **chat-during-a-span and mounted-screen refresh PASSED; both live regions were SILENT under a screen reader (#436, #437 — code fixed 2026-09-10, by-ear re-verification still outstanding) and an automatic run's step list never advances (#438, open owner call)**. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run"; `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md` |
 | HW4 | follow-up issue #332 | Hybrid `[iGPU, dGPU]` Vulkan order and Apple Silicon unified memory: synthetic fixtures only. | — |
 | DR1 | fixed P5 `be177a34` | Chat/translation "on the card" rows now respect `gpuMode`, `gpuAutoDisabled` and the matching observed backend, not the hardware class alone. | `performance-gpu.test.ts` "gpuMode 'off': both rows say cpu, the verdict is the processor estimate against RAM, bothOnCard is false — the hardware class is untouched"; "a matching start OBSERVED on the CPU backend puts the chat row on the processor and judges it against RAM" |
 | DR2 | fixed P5 `be177a34` | `ModelPlacement.devices` keeps every GPU row of the `device_info` block; `attributedGpuFigures` matches by device name, never the first row's. | `placement-parser.test.ts` "keeps every GPU row of a hybrid device_info block with its own compute buffer, by label (DR2)"; `performance-gpu.test.ts` "a hybrid log: the figures are the selected dGPU's, by name — never the first row's" |
@@ -1405,23 +1405,39 @@ commit references, and added the changelog entry.
   matching what was persisted.
 
   **Failed — three defects, filed separately.** Under Narrator, against a positive control that
-  proved live regions DO work in this window, **neither** live region on the screen is announced.
-  The progress steps are inserted already containing their content, and progress rides only on a
-  CSS class and an `aria-hidden` icon, so there is nothing to announce even once that is fixed
-  (#437). Worse, the FAILURE BANNER is silent too (#436): `ErrorBanner`'s always-mounted
-  `role="alert"` wrapper is defeated by the `Banner` nested inside it, whose `role="status"` is
+  proved live regions DO work in this window, **neither** live region on the screen was announced.
+  The progress steps were inserted already containing their content, and progress rode only on a
+  CSS class and an `aria-hidden` icon, so there was nothing to announce even once that was fixed
+  (#437). Worse, the FAILURE BANNER was silent too (#436): `ErrorBanner`'s always-mounted
+  `role="alert"` wrapper was defeated by the `Banner` nested inside it, whose `role="status"` is
   itself a live region mounted WITH its text — M-U1 reintroduced one level down, on a component
   11 screens and the workspace gate's #145 fix depend on. A control isolated the fix: an inner
   `aria-live="off"` does NOT help; the inner role has to go. And an automatic run's step list
   never advances, because progress is addressed to the window that pressed the button while the
   screen renders the list for any held span (#438).
+
+  **#436 and #437 fixed 2026-09-10** (`fix/436-437-live-region-announce`). `Banner`'s `role` prop
+  now takes `null` — no role at all — and `ErrorBanner` passes it, so its wrapper is the only live
+  region in the subtree; the same defect in `ModelsScreen`'s hand-rolled copy of that wrapper (two
+  more nested `role="status"` Banners, beyond the blast radius #436 stated) went with it. The step
+  list is mounted unconditionally and each step's state now lives in its accessible text — an
+  `aria-hidden` visible label beside an sr-only "<step>: <state>" twin, so an advance is a
+  whole-line text change rather than a CSS class — plus `aria-current="step"` on the active step.
+  A repo-wide guard (`tests/unit/live-region-nesting.test.ts`) parses every renderer `.tsx` and
+  fails on any live-region role nested inside another; it flags all three pre-fix sites.
+  **The acceptance is not complete:** both issues require re-verification BY EAR (a real failure
+  and a wrong-password unlock for #436; a real multi-second check for #437), and that needs a
+  screen reader on this box. What is pinned so far is the DOM, not the sound. #438 remains an
+  open owner call on the same subtree; the #437 fix is forward-compatible with either of its
+  options (under option 2 the items render on `ownActionInFlight` rather than `busy`).
 - **HW3-focus**: the keyboard-focus-after-a-run fix (`PerformanceScreen.test.tsx` "PerformanceScreen:
   focus survives the run") is pinned in jsdom and was re-verified live at P11 in the dev app
   built from `ab01e14b`: with "Check again" focused, a real Enter press ran the check (the
   "Checked" time advanced) and the active element was the "Check again" button again once the
   idle row returned — twice in a row. Announcements were audible-tested separately on
   2026-09-09 (HW3 above, issue #331): the focus behaviour is unaffected, but neither live region
-  on the screen is announced (#436, #437).
+  on the screen was announced (#436, #437 — both fixed 2026-09-10, by-ear re-verification still
+  outstanding; see HW3 above).
 - **HW4** (follow-up issue #332): a hybrid `[iGPU, dGPU]` Vulkan enumeration order and Apple
   Silicon `unified` memory. P5's device-pairing logic is exercised only by synthetic
   two-device fixtures.

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,72 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-10 — the three 2026-09-06 entries retired verbatim (preamble budget)
+
+_Moved out of `BUILD_STATE.md` while making room for the #436/#437 accessibility entry. All three
+waves are closed: the #303 follow-up wave, the PR #308 audit remediation, and the PR #303 audit
+remediation. Their durable records live in `docs/benchmark.md` and `docs/model-benchmarks.md` §6.5/§6.6._
+
+_2026-09-06 — **Follow-up wave on `feat/performance-screen` (#303), one commit per issue, ledger `tmp/followups-303-ledger.md`:**
+#325 closed `4293f95f` (GPU-off tile never falls back to a recorded card; Copy report carries the live pick; "Running on the graphics card right now." line — visual unverified);
+#323 closed `b0b26eec` (a completed chat-engine install re-runs the probe refresh when this machine's eligible probe is empty); #335 closed `6f1bcde1` (the harness records and removes every suite's temp root; ~2,500 leaked roots per run → 0); #322 closed — `speedIdentity` + the one-directional gate in `speedSignalFor` (a sample counts for a next start no faster than the measured path; §6.5 2026-09-06 amendment, owner-confirmed on review of the first draft)._
+
+_2026-09-06 — **PR #308 audit remediation (`feat/vram-aware-picker`, stacked on #303):** R1–R6 closed —
+P1 sync (`7aae2716`), P2 budget device + next-start class (`81661c69`), P2a empty-probe persistence
+(`8cb4422d`), P3 rule C on the free-memory budget + per-model cache term (`bf9a09b0`), P4 live
+Performance recommendation (`a468f6e1`), P5 records (`e4b762e9`); base re-merged as #303 landed (the
+second merge unified #303 P5's `gpu-rules` with this wave's helper). Decisions 1–11 adopted; record
+`model-benchmarks.md` §6.6 (2026-09-06 amendment) + §6.5; **owner sign-off given 2026-09-06** in the PR
+review. #318 hardware legs (not a gate); (h)–(k) → #320 / #319 / #320 / #321 (all: keep, measure first);
+#324 omitted; #326 → strictly ranked card-path fallback; residuals #322, #323, #325; #327 fixed by #303._
+
+_2026-09-06 — **PR #303 audit remediation on `feat/performance-screen` (master `ddd704ad` merged in
+first; one commit per phase, CI green on each; working ledger `tmp/pr-303-fix-plan-ledger.md`,
+untracked; durable record → `docs/benchmark.md` at P9).** P1 pinned the M7 `_Host` and L7
+empty-reading fixes of `ce741533`, removed the `skills.title` orphan, archived §5 item 20. P2 repaired
+M2/M4/M6/L2 together (`services/benchmark-persistence.ts`: identity before source ranking under G3,
+outgoing-result backfill, commit-time re-resolution, samples to both destinations). P3 made the screen
+pushed, never polled (`performance:changed` after every mutation incl. runtime and sidecar residency;
+`running` = the held span; observed rows = session latches; honest `drive`/`speed` steps; the renderer
+splits backend running from its own action) — the dev launch smoke caught and fixed a StrictMode
+double-mount defect and measured `performance:get` ≈ 100 ms (I5). P4 validates `lastBenchmark`,
+`benchmarkHistory`, `modelPlacements` on read and write (`shared/benchmark-schema.ts`; the legacy
+profile-only record survives unkeyed), resolves the displayed context with `launchContextTokens`, and
+counts a placement as measured only when its context/backend match the configuration. P5 made one
+machine-eligible GPU source (`gpuProbe.machineKey`, `shared/gpu-rules.ts`, paired name + memory,
+configuration-aware resident rows, class-aware RAM total, free/working figures by device; a CI-only
+same-millisecond sample clash was fixed by an injectable read-speed clock). P6 carried the speed basis
+into the report and rows, fixed the first-start / per-drive / observed-unknown / N4 / N5 copy, named
+the fit margin from `shared/performance-rules.ts`, added the German smoke and the display-device labels. P7 sequenced the first-run / moved-drive
+measurement behind the auto-start (L1/SD2, G5): `prepareFirstBenchmark` does the cheap seed /
+backfill / restore before `maybeAutoStartActiveModel` (now awaitable), `scheduleFirstBenchmark` waits
+for the start to settle under a 120 s bound and otherwise keeps one continuation, re-checks admission
+/ epoch / shutdown / busy / "already current" before running, allows one automatic attempt per unlock
+epoch, and the run refuses to persist into a session that locked or re-opened meanwhile. P8 closed the test gaps (T7/T8/T11/TH1/TH2): the history-order assertion names both
+identities, a source-text + behavioural pin covers the answer-speed observer wiring, the 300 ms sleep
+became an await on P7's outcome, one shared teardown closes the fixture's DBs and removes its temp
+roots (2,683 leaked roots from earlier runs cleared), and a ladder-to-placement wiring test drives
+the real rung factory with a fake sidecar's stderr (one parser per attempt; the persister writes,
+skips while locked, and survives a throwing observer). P9 wrote the durable record — `docs/benchmark.md` "Audit remediation record — PR #303"
+§1–§5 (decisions, a 63-row disposition matrix, the design as built, what is not verified, a §-anchor
+legend) — plus user-guide §5a "Performance", the privacy inventories in `PRIVACY.md` /
+`security-model.md`, the known-limitations block, the `architecture.md` supersession notes, and the
+DR11 host-conditional assertion turned into a fixed expectation. P10 cross-reviewed the candidate `07dd9085` (Opus over the Fable phases, Fable
+over the Opus phases, both over the Sonnet docs and the P0 delta inventory): no user-facing defect;
+four low main-process items, one schema hardening gap, a keyboard focus loss after "Check again" and
+issue #327 (the Diagnostics acceleration line bypassing the eligible-probe rule, filed by the PR #308
+review against this branch) repaired with fail-before/pass-after tests; the audit probes re-run at the
+candidate pass every main-process case (22 / 2 superseded by design / 1 retired); HW3 performed live
+over CDP — EN/DE, light/dark, 880/1024/1280 px, the German rail at weight 600, a real Tab walk and
+Enter activation all passed; a synthetic moved-drive restart verified M2/M4/P7 end to end. Blocked
+legs (screen-reader announcements; a first-run, chat or model-load while mounted — no runtime here)
+carried into the follow-up issues. P11 closed the wave without a source change: follow-up
+issues #329–#334 (a real partial-offload log, the two-computer round trip, the blocked HW3 legs,
+hybrid / Apple Silicon hardware, the slow-media read cost, slow-USB sequencing) and #335 (temp-root
+hygiene in other suites), the record's issue and commit references filled, the changelog entry,
+the keyboard-focus repair re-verified live in the dev app. Merge is the owner's call; the branch
+stays._
+
 ## 2026-09-09 — the two 2026-09-05 dated entries retired verbatim (preamble budget)
 
 Moved out of `BUILD_STATE.md` on 2026-09-09 to keep the preamble inside its 200-line budget

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -305,7 +305,14 @@ The current dark palette survives as the dark theme (lightly tuned per §4.3).
 - **Error announcements (#151 D-5).** Error slots use the shared always-mounted `ErrorBanner`
   (`components/ErrorBanner.tsx`), never the raw `{error && <Banner tone="error">…}` idiom —
   a freshly inserted pre-filled alert is missed by many screen readers (M-U1); the mounted
-  region announces the FIRST failure too. Render-error containment is the shared
+  region announces the FIRST failure too. **`role="status"` is itself a live region** (implicit
+  `aria-live="polite"`), so NOTHING inside an always-mounted region may carry `role="status"`
+  or `role="alert"`: the nearest live-region ancestor governs, and a nested one is inserted
+  already holding its text, which reintroduces M-U1 one level down. `ErrorBanner` shipped that
+  way and was silent under Narrator for every screen that used it (#436); `aria-live="off"` on
+  the inner element does NOT rescue it — the role has to go, so `Banner` takes `role={null}`
+  when nested. Pinned by `tests/unit/live-region-nesting.test.ts`, which fails on any nested
+  live-region role anywhere in the renderer. Render-error containment is the shared
   `ErrorBoundary` (per-screen, keyed by destination; the nav rail lives outside it).
 - **Password entry.** The shared `PasswordField` (+ `PasswordStrengthMeter`) — show/hide
   toggle, paste and password managers allowed (WCAG 3.3.8), advisory-only strength. Used by

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2473,12 +2473,19 @@ All of these are decided scope, not oversights; the design record's §7 carries 
 - **The silent re-check has no Home-screen notice yet.** The moved-drive re-check above runs with
   no visible sign beyond Performance itself refreshing; a Home notice while it is pending is
   tracked in BUILD_STATE §5 item 22 (a).
-- **Nothing on this screen is announced to a screen reader** (verified by ear with Narrator on
-  2026-09-09, issue #331, against a positive control proving live regions do work in the app's
-  window). Two separate defects, neither fixed yet: the progress-step list is inserted already
-  containing its content AND carries progress only in a CSS class and an `aria-hidden` icon, so
-  a check is silent from start to finish (#437); and the failure banner is silent too (#436) —
-  which is NOT specific to this screen, see the entry below.
+- **Nothing on this screen was announced to a screen reader — FIXED 2026-09-10, by-ear
+  re-verification outstanding** (found by ear with Narrator on 2026-09-09, issue #331, against a
+  positive control proving live regions do work in the app's window). Two separate defects: the
+  progress-step list was inserted already containing its content AND carried progress only in a
+  CSS class and an `aria-hidden` icon, so a check was silent from start to finish (#437); and the
+  failure banner was silent too (#436) — not specific to this screen, see the Accessibility entry.
+  The step list is now mounted unconditionally (`.perf-steps:empty` keeps the idle layout) and
+  every step carries its state in its accessible text (an `aria-hidden` visible label plus an
+  sr-only "<step>: <state>" twin, so an advance is a whole-line text change) with
+  `aria-current="step"` on the active item. Pinned by `PerformanceScreen.test.tsx` describe
+  "the step list is announceable (#437)". **What is pinned is the DOM, not the sound:** both
+  issues ask for re-verification by ear during a real multi-second check, and that still needs a
+  screen reader on the hardware box.
 - **An automatic check shows a step list that never advances.** A first-run or moved-drive check
   is run by the main process, and progress steps are addressed only to the window that pressed
   the button — but the screen renders the list whenever the backend span is held (correct per
@@ -2611,18 +2618,26 @@ meter `.context-meter-track/-fill` joined later and carries no forced-colors rul
 because its value is never color-only — the numeric label carries the meaning), and verified
 the reduced-motion kill-switch.
 
-**NOT accepted — an open defect, recorded here so it is not mistaken for one of the acceptances
-below.** Verified by ear with Narrator on 2026-09-09 (issue #331), against a positive control
-that proved live regions do work in the app's own Electron window: **`ErrorBanner`'s message is
-never announced** (#436). The component exists to implement audit finding M-U1 — an always-mounted
-`role="alert" aria-live="assertive"` container whose text swaps inside it — but the `Banner`
-nested within it carries `role="status"`, which is itself a live region (implicit
-`aria-live="polite"`) and IS mounted with its text. The nearest live-region ancestor governs, so
-M-U1's anti-pattern is reintroduced one level down. This is the shared failure surface for **11
-screens**, and for `WorkspaceGate`'s wrong-password banner — the SH-2 / #145 fix — so a failed
-unlock is silent too. A control isolated the remedy: `aria-live="off"` on the inner element does
-NOT help; the inner live-region role has to go. The lesson generalises — **`role="status"` and
-`role="alert"` are both live regions, so nesting one inside the other silences the outer one.**
+**Was an open defect; FIXED 2026-09-10 (#436), kept here for the lesson.** Verified by ear with
+Narrator on 2026-09-09 (issue #331), against a positive control that proved live regions do work
+in the app's own Electron window: **`ErrorBanner`'s message was never announced**. The component
+exists to implement audit finding M-U1 — an always-mounted `role="alert" aria-live="assertive"`
+container whose text swaps inside it — but the `Banner` nested within it carried `role="status"`,
+which is itself a live region (implicit `aria-live="polite"`) and WAS mounted with its text. The
+nearest live-region ancestor governs, so M-U1's anti-pattern was reintroduced one level down. It
+was the shared failure surface for **11 screens**, and for `WorkspaceGate`'s wrong-password banner
+— the SH-2 / #145 fix — so a failed unlock was silent too. A control isolated the remedy:
+`aria-live="off"` on the inner element does NOT help; the inner live-region role has to go. The
+lesson generalises — **`role="status"` and `role="alert"` are both live regions, so nesting one
+inside the other silences the outer one.**
+
+  The fix: `Banner`'s `role` prop takes `null` (render no role), `ErrorBanner` passes it, and
+  `ModelsScreen`'s hand-rolled copy of the same wrapper — two more nested `role="status"` Banners,
+  outside the issue's stated blast radius — was corrected with it.
+  `tests/unit/live-region-nesting.test.ts` now parses every renderer `.tsx` and fails on any
+  live-region role nested inside another, so the shape cannot return unnoticed. **The by-ear
+  re-verification (Narrator, on a real failure and on a wrong-password unlock) is still
+  outstanding** — the DOM half is pinned, the audible half needs the hardware box.
 
 Accepted as-is, with reasons:
 


### PR DESCRIPTION
Closes #436. Closes #437.

Both issues are the same lesson in two places: **`role="status"` is a live region** (implicit `aria-live="polite"`), and a live region only announces text that changes *inside* a region that was already there.

## #436 — `ErrorBanner` was silent on 11 screens + the workspace gate

`ErrorBanner` exists to implement audit finding M-U1: keep the `role="alert"` container mounted and swap the text inside it. But the `Banner` nested within carried `role="status"`, which made it the **nearest live-region ancestor** of the message — and it was inserted already containing that message. M-U1, reintroduced one level down, on the shared failure surface of 11 screens and the gate's #145 wrong-password banner.

The fix is variant **C** from the issue: `Banner`'s `role` prop now takes `null` (render no role at all), and `ErrorBanner` passes it. `aria-live="off"` on the inner node does **not** work — the role itself has to go.

**Blast radius was one site larger than the issue stated.** `ModelsScreen`'s download panel keeps its own hand-rolled copy of the same wrapper, with **two** nested `role="status"` Banners (`ModelsScreen.tsx:1419-1431`). Same defect, fixed the same way.

## #437 — the Performance steps were silent, for two independent reasons

1. The `aria-live` `<ul>` was built inside `steps()` and only called from the `busy` branch, so it was inserted with its three `<li>`s already in it.
2. Even mounted, its text never changed: progress rode only on the `perf-step-{state}` class and on `StepIcon`, which is `aria-hidden`.

The `<ul>` is now mounted unconditionally (`.perf-steps:empty` collapses it, so the idle layout is unchanged), and each step carries its state **in its accessible text**: the visible label is `aria-hidden` and an sr-only twin reads `"<step>: <state>"` (new `perf.step.state.*` keys, EN + DE). That makes an advance a whole-line text change **with context** — "Drive speed: in progress" rather than a context-free "done" — plus `aria-current="step"` on the active item.

## Guard

`tests/unit/live-region-nesting.test.ts` parses every renderer `.tsx` with the TypeScript compiler API and fails on **any** live-region role nested inside another. Checked against the pre-fix tree, it flags all three real sites:

```
components/ErrorBanner.tsx:42 <Banner> inside <div>
screens/ModelsScreen.tsx:1421 <Banner> inside <div>
screens/ModelsScreen.tsx:1427 <Banner> inside <div>
```

Two fixtures pin the broken and the fixed shape, so a green run cannot be vacuous. Its known limits (a child component that renders a live region internally; a computed `role`) are stated in the file header.

## Verified in the real app

Driven over CDP against the E: test drive, on the real #145 wrong-password path:

```json
before:  { "regionPresent": true, "regionRole": "alert", "regionAriaLive": "assertive", "regionEmpty": true }
after:   { "text": "⚠Dieses Passwort hat deinen Arbeitsbereich nicht entsperrt. …",
           "nestedLiveRegionCount": 0, "innerBannerHasRole": false, "totalAlertsInDoc": 1 }
```

And the app's real stylesheet resolves `.perf-steps` to `display: none` / height 0 when empty, and to the unchanged flex column with its 12px margin when filled — so the idle Performance card is visually identical.

`npm test` 7146 passed / 0 failed, `npm run typecheck` and `npm run build` clean.

## ⚠ Still open — the by-ear acceptance

Both issues require re-verification **with a screen reader**, and this branch cannot close that:

- [ ] #436 — Narrator on a real failure **and** on a wrong-password unlock
- [ ] #437 — Narrator during a real multi-second check

That needs the GTX 1070 Ti box. **What is pinned here is the DOM, not the sound.**

## Sequencing with #438

#438 (an automatic run's step list never advances) is still an open **owner call** on this same subtree, and both issues warn against reworking the region twice. This fix is forward-compatible with either option: under option 2 the items would render on `ownActionInFlight` instead of `busy` — a one-condition change, not a rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
