### PR TITLE
fix(deps): @xmldom/xmldom 0.8.13 → 0.8.15 — the one advisory that reaches a packaged build

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -41,20 +41,16 @@ joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES` (`shared/prompt-cache-rules.ts`), a
 positive control, and the concrete case for the cache-ON default. Control `qwen3.8-27b-ud-q5km` reproduced the sweep token for
 token (1,492 of 1,571, 79 kept). Trap held a fourth time: `forcing full` appears **0 times** in all four captures, including the
 two that re-prefilled. Every catalog `family:` now has a verdict; the default still governs the family added next._
-_2026-09-10 — **`@xmldom/xmldom` 0.8.13 → 0.8.15 — the one dependency advisory that reached users** (PR-XMLDOM,
-`fix/xmldom-parser-dos-0815`; record `security-model.md` BE-9 + its DOCX-parser paragraph). Ten advisories, of which the four
-PARSER-side ones (quadratic attribute dedup, end-tag ReDoS, quadratic memory, quadratic malformed-input recovery) are reachable
-from `parsers/docx.ts` → `mammoth.extractRawText` → `DOMParser` on an imported `.docx`; the six serializer-side injection CVEs are
-not (nothing here calls `XMLSerializer` — the DOCX export path splices raw `<w:t>` bytes). Impact was a main-process freeze: the
-M-3 guard bounds inflated BYTES not TIME, and `parseTimeoutMs` is a `Promise.race` a synchronous parser never loses. Lockfile-only
-(mammoth's range is `^0.8.6`), 3 lines + the regenerated notices. **Two findings worth keeping.** (a) Dependabot's alert list is
-NOT the inventory: it had opened 1 of these 10 — and the 1 it opened was a serializer CVE, i.e. the only unreachable class —
-while local `npm audit` on the same advisory DB found all ten plus unalerted js-yaml/baseline-browser-mapping. Automated security
-fixes are OFF, there is no `.github/dependabot.yml`, and CI runs no `npm audit`, so nothing catches this on a PR. (b) A bare
-`npm install` rewrites ~28 unrelated `"peer": true` markers in `package-lock.json` — PRE-EXISTING drift, reproducible on a clean
-master with no version change, so dependency PRs should bump the lockfile surgically and keep the diff to the versions touched.
-Follow-ups: PR-DEVCHAIN (`chore/dev-chain-advisory-bumps`) for the build-only advisories; the vitest 3→4 major (`@vitest/mocker`
-CVE-2026-84373, unreachable here — no browser mode, no dev server) is DEFERRED and still needs an owner._
+_2026-09-10 — **`@xmldom/xmldom` 0.8.13 → 0.8.15 — the one dependency advisory that reached users** (PR #451,
+`fix/xmldom-parser-dos-0815`; record `security-model.md` BE-9 + the DOCX-parser paragraph under it, which carries the
+reachability analysis). Ten advisories: the four PARSER-side ones reach `parsers/docx.ts` → mammoth → `DOMParser` on an imported
+`.docx` and freeze the main process (M-3 bounds inflated BYTES not TIME; `parseTimeoutMs` is a `Promise.race` a synchronous
+parser never loses); the six serializer-side ones are unreachable. Lockfile-only, 3 lines + regenerated notices. **Two findings
+to keep:** (a) the Dependabot alert list is NOT the inventory — it had opened 1 of the 10 and that 1 was the unreachable class,
+while `npm audit` on the same DB found all ten plus unalerted js-yaml/baseline-browser-mapping; security updates are OFF, there
+is no `.github/dependabot.yml`, and CI runs no `npm audit`. (b) A bare `npm install` rewrites ~28 unrelated `"peer": true`
+markers — PRE-EXISTING drift (reproduces on a clean master with no version change), so bump dependency lockfiles surgically.
+Follow-up PR #452; the vitest 3→4 major (CVE-2026-84373, unreachable — no browser mode, no dev server) is DEFERRED, needs an owner._
 _2026-09-10 — **#436 + #437 CLOSED — the two silent live regions fixed** (`fix/436-437-live-region-announce`).
 **#436:** `role="status"` is a LIVE REGION (implicit `aria-live="polite"`), not a quieter label — so the `Banner` nested inside
 `ErrorBanner`'s always-mounted `role="alert"` wrapper became the nearest live-region ancestor of the message AND arrived already

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -41,6 +41,20 @@ joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES` (`shared/prompt-cache-rules.ts`), a
 positive control, and the concrete case for the cache-ON default. Control `qwen3.8-27b-ud-q5km` reproduced the sweep token for
 token (1,492 of 1,571, 79 kept). Trap held a fourth time: `forcing full` appears **0 times** in all four captures, including the
 two that re-prefilled. Every catalog `family:` now has a verdict; the default still governs the family added next._
