### PR TITLE
chore(deps): clear the build-chain advisories (fast-uri, browserslist, js-yaml)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -41,6 +41,13 @@ joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES` (`shared/prompt-cache-rules.ts`), a
 positive control, and the concrete case for the cache-ON default. Control `qwen3.8-27b-ud-q5km` reproduced the sweep token for
 token (1,492 of 1,571, 79 kept). Trap held a fourth time: `forcing full` appears **0 times** in all four captures, including the
 two that re-prefilled. Every catalog `family:` now has a verdict; the default still governs the family added next._
+_2026-09-10 — **Build-chain advisories cleared: `fast-uri` 3.1.7, `browserslist` 4.28.9, `js-yaml` 4.3.2,
+`baseline-browser-mapping` 2.11.21** (PR #452, stacked on PR #451). All dev-scope, in-range, lockfile-only; browserslist brings
+its data chain with it. `npm audit` after this is **0 high / 0 critical** — only the deferred vitest chain remains. The four
+`fast-uri` CVEs all need an untrusted URI and the only consumer is `ajv` reading our own `electron-builder.yml` on the MANUAL
+package step (R2) — no exposure. The one that matters on a PUBLIC repo is `browserslist` CVE-2026-73088: `normalizeStats()` runs
+on every `browserslist()` call and auto-discovers `browserslist-stats.json` up the directory tree, so a contributor PR adding one
+file crashes every Babel/Vite build in CI. Build-availability only._
 _2026-09-10 — **`@xmldom/xmldom` 0.8.13 → 0.8.15 — the one dependency advisory that reached users** (PR #451,
 `fix/xmldom-parser-dos-0815`; record `security-model.md` BE-9 + the DOCX-parser paragraph under it, which carries the
 reachability analysis). Ten advisories: the four PARSER-side ones reach `parsers/docx.ts` → mammoth → `DOMParser` on an imported

--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,9 +4388,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.34",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4445,9 +4445,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4466,11 +4466,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4590,9 +4590,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001797",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -5890,9 +5890,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.368",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
-      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -6220,9 +6220,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -7381,9 +7381,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -9072,9 +9072,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11114,9 +11114,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
> **Stacked on #451** — targets `fix/xmldom-parser-dos-0815`, not `master`, because both PRs touch `package-lock.json`. Retarget to `master` once #451 merges. Review only the second commit.

## What

Dev-scope only — none of these ship in a packaged build. All in-range, so lockfile-only.

| Package | From | To | Advisories |
|---|---|---|---|
| `fast-uri` | 3.1.5 | 3.1.7 | 4 high |
| `browserslist` | 4.28.2 | 4.28.9 | 2 high (1 auto-dismissed) |
| `js-yaml` | 4.3.1 | 4.3.2 | 1 high (**never alerted**) |
| `baseline-browser-mapping` | 2.10.34 | 2.11.21 | 1 moderate (**never alerted**) |

`browserslist` brings its data chain along (`caniuse-lite`, `electron-to-chromium`, `node-releases`, `update-browserslist-db`) — routine data updates, all dev.

**After this, `npm audit` reports 0 high / 0 critical.**

## Reachability

- **`fast-uri` ×4** — all CVSS 7.5, which is why they dominated the alert page, and all effectively **non-exploitable here**. Every one is a host-confusion / SSRF class requiring an untrusted URI. The only consumer is `ajv`, validating our own `electron-builder.yml` and ajv's bundled meta-schemas during a **manual, network-touching package step (R2)** that never runs in CI. No attacker-controlled URI reaches it, and ajv issues no outbound requests. Cleared because four highs masking a real one is its own hazard.

- **`browserslist` CVE-2026-73088** — the one with a real story on a *public* repo. `normalizeStats()` runs on **every** `browserslist()` call regardless of query, and auto-discovers `browserslist-stats.json` by walking up from the project root. So a contributor PR adding one JSON file crashes every Babel/PostCSS/Vite build in CI, with an error pointing nowhere near the cause. Build-availability only — the prototype write lands on a function-local object, not a shared prototype.

- **CVE-2026-73089** (unbounded-cache OOM) was auto-dismissed by GitHub as a dev-scope DoS. Correctly — it needs a long-running process fed varying queries, and a build invocation is short-lived. Cleared by the same bump anyway, so the dismissal stops hiding it.

- **`js-yaml`** is a trap worth naming: alert #79 reads **"fixed"** (the older omap CVE, patched at the 4.3.1 we had), so the package looked clean on the alerts page while carrying an unpatched high published 2026-09-08 that Dependabot never alerted on at all.

## What is deliberately left open

The **vitest chain** (`vitest`, `@vitest/mocker`, `@vitest/coverage-v8` — CVE-2026-84373), the only remaining `npm audit` entries, all moderate.

Not reachable here: the sink is `@vitest/mocker`'s interceptor plugin registered on a Vite dev server's unauthenticated HMR socket, and `vitest.config.ts` has no browser mode, no dev server, `environment: 'node'`, `pool: 'forks'`.

It is also the one bump that is not free — `vitest` pins `@vitest/mocker` to an **exact** version, so the patch is a **vitest 3 → 4 major** across a 424-file / 7138-test suite with a custom reporter and `FullSuiteGuard`. `npm audit fix --force` proposes vitest 5.0.0, which is worse. **This still needs an owner and an issue** — leaving it as a silently-ignored alert is precisely the failure mode #451 documents.

## Verification

- `npm ci` clean; lockfile unchanged by it.
- `npm audit`: 8 vulnerable packages → 3, **0 high / 0 critical**.
- `npm run typecheck`, `npm run build`, and the full suite (424 files / 7138 tests) green.
- `THIRD-PARTY-NOTICES.md` correctly **unchanged** — all four are dev-only and none enters the shipped closure.

## Note on the diff

Lockfile bumped surgically, same rule as #451: a bare `npm install` also rewrites ~28 unrelated `"peer": true` markers (pre-existing drift, reproducible on clean `master` with no version change). Excluded everywhere, so this diff is versions, hashes, and one dependency range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