+_2026-09-10 — **`@xmldom/xmldom` 0.8.13 → 0.8.15 — the one dependency advisory that reached users** (PR-XMLDOM,
+`fix/xmldom-parser-dos-0815`; record `security-model.md` BE-9 + its DOCX-parser paragraph). Ten advisories, of which the four
+PARSER-side ones (quadratic attribute dedup, end-tag ReDoS, quadratic memory, quadratic malformed-input recovery) are reachable
+from `parsers/docx.ts` → `mammoth.extractRawText` → `DOMParser` on an imported `.docx`; the six serializer-side injection CVEs are
+not (nothing here calls `XMLSerializer` — the DOCX export path splices raw `<w:t>` bytes). Impact was a main-process freeze: the
+M-3 guard bounds inflated BYTES not TIME, and `parseTimeoutMs` is a `Promise.race` a synchronous parser never loses. Lockfile-only
+(mammoth's range is `^0.8.6`), 3 lines + the regenerated notices. **Two findings worth keeping.** (a) Dependabot's alert list is
+NOT the inventory: it had opened 1 of these 10 — and the 1 it opened was a serializer CVE, i.e. the only unreachable class —
+while local `npm audit` on the same advisory DB found all ten plus unalerted js-yaml/baseline-browser-mapping. Automated security
+fixes are OFF, there is no `.github/dependabot.yml`, and CI runs no `npm audit`, so nothing catches this on a PR. (b) A bare
+`npm install` rewrites ~28 unrelated `"peer": true` markers in `package-lock.json` — PRE-EXISTING drift, reproducible on a clean
+master with no version change, so dependency PRs should bump the lockfile surgically and keep the diff to the versions touched.
+Follow-ups: PR-DEVCHAIN (`chore/dev-chain-advisory-bumps`) for the build-only advisories; the vitest 3→4 major (`@vitest/mocker`
+CVE-2026-84373, unreachable here — no browser mode, no dev server) is DEFERRED and still needs an owner._
 _2026-09-10 — **#436 + #437 CLOSED — the two silent live regions fixed** (`fix/436-437-live-region-announce`).
 **#436:** `role="status"` is a LIVE REGION (implicit `aria-live="polite"`), not a quieter label — so the `Banner` nested inside
 `ErrorBanner`'s always-mounted `role="alert"` wrapper became the nearest live-region ancestor of the message AND arrived already

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -74,7 +74,7 @@ node scripts/generate-third-party-notices.mjs
 @types/unist@2.0.11
 @types/unist@3.0.3
 @ungap/structured-clone@1.3.1
-@xmldom/xmldom@0.8.13
+@xmldom/xmldom@0.8.15
 argparse@1.0.10
 aria-hidden@1.2.6
 bail@2.0.2
@@ -1735,7 +1735,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 ```
 
-### @xmldom/xmldom@0.8.13
+### @xmldom/xmldom@0.8.15
 
 - License: MIT
 - Repository: git://github.com/xmldom/xmldom

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -154,10 +154,26 @@ the **OCR rasterizer's hidden window** — which renders untrusted PDF bytes and
 WebContents that proves both events are registered and a remote redirect is prevented.
 
 **Pinned parser libraries carry no update channel (ocr-audit 2026-07-18 BE-9).** pdfjs
-(main process and the hidden OCR window) and tesseract.js parse untrusted bytes from
-imported PDFs/images and are pinned only via the lockfile — review upstream advisories for
-both each release; the offline posture means there is no auto-update channel to catch a
-disclosed vulnerability between releases.
+(main process and the hidden OCR window), tesseract.js, and **mammoth — with its transitive
+`@xmldom/xmldom`** — parse untrusted bytes from imported PDFs/images/DOCX and are pinned only
+via the lockfile — review upstream advisories for all of them each release; the offline posture
+means there is no auto-update channel to catch a disclosed vulnerability between releases.
+The DOCX pair was missing from this list until the 0.8.15 bump, which is exactly how ten xmldom
+advisories went unwatched.
+
+**Why the DOCX parser needs that watch specifically.** The ingestion caps bound *bytes*,
+not *time*: the M-3 zip-bomb guard checks the DECLARED inflated size, and `parseWithLimits`'
+`parseTimeoutMs` is a `Promise.race` that a **synchronous** parser can never lose — mammoth
+ignores the abort signal (`services/ingestion/index.ts`), and document parsing runs on the
+**main process** with no worker. So a super-linear parse inside xmldom is an unbounded
+main-process freeze, not a caught timeout. That is not hypothetical: xmldom 0.8.13 carried four
+such advisories (quadratic attribute dedup CVE-2026-83613, end-tag ReDoS CVE-2026-83619,
+quadratic memory, quadratic malformed-input recovery), each reachable from `parsers/docx.ts` →
+`mammoth.extractRawText` → `DOMParser` on an imported `.docx`. The 0.8.15 bump closes them; the
+STRUCTURAL exposure remains, so a future advisory in this class is a release blocker, not a
+dev-chain nuisance. (The same version's six *serializer*-side injection CVEs were unreachable —
+nothing in mammoth or this app calls `XMLSerializer`; the DOCX export path in
+`services/export/docx-rewrite.ts` splices raw `<w:t>` bytes and never builds a DOM.)
 
 ### Voice dictation data path (Phase 37, decision D30)
 The composer mic records **in the renderer** (`getUserMedia` → `MediaRecorder`), resamples to

--- a/package-lock.json
+++ b/package-lock.json
@@ -4001,9 +4001,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## What

Bumps `@xmldom/xmldom` 0.8.13 → 0.8.15, clearing **ten** advisories. Lockfile-only — `mammoth` declares `^0.8.6`.

## Why this one first

It is the only currently-open dependency advisory with **runtime** scope. `mammoth` is a production dependency of `apps/desktop`, `externalizeDepsPlugin` keeps it out of the bundle, and it ships inside `app.asar` — so `@xmldom/xmldom` ships to users, where the offline posture means there is no auto-update channel to catch it between releases.

## Reachability — 4 of 10

**Reachable (parser side).** `parsers/docx.ts` → `mammoth.extractRawText` → `DOMParser` on an imported `.docx`:

| CVE | Advisory |
|---|---|
| CVE-2026-83613 | Quadratic-time attribute deduplication |
| CVE-2026-83619 | End-tag whitespace-trim regex ReDoS |
| CVE-2026-83615 | Quadratic-memory consumption |
| CVE-2026-83614 | Quadratic-time parsing via malformed-input recovery |

The existing caps do **not** contain these:

- The M-3 zip-bomb guard bounds *declared inflated bytes* (1 GiB default), not *time*. Quadratic behaviour on a 10 MB `document.xml` sits far under the cap.
- `parseWithLimits`' 30-minute `parseTimeoutMs` is a `Promise.race` that a **synchronous** parser can never lose. `services/ingestion/index.ts` already says so: *"pdfjs/mammoth/txt ignore it and are bounded by the lock/quit sweep instead."*
- Document parsing runs on the **main process** — no worker, no `utilityProcess`.

So a crafted `.docx` freezes the app until force-quit. **Availability only** — no code execution, no disclosure, and nowhere for data to go.

**Not reachable (serializer side).** The other six are injection bugs behind `XMLSerializer.serializeToString(..., { requireWellFormed: true })`. A grep for `XMLSerializer|serializeToString|createEntityReference|requireWellFormed` across `node_modules/mammoth/lib` and all of `apps/desktop/src` returns zero hits; mammoth uses only `DOMParser`, and the DOCX *export* path (`services/export/docx-rewrite.ts`) splices raw `<w:t>` bytes rather than building a DOM.

Worth noting: **the serializer CVE is the one of the ten Dependabot had opened an alert for** (#86) — i.e. the only unreachable class.

## Two things this turned up

**1. The Dependabot alert list is not the inventory.** Dependabot had opened 1 of these 10. Local `npm audit`, against the same GitHub Advisory Database and the same committed lockfile, found all ten — plus a high in `js-yaml` and a medium in `baseline-browser-mapping` with no alerts at all. The nine missing xmldom advisories were published 2026-09-08, are `type=reviewed`, and carry CVE ids.

That gap is structural, not bad luck: `automated-security-fixes` is **disabled**, there is no `.github/dependabot.yml`, and CI runs no `npm audit`. Suggested follow-up (not in this PR): enable security updates and gate CI on `npm audit --omit=dev --audit-level=moderate` for the shipping closure, reporting-only on the dev tree.

**2. The lockfile carries pre-existing drift.** A bare `npm install` rewrites ~28 unrelated `"peer": true` markers — reproducible on a clean `master` with no version change. Excluded here so the diff shows only what actually moved; worth a separate cleanup.

## Verification

- `npm ci` clean, `@xmldom/xmldom@0.8.15` installed, lockfile diff stays at 3 lines.
- `npm audit`: `@xmldom/xmldom` gone entirely (8 vulnerable packages → 7; the rest are dev-only and follow separately).
- `repo-hygiene` + `third-party-notices` gates green; `docx-rewrite`, `ingestion`, `ingestion-limits` green.
- `THIRD-PARTY-NOTICES.md` regenerated (its CI gate pins it to the lockfile).

## Docs

`security-model.md` BE-9 now names `mammoth` / `@xmldom/xmldom` in the pinned-parser watch list — their absence is exactly how ten advisories went unwatched — and records why a future advisory in this class is a **release blocker** rather than a dev-chain nuisance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
