### PR TITLE
eval(#446): the three untested chat entries measured — qwen3.6 loses the restore, granite keeps it

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,19 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-10 — **#446 CLOSED — the three untested chat entries measured; `qwen3.6` joins the rule, `granite` does not**
+(`eval/446-untested-families-sweep`; record `model-benchmarks.md` §6.6 "2026-09-10 addition (#446)",
+`known-limitations.md` "The one chat slot and the prompt cache"; evidence
+`eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-*`). The #399 sweep skipped these three for logistics:
+both `qwen3.6-27b` quants were broken symlinks into the eval drive deleted 2026-09-04, `granite-4.1-8b-q4` was never on the rig.
+Weights re-fetched and verified against manifest `sha256` **and** `size_bytes`, then run through the **unchanged** leg-A driver,
+same pinned b9849 (`799fcc04a`), no MTP, all fully offloaded. **`qwen3.6` RE-PREFILLED** — both quants report arch `qwen35` with a
+149.62 MiB recurrent state over 64 layers and re-prefill **1,488 of 1,529** tokens, keeping only the 41-token system prefix; it
+joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES` (`shared/prompt-cache-rules.ts`), affected set now **13 of 17 measured models**.
+**`granite` RESTORED** — arch `granite`, `n_swa` 0, no recurrent state, **22 of 1,414** re-prefilled with 1,392 kept; a fourth
+positive control, and the concrete case for the cache-ON default. Control `qwen3.8-27b-ud-q5km` reproduced the sweep token for
+token (1,492 of 1,571, 79 kept). Trap held a fourth time: `forcing full` appears **0 times** in all four captures, including the
+two that re-prefilled. Every catalog `family:` now has a verdict; the default still governs the family added next._
 _2026-09-10 — **#436 + #437 CLOSED — the two silent live regions fixed** (`fix/436-437-live-region-announce`).
 **#436:** `role="status"` is a LIVE REGION (implicit `aria-live="polite"`), not a quieter label — so the `Banner` nested inside
 `ErrorBanner`'s always-mounted `role="alert"` wrapper became the nearest live-region ancestor of the message AND arrived already
@@ -60,8 +73,8 @@ resume, never on `acquireForChat`, which chat awaits). **D5** — `--cache-ram 0
 (`shared/prompt-cache-rules.ts`); unmeasured families keep cache-ON, the safe direction. **D4 deferred**: leg B showed a
 documents ask keeps only its ~227-token system prefix with or without a helper, so the length-proportional cost belongs to
 the plain-CHAT path alone and a picker warning would overstate it. Residual: a break longer than the delay still costs ONE
-slow reply, once. Follow-ups **#446** (`qwen3.6-27b` ×2 + `granite-4.1-8b` never tested — must not be read as "measured and
-fine") and **#447** (the ZIM query expander is bounded by inference, not measurement). Trap for reproducers: `forcing full
+slow reply, once. Follow-ups **#446** (`qwen3.6-27b` ×2 + `granite-4.1-8b` never tested — CLOSED 2026-09-10, see that entry)
+and **#447** (the ZIM query expander is bounded by inference, not measurement). Trap for reproducers: `forcing full
 prompt re-processing` appears only on MTP starts — the token count is the only honest read._
 
 _2026-09-09 — **#331 CLOSED — the four blocked HW3 acceptance legs performed** (`docs/331-hardware-acceptance-legs`;

--- a/apps/desktop/src/shared/prompt-cache-rules.ts
+++ b/apps/desktop/src/shared/prompt-cache-rules.ts
@@ -7,41 +7,55 @@
 // server writes the evicted conversation to a host-RAM prompt cache — 8,192 MiB of it by default —
 // so it can restore the prefix instead of re-processing it when that conversation comes back.
 //
-// WHAT WAS MEASURED. On 11 of our 14 chat models it CANNOT restore it. The server saves the
-// conversation and then silently re-prefills the whole prompt anyway: llama.cpp cannot rebuild
+// WHAT WAS MEASURED. On 13 of our 17 measured chat models it CANNOT restore it. The server saves
+// the conversation and then silently re-prefills the whole prompt anyway: llama.cpp cannot rebuild
 // either a recurrent state or a sliding-window cache from a saved prompt (llama.cpp PR #13194).
-// A fourteen-model sweep on `i9-9900x-rtx-3090-24gb-128gb` — raw `llama-server`, the app's argv
-// shape at `--ctx-size 8192 -np 1`, no MTP, every model fully offloaded, three requests per start
-// (conversation A → an unrelated B takes the slot → back to A) — split them exactly along the
-// architecture line, with three positive controls that DID restore (a dense Qwen, a Qwen MoE and a
-// Mistral, each re-prefilling only 14–21 tokens of a ~1,470-token return prompt):
+// A fourteen-model sweep on `i9-9900x-rtx-3090-24gb-128gb`, extended by three models under #446 —
+// raw `llama-server`, the app's argv shape at `--ctx-size 8192 -np 1`, no MTP, every model fully
+// offloaded, three requests per start (conversation A → an unrelated B takes the slot → back to A)
+// — split them exactly along the architecture line, with four positive controls that DID restore
+// (a dense Qwen, a Qwen MoE, a Mistral and a Granite, each re-prefilling only 14–22 tokens of a
+// ~1,470-token return prompt):
 //
 //   RE-PREFILLED, recurrent state   qwen3.5 (2b, 4b, 9b, 35b-a3b)  ·  qwen3.8 (three 27b quants)
+//                                   qwen3.6 (both 27b quants — added by #446, arch `qwen35`)
 //   RE-PREFILLED, sliding window    gemma4 (e2b, e4b, 12b, 26b-a4b), n_swa 512 / 1024
-//   RESTORED                        qwen3 (dense + moe)  ·  mistral3
+//   RESTORED                        qwen3 (dense + moe)  ·  mistral3  ·  granite (#446)
 //
-// So on those eleven the cache is pure waste: 14.86–343.59 MiB of host RAM written per eviction
+// So on those thirteen the cache is pure waste: 14.86–343.59 MiB of host RAM written per eviction
 // and never read once. `--cache-ram 0` gives that back and costs nothing.
 //
-// Record + evidence: `docs/model-benchmarks.md` §6.6 "2026-09-09 correction (#399)"; PR #445,
-// `eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue399-arch-sweep-*`.
+// Record + evidence: `docs/model-benchmarks.md` §6.6 "2026-09-09 correction (#399)" and its
+// "2026-09-10 addition (#446)"; PR #445, `eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/`
+// `issue399-arch-sweep-*` and `issue446-arch-sweep-*`.
 //
 // WHY THIS IS A FAMILY LIST AND NOT AN ARCHITECTURE PROBE. The manifests already carry `family:`,
 // and the measured split maps onto it exactly. We could ask the GGUF header instead, but that
 // would be an inference from metadata we have not validated against this outcome; the list is what
-// was actually measured, and #446 tracks the entries that were not.
+// was actually measured. #446 closed the last two unmeasured families, so every `family:` in the
+// catalog now has a verdict — but the DEFAULT below still has to hold, for the family added next.
 
 /**
  * Manifest `family:` values whose models CANNOT restore an evicted chat prefix, so llama-server's
  * host prompt cache is written and never read for them. Measured, not inferred — see the module
  * comment for the sweep and its evidence.
  *
- * NOT on this list, deliberately: `qwen3.6` and `granite` (#446). `qwen3.6` is almost certainly
- * affected — same lineage as the `qwen3.8` 27Bs that failed — but its weights were broken symlinks
- * on the test rig and it was never started, and `granite-4.1-8b-q4` was not on that rig at all.
- * They stay off until someone measures them.
+ * `qwen3.6` was added 2026-09-10 by #446, which fetched the weights the #399 sweep could not start
+ * (they were broken symlinks on the rig) and ran the same protocol: both 27B quants report arch
+ * `qwen35` with a 149.62 MiB recurrent state over 64 layers, fully offloaded, and re-prefilled
+ * 1,488 of 1,529 tokens on return, keeping only the 41-token shared system prefix.
+ *
+ * NOT on this list, and now for a MEASURED reason: `granite` (#446). `granite-4.1-8b-q4` was not on
+ * the rig for the #399 sweep; fetched and run under the same protocol it RESTORED — arch `granite`,
+ * `n_swa` 0, no recurrent state, 22 of 1,414 tokens re-prefilled with 1,392 kept. It is the fourth
+ * positive control, not an untested entry.
  */
-export const PROMPT_CACHE_RESTORE_BROKEN_FAMILIES: readonly string[] = ['qwen3.5', 'qwen3.8', 'gemma4']
+export const PROMPT_CACHE_RESTORE_BROKEN_FAMILIES: readonly string[] = [
+  'qwen3.5',
+  'qwen3.6',
+  'qwen3.8',
+  'gemma4'
+]
 
 /**
  * The chat sidecar args this model's family needs for the prompt cache, appended to
@@ -52,7 +66,11 @@ export const PROMPT_CACHE_RESTORE_BROKEN_FAMILIES: readonly string[] = ['qwen3.5
  * model with no manifest family at all. The asymmetry decides it: turning the cache off on a model
  * that CAN restore costs real prompt-cache restores on every hand-back, while leaving it on for a
  * model that cannot merely continues a waste we can already name and bound. So an unmeasured family
- * keeps today's behaviour, and adding one here requires a measurement.
+ * keeps today's behaviour, and adding one here requires a measurement. #446 measured the last two
+ * families that had none, and the default it protects is still live: it is what a family added to
+ * the catalog tomorrow will get until someone runs the sweep against it. `granite` is the proof
+ * that the caution is not theatre — the family everyone expected to be affected, `qwen3.6`, was;
+ * the one nobody had an opinion about restored.
  *
  * `-cram, --cache-ram N` — "set the maximum cache size in MiB (default: 8192, -1 = no limit,
  * 0 = disable)" — verified present on the pinned b9849 binary (`799fcc04a`) before this shipped.

--- a/apps/desktop/tests/integration/llama-runtime.test.ts
+++ b/apps/desktop/tests/integration/llama-runtime.test.ts
@@ -516,10 +516,10 @@ describe('answer-depth mode → request mapping (D4)', () => {
     await runtime.stop()
   })
 
-  // ---- #399 D5: the family-gated prompt-cache switch ----------------------------------
+  // ---- #399 D5 (+ #446): the family-gated prompt-cache switch --------------------------
   //
-  // On 11 of our 14 chat models llama-server writes the evicted conversation to its host-RAM
-  // prompt cache and can never read it back (recurrent state / sliding window — see
+  // On 13 of our 17 measured chat models llama-server writes the evicted conversation to its
+  // host-RAM prompt cache and can never read it back (recurrent state / sliding window — see
   // shared/prompt-cache-rules.ts for the sweep). `--cache-ram 0` stops paying for a copy that is
   // never used. CHAT_SERVER_ARGS is shared by EVERY chat model start on every machine, so these
   // pin both halves: the flag appears for an affected family, and the argv of every other family
@@ -548,9 +548,12 @@ describe('answer-depth mode → request mapping (D4)', () => {
   })
 
   it('adds nothing for an unaffected OR unmeasured family, and for a model with no family', async () => {
-    // 'qwen3' restored in the sweep; 'qwen3.6' was never started (#446) and defaults to cache-ON;
-    // no family at all is the same safe default. All three must produce the pre-#399 argv.
-    for (const family of ['qwen3', 'qwen3.6', undefined]) {
+    // 'qwen3' and 'granite' restored in the sweep (granite measured by #446); 'llama9' is not a
+    // family in the catalog at all, so it stands for the family added NEXT, which defaults to
+    // cache-ON until someone measures it; no family at all is the same safe default. All four must
+    // produce the pre-#399 argv. ('qwen3.6' used to be the unmeasured example here — #446 measured
+    // it and it turned out AFFECTED, so it would no longer test the default it was standing for.)
+    for (const family of ['qwen3', 'granite', 'llama9', undefined]) {
       const { spawn, calls } = fakeSpawn()
       const runtime = new LlamaRuntime(
         { ...startOpts, family },

--- a/apps/desktop/tests/unit/prompt-cache-rules.test.ts
+++ b/apps/desktop/tests/unit/prompt-cache-rules.test.ts
@@ -4,33 +4,39 @@ import {
   promptCacheServerArgs
 } from '../../src/shared/prompt-cache-rules'
 
-// Issue #399 D5. The rule is a NAMED list with a measured basis, not an inline literal at the
-// argv call site, so these tests can pin (a) the measured split, (b) that the default for
-// anything unmeasured is cache-ON, and (c) that the flag we emit is the one the pinned binary
-// takes. The families come from the fourteen-model sweep recorded in model-benchmarks.md §6.6
-// ("2026-09-09 correction (#399)"); the three RESTORED rows below are its positive controls.
+// Issue #399 D5, extended by #446. The rule is a NAMED list with a measured basis, not an inline
+// literal at the argv call site, so these tests can pin (a) the measured split, (b) that the
+// default for anything unmeasured is cache-ON, and (c) that the flag we emit is the one the pinned
+// binary takes. The families come from the fourteen-model sweep recorded in model-benchmarks.md
+// §6.6 ("2026-09-09 correction (#399)") plus the three models #446 added ("2026-09-10 addition
+// (#446)"); the four RESTORED rows below are its positive controls.
 
 describe('prompt-cache family rule (#399 D5)', () => {
   it('disables the host prompt cache for every family measured to lose the restore', () => {
-    // RE-PREFILLED in the sweep: qwen3.5 / qwen3.8 by recurrent state, gemma4 by sliding window.
-    for (const family of ['qwen3.5', 'qwen3.8', 'gemma4']) {
+    // RE-PREFILLED in the sweep: qwen3.5 / qwen3.6 / qwen3.8 by recurrent state (all three report
+    // arch `qwen35`), gemma4 by sliding window.
+    for (const family of ['qwen3.5', 'qwen3.6', 'qwen3.8', 'gemma4']) {
       expect(promptCacheServerArgs(family)).toEqual(['--cache-ram', '0'])
     }
   })
 
   it('leaves every family that DID restore alone — argv byte-identical to before #399', () => {
-    // The sweep's three positive controls, by the `family:` their manifests declare.
-    for (const family of ['qwen3', 'mistral3']) {
+    // The sweep's four positive controls, by the `family:` their manifests declare. `granite` is
+    // the one #446 added: measured, and measured to RESTORE (22 of 1,414 tokens re-prefilled).
+    for (const family of ['qwen3', 'mistral3', 'granite']) {
       expect(promptCacheServerArgs(family)).toEqual([])
     }
   })
 
   it('defaults an UNMEASURED family to cache-ON (the deliberate safe direction)', () => {
-    // qwen3.6 and granite were never started in the sweep (#446) — broken symlinks / not on the
-    // rig. Turning the cache off on a model that CAN restore costs real restores on every
-    // hand-back; leaving it on for one that cannot merely continues a waste we can bound. So an
-    // unknown family, and a model with no family at all, must add nothing to the argv.
-    for (const family of ['qwen3.6', 'granite', 'llama9', 'phi-next']) {
+    // #446 measured the last two families that had no verdict, so every `family:` in today's
+    // catalog is now on one side of the split — which is exactly why the examples here must be
+    // families that do NOT exist in the catalog. This test is not about qwen3.6 or granite; it is
+    // about the family somebody adds NEXT, before anyone has run the sweep against it. Turning the
+    // cache off on a model that CAN restore costs real restores on every hand-back; leaving it on
+    // for one that cannot merely continues a waste we can bound. So an unknown family, and a model
+    // with no family at all, must add nothing to the argv.
+    for (const family of ['llama9', 'phi-next', 'qwen4', 'gemma5']) {
       expect(promptCacheServerArgs(family)).toEqual([])
     }
     expect(promptCacheServerArgs(null)).toEqual([])
@@ -43,6 +49,7 @@ describe('prompt-cache family rule (#399 D5)', () => {
     // `qwen3.5x`. A prefix match here would silently disable the cache on models that restore.
     expect(promptCacheServerArgs('qwen3')).toEqual([])
     expect(promptCacheServerArgs('qwen3.55')).toEqual([])
+    expect(promptCacheServerArgs('qwen3.65')).toEqual([])
     expect(promptCacheServerArgs('gemma4x')).toEqual([])
     expect(promptCacheServerArgs('GEMMA4')).toEqual([]) // manifests are lower-case
   })
@@ -57,8 +64,19 @@ describe('prompt-cache family rule (#399 D5)', () => {
     expect(args[1]).toBe('0')
   })
 
-  it('the exported list is exactly the three measured families', () => {
-    // A guard against quietly widening the rule: adding a family here requires a measurement.
-    expect([...PROMPT_CACHE_RESTORE_BROKEN_FAMILIES].sort()).toEqual(['gemma4', 'qwen3.5', 'qwen3.8'])
+  it('the exported list is exactly the four families measured to lose the restore', () => {
+    // A guard against quietly widening the rule: adding a family here requires a measurement, and
+    // this expectation is the place where that measurement has to be produced. It went from three
+    // to four on 2026-09-10 because #446 fetched qwen3.6's weights and ran the #399 protocol
+    // against both quants — not because qwen3.6 looked like the families around it. Anything else
+    // arriving in this array without an evidence file under
+    // eval/results/hardware/*/issue*-arch-sweep-* behind it is the failure this test exists to
+    // catch.
+    expect([...PROMPT_CACHE_RESTORE_BROKEN_FAMILIES].sort()).toEqual([
+      'gemma4',
+      'qwen3.5',
+      'qwen3.6',
+      'qwen3.8'
+    ])
   })
 })

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2508,18 +2508,19 @@ between a full and a half offload. The consequence is that when something else t
 conversation's KV prefix is evicted — and on most of the models we ship, llama-server **cannot give
 it back**.
 
-- **On 11 of our 14 chat models an evicted chat prefix is re-prefilled from scratch, not restored**
-  (measured 2026-09-08/09, #399). llama-server saves the conversation to its host-RAM prompt cache
-  and then silently re-processes the whole prompt anyway. Two architectures lose the restore:
-  **recurrent state** — the whole `qwen3.5` line (`-2b`, `-4b`, `-9b`, `-35b-a3b`) and all three
-  `qwen3.8-27b` quants — and a **sliding window** — all four `gemma4` manifests (`e2b`, `e4b`,
-  `12b`, `26b-a4b`). That includes the **catalog-default 4B and the 9B**, i.e. the 8–12 GB tier
-  picks. Among ranked models only `ministral3-8b-instruct-2512-q4` keeps the restore; the dense
-  `qwen3-8b` and the `qwen3-30b-a3b` MoE keep it too, which is what makes this a measured
-  architecture split rather than an anecdote. **Not measured:** `qwen3.6-27b-q4` / `-q5` and
-  `granite-4.1-8b-q4` (#446 — almost certainly affected, treated as unaffected by the conservative
-  default), and the ZIM query expander's own call (#447). If llama.cpp PR #13194 lands
-  recurrent-state restore upstream, this whole entry becomes removable.
+- **On 13 of our 17 measured chat models an evicted chat prefix is re-prefilled from scratch, not
+  restored** (measured 2026-09-08/09, #399; extended 2026-09-10, #446). llama-server saves the
+  conversation to its host-RAM prompt cache and then silently re-processes the whole prompt anyway.
+  Two architectures lose the restore: **recurrent state** — the whole `qwen3.5` line (`-2b`, `-4b`,
+  `-9b`, `-35b-a3b`), both `qwen3.6-27b` quants and all three `qwen3.8-27b` quants — and a **sliding
+  window** — all four `gemma4` manifests (`e2b`, `e4b`, `12b`, `26b-a4b`). That includes the
+  **catalog-default 4B and the 9B**, i.e. the 8–12 GB tier picks. Among ranked models only
+  `ministral3-8b-instruct-2512-q4` keeps the restore; the dense `qwen3-8b`, the `qwen3-30b-a3b` MoE
+  and `granite-4.1-8b-q4` keep it too, which is what makes this a measured architecture split rather
+  than an anecdote. **Not measured:** the ZIM query expander's own call (#447) — every chat family in
+  the catalog now has a verdict, `qwen3.6` (affected) and `granite` (unaffected) being the last two,
+  measured under #446. If llama.cpp PR #13194 lands recurrent-state restore upstream, this whole
+  entry becomes removable.
 - **What can actually evict a live conversation is narrower than it sounds.** `assertChatStreamReady`
   makes categorisation, summary, translate, compare, OCR and every `modelLane` skill run **refuse**
   a chat turn rather than take the slot from it. The one cooperative hand-back is the **yielding
@@ -2538,13 +2539,15 @@ it back**.
   never gets its deep index is a worse outcome than one slow reply. A steady chat every 30 s
   therefore still pays a re-prefill roughly every 10 minutes.
 - **Behaviour change on affected models: llama-server's host prompt cache is switched off**
-  (`--cache-ram 0`, gated on the manifest's `family:` — `qwen3.5`, `qwen3.8`, `gemma4`). On those
-  models the cache was written on every hand-back (15–344 MiB per eviction, up to an 8 GiB host-RAM
-  default) and **never read**, so this gives that RAM back and costs nothing. Every other family —
-  **including a family nobody has measured** — keeps the cache on. That asymmetry is the point:
-  disabling it on an unaffected model would cost real restores, while leaving it on an affected one
-  merely continues a waste we can already name. Chat only; the embedder, reranker, translation and
-  vision sidecars do not inherit the chat args and are untouched.
+  (`--cache-ram 0`, gated on the manifest's `family:` — `qwen3.5`, `qwen3.6`, `qwen3.8`, `gemma4`).
+  On those models the cache was written on every hand-back (15–344 MiB per eviction, up to an 8 GiB
+  host-RAM default) and **never read**, so this gives that RAM back and costs nothing. Every other
+  family — **including a family nobody has measured** — keeps the cache on. That asymmetry is the
+  point: disabling it on an unaffected model would cost real restores, while leaving it on an
+  affected one merely continues a waste we can already name. `granite-4.1-8b-q4` is what that
+  caution is for: it was the entry expected to be a formality and it turned out to restore. Chat
+  only; the embedder, reranker, translation and vision sidecars do not inherit the chat args and are
+  untouched.
 
 ## Speculative decoding (MTP — [`architecture.md`](architecture.md) "MTP speculative decoding" record)
 

--- a/docs/model-benchmarks.md
+++ b/docs/model-benchmarks.md
@@ -1038,10 +1038,10 @@ fourteen-model sweep, not on the 27B Q5 control, not on any Gemma. Without MTP t
 confident `load: - found better prompt with f_keep = 0.990, sim = 0.983` and then silently re-prefills
 the whole prompt anyway. Grepping for `forcing full` gives the **opposite** answer; the TOKEN COUNT
 (`prompt eval time = … / N tokens` against `cached n_tokens`) is the only honest read. Still
-unmeasured: `qwen3.6-27b-q4` / `-q5` and `granite-4.1-8b-q4` (#446), and the ZIM query expander
-(#447). If llama.cpp PR #13194 lands recurrent-state restore upstream, both the delay and the D5
-switch become removable. Follow-up: #399 (closed by this work). **What it does NOT change: the
-context window.**
+unmeasured: the ZIM query expander (#447) — the three chat entries this paragraph used to list are
+measured, see the 2026-09-10 addition below. If llama.cpp PR #13194 lands recurrent-state restore
+upstream, both the delay and the D5 switch become removable. Follow-up: #399 (closed by this work).
+**What it does NOT change: the context window.**
 `--ctx-size` is the TOTAL cache size on both settings and every slot sees all of it
 (`n_ctx_slot = 8192` either way; `kv_unified` goes true → false, `n_seq_max` 4 → 1). That is the
 whole reason only four of the seven cache terms moved — see point 4 above for the rule and the
@@ -1051,6 +1051,37 @@ is the safe direction (the guard refuses a rung it could have run, never the rev
 verdicts it was calibrated to reproduce — Q4/Q5 clear a 24 GB card, Q6_K does not — are unchanged.
 Evidence: `eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/leg1-np-1.*` against
 `leg7-baseline-q5km.*`; finding 4 below is the measurement this decision was waiting for.
+
+**2026-09-10 addition (#446): the three entries the sweep could not start, measured — `qwen3.6`
+loses the restore, `granite` keeps it.** The #399 sweep left three catalog entries untested for
+reasons of logistics, not judgement: `qwen3.6-27b-q4` and `-q5` were broken symlinks into the eval
+drive deleted 2026-09-04, and `granite-4.1-8b-q4` was not on the rig. Under the conservative D5
+default all three were treated as unaffected, which was safe but left the record ambiguous — the
+standing risk being that "never tested" quietly reads as "measured and fine". All three weights were
+fetched, verified against the manifest's `sha256` **and** `size_bytes`, and run through the
+**unchanged** leg-A driver on the same machine and the same pinned binary, no MTP. Evidence:
+`eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-*`.
+
+| model | arch | n_swa | recurrent state | layers | R3 prefilled | kept | verdict |
+|---|---|---|---|---|---|---|---|
+| `qwen3.6-27b-q4` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | **1488 of 1529** | 41 | **RE-PREFILLED** |
+| `qwen3.6-27b-q5` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | **1488 of 1529** | 41 | **RE-PREFILLED** |
+| `granite-4.1-8b-q4` | granite | 0 | none | 41/41 | **22 of 1414** | 1392 | **RESTORED** |
+| `qwen3.8-27b-ud-q5km` (control) | qwen35 | 0 | 149.62 MiB (64 layers) | 66/66 | **1492 of 1571** | 79 | **RE-PREFILLED** |
+
+The control reproduced the sweep **token for token** (1,492 of 1,571, 79 kept), so the rows above
+belong in the same table as the fourteen. **`qwen3.6` is affected because it reports arch `qwen35`
+with a 149.62 MiB recurrent state** — the expectation from its lineage happened to be right, but the
+architecture line is what decided it, and both quants are identical in every column. `--cache-ram 0`
+therefore extends to the `qwen3.6` family (`shared/prompt-cache-rules.ts`), making the affected set
+**13 of 17 measured models**. **`granite` restored** — no sliding window, no recurrent state, 22 of
+1,414 tokens re-prefilled, and the 217.517 MiB it saved on the hand-back was actually read back. It
+becomes the fourth positive control beside `qwen3`, `qwen3moe` and `mistral3`, and it is the
+concrete case for keeping the cache-ON default: the family nobody had an opinion about is the one
+that would have lost real restores. Every `family:` in the catalog now has a verdict; the default
+still governs the family added next. The `forcing full` trap held a fourth time — that line appears
+**0 times** in all four captures, including the two `qwen3.6` runs, which instead logged a confident
+`found better prompt with f_keep = 0.989, sim = 0.985` before re-prefilling 1,488 tokens.
 
 **2026-09-07 amendment (#320, owner decision).** Both halves of the hybrid-laptop question are now
 closed. (j) The app keeps its **never-`--device`** rule: the premise it rested on — llama.cpp's fit

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.cache-lines.txt
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.cache-lines.txt
@@ -1,0 +1,49 @@
+0.00.600.506 I load: 69 unused tokens
+0.00.617.980 I load: printing all EOG tokens:
+0.00.617.984 I load:   - 100257 ('<|end_of_text|>')
+0.00.617.985 I load:   - 100261 ('<|fim_pad|>')
+0.00.618.176 I load: special tokens cache size = 96
+0.00.651.509 I load: token to piece cache size = 0.6152 MB
+0.00.651.539 I print_info: n_swa                 = 0
+0.00.651.540 I print_info: is_swa_any            = 0
+0.02.254.833 I llama_context: n_seq_max     = 1
+0.02.254.835 I llama_context: kv_unified    = false
+0.02.494.990 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.02.495.255 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.02.495.260 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.02.495.288 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.04.071.948 I srv  get_availabl: updating prompt cache
+0.04.071.958 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.04.071.965 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.04.071.966 I srv  get_availabl: prompt cache update took 0.02 ms
+0.04.072.109 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1377
+0.04.072.114 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.04.085.259 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.05.101.182 I slot print_timing: id  0 | task 0 | prompt eval time =     760.18 ms /  1377 tokens (    0.55 ms per token,  1811.41 tokens per second)
+0.05.101.187 I slot print_timing: id  0 | task 0 |        eval time =     268.88 ms /    16 tokens (   16.80 ms per token,    59.51 tokens per second)
+0.05.101.188 I slot print_timing: id  0 | task 0 |       total time =    1029.06 ms /  1393 tokens
+0.05.101.193 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.07.114.001 I srv  get_availabl: updating prompt cache
+0.07.114.074 I srv   prompt_save:  - saving prompt with length 1392, total state size = 217.517 MiB (draft: 0.000 MiB)
+0.07.261.733 I srv          load:  - looking for better prompt, base f_keep = 0.032, sim = 0.710
+0.07.261.740 I srv        update:  - cache state: 1 prompts, 217.517 MiB (limits: 8192.000 MiB, 8192 tokens, 52424 est)
+0.07.261.743 I srv  get_availabl: prompt cache update took 147.74 ms
+0.07.261.835 I slot   operator(): id  0 | task 18 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 62
+0.07.261.838 I slot   operator(): id  0 | task 18 | cached n_tokens = 44, memory_seq_rm [44, end)
+0.07.682.783 I slot print_timing: id  0 | task 18 | prompt eval time =     174.67 ms /    18 tokens (    9.70 ms per token,   103.05 tokens per second)
+0.07.682.788 I slot print_timing: id  0 | task 18 |        eval time =     246.27 ms /    11 tokens (   22.39 ms per token,    44.67 tokens per second)
+0.07.682.789 I slot print_timing: id  0 | task 18 |       total time =     420.94 ms /    29 tokens
+0.07.682.790 I slot print_timing: id  0 | task 18 |    graphs reused =         24
+0.09.702.567 I srv  get_availabl: updating prompt cache
+0.09.702.600 I srv   prompt_save:  - saving prompt with length 72, total state size = 11.252 MiB (draft: 0.000 MiB)
+0.09.715.149 I srv          load:  - looking for better prompt, base f_keep = 0.611, sim = 0.031
+0.09.715.154 I srv          load:  - found better prompt with f_keep = 1.000, sim = 0.984
+0.09.779.781 I srv        update:  - cache state: 1 prompts, 11.252 MiB (limits: 8192.000 MiB, 8192 tokens, 52420 est)
+0.09.779.787 I srv  get_availabl: prompt cache update took 77.22 ms
+0.09.779.874 I slot   operator(): id  0 | task 30 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1414
+0.09.779.879 I slot   operator(): id  0 | task 30 | cached n_tokens = 1392, memory_seq_rm [1392, end)
+0.09.786.843 I slot   operator(): id  0 | task 30 | cached n_tokens = 1395, memory_seq_rm [1395, end)
+0.10.260.856 I slot print_timing: id  0 | task 30 | prompt eval time =     189.85 ms /    22 tokens (    8.63 ms per token,   115.88 tokens per second)
+0.10.260.862 I slot print_timing: id  0 | task 30 |        eval time =     291.12 ms /    16 tokens (   18.19 ms per token,    54.96 tokens per second)
+0.10.260.864 I slot print_timing: id  0 | task 30 |       total time =     480.97 ms /    38 tokens
+0.10.260.865 I slot print_timing: id  0 | task 30 |    graphs reused =         38

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.json
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.json
@@ -1,0 +1,123 @@
+{
+  "model": "<drive>/models/chat/granite-4.1-8b-q4.gguf",
+  "bin": "<runtime>/llama-server",
+  "argv": [
+    "<runtime>/llama-server",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "8446",
+    "--model",
+    "<drive>/models/chat/granite-4.1-8b-q4.gguf",
+    "--ctx-size",
+    "8192",
+    "--threads",
+    "10",
+    "--batch-size",
+    "2048",
+    "--ubatch-size",
+    "2048",
+    "--jinja",
+    "--reasoning-format",
+    "deepseek",
+    "-lv",
+    "4",
+    "-np",
+    "1"
+  ],
+  "requests": [
+    {
+      "label": "R1 (conversation A, long)",
+      "http": 200,
+      "elapsedMs": 1060,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1377,
+        "total_tokens": 1393,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        }
+      },
+      "timings": {
+        "cache_n": 0,
+        "prompt_n": 1377,
+        "prompt_ms": 760.18,
+        "prompt_per_token_ms": 0.5520551924473492,
+        "prompt_per_second": 1811.4130863742798,
+        "predicted_n": 16,
+        "predicted_ms": 268.88,
+        "predicted_per_token_ms": 16.805,
+        "predicted_per_second": 59.506099375185954
+      },
+      "content": "A spare gasket set is kept in the grey cabinet beside the workshop door and"
+    },
+    {
+      "label": "R2 (conversation B, short)",
+      "http": 200,
+      "elapsedMs": 579,
+      "usage": {
+        "completion_tokens": 11,
+        "prompt_tokens": 62,
+        "total_tokens": 73,
+        "prompt_tokens_details": {
+          "cached_tokens": 44
+        }
+      },
+      "timings": {
+        "cache_n": 44,
+        "prompt_n": 18,
+        "prompt_ms": 174.669,
+        "prompt_per_token_ms": 9.703833333333334,
+        "prompt_per_second": 103.05205846486783,
+        "predicted_n": 11,
+        "predicted_ms": 246.268,
+        "predicted_per_token_ms": 22.388,
+        "predicted_per_second": 44.66678577809541
+      },
+      "content": "A barometer is used to measure atmospheric pressure."
+    },
+    {
+      "label": "R3 (back to conversation A)",
+      "http": 200,
+      "elapsedMs": 576,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1414,
+        "total_tokens": 1430,
+        "prompt_tokens_details": {
+          "cached_tokens": 1392
+        }
+      },
+      "timings": {
+        "cache_n": 1392,
+        "prompt_n": 22,
+        "prompt_ms": 189.85,
+        "prompt_per_token_ms": 8.629545454545454,
+        "prompt_per_second": 115.88095865156704,
+        "predicted_n": 16,
+        "predicted_ms": 291.117,
+        "predicted_per_token_ms": 18.1948125,
+        "predicted_per_second": 54.96072026023901
+      },
+      "content": "The compressor room door stays closed while the machine is running to keep the noise contained"
+    }
+  ],
+  "promptEvals": [
+    {
+      "task": 0,
+      "ms": 760.18,
+      "tokens": 1377
+    },
+    {
+      "task": 18,
+      "ms": 174.67,
+      "tokens": 18
+    },
+    {
+      "task": 30,
+      "ms": 189.85,
+      "tokens": 22
+    }
+  ],
+  "stderrLines": 269
+}

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.run.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.run.log
@@ -1,0 +1,11 @@
+2026-09-10T08:04:28.026Z bin      <runtime>/llama-server
+2026-09-10T08:04:28.027Z model    <drive>/models/chat/granite-4.1-8b-q4.gguf
+2026-09-10T08:04:28.027Z ctx      8192  np 1  threads 10  extra []
+2026-09-10T08:04:28.027Z argv     <runtime>/llama-server --host 127.0.0.1 --port 8446 --model <drive>/models/chat/granite-4.1-8b-q4.gguf --ctx-size 8192 --threads 10 --batch-size 2048 --ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1
+2026-09-10T08:04:28.031Z waiting for /health ...
+2026-09-10T08:04:31.082Z server ready
+2026-09-10T08:04:33.143Z R1 (conversation A, long)  http=200  1060 ms  prompt_tokens=1377  completion_tokens=16  prompt_ms=760.18  prompt_n=1377  cache_n=0
+2026-09-10T08:04:35.722Z R2 (conversation B, short)  http=200  579 ms  prompt_tokens=62  completion_tokens=11  prompt_ms=174.669  prompt_n=18  cache_n=44
+2026-09-10T08:04:38.299Z R3 (back to conversation A)  http=200  576 ms  prompt_tokens=1414  completion_tokens=16  prompt_ms=189.85  prompt_n=22  cache_n=1392
+2026-09-10T08:04:42.301Z stopping server
+2026-09-10T08:04:42.608Z server exited code=0 signal=null

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.stderr.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-granite-4.1-8b-q4.stderr.log
@@ -1,0 +1,268 @@
+0.00.118.638 I cmn  common_param: common_params_print_info: build 9849 (799fcc04a) with GNU 11.4.0 for Linux x86_64
+0.00.118.641 I cmn  common_param: common_params_print_info: verbosity = 4 (adjust with the `-lv N` CLI arg)
+0.00.118.642 I cmn  common_param: device_info:
+0.00.122.871 I cmn  common_param:   - Vulkan0 : NVIDIA GeForce RTX 3090 (24822 MiB, 23726 MiB free)
+0.00.122.877 I cmn  common_param:   - CPU     : Intel(R) Core(TM) i9-9900X CPU @ 3.50GHz (128493 MiB, 128493 MiB free)
+0.00.122.911 I cmn  common_param: system_info: n_threads = 10 (n_threads_batch = 10) / 20 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
+0.00.122.948 I srv          init: running without SSL
+0.00.123.001 I srv          init: using 19 threads for HTTP server
+0.00.123.291 I srv         start: binding port with default address family
+0.00.124.500 I srv    load_model: loading model '<drive>/models/chat/granite-4.1-8b-q4.gguf'
+0.00.124.504 I srv    load_model: local path '<drive>/models/chat/granite-4.1-8b-q4.gguf'
+0.00.124.523 I cmn  common_init_: fitting params to device memory ...
+0.00.124.525 I cmn  common_init_: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
+0.00.124.534 I common_params_fit_impl: getting device memory data for initial parameters:
+0.00.474.023 I common_memory_breakdown_print: | memory breakdown [MiB] | total    free    self   model   context   compute    unaccounted |
+0.00.474.026 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 23695 + (6552 =  4876 +    1280 +     396) +       -5426 |
+0.00.474.026 I common_memory_breakdown_print: |   - Host               |                   316 =   220 +       0 +      96                |
+0.00.494.552 I common_params_fit_impl: projected to use 6552 MiB of device memory vs. 23695 MiB of free device memory
+0.00.494.556 I common_params_fit_impl: will leave 17143 >= 1024 MiB of free device memory, no changes needed
+0.00.494.557 I common_fit_params: successfully fit params to free device memory
+0.00.494.561 I common_fit_params: fitting params to free memory took 0.37 seconds
+0.00.513.655 I llama_model_loader: loaded meta data with 34 key-value pairs and 363 tensors from <drive>/models/chat/granite-4.1-8b-q4.gguf (version GGUF V3 (latest))
+0.00.513.670 I llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+0.00.513.673 I llama_model_loader: - kv   0:                       general.architecture str              = granite
+0.00.513.674 I llama_model_loader: - kv   1:                               general.type str              = model
+0.00.513.675 I llama_model_loader: - kv   2:                               general.name str              = Granite 4.1 8b
+0.00.513.676 I llama_model_loader: - kv   3:                           general.basename str              = granite-4.1
+0.00.513.676 I llama_model_loader: - kv   4:                         general.size_label str              = 8B
+0.00.513.676 I llama_model_loader: - kv   5:                            general.license str              = apache-2.0
+0.00.513.678 I llama_model_loader: - kv   6:                        granite.block_count u32              = 40
+0.00.513.678 I llama_model_loader: - kv   7:                     granite.context_length u32              = 131072
+0.00.513.679 I llama_model_loader: - kv   8:                   granite.embedding_length u32              = 4096
+0.00.513.680 I llama_model_loader: - kv   9:                granite.feed_forward_length u32              = 12800
+0.00.513.680 I llama_model_loader: - kv  10:               granite.attention.head_count u32              = 32
+0.00.513.681 I llama_model_loader: - kv  11:            granite.attention.head_count_kv u32              = 8
+0.00.513.684 I llama_model_loader: - kv  12:                     granite.rope.freq_base f32              = 10000000.000000
+0.00.513.685 I llama_model_loader: - kv  13:   granite.attention.layer_norm_rms_epsilon f32              = 0.000010
+0.00.513.686 I llama_model_loader: - kv  14:                         granite.vocab_size u32              = 100352
+0.00.513.686 I llama_model_loader: - kv  15:               granite.rope.dimension_count u32              = 128
+0.00.513.687 I llama_model_loader: - kv  16:                    granite.attention.scale f32              = 0.007812
+0.00.513.688 I llama_model_loader: - kv  17:                    granite.embedding_scale f32              = 12.000000
+0.00.513.689 I llama_model_loader: - kv  18:                     granite.residual_scale f32              = 0.220000
+0.00.513.690 I llama_model_loader: - kv  19:                        granite.logit_scale f32              = 16.000000
+0.00.513.690 I llama_model_loader: - kv  20:                       tokenizer.ggml.model str              = gpt2
+0.00.513.691 I llama_model_loader: - kv  21:                         tokenizer.ggml.pre str              = dbrx
+0.00.524.001 I llama_model_loader: - kv  22:                      tokenizer.ggml.tokens arr[str,100352]  = ["!", "\"", "#", "$", "%", "&", "'", ...
+0.00.526.642 I llama_model_loader: - kv  23:                  tokenizer.ggml.token_type arr[i32,100352]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+0.00.536.984 I llama_model_loader: - kv  24:                      tokenizer.ggml.merges arr[str,100000]  = ["Ġ Ġ", "ĠĠ ĠĠ", "i n", "Ġ t",...
+0.00.536.991 I llama_model_loader: - kv  25:                tokenizer.ggml.bos_token_id u32              = 100257
+0.00.536.992 I llama_model_loader: - kv  26:                tokenizer.ggml.eos_token_id u32              = 100257
+0.00.536.992 I llama_model_loader: - kv  27:            tokenizer.ggml.unknown_token_id u32              = 100269
+0.00.536.992 I llama_model_loader: - kv  28:            tokenizer.ggml.padding_token_id u32              = 100256
+0.00.536.993 I llama_model_loader: - kv  29:               tokenizer.ggml.add_bos_token bool             = false
+0.00.536.996 I llama_model_loader: - kv  30:                    tokenizer.chat_template str              = {%- set tools_system_message_prefix =...
+0.00.536.996 I llama_model_loader: - kv  31:            tokenizer.ggml.add_space_prefix bool             = false
+0.00.536.997 I llama_model_loader: - kv  32:               general.quantization_version u32              = 2
+0.00.536.998 I llama_model_loader: - kv  33:                          general.file_type u32              = 15
+0.00.536.999 I llama_model_loader: - type  f32:   81 tensors
+0.00.537.000 I llama_model_loader: - type q4_K:  241 tensors
+0.00.537.000 I llama_model_loader: - type q6_K:   41 tensors
+0.00.537.002 I print_info: file format = GGUF V3 (latest)
+0.00.537.002 I print_info: file type   = Q4_K - Medium
+0.00.537.004 I print_info: file size   = 4.98 GiB (4.86 BPW) 
+0.00.545.554 I llama_prepare_model_devices: using device Vulkan0 (NVIDIA GeForce RTX 3090) (0000:c1:00.0) - 23695 MiB free
+0.00.600.506 I load: 69 unused tokens
+0.00.617.980 I load: printing all EOG tokens:
+0.00.617.984 I load:   - 100257 ('<|end_of_text|>')
+0.00.617.985 I load:   - 100261 ('<|fim_pad|>')
+0.00.618.176 I load: special tokens cache size = 96
+0.00.651.509 I load: token to piece cache size = 0.6152 MB
+0.00.651.524 I print_info: arch                  = granite
+0.00.651.525 I print_info: vocab_only            = 0
+0.00.651.525 I print_info: no_alloc              = 0
+0.00.651.525 I print_info: n_ctx_train           = 131072
+0.00.651.527 I print_info: n_embd_inp            = 4096
+0.00.651.528 I print_info: n_embd                = 4096
+0.00.651.528 I print_info: n_embd_out            = 4096
+0.00.651.529 I print_info: n_layer               = 40
+0.00.651.529 I print_info: n_layer_all           = 40
+0.00.651.538 I print_info: n_head                = 32
+0.00.651.539 I print_info: n_head_kv             = 8
+0.00.651.539 I print_info: n_rot                 = 128
+0.00.651.539 I print_info: n_swa                 = 0
+0.00.651.540 I print_info: is_swa_any            = 0
+0.00.651.540 I print_info: n_embd_head_k         = 128
+0.00.651.541 I print_info: n_embd_head_v         = 128
+0.00.651.542 I print_info: n_gqa                 = 4
+0.00.651.543 I print_info: n_embd_k_gqa          = 1024
+0.00.651.544 I print_info: n_embd_v_gqa          = 1024
+0.00.651.545 I print_info: f_norm_eps            = 0.0e+00
+0.00.651.546 I print_info: f_norm_rms_eps        = 1.0e-05
+0.00.651.546 I print_info: f_clamp_kqv           = 0.0e+00
+0.00.651.547 I print_info: f_max_alibi_bias      = 0.0e+00
+0.00.651.548 I print_info: f_logit_scale         = 1.6e+01
+0.00.651.548 I print_info: f_attn_scale          = 7.8e-03
+0.00.651.549 I print_info: f_attn_value_scale    = 0.0000
+0.00.651.550 I print_info: n_ff                  = 12800
+0.00.651.550 I print_info: n_expert              = 0
+0.00.651.550 I print_info: n_expert_used         = 0
+0.00.651.551 I print_info: n_expert_groups       = 0
+0.00.651.551 I print_info: n_group_used          = 0
+0.00.651.551 I print_info: causal attn           = 1
+0.00.651.551 I print_info: pooling type          = -1
+0.00.651.552 I print_info: rope type             = 0
+0.00.651.552 I print_info: rope scaling          = linear
+0.00.651.553 I print_info: freq_base_train       = 10000000.0
+0.00.651.553 I print_info: freq_scale_train      = 1
+0.00.651.554 I print_info: n_ctx_orig_yarn       = 131072
+0.00.651.554 I print_info: rope_yarn_log_mul     = 0.0000
+0.00.651.554 I print_info: rope_finetuned        = yes
+0.00.651.556 I print_info: model type            = 3B
+0.00.651.556 I print_info: model params          = 8.79 B
+0.00.651.556 I print_info: general.name          = Granite 4.1 8b
+0.00.651.557 I print_info: f_embedding_scale     = 12.000000
+0.00.651.557 I print_info: f_residual_scale      = 0.220000
+0.00.651.558 I print_info: f_attention_scale     = 0.007812
+0.00.651.558 I print_info: n_ff_shexp            = 0
+0.00.651.559 I print_info: vocab type            = BPE
+0.00.651.560 I print_info: n_vocab               = 100352
+0.00.651.560 I print_info: n_merges              = 100000
+0.00.651.560 I print_info: BOS token             = 100257 '<|end_of_text|>'
+0.00.651.561 I print_info: EOS token             = 100257 '<|end_of_text|>'
+0.00.651.561 I print_info: EOT token             = 100257 '<|end_of_text|>'
+0.00.651.561 I print_info: UNK token             = 100269 '<|unk|>'
+0.00.651.562 I print_info: PAD token             = 100256 '<|pad|>'
+0.00.651.562 I print_info: LF token              = 198 'Ċ'
+0.00.651.562 I print_info: FIM PRE token         = 100258 '<|fim_prefix|>'
+0.00.651.562 I print_info: FIM SUF token         = 100260 '<|fim_suffix|>'
+0.00.651.563 I print_info: FIM MID token         = 100259 '<|fim_middle|>'
+0.00.651.563 I print_info: FIM PAD token         = 100261 '<|fim_pad|>'
+0.00.651.563 I print_info: EOG token             = 100257 '<|end_of_text|>'
+0.00.651.564 I print_info: EOG token             = 100261 '<|fim_pad|>'
+0.00.651.564 I print_info: max token length      = 256
+0.00.651.565 I load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+0.01.053.918 I load_tensors: offloading output layer to GPU
+0.01.053.922 I load_tensors: offloading 39 repeating layers to GPU
+0.01.053.923 I load_tensors: offloaded 41/41 layers to GPU
+0.01.053.928 I load_tensors:   CPU_Mapped model buffer size =   220.50 MiB
+0.01.053.931 I load_tensors:      Vulkan0 model buffer size =  4876.27 MiB
+0.02.254.737 I cmn  common_init_: added <|end_of_text|> logit bias = -inf
+0.02.254.750 I cmn  common_init_: added <|fim_pad|> logit bias = -inf
+0.02.254.829 I llama_context: constructing llama_context
+0.02.254.833 I llama_context: n_seq_max     = 1
+0.02.254.833 I llama_context: n_ctx         = 8192
+0.02.254.834 I llama_context: n_ctx_seq     = 8192
+0.02.254.834 I llama_context: n_batch       = 2048
+0.02.254.834 I llama_context: n_ubatch      = 2048
+0.02.254.834 I llama_context: causal_attn   = 1
+0.02.254.835 I llama_context: flash_attn    = auto
+0.02.254.835 I llama_context: kv_unified    = false
+0.02.254.837 I llama_context: freq_base     = 10000000.0
+0.02.254.838 I llama_context: freq_scale    = 1
+0.02.254.838 I llama_context: n_rs_seq      = 0
+0.02.254.838 I llama_context: n_outputs_max = 1
+0.02.254.839 I llama_context: n_ctx_seq (8192) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+0.02.256.247 I llama_context: Vulkan_Host  output buffer size =     0.38 MiB
+0.02.279.100 I llama_kv_cache:    Vulkan0 KV buffer size =  1280.00 MiB
+0.02.318.320 I llama_kv_cache: size = 1280.00 MiB (  8192 cells,  40 layers,  1/1 seqs), K (f16):  640.00 MiB, V (f16):  640.00 MiB
+0.02.318.329 I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 128
+0.02.318.331 I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 128
+0.02.318.363 I sched_reserve: reserving ...
+0.02.321.286 I sched_reserve: Flash Attention was auto, set to enabled
+0.02.321.288 I sched_reserve: resolving fused Gated Delta Net support:
+0.02.322.705 I sched_reserve: fused Gated Delta Net (autoregressive) enabled
+0.02.324.111 I sched_reserve: fused Gated Delta Net (chunked) enabled
+0.02.350.720 I sched_reserve:    Vulkan0 compute buffer size =   396.04 MiB
+0.02.350.725 I sched_reserve: Vulkan_Host compute buffer size =    96.05 MiB
+0.02.350.725 I sched_reserve: graph nodes  = 1328
+0.02.350.726 I sched_reserve: graph splits = 2
+0.02.350.727 I sched_reserve: reserve took 32.36 ms, sched copies = 1
+0.02.350.778 I cmn  common_init_: warming up the model with an empty run - please wait ... (--no-warmup to disable)
+0.02.494.990 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.02.495.008 I spec common_specu: no implementations specified for speculative decoding
+0.02.495.013 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 8192
+0.02.495.255 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.02.495.260 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.02.495.261 I srv    load_model: for more info see https://github.com/ggml-org/llama.cpp/pull/16391
+0.02.495.262 I srv    load_model: context checkpoints enabled, max = 32, min spacing = 8192
+0.02.495.288 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.02.508.504 I srv          init: init: chat template, example_format: '<|start_of_role|>system<|end_of_role|>You are a helpful assistant<|end_of_text|>
+<|start_of_role|>user<|end_of_role|>Hello<|end_of_text|>
+<|start_of_role|>assistant<|end_of_role|>Hi there<|end_of_text|>
+<|start_of_role|>user<|end_of_role|>How are you?<|end_of_text|>
+<|start_of_role|>assistant<|end_of_role|>'
+0.02.513.403 I srv          init: init: chat template, thinking = 0
+0.02.513.442 I srv  llama_server: model loaded
+0.02.513.447 I srv  llama_server: listening on http://127.0.0.1:8446
+0.02.513.451 I srv  update_slots: all slots are idle
+0.04.071.572 I srv    operator(): chat format: peg-native
+0.04.071.943 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1
+0.04.071.948 I srv  get_availabl: updating prompt cache
+0.04.071.958 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.04.071.965 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.04.071.966 I srv  get_availabl: prompt cache update took 0.02 ms
+0.04.072.076 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.04.072.088 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 40, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.04.072.090 I slot launch_slot_: id  0 | task 0 | processing task, is_child = 0
+0.04.072.109 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1377
+0.04.072.114 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.04.085.259 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.04.085.493 I slot init_sampler: id  0 | task 0 | init sampler, took 0.17 ms, tokens: text = 1377, total = 1377
+0.05.101.182 I slot print_timing: id  0 | task 0 | prompt eval time =     760.18 ms /  1377 tokens (    0.55 ms per token,  1811.41 tokens per second)
+0.05.101.187 I slot print_timing: id  0 | task 0 |        eval time =     268.88 ms /    16 tokens (   16.80 ms per token,    59.51 tokens per second)
+0.05.101.188 I slot print_timing: id  0 | task 0 |       total time =    1029.06 ms /  1393 tokens
+0.05.101.193 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.05.101.308 I slot      release: id  0 | task 0 | stop processing: n_tokens = 1392, truncated = 0
+0.05.101.313 I srv  update_slots: all slots are idle
+0.05.101.616 I srv  stream_sessi: conv_id= (empty=1)
+0.07.113.923 I srv    operator(): chat format: peg-native
+0.07.113.998 I slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.710 (> 0.100 thold), f_keep = 0.032
+0.07.114.001 I srv  get_availabl: updating prompt cache
+0.07.114.074 I srv   prompt_save:  - saving prompt with length 1392, total state size = 217.517 MiB (draft: 0.000 MiB)
+0.07.261.733 I srv          load:  - looking for better prompt, base f_keep = 0.032, sim = 0.710
+0.07.261.740 I srv        update:  - cache state: 1 prompts, 217.517 MiB (limits: 8192.000 MiB, 8192 tokens, 52424 est)
+0.07.261.741 I srv        update:    - prompt 0x5e5927571580:    1392 tokens, checkpoints:  0,   217.517 MiB
+0.07.261.743 I srv  get_availabl: prompt cache update took 147.74 ms
+0.07.261.819 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.07.261.824 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 40, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.07.261.827 I slot launch_slot_: id  0 | task 18 | processing task, is_child = 0
+0.07.261.835 I slot   operator(): id  0 | task 18 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 62
+0.07.261.838 I slot   operator(): id  0 | task 18 | cached n_tokens = 44, memory_seq_rm [44, end)
+0.07.261.992 I slot init_sampler: id  0 | task 18 | init sampler, took 0.01 ms, tokens: text = 62, total = 62
+0.07.682.783 I slot print_timing: id  0 | task 18 | prompt eval time =     174.67 ms /    18 tokens (    9.70 ms per token,   103.05 tokens per second)
+0.07.682.788 I slot print_timing: id  0 | task 18 |        eval time =     246.27 ms /    11 tokens (   22.39 ms per token,    44.67 tokens per second)
+0.07.682.789 I slot print_timing: id  0 | task 18 |       total time =     420.94 ms /    29 tokens
+0.07.682.790 I slot print_timing: id  0 | task 18 |    graphs reused =         24
+0.07.682.813 I slot      release: id  0 | task 18 | stop processing: n_tokens = 72, truncated = 0
+0.07.682.822 I srv  update_slots: all slots are idle
+0.07.682.898 I srv  stream_sessi: conv_id= (empty=1)
+0.09.702.471 I srv    operator(): chat format: peg-native
+0.09.702.566 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = 9684408472
+0.09.702.567 I srv  get_availabl: updating prompt cache
+0.09.702.600 I srv   prompt_save:  - saving prompt with length 72, total state size = 11.252 MiB (draft: 0.000 MiB)
+0.09.715.149 I srv          load:  - looking for better prompt, base f_keep = 0.611, sim = 0.031
+0.09.715.154 I srv          load:  - found better prompt with f_keep = 1.000, sim = 0.984
+0.09.779.781 I srv        update:  - cache state: 1 prompts, 11.252 MiB (limits: 8192.000 MiB, 8192 tokens, 52420 est)
+0.09.779.786 I srv        update:    - prompt 0x5e5927578060:      72 tokens, checkpoints:  0,    11.252 MiB
+0.09.779.787 I srv  get_availabl: prompt cache update took 77.22 ms
+0.09.779.857 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.09.779.864 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 40, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.09.779.866 I slot launch_slot_: id  0 | task 30 | processing task, is_child = 0
+0.09.779.874 I slot   operator(): id  0 | task 30 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1414
+0.09.779.879 I slot   operator(): id  0 | task 30 | cached n_tokens = 1392, memory_seq_rm [1392, end)
+0.09.786.843 I slot   operator(): id  0 | task 30 | cached n_tokens = 1395, memory_seq_rm [1395, end)
+0.09.787.009 I slot init_sampler: id  0 | task 30 | init sampler, took 0.15 ms, tokens: text = 1414, total = 1414
+0.10.260.856 I slot print_timing: id  0 | task 30 | prompt eval time =     189.85 ms /    22 tokens (    8.63 ms per token,   115.88 tokens per second)
+0.10.260.862 I slot print_timing: id  0 | task 30 |        eval time =     291.12 ms /    16 tokens (   18.19 ms per token,    54.96 tokens per second)
+0.10.260.864 I slot print_timing: id  0 | task 30 |       total time =     480.97 ms /    38 tokens
+0.10.260.865 I slot print_timing: id  0 | task 30 |    graphs reused =         38
+0.10.261.040 I slot      release: id  0 | task 30 | stop processing: n_tokens = 1429, truncated = 0
+0.10.261.058 I srv  update_slots: all slots are idle
+0.10.261.246 I srv  stream_sessi: conv_id= (empty=1)
+0.14.264.233 I srv    operator(): operator(): cleaning up before exit...
+0.14.273.642 I common_memory_breakdown_print: | memory breakdown [MiB] | total    free    self   model   context   compute    unaccounted |
+0.14.273.647 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 16981 + (6552 =  4876 +    1280 +     396) +        1288 |
+0.14.273.648 I common_memory_breakdown_print: |   - Host               |                   316 =   220 +       0 +      96                |

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.cache-lines.txt
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.cache-lines.txt
@@ -1,0 +1,57 @@
+0.01.306.965 I load: 0 unused tokens
+0.01.369.836 I load: printing all EOG tokens:
+0.01.369.841 I load:   - 248044 ('<|endoftext|>')
+0.01.369.842 I load:   - 248046 ('<|im_end|>')
+0.01.369.842 I load:   - 248063 ('<|fim_pad|>')
+0.01.369.843 I load:   - 248064 ('<|repo_name|>')
+0.01.369.843 I load:   - 248065 ('<|file_sep|>')
+0.01.370.536 I load: special tokens cache size = 33
+0.01.471.089 I load: token to piece cache size = 1.7581 MB
+0.01.471.119 I print_info: n_swa                 = 0
+0.01.471.120 I print_info: is_swa_any            = 0
+0.06.768.871 I llama_context: n_seq_max     = 1
+0.06.768.873 I llama_context: kv_unified    = false
+0.06.821.156 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.06.821.181 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.07.198.136 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.07.198.213 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.07.198.213 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.07.198.230 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.08.796.769 I srv  get_availabl: updating prompt cache
+0.08.796.777 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.08.796.782 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.08.796.783 I srv  get_availabl: prompt cache update took 0.01 ms
+0.08.796.897 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1508
+0.08.796.901 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.08.826.234 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.09.198.913 I slot   operator(): id  0 | task 0 | cached n_tokens = 1504, memory_seq_rm [1504, end)
+0.11.563.116 I slot print_timing: id  0 | task 0 | prompt eval time =    2338.67 ms /  1508 tokens (    1.55 ms per token,   644.81 tokens per second)
+0.11.563.121 I slot print_timing: id  0 | task 0 |        eval time =     427.53 ms /    16 tokens (   26.72 ms per token,    37.42 tokens per second)
+0.11.563.122 I slot print_timing: id  0 | task 0 |       total time =    2766.20 ms /  1524 tokens
+0.11.563.126 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.13.590.839 I srv  get_availabl: updating prompt cache
+0.13.590.919 I srv   prompt_save:  - saving prompt with length 1523, total state size = 244.843 MiB (draft: 0.000 MiB)
+0.13.862.159 I srv          load:  - looking for better prompt, base f_keep = 0.029, sim = 0.688
+0.13.862.180 I srv        update:  - cache state: 1 prompts, 394.469 MiB (limits: 8192.000 MiB, 8192 tokens, 31628 est)
+0.13.862.196 I srv  get_availabl: prompt cache update took 271.35 ms
+0.13.862.387 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 64
+0.13.887.843 I slot   operator(): id  0 | task 19 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.14.005.488 I slot   operator(): id  0 | task 19 | cached n_tokens = 60, memory_seq_rm [60, end)
+0.15.129.922 I slot print_timing: id  0 | task 19 | prompt eval time =     583.66 ms /    23 tokens (   25.38 ms per token,    39.41 tokens per second)
+0.15.129.928 I slot print_timing: id  0 | task 19 |        eval time =     683.87 ms /    16 tokens (   42.74 ms per token,    23.40 tokens per second)
+0.15.129.929 I slot print_timing: id  0 | task 19 |       total time =    1267.52 ms /    39 tokens
+0.15.129.930 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.17.159.704 I srv  get_availabl: updating prompt cache
+0.17.159.778 I srv   prompt_save:  - saving prompt with length 79, total state size = 154.566 MiB (draft: 0.000 MiB)
+0.17.462.055 I srv          load:  - looking for better prompt, base f_keep = 0.557, sim = 0.029
+0.17.462.070 I srv          load:  - found better prompt with f_keep = 0.989, sim = 0.985
+0.17.527.802 I srv        update:  - cache state: 1 prompts, 453.818 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.17.527.809 I srv  get_availabl: prompt cache update took 368.10 ms
+0.17.527.909 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1529
+0.17.543.787 I slot   operator(): id  0 | task 37 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.17.939.535 I slot   operator(): id  0 | task 37 | cached n_tokens = 1508, memory_seq_rm [1508, end)
+0.19.869.586 I slot   operator(): id  0 | task 37 | cached n_tokens = 1525, memory_seq_rm [1525, end)
+0.20.710.926 I slot print_timing: id  0 | task 37 | prompt eval time =    2531.04 ms /  1488 tokens (    1.70 ms per token,   587.90 tokens per second)
+0.20.710.931 I slot print_timing: id  0 | task 37 |        eval time =     651.96 ms /    16 tokens (   40.75 ms per token,    24.54 tokens per second)
+0.20.710.933 I slot print_timing: id  0 | task 37 |       total time =    3183.00 ms /  1504 tokens
+0.20.710.933 I slot print_timing: id  0 | task 37 |    graphs reused =         42

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.json
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.json
@@ -1,0 +1,123 @@
+{
+  "model": "<drive>/models/chat/qwen3.6-27b-q4.gguf",
+  "bin": "<runtime>/llama-server",
+  "argv": [
+    "<runtime>/llama-server",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "8447",
+    "--model",
+    "<drive>/models/chat/qwen3.6-27b-q4.gguf",
+    "--ctx-size",
+    "8192",
+    "--threads",
+    "10",
+    "--batch-size",
+    "2048",
+    "--ubatch-size",
+    "2048",
+    "--jinja",
+    "--reasoning-format",
+    "deepseek",
+    "-lv",
+    "4",
+    "-np",
+    "1"
+  ],
+  "requests": [
+    {
+      "label": "R1 (conversation A, long)",
+      "http": 200,
+      "elapsedMs": 2797,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1508,
+        "total_tokens": 1524,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        }
+      },
+      "timings": {
+        "cache_n": 0,
+        "prompt_n": 1508,
+        "prompt_ms": 2338.671,
+        "prompt_per_token_ms": 1.5508428381962864,
+        "prompt_per_second": 644.8106638342889,
+        "predicted_n": 16,
+        "predicted_ms": 427.529,
+        "predicted_per_token_ms": 26.7205625,
+        "predicted_per_second": 37.42436185615479
+      },
+      "content": ""
+    },
+    {
+      "label": "R2 (conversation B, short)",
+      "http": 200,
+      "elapsedMs": 1566,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 64,
+        "total_tokens": 80,
+        "prompt_tokens_details": {
+          "cached_tokens": 41
+        }
+      },
+      "timings": {
+        "cache_n": 41,
+        "prompt_n": 23,
+        "prompt_ms": 583.656,
+        "prompt_per_token_ms": 25.376347826086953,
+        "prompt_per_second": 39.40677385309155,
+        "predicted_n": 16,
+        "predicted_ms": 683.866,
+        "predicted_per_token_ms": 42.741625,
+        "predicted_per_second": 23.396396370049104
+      },
+      "content": ""
+    },
+    {
+      "label": "R3 (back to conversation A)",
+      "http": 200,
+      "elapsedMs": 3578,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1529,
+        "total_tokens": 1545,
+        "prompt_tokens_details": {
+          "cached_tokens": 41
+        }
+      },
+      "timings": {
+        "cache_n": 41,
+        "prompt_n": 1488,
+        "prompt_ms": 2531.038,
+        "prompt_per_token_ms": 1.7009663978494625,
+        "prompt_per_second": 587.9010903826809,
+        "predicted_n": 16,
+        "predicted_ms": 651.962,
+        "predicted_per_token_ms": 40.747625,
+        "predicted_per_second": 24.541307622223382
+      },
+      "content": ""
+    }
+  ],
+  "promptEvals": [
+    {
+      "task": 0,
+      "ms": 2338.67,
+      "tokens": 1508
+    },
+    {
+      "task": 19,
+      "ms": 583.66,
+      "tokens": 23
+    },
+    {
+      "task": 37,
+      "ms": 2531.04,
+      "tokens": 1488
+    }
+  ],
+  "stderrLines": 321
+}

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.run.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.run.log
@@ -1,0 +1,11 @@
+2026-09-10T08:40:39.787Z bin      <runtime>/llama-server
+2026-09-10T08:40:39.787Z model    <drive>/models/chat/qwen3.6-27b-q4.gguf
+2026-09-10T08:40:39.787Z ctx      8192  np 1  threads 10  extra []
+2026-09-10T08:40:39.787Z argv     <runtime>/llama-server --host 127.0.0.1 --port 8447 --model <drive>/models/chat/qwen3.6-27b-q4.gguf --ctx-size 8192 --threads 10 --batch-size 2048 --ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1
+2026-09-10T08:40:39.792Z waiting for /health ...
+2026-09-10T08:40:47.567Z server ready
+2026-09-10T08:40:51.365Z R1 (conversation A, long)  http=200  2797 ms  prompt_tokens=1508  completion_tokens=16  prompt_ms=2338.671  prompt_n=1508  cache_n=0
+2026-09-10T08:40:54.933Z R2 (conversation B, short)  http=200  1566 ms  prompt_tokens=64  completion_tokens=16  prompt_ms=583.656  prompt_n=23  cache_n=41
+2026-09-10T08:41:00.512Z R3 (back to conversation A)  http=200  3578 ms  prompt_tokens=1529  completion_tokens=16  prompt_ms=2531.038  prompt_n=1488  cache_n=41
+2026-09-10T08:41:04.512Z stopping server
+2026-09-10T08:41:05.170Z server exited code=0 signal=null

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.stderr.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q4.stderr.log
@@ -1,0 +1,320 @@
+0.00.126.447 I cmn  common_param: common_params_print_info: build 9849 (799fcc04a) with GNU 11.4.0 for Linux x86_64
+0.00.126.451 I cmn  common_param: common_params_print_info: verbosity = 4 (adjust with the `-lv N` CLI arg)
+0.00.126.451 I cmn  common_param: device_info:
+0.00.131.550 I cmn  common_param:   - Vulkan0 : NVIDIA GeForce RTX 3090 (24822 MiB, 23803 MiB free)
+0.00.131.556 I cmn  common_param:   - CPU     : Intel(R) Core(TM) i9-9900X CPU @ 3.50GHz (128493 MiB, 128493 MiB free)
+0.00.131.595 I cmn  common_param: system_info: n_threads = 10 (n_threads_batch = 10) / 20 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
+0.00.131.640 I srv          init: running without SSL
+0.00.131.705 I srv          init: using 19 threads for HTTP server
+0.00.132.068 I srv         start: binding port with default address family
+0.00.133.257 I srv    load_model: loading model '<drive>/models/chat/qwen3.6-27b-q4.gguf'
+0.00.133.259 I srv    load_model: local path '<drive>/models/chat/qwen3.6-27b-q4.gguf'
+0.00.133.274 I cmn  common_init_: fitting params to device memory ...
+0.00.133.275 I cmn  common_init_: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
+0.00.133.283 I common_params_fit_impl: getting device memory data for initial parameters:
+0.00.898.197 I common_memory_breakdown_print: | memory breakdown [MiB] | total    free     self   model   context   compute    unaccounted |
+0.00.898.201 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 23323 + (16575 = 15345 +     661 +     568) +      -15077 |
+0.00.898.201 I common_memory_breakdown_print: |   - Host               |                    794 =   682 +       0 +     112                |
+0.00.977.147 I common_params_fit_impl: projected to use 16575 MiB of device memory vs. 23323 MiB of free device memory
+0.00.977.151 I common_params_fit_impl: will leave 6748 >= 1024 MiB of free device memory, no changes needed
+0.00.977.152 I common_fit_params: successfully fit params to free device memory
+0.00.977.155 I common_fit_params: fitting params to free memory took 0.84 seconds
+0.01.041.517 I llama_model_loader: loaded meta data with 51 key-value pairs and 851 tensors from <drive>/models/chat/qwen3.6-27b-q4.gguf (version GGUF V3 (latest))
+0.01.041.550 I llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+0.01.041.556 I llama_model_loader: - kv   0:                       general.architecture str              = qwen35
+0.01.041.557 I llama_model_loader: - kv   1:                               general.type str              = model
+0.01.041.559 I llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 20
+0.01.041.562 I llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+0.01.041.563 I llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+0.01.041.564 I llama_model_loader: - kv   5:                               general.name str              = Qwen3.6-27B
+0.01.041.564 I llama_model_loader: - kv   6:                           general.basename str              = Qwen3.6-27B
+0.01.041.565 I llama_model_loader: - kv   7:                       general.quantized_by str              = Unsloth
+0.01.041.565 I llama_model_loader: - kv   8:                         general.size_label str              = 27B
+0.01.041.566 I llama_model_loader: - kv   9:                            general.license str              = apache-2.0
+0.01.041.568 I llama_model_loader: - kv  10:                       general.license.link str              = https://huggingface.co/Qwen/Qwen3.6-2...
+0.01.041.568 I llama_model_loader: - kv  11:                           general.repo_url str              = https://huggingface.co/unsloth
+0.01.041.570 I llama_model_loader: - kv  12:                   general.base_model.count u32              = 1
+0.01.041.570 I llama_model_loader: - kv  13:                  general.base_model.0.name str              = Qwen3.6 27B
+0.01.041.571 I llama_model_loader: - kv  14:          general.base_model.0.organization str              = Qwen
+0.01.041.572 I llama_model_loader: - kv  15:              general.base_model.0.repo_url str              = https://huggingface.co/Qwen/Qwen3.6-27B
+0.01.041.580 I llama_model_loader: - kv  16:                               general.tags arr[str,2]       = ["unsloth", "image-text-to-text"]
+0.01.041.581 I llama_model_loader: - kv  17:                         qwen35.block_count u32              = 64
+0.01.041.582 I llama_model_loader: - kv  18:                      qwen35.context_length u32              = 262144
+0.01.041.583 I llama_model_loader: - kv  19:                    qwen35.embedding_length u32              = 5120
+0.01.041.583 I llama_model_loader: - kv  20:                 qwen35.feed_forward_length u32              = 17408
+0.01.041.584 I llama_model_loader: - kv  21:                qwen35.attention.head_count u32              = 24
+0.01.041.584 I llama_model_loader: - kv  22:             qwen35.attention.head_count_kv u32              = 4
+0.01.041.586 I llama_model_loader: - kv  23:             qwen35.rope.dimension_sections arr[i32,4]       = [11, 11, 10, 0]
+0.01.041.587 I llama_model_loader: - kv  24:                      qwen35.rope.freq_base f32              = 10000000.000000
+0.01.041.588 I llama_model_loader: - kv  25:    qwen35.attention.layer_norm_rms_epsilon f32              = 0.000001
+0.01.041.589 I llama_model_loader: - kv  26:                qwen35.attention.key_length u32              = 256
+0.01.041.589 I llama_model_loader: - kv  27:              qwen35.attention.value_length u32              = 256
+0.01.041.590 I llama_model_loader: - kv  28:                     qwen35.ssm.conv_kernel u32              = 4
+0.01.041.590 I llama_model_loader: - kv  29:                      qwen35.ssm.state_size u32              = 128
+0.01.041.591 I llama_model_loader: - kv  30:                     qwen35.ssm.group_count u32              = 16
+0.01.041.591 I llama_model_loader: - kv  31:                  qwen35.ssm.time_step_rank u32              = 48
+0.01.041.592 I llama_model_loader: - kv  32:                      qwen35.ssm.inner_size u32              = 6144
+0.01.041.592 I llama_model_loader: - kv  33:             qwen35.full_attention_interval u32              = 4
+0.01.041.593 I llama_model_loader: - kv  34:                qwen35.rope.dimension_count u32              = 64
+0.01.041.593 I llama_model_loader: - kv  35:                       tokenizer.ggml.model str              = gpt2
+0.01.041.594 I llama_model_loader: - kv  36:                         tokenizer.ggml.pre str              = qwen35
+0.01.071.992 I llama_model_loader: - kv  37:                      tokenizer.ggml.tokens arr[str,248320]  = ["!", "\"", "#", "$", "%", "&", "'", ...
+0.01.079.008 I llama_model_loader: - kv  38:                  tokenizer.ggml.token_type arr[i32,248320]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+0.01.119.882 I llama_model_loader: - kv  39:                      tokenizer.ggml.merges arr[str,247587]  = ["Ġ Ġ", "ĠĠ ĠĠ", "i n", "Ġ t",...
+0.01.119.893 I llama_model_loader: - kv  40:                tokenizer.ggml.eos_token_id u32              = 248046
+0.01.119.895 I llama_model_loader: - kv  41:            tokenizer.ggml.padding_token_id u32              = 248055
+0.01.119.898 I llama_model_loader: - kv  42:                tokenizer.ggml.bos_token_id u32              = 248044
+0.01.119.900 I llama_model_loader: - kv  43:               tokenizer.ggml.add_bos_token bool             = false
+0.01.119.907 I llama_model_loader: - kv  44:                    tokenizer.chat_template str              = {%- set image_count = namespace(value...
+0.01.119.908 I llama_model_loader: - kv  45:               general.quantization_version u32              = 2
+0.01.119.910 I llama_model_loader: - kv  46:                          general.file_type u32              = 15
+0.01.119.913 I llama_model_loader: - kv  47:                      quantize.imatrix.file str              = Qwen3.6-27B-GGUF/imatrix_unsloth.gguf
+0.01.119.915 I llama_model_loader: - kv  48:                   quantize.imatrix.dataset str              = unsloth_calibration_Qwen3.6-27B.txt
+0.01.119.916 I llama_model_loader: - kv  49:             quantize.imatrix.entries_count u32              = 496
+0.01.119.918 I llama_model_loader: - kv  50:              quantize.imatrix.chunks_count u32              = 76
+0.01.119.919 I llama_model_loader: - type  f32:  449 tensors
+0.01.119.921 I llama_model_loader: - type q4_K:  289 tensors
+0.01.119.922 I llama_model_loader: - type q5_K:   48 tensors
+0.01.119.922 I llama_model_loader: - type q6_K:   65 tensors
+0.01.119.924 I print_info: file format = GGUF V3 (latest)
+0.01.119.925 I print_info: file type   = Q4_K - Medium
+0.01.119.931 I print_info: file size   = 15.65 GiB (5.00 BPW) 
+0.01.132.551 I llama_prepare_model_devices: using device Vulkan0 (NVIDIA GeForce RTX 3090) (0000:c1:00.0) - 23780 MiB free
+0.01.306.965 I load: 0 unused tokens
+0.01.369.836 I load: printing all EOG tokens:
+0.01.369.841 I load:   - 248044 ('<|endoftext|>')
+0.01.369.842 I load:   - 248046 ('<|im_end|>')
+0.01.369.842 I load:   - 248063 ('<|fim_pad|>')
+0.01.369.843 I load:   - 248064 ('<|repo_name|>')
+0.01.369.843 I load:   - 248065 ('<|file_sep|>')
+0.01.370.536 I load: special tokens cache size = 33
+0.01.471.089 I load: token to piece cache size = 1.7581 MB
+0.01.471.105 I print_info: arch                  = qwen35
+0.01.471.106 I print_info: vocab_only            = 0
+0.01.471.106 I print_info: no_alloc              = 0
+0.01.471.106 I print_info: n_ctx_train           = 262144
+0.01.471.107 I print_info: n_embd_inp            = 5120
+0.01.471.107 I print_info: n_embd                = 5120
+0.01.471.108 I print_info: n_embd_out            = 5120
+0.01.471.108 I print_info: n_layer               = 64
+0.01.471.108 I print_info: n_layer_all           = 64
+0.01.471.117 I print_info: n_head                = 24
+0.01.471.119 I print_info: n_head_kv             = 4
+0.01.471.119 I print_info: n_rot                 = 64
+0.01.471.119 I print_info: n_swa                 = 0
+0.01.471.120 I print_info: is_swa_any            = 0
+0.01.471.120 I print_info: n_embd_head_k         = 256
+0.01.471.120 I print_info: n_embd_head_v         = 256
+0.01.471.122 I print_info: n_gqa                 = 6
+0.01.471.123 I print_info: n_embd_k_gqa          = 1024
+0.01.471.125 I print_info: n_embd_v_gqa          = 1024
+0.01.471.126 I print_info: f_norm_eps            = 0.0e+00
+0.01.471.127 I print_info: f_norm_rms_eps        = 1.0e-06
+0.01.471.127 I print_info: f_clamp_kqv           = 0.0e+00
+0.01.471.128 I print_info: f_max_alibi_bias      = 0.0e+00
+0.01.471.128 I print_info: f_logit_scale         = 0.0e+00
+0.01.471.128 I print_info: f_attn_scale          = 0.0e+00
+0.01.471.129 I print_info: f_attn_value_scale    = 0.0000
+0.01.471.130 I print_info: n_ff                  = 17408
+0.01.471.130 I print_info: n_expert              = 0
+0.01.471.131 I print_info: n_expert_used         = 0
+0.01.471.131 I print_info: n_expert_groups       = 0
+0.01.471.131 I print_info: n_group_used          = 0
+0.01.471.131 I print_info: causal attn           = 1
+0.01.471.132 I print_info: pooling type          = -1
+0.01.471.132 I print_info: rope type             = 40
+0.01.471.132 I print_info: rope scaling          = linear
+0.01.471.133 I print_info: freq_base_train       = 10000000.0
+0.01.471.134 I print_info: freq_scale_train      = 1
+0.01.471.134 I print_info: n_ctx_orig_yarn       = 262144
+0.01.471.135 I print_info: rope_yarn_log_mul     = 0.0000
+0.01.471.136 I print_info: rope_finetuned        = unknown
+0.01.471.137 I print_info: mrope sections        = [11, 11, 10, 0]
+0.01.471.137 I print_info: ssm_d_conv            = 4
+0.01.471.138 I print_info: ssm_d_inner           = 6144
+0.01.471.139 I print_info: ssm_d_state           = 128
+0.01.471.140 I print_info: ssm_dt_rank           = 48
+0.01.471.140 I print_info: ssm_n_group           = 16
+0.01.471.141 I print_info: ssm_dt_b_c_rms        = 0
+0.01.471.142 I print_info: model type            = 27B
+0.01.471.144 I print_info: model params          = 26.90 B
+0.01.471.145 I print_info: general.name          = Qwen3.6-27B
+0.01.471.146 I print_info: vocab type            = BPE
+0.01.471.147 I print_info: n_vocab               = 248320
+0.01.471.148 I print_info: n_merges              = 247587
+0.01.471.149 I print_info: BOS token             = 248044 '<|endoftext|>'
+0.01.471.150 I print_info: EOS token             = 248046 '<|im_end|>'
+0.01.471.151 I print_info: EOT token             = 248046 '<|im_end|>'
+0.01.471.152 I print_info: PAD token             = 248055 '<|vision_pad|>'
+0.01.471.153 I print_info: LF token              = 198 'Ċ'
+0.01.471.154 I print_info: FIM PRE token         = 248060 '<|fim_prefix|>'
+0.01.471.155 I print_info: FIM SUF token         = 248062 '<|fim_suffix|>'
+0.01.471.156 I print_info: FIM MID token         = 248061 '<|fim_middle|>'
+0.01.471.158 I print_info: FIM PAD token         = 248063 '<|fim_pad|>'
+0.01.471.160 I print_info: FIM REP token         = 248064 '<|repo_name|>'
+0.01.471.161 I print_info: FIM SEP token         = 248065 '<|file_sep|>'
+0.01.471.162 I print_info: EOG token             = 248044 '<|endoftext|>'
+0.01.471.163 I print_info: EOG token             = 248046 '<|im_end|>'
+0.01.471.164 I print_info: EOG token             = 248063 '<|fim_pad|>'
+0.01.471.165 I print_info: EOG token             = 248064 '<|repo_name|>'
+0.01.471.166 I print_info: EOG token             = 248065 '<|file_sep|>'
+0.01.471.167 I print_info: max token length      = 256
+0.01.471.169 I load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+0.02.716.967 I load_tensors: offloading output layer to GPU
+0.02.716.970 I load_tensors: offloading 63 repeating layers to GPU
+0.02.716.971 I load_tensors: offloaded 65/65 layers to GPU
+0.02.716.977 I load_tensors:   CPU_Mapped model buffer size =   682.03 MiB
+0.02.716.978 I load_tensors:      Vulkan0 model buffer size = 15345.66 MiB
+0.06.768.765 I cmn  common_init_: added <|endoftext|> logit bias = -inf
+0.06.768.777 I cmn  common_init_: added <|im_end|> logit bias = -inf
+0.06.768.778 I cmn  common_init_: added <|fim_pad|> logit bias = -inf
+0.06.768.778 I cmn  common_init_: added <|repo_name|> logit bias = -inf
+0.06.768.779 I cmn  common_init_: added <|file_sep|> logit bias = -inf
+0.06.768.866 I llama_context: constructing llama_context
+0.06.768.871 I llama_context: n_seq_max     = 1
+0.06.768.871 I llama_context: n_ctx         = 8192
+0.06.768.871 I llama_context: n_ctx_seq     = 8192
+0.06.768.871 I llama_context: n_batch       = 2048
+0.06.768.872 I llama_context: n_ubatch      = 2048
+0.06.768.872 I llama_context: causal_attn   = 1
+0.06.768.873 I llama_context: flash_attn    = auto
+0.06.768.873 I llama_context: kv_unified    = false
+0.06.768.876 I llama_context: freq_base     = 10000000.0
+0.06.768.876 I llama_context: freq_scale    = 1
+0.06.768.877 I llama_context: n_rs_seq      = 0
+0.06.768.877 I llama_context: n_outputs_max = 1
+0.06.768.878 I llama_context: n_ctx_seq (8192) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
+0.06.771.286 I llama_context: Vulkan_Host  output buffer size =     0.95 MiB
+0.06.783.525 I llama_kv_cache:    Vulkan0 KV buffer size =   512.00 MiB
+0.06.808.930 I llama_kv_cache: size =  512.00 MiB (  8192 cells,  16 layers,  1/1 seqs), K (f16):  256.00 MiB, V (f16):  256.00 MiB
+0.06.808.938 I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+0.06.808.940 I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+0.06.821.156 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.06.821.181 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.06.821.192 I sched_reserve: reserving ...
+0.06.859.355 I sched_reserve: Flash Attention was auto, set to enabled
+0.06.859.359 I sched_reserve: resolving fused Gated Delta Net support:
+0.06.863.415 I sched_reserve: fused Gated Delta Net (autoregressive) enabled
+0.06.866.928 I sched_reserve: fused Gated Delta Net (chunked) enabled
+0.06.909.899 I sched_reserve:    Vulkan0 compute buffer size =   568.18 MiB
+0.06.909.904 I sched_reserve: Vulkan_Host compute buffer size =   112.07 MiB
+0.06.909.904 I sched_reserve: graph nodes  = 3655
+0.06.909.904 I sched_reserve: graph splits = 2
+0.06.909.906 I sched_reserve: reserve took 88.71 ms, sched copies = 1
+0.06.910.005 I cmn  common_init_: warming up the model with an empty run - please wait ... (--no-warmup to disable)
+0.07.148.299 I cmn  common_conte: the context does not support partial sequence removal
+0.07.198.133 I srv    load_model: speculative decoding will use checkpoints
+0.07.198.136 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.07.198.146 I spec common_specu: no implementations specified for speculative decoding
+0.07.198.147 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 8192
+0.07.198.213 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.07.198.213 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.07.198.214 I srv    load_model: for more info see https://github.com/ggml-org/llama.cpp/pull/16391
+0.07.198.214 I srv    load_model: context checkpoints enabled, max = 32, min spacing = 8192
+0.07.198.230 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.07.220.194 I srv          init: init: chat template, example_format: '<|im_start|>system
+You are a helpful assistant<|im_end|>
+<|im_start|>user
+Hello<|im_end|>
+<|im_start|>assistant
+Hi there<|im_end|>
+<|im_start|>user
+How are you?<|im_end|>
+<|im_start|>assistant
+<think>
+'
+0.07.236.834 I srv          init: init: chat template, thinking = 1
+0.07.236.846 I srv          init: chat template supports preserving reasoning, consider enabling it via --reasoning-preserve
+0.07.236.881 I srv  llama_server: model loaded
+0.07.236.886 I srv  llama_server: listening on http://127.0.0.1:8447
+0.07.236.891 I srv  update_slots: all slots are idle
+0.08.796.572 I srv    operator(): chat format: peg-native
+0.08.796.766 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1
+0.08.796.769 I srv  get_availabl: updating prompt cache
+0.08.796.777 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.08.796.782 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.08.796.783 I srv  get_availabl: prompt cache update took 0.01 ms
+0.08.796.871 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.08.796.883 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.08.796.884 I slot launch_slot_: id  0 | task 0 | processing task, is_child = 0
+0.08.796.897 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1508
+0.08.796.901 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.08.826.234 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.09.033.852 I slot create_check: id  0 | task 0 | created context checkpoint 1 of 32 (pos_min = 40, pos_max = 40, n_tokens = 41, size = 149.626 MiB)
+0.09.198.913 I slot   operator(): id  0 | task 0 | cached n_tokens = 1504, memory_seq_rm [1504, end)
+0.09.199.106 I slot init_sampler: id  0 | task 0 | init sampler, took 0.17 ms, tokens: text = 1508, total = 1508
+0.11.563.116 I slot print_timing: id  0 | task 0 | prompt eval time =    2338.67 ms /  1508 tokens (    1.55 ms per token,   644.81 tokens per second)
+0.11.563.121 I slot print_timing: id  0 | task 0 |        eval time =     427.53 ms /    16 tokens (   26.72 ms per token,    37.42 tokens per second)
+0.11.563.122 I slot print_timing: id  0 | task 0 |       total time =    2766.20 ms /  1524 tokens
+0.11.563.126 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.11.563.224 I slot      release: id  0 | task 0 | stop processing: n_tokens = 1523, truncated = 0
+0.11.563.239 I srv  update_slots: all slots are idle
+0.11.563.360 I srv  stream_sessi: conv_id= (empty=1)
+0.13.590.655 I srv    operator(): chat format: peg-native
+0.13.590.836 I slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.688 (> 0.100 thold), f_keep = 0.029
+0.13.590.839 I srv  get_availabl: updating prompt cache
+0.13.590.919 I srv   prompt_save:  - saving prompt with length 1523, total state size = 244.843 MiB (draft: 0.000 MiB)
+0.13.862.159 I srv          load:  - looking for better prompt, base f_keep = 0.029, sim = 0.688
+0.13.862.180 I srv        update:  - cache state: 1 prompts, 394.469 MiB (limits: 8192.000 MiB, 8192 tokens, 31628 est)
+0.13.862.188 I srv        update:    - prompt 0x616ffd7b0cd0:    1523 tokens, checkpoints:  1,   394.469 MiB
+0.13.862.196 I srv  get_availabl: prompt cache update took 271.35 ms
+0.13.862.357 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.13.862.370 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.13.862.375 I slot launch_slot_: id  0 | task 19 | processing task, is_child = 0
+0.13.862.387 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 64
+0.13.862.393 I slot   operator(): id  0 | task 19 | checking checkpoint with [40, 40] against 44...
+0.13.887.837 I slot   operator(): id  0 | task 19 | restored context checkpoint (pos_min = 40, pos_max = 40, n_tokens = 41, n_past = 41, size = 149.626 MiB)
+0.13.887.843 I slot   operator(): id  0 | task 19 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.13.995.799 I slot create_check: id  0 | task 19 | created context checkpoint 2 of 32 (pos_min = 40, pos_max = 40, n_tokens = 41, size = 149.626 MiB)
+0.14.005.488 I slot   operator(): id  0 | task 19 | cached n_tokens = 60, memory_seq_rm [60, end)
+0.14.005.515 I slot init_sampler: id  0 | task 19 | init sampler, took 0.01 ms, tokens: text = 64, total = 64
+0.15.129.922 I slot print_timing: id  0 | task 19 | prompt eval time =     583.66 ms /    23 tokens (   25.38 ms per token,    39.41 tokens per second)
+0.15.129.928 I slot print_timing: id  0 | task 19 |        eval time =     683.87 ms /    16 tokens (   42.74 ms per token,    23.40 tokens per second)
+0.15.129.929 I slot print_timing: id  0 | task 19 |       total time =    1267.52 ms /    39 tokens
+0.15.129.930 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.15.129.955 I slot      release: id  0 | task 19 | stop processing: n_tokens = 79, truncated = 0
+0.15.129.966 I srv  update_slots: all slots are idle
+0.15.130.318 I srv  stream_sessi: conv_id= (empty=1)
+0.17.159.518 I srv    operator(): chat format: peg-native
+0.17.159.698 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = 11863618715
+0.17.159.704 I srv  get_availabl: updating prompt cache
+0.17.159.778 I srv   prompt_save:  - saving prompt with length 79, total state size = 154.566 MiB (draft: 0.000 MiB)
+0.17.462.055 I srv          load:  - looking for better prompt, base f_keep = 0.557, sim = 0.029
+0.17.462.070 I srv          load:  - found better prompt with f_keep = 0.989, sim = 0.985
+0.17.527.802 I srv        update:  - cache state: 1 prompts, 453.818 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.17.527.807 I srv        update:    - prompt 0x616ffd4aade0:      79 tokens, checkpoints:  2,   453.818 MiB
+0.17.527.809 I srv  get_availabl: prompt cache update took 368.10 ms
+0.17.527.889 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.17.527.897 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.17.527.901 I slot launch_slot_: id  0 | task 37 | processing task, is_child = 0
+0.17.527.909 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1529
+0.17.527.914 I slot   operator(): id  0 | task 37 | checking checkpoint with [40, 40] against 1506...
+0.17.543.781 I slot   operator(): id  0 | task 37 | restored context checkpoint (pos_min = 40, pos_max = 40, n_tokens = 41, n_past = 41, size = 149.626 MiB)
+0.17.543.787 I slot   operator(): id  0 | task 37 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.17.939.535 I slot   operator(): id  0 | task 37 | cached n_tokens = 1508, memory_seq_rm [1508, end)
+0.19.860.847 I slot create_check: id  0 | task 37 | created context checkpoint 2 of 32 (pos_min = 1507, pos_max = 1507, n_tokens = 1508, size = 149.626 MiB)
+0.19.869.586 I slot   operator(): id  0 | task 37 | cached n_tokens = 1525, memory_seq_rm [1525, end)
+0.19.869.772 I slot init_sampler: id  0 | task 37 | init sampler, took 0.16 ms, tokens: text = 1529, total = 1529
+0.20.710.926 I slot print_timing: id  0 | task 37 | prompt eval time =    2531.04 ms /  1488 tokens (    1.70 ms per token,   587.90 tokens per second)
+0.20.710.931 I slot print_timing: id  0 | task 37 |        eval time =     651.96 ms /    16 tokens (   40.75 ms per token,    24.54 tokens per second)
+0.20.710.933 I slot print_timing: id  0 | task 37 |       total time =    3183.00 ms /  1504 tokens
+0.20.710.933 I slot print_timing: id  0 | task 37 |    graphs reused =         42
+0.20.711.016 I slot      release: id  0 | task 37 | stop processing: n_tokens = 1544, truncated = 0
+0.20.711.030 I srv  update_slots: all slots are idle
+0.20.711.143 I srv  stream_sessi: conv_id= (empty=1)
+0.24.712.579 I srv    operator(): operator(): cleaning up before exit...
+0.24.719.387 I common_memory_breakdown_print: | memory breakdown [MiB] | total   free     self   model   context   compute    unaccounted |
+0.24.719.391 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 6645 + (16575 = 15345 +     661 +     568) +        1601 |
+0.24.719.391 I common_memory_breakdown_print: |   - Host               |                   794 =   682 +       0 +     112                |

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.cache-lines.txt
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.cache-lines.txt
@@ -1,0 +1,57 @@
+0.01.223.329 I load: 0 unused tokens
+0.01.281.187 I load: printing all EOG tokens:
+0.01.281.191 I load:   - 248044 ('<|endoftext|>')
+0.01.281.192 I load:   - 248046 ('<|im_end|>')
+0.01.281.193 I load:   - 248063 ('<|fim_pad|>')
+0.01.281.193 I load:   - 248064 ('<|repo_name|>')
+0.01.281.193 I load:   - 248065 ('<|file_sep|>')
+0.01.281.874 I load: special tokens cache size = 33
+0.01.375.927 I load: token to piece cache size = 1.7581 MB
+0.01.375.958 I print_info: n_swa                 = 0
+0.01.375.958 I print_info: is_swa_any            = 0
+0.07.490.502 I llama_context: n_seq_max     = 1
+0.07.490.504 I llama_context: kv_unified    = false
+0.07.544.541 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.07.544.554 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.07.934.902 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.07.934.977 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.07.934.977 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.07.934.995 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.09.519.000 I srv  get_availabl: updating prompt cache
+0.09.519.012 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.09.519.021 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.09.519.022 I srv  get_availabl: prompt cache update took 0.02 ms
+0.09.519.173 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1508
+0.09.519.178 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.09.547.665 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.09.935.134 I slot   operator(): id  0 | task 0 | cached n_tokens = 1504, memory_seq_rm [1504, end)
+0.12.416.283 I slot print_timing: id  0 | task 0 | prompt eval time =    2432.14 ms /  1508 tokens (    1.61 ms per token,   620.03 tokens per second)
+0.12.416.289 I slot print_timing: id  0 | task 0 |        eval time =     464.95 ms /    16 tokens (   29.06 ms per token,    34.41 tokens per second)
+0.12.416.290 I slot print_timing: id  0 | task 0 |       total time =    2897.09 ms /  1524 tokens
+0.12.416.295 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.14.443.102 I srv  get_availabl: updating prompt cache
+0.14.443.296 I srv   prompt_save:  - saving prompt with length 1523, total state size = 244.843 MiB (draft: 0.000 MiB)
+0.14.712.376 I srv          load:  - looking for better prompt, base f_keep = 0.029, sim = 0.688
+0.14.712.383 I srv        update:  - cache state: 1 prompts, 394.469 MiB (limits: 8192.000 MiB, 8192 tokens, 31628 est)
+0.14.712.387 I srv  get_availabl: prompt cache update took 269.28 ms
+0.14.712.514 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 64
+0.14.738.195 I slot   operator(): id  0 | task 19 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.14.852.857 I slot   operator(): id  0 | task 19 | cached n_tokens = 60, memory_seq_rm [60, end)
+0.16.079.893 I slot print_timing: id  0 | task 19 | prompt eval time =     595.87 ms /    23 tokens (   25.91 ms per token,    38.60 tokens per second)
+0.16.079.899 I slot print_timing: id  0 | task 19 |        eval time =     771.49 ms /    16 tokens (   48.22 ms per token,    20.74 tokens per second)
+0.16.079.900 I slot print_timing: id  0 | task 19 |       total time =    1367.36 ms /    39 tokens
+0.16.079.901 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.18.111.082 I srv  get_availabl: updating prompt cache
+0.18.111.126 I srv   prompt_save:  - saving prompt with length 79, total state size = 154.566 MiB (draft: 0.000 MiB)
+0.18.417.971 I srv          load:  - looking for better prompt, base f_keep = 0.557, sim = 0.029
+0.18.417.978 I srv          load:  - found better prompt with f_keep = 0.989, sim = 0.985
+0.18.480.559 I srv        update:  - cache state: 1 prompts, 453.818 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.18.480.565 I srv  get_availabl: prompt cache update took 369.48 ms
+0.18.480.663 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1529
+0.18.496.391 I slot   operator(): id  0 | task 37 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.18.833.220 I slot   operator(): id  0 | task 37 | cached n_tokens = 1508, memory_seq_rm [1508, end)
+0.20.721.033 I slot   operator(): id  0 | task 37 | cached n_tokens = 1525, memory_seq_rm [1525, end)
+0.21.364.223 I slot print_timing: id  0 | task 37 | prompt eval time =    2414.53 ms /  1488 tokens (    1.62 ms per token,   616.27 tokens per second)
+0.21.364.230 I slot print_timing: id  0 | task 37 |        eval time =     469.01 ms /    16 tokens (   29.31 ms per token,    34.11 tokens per second)
+0.21.364.231 I slot print_timing: id  0 | task 37 |       total time =    2883.55 ms /  1504 tokens
+0.21.364.233 I slot print_timing: id  0 | task 37 |    graphs reused =         42

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.json
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.json
@@ -1,0 +1,123 @@
+{
+  "model": "<drive>/models/chat/qwen3.6-27b-q5.gguf",
+  "bin": "<runtime>/llama-server",
+  "argv": [
+    "<runtime>/llama-server",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "8448",
+    "--model",
+    "<drive>/models/chat/qwen3.6-27b-q5.gguf",
+    "--ctx-size",
+    "8192",
+    "--threads",
+    "10",
+    "--batch-size",
+    "2048",
+    "--ubatch-size",
+    "2048",
+    "--jinja",
+    "--reasoning-format",
+    "deepseek",
+    "-lv",
+    "4",
+    "-np",
+    "1"
+  ],
+  "requests": [
+    {
+      "label": "R1 (conversation A, long)",
+      "http": 200,
+      "elapsedMs": 2927,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1508,
+        "total_tokens": 1524,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        }
+      },
+      "timings": {
+        "cache_n": 0,
+        "prompt_n": 1508,
+        "prompt_ms": 2432.144,
+        "prompt_per_token_ms": 1.6128275862068964,
+        "prompt_per_second": 620.0290772256907,
+        "predicted_n": 16,
+        "predicted_ms": 464.949,
+        "predicted_per_token_ms": 29.0593125,
+        "predicted_per_second": 34.412376411176275
+      },
+      "content": ""
+    },
+    {
+      "label": "R2 (conversation B, short)",
+      "http": 200,
+      "elapsedMs": 1663,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 64,
+        "total_tokens": 80,
+        "prompt_tokens_details": {
+          "cached_tokens": 41
+        }
+      },
+      "timings": {
+        "cache_n": 41,
+        "prompt_n": 23,
+        "prompt_ms": 595.87,
+        "prompt_per_token_ms": 25.907391304347826,
+        "prompt_per_second": 38.599023276889255,
+        "predicted_n": 16,
+        "predicted_ms": 771.494,
+        "predicted_per_token_ms": 48.218375,
+        "predicted_per_second": 20.738981767842652
+      },
+      "content": ""
+    },
+    {
+      "label": "R3 (back to conversation A)",
+      "http": 200,
+      "elapsedMs": 3282,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1529,
+        "total_tokens": 1545,
+        "prompt_tokens_details": {
+          "cached_tokens": 41
+        }
+      },
+      "timings": {
+        "cache_n": 41,
+        "prompt_n": 1488,
+        "prompt_ms": 2414.531,
+        "prompt_per_token_ms": 1.6226686827956989,
+        "prompt_per_second": 616.2687495004205,
+        "predicted_n": 16,
+        "predicted_ms": 469.015,
+        "predicted_per_token_ms": 29.3134375,
+        "predicted_per_second": 34.114047525132456
+      },
+      "content": ""
+    }
+  ],
+  "promptEvals": [
+    {
+      "task": 0,
+      "ms": 2432.14,
+      "tokens": 1508
+    },
+    {
+      "task": 19,
+      "ms": 595.87,
+      "tokens": 23
+    },
+    {
+      "task": 37,
+      "ms": 2414.53,
+      "tokens": 1488
+    }
+  ],
+  "stderrLines": 320
+}

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.run.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.run.log
@@ -1,0 +1,11 @@
+2026-09-10T08:55:33.607Z bin      <runtime>/llama-server
+2026-09-10T08:55:33.608Z model    <drive>/models/chat/qwen3.6-27b-q5.gguf
+2026-09-10T08:55:33.608Z ctx      8192  np 1  threads 10  extra []
+2026-09-10T08:55:33.608Z argv     <runtime>/llama-server --host 127.0.0.1 --port 8448 --model <drive>/models/chat/qwen3.6-27b-q5.gguf --ctx-size 8192 --threads 10 --batch-size 2048 --ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1
+2026-09-10T08:55:33.612Z waiting for /health ...
+2026-09-10T08:55:42.109Z server ready
+2026-09-10T08:55:46.038Z R1 (conversation A, long)  http=200  2927 ms  prompt_tokens=1508  completion_tokens=16  prompt_ms=2432.144  prompt_n=1508  cache_n=0
+2026-09-10T08:55:49.701Z R2 (conversation B, short)  http=200  1663 ms  prompt_tokens=64  completion_tokens=16  prompt_ms=595.87  prompt_n=23  cache_n=41
+2026-09-10T08:55:54.984Z R3 (back to conversation A)  http=200  3282 ms  prompt_tokens=1529  completion_tokens=16  prompt_ms=2414.531  prompt_n=1488  cache_n=41
+2026-09-10T08:55:58.986Z stopping server
+2026-09-10T08:55:59.584Z server exited code=0 signal=null

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.stderr.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.6-27b-q5.stderr.log
@@ -1,0 +1,319 @@
+0.00.123.101 I cmn  common_param: common_params_print_info: build 9849 (799fcc04a) with GNU 11.4.0 for Linux x86_64
+0.00.123.105 I cmn  common_param: common_params_print_info: verbosity = 4 (adjust with the `-lv N` CLI arg)
+0.00.123.106 I cmn  common_param: device_info:
+0.00.127.428 I cmn  common_param:   - Vulkan0 : NVIDIA GeForce RTX 3090 (24822 MiB, 23792 MiB free)
+0.00.127.436 I cmn  common_param:   - CPU     : Intel(R) Core(TM) i9-9900X CPU @ 3.50GHz (128493 MiB, 128493 MiB free)
+0.00.127.500 I cmn  common_param: system_info: n_threads = 10 (n_threads_batch = 10) / 20 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
+0.00.127.551 I srv          init: running without SSL
+0.00.127.613 I srv          init: using 19 threads for HTTP server
+0.00.127.903 I srv         start: binding port with default address family
+0.00.129.122 I srv    load_model: loading model '<drive>/models/chat/qwen3.6-27b-q5.gguf'
+0.00.129.126 I srv    load_model: local path '<drive>/models/chat/qwen3.6-27b-q5.gguf'
+0.00.129.147 I cmn  common_init_: fitting params to device memory ...
+0.00.129.148 I cmn  common_init_: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
+0.00.129.157 I common_params_fit_impl: getting device memory data for initial parameters:
+0.00.855.141 I common_memory_breakdown_print: | memory breakdown [MiB] | total    free     self   model   context   compute    unaccounted |
+0.00.855.145 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 23312 + (18991 = 17761 +     661 +     568) +      -17482 |
+0.00.855.146 I common_memory_breakdown_print: |   - Host               |                    945 =   833 +       0 +     112                |
+0.00.931.721 I common_params_fit_impl: projected to use 18991 MiB of device memory vs. 23312 MiB of free device memory
+0.00.931.725 I common_params_fit_impl: will leave 4321 >= 1024 MiB of free device memory, no changes needed
+0.00.931.726 I common_fit_params: successfully fit params to free device memory
+0.00.931.730 I common_fit_params: fitting params to free memory took 0.80 seconds
+0.00.989.512 I llama_model_loader: loaded meta data with 51 key-value pairs and 851 tensors from <drive>/models/chat/qwen3.6-27b-q5.gguf (version GGUF V3 (latest))
+0.00.989.538 I llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+0.00.989.542 I llama_model_loader: - kv   0:                       general.architecture str              = qwen35
+0.00.989.543 I llama_model_loader: - kv   1:                               general.type str              = model
+0.00.989.545 I llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 20
+0.00.989.548 I llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+0.00.989.549 I llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+0.00.989.550 I llama_model_loader: - kv   5:                               general.name str              = Qwen3.6-27B
+0.00.989.550 I llama_model_loader: - kv   6:                           general.basename str              = Qwen3.6-27B
+0.00.989.551 I llama_model_loader: - kv   7:                       general.quantized_by str              = Unsloth
+0.00.989.551 I llama_model_loader: - kv   8:                         general.size_label str              = 27B
+0.00.989.552 I llama_model_loader: - kv   9:                            general.license str              = apache-2.0
+0.00.989.553 I llama_model_loader: - kv  10:                       general.license.link str              = https://huggingface.co/Qwen/Qwen3.6-2...
+0.00.989.554 I llama_model_loader: - kv  11:                           general.repo_url str              = https://huggingface.co/unsloth
+0.00.989.555 I llama_model_loader: - kv  12:                   general.base_model.count u32              = 1
+0.00.989.556 I llama_model_loader: - kv  13:                  general.base_model.0.name str              = Qwen3.6 27B
+0.00.989.556 I llama_model_loader: - kv  14:          general.base_model.0.organization str              = Qwen
+0.00.989.557 I llama_model_loader: - kv  15:              general.base_model.0.repo_url str              = https://huggingface.co/Qwen/Qwen3.6-27B
+0.00.989.567 I llama_model_loader: - kv  16:                               general.tags arr[str,2]       = ["unsloth", "image-text-to-text"]
+0.00.989.576 I llama_model_loader: - kv  17:                         qwen35.block_count u32              = 64
+0.00.989.577 I llama_model_loader: - kv  18:                      qwen35.context_length u32              = 262144
+0.00.989.578 I llama_model_loader: - kv  19:                    qwen35.embedding_length u32              = 5120
+0.00.989.578 I llama_model_loader: - kv  20:                 qwen35.feed_forward_length u32              = 17408
+0.00.989.579 I llama_model_loader: - kv  21:                qwen35.attention.head_count u32              = 24
+0.00.989.579 I llama_model_loader: - kv  22:             qwen35.attention.head_count_kv u32              = 4
+0.00.989.581 I llama_model_loader: - kv  23:             qwen35.rope.dimension_sections arr[i32,4]       = [11, 11, 10, 0]
+0.00.989.583 I llama_model_loader: - kv  24:                      qwen35.rope.freq_base f32              = 10000000.000000
+0.00.989.583 I llama_model_loader: - kv  25:    qwen35.attention.layer_norm_rms_epsilon f32              = 0.000001
+0.00.989.584 I llama_model_loader: - kv  26:                qwen35.attention.key_length u32              = 256
+0.00.989.584 I llama_model_loader: - kv  27:              qwen35.attention.value_length u32              = 256
+0.00.989.585 I llama_model_loader: - kv  28:                     qwen35.ssm.conv_kernel u32              = 4
+0.00.989.585 I llama_model_loader: - kv  29:                      qwen35.ssm.state_size u32              = 128
+0.00.989.586 I llama_model_loader: - kv  30:                     qwen35.ssm.group_count u32              = 16
+0.00.989.586 I llama_model_loader: - kv  31:                  qwen35.ssm.time_step_rank u32              = 48
+0.00.989.587 I llama_model_loader: - kv  32:                      qwen35.ssm.inner_size u32              = 6144
+0.00.989.587 I llama_model_loader: - kv  33:             qwen35.full_attention_interval u32              = 4
+0.00.989.588 I llama_model_loader: - kv  34:                qwen35.rope.dimension_count u32              = 64
+0.00.989.588 I llama_model_loader: - kv  35:                       tokenizer.ggml.model str              = gpt2
+0.00.989.589 I llama_model_loader: - kv  36:                         tokenizer.ggml.pre str              = qwen35
+0.01.017.391 I llama_model_loader: - kv  37:                      tokenizer.ggml.tokens arr[str,248320]  = ["!", "\"", "#", "$", "%", "&", "'", ...
+0.01.023.995 I llama_model_loader: - kv  38:                  tokenizer.ggml.token_type arr[i32,248320]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+0.01.051.416 I llama_model_loader: - kv  39:                      tokenizer.ggml.merges arr[str,247587]  = ["Ġ Ġ", "ĠĠ ĠĠ", "i n", "Ġ t",...
+0.01.051.421 I llama_model_loader: - kv  40:                tokenizer.ggml.eos_token_id u32              = 248046
+0.01.051.422 I llama_model_loader: - kv  41:            tokenizer.ggml.padding_token_id u32              = 248055
+0.01.051.422 I llama_model_loader: - kv  42:                tokenizer.ggml.bos_token_id u32              = 248044
+0.01.051.423 I llama_model_loader: - kv  43:               tokenizer.ggml.add_bos_token bool             = false
+0.01.051.426 I llama_model_loader: - kv  44:                    tokenizer.chat_template str              = {%- set image_count = namespace(value...
+0.01.051.427 I llama_model_loader: - kv  45:               general.quantization_version u32              = 2
+0.01.051.428 I llama_model_loader: - kv  46:                          general.file_type u32              = 17
+0.01.051.429 I llama_model_loader: - kv  47:                      quantize.imatrix.file str              = Qwen3.6-27B-GGUF/imatrix_unsloth.gguf
+0.01.051.430 I llama_model_loader: - kv  48:                   quantize.imatrix.dataset str              = unsloth_calibration_Qwen3.6-27B.txt
+0.01.051.430 I llama_model_loader: - kv  49:             quantize.imatrix.entries_count u32              = 496
+0.01.051.431 I llama_model_loader: - kv  50:              quantize.imatrix.chunks_count u32              = 76
+0.01.051.432 I llama_model_loader: - type  f32:  449 tensors
+0.01.051.432 I llama_model_loader: - type q5_K:  289 tensors
+0.01.051.433 I llama_model_loader: - type q6_K:  113 tensors
+0.01.051.434 I print_info: file format = GGUF V3 (latest)
+0.01.051.435 I print_info: file type   = Q5_K - Medium
+0.01.051.454 I print_info: file size   = 18.16 GiB (5.80 BPW) 
+0.01.059.897 I llama_prepare_model_devices: using device Vulkan0 (NVIDIA GeForce RTX 3090) (0000:c1:00.0) - 23769 MiB free
+0.01.223.329 I load: 0 unused tokens
+0.01.281.187 I load: printing all EOG tokens:
+0.01.281.191 I load:   - 248044 ('<|endoftext|>')
+0.01.281.192 I load:   - 248046 ('<|im_end|>')
+0.01.281.193 I load:   - 248063 ('<|fim_pad|>')
+0.01.281.193 I load:   - 248064 ('<|repo_name|>')
+0.01.281.193 I load:   - 248065 ('<|file_sep|>')
+0.01.281.874 I load: special tokens cache size = 33
+0.01.375.927 I load: token to piece cache size = 1.7581 MB
+0.01.375.944 I print_info: arch                  = qwen35
+0.01.375.944 I print_info: vocab_only            = 0
+0.01.375.945 I print_info: no_alloc              = 0
+0.01.375.945 I print_info: n_ctx_train           = 262144
+0.01.375.946 I print_info: n_embd_inp            = 5120
+0.01.375.946 I print_info: n_embd                = 5120
+0.01.375.946 I print_info: n_embd_out            = 5120
+0.01.375.947 I print_info: n_layer               = 64
+0.01.375.947 I print_info: n_layer_all           = 64
+0.01.375.956 I print_info: n_head                = 24
+0.01.375.957 I print_info: n_head_kv             = 4
+0.01.375.958 I print_info: n_rot                 = 64
+0.01.375.958 I print_info: n_swa                 = 0
+0.01.375.958 I print_info: is_swa_any            = 0
+0.01.375.959 I print_info: n_embd_head_k         = 256
+0.01.375.959 I print_info: n_embd_head_v         = 256
+0.01.375.960 I print_info: n_gqa                 = 6
+0.01.375.962 I print_info: n_embd_k_gqa          = 1024
+0.01.375.963 I print_info: n_embd_v_gqa          = 1024
+0.01.375.964 I print_info: f_norm_eps            = 0.0e+00
+0.01.375.965 I print_info: f_norm_rms_eps        = 1.0e-06
+0.01.375.965 I print_info: f_clamp_kqv           = 0.0e+00
+0.01.375.965 I print_info: f_max_alibi_bias      = 0.0e+00
+0.01.375.966 I print_info: f_logit_scale         = 0.0e+00
+0.01.375.966 I print_info: f_attn_scale          = 0.0e+00
+0.01.375.967 I print_info: f_attn_value_scale    = 0.0000
+0.01.375.968 I print_info: n_ff                  = 17408
+0.01.375.968 I print_info: n_expert              = 0
+0.01.375.968 I print_info: n_expert_used         = 0
+0.01.375.969 I print_info: n_expert_groups       = 0
+0.01.375.969 I print_info: n_group_used          = 0
+0.01.375.969 I print_info: causal attn           = 1
+0.01.375.970 I print_info: pooling type          = -1
+0.01.375.970 I print_info: rope type             = 40
+0.01.375.970 I print_info: rope scaling          = linear
+0.01.375.971 I print_info: freq_base_train       = 10000000.0
+0.01.375.972 I print_info: freq_scale_train      = 1
+0.01.375.972 I print_info: n_ctx_orig_yarn       = 262144
+0.01.375.972 I print_info: rope_yarn_log_mul     = 0.0000
+0.01.375.973 I print_info: rope_finetuned        = unknown
+0.01.375.974 I print_info: mrope sections        = [11, 11, 10, 0]
+0.01.375.974 I print_info: ssm_d_conv            = 4
+0.01.375.974 I print_info: ssm_d_inner           = 6144
+0.01.375.975 I print_info: ssm_d_state           = 128
+0.01.375.975 I print_info: ssm_dt_rank           = 48
+0.01.375.975 I print_info: ssm_n_group           = 16
+0.01.375.975 I print_info: ssm_dt_b_c_rms        = 0
+0.01.375.976 I print_info: model type            = 27B
+0.01.375.977 I print_info: model params          = 26.90 B
+0.01.375.977 I print_info: general.name          = Qwen3.6-27B
+0.01.375.978 I print_info: vocab type            = BPE
+0.01.375.979 I print_info: n_vocab               = 248320
+0.01.375.979 I print_info: n_merges              = 247587
+0.01.375.979 I print_info: BOS token             = 248044 '<|endoftext|>'
+0.01.375.980 I print_info: EOS token             = 248046 '<|im_end|>'
+0.01.375.980 I print_info: EOT token             = 248046 '<|im_end|>'
+0.01.375.981 I print_info: PAD token             = 248055 '<|vision_pad|>'
+0.01.375.981 I print_info: LF token              = 198 'Ċ'
+0.01.375.981 I print_info: FIM PRE token         = 248060 '<|fim_prefix|>'
+0.01.375.982 I print_info: FIM SUF token         = 248062 '<|fim_suffix|>'
+0.01.375.982 I print_info: FIM MID token         = 248061 '<|fim_middle|>'
+0.01.375.982 I print_info: FIM PAD token         = 248063 '<|fim_pad|>'
+0.01.375.983 I print_info: FIM REP token         = 248064 '<|repo_name|>'
+0.01.375.983 I print_info: FIM SEP token         = 248065 '<|file_sep|>'
+0.01.375.983 I print_info: EOG token             = 248044 '<|endoftext|>'
+0.01.375.984 I print_info: EOG token             = 248046 '<|im_end|>'
+0.01.375.984 I print_info: EOG token             = 248063 '<|fim_pad|>'
+0.01.375.984 I print_info: EOG token             = 248064 '<|repo_name|>'
+0.01.375.985 I print_info: EOG token             = 248065 '<|file_sep|>'
+0.01.375.985 I print_info: max token length      = 256
+0.01.375.986 I load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+0.02.759.749 I load_tensors: offloading output layer to GPU
+0.02.759.753 I load_tensors: offloading 63 repeating layers to GPU
+0.02.759.753 I load_tensors: offloaded 65/65 layers to GPU
+0.02.759.758 I load_tensors:   CPU_Mapped model buffer size =   833.59 MiB
+0.02.759.759 I load_tensors:      Vulkan0 model buffer size = 17761.91 MiB
+0.07.490.394 I cmn  common_init_: added <|endoftext|> logit bias = -inf
+0.07.490.407 I cmn  common_init_: added <|im_end|> logit bias = -inf
+0.07.490.408 I cmn  common_init_: added <|fim_pad|> logit bias = -inf
+0.07.490.409 I cmn  common_init_: added <|repo_name|> logit bias = -inf
+0.07.490.409 I cmn  common_init_: added <|file_sep|> logit bias = -inf
+0.07.490.499 I llama_context: constructing llama_context
+0.07.490.502 I llama_context: n_seq_max     = 1
+0.07.490.502 I llama_context: n_ctx         = 8192
+0.07.490.502 I llama_context: n_ctx_seq     = 8192
+0.07.490.502 I llama_context: n_batch       = 2048
+0.07.490.503 I llama_context: n_ubatch      = 2048
+0.07.490.503 I llama_context: causal_attn   = 1
+0.07.490.503 I llama_context: flash_attn    = auto
+0.07.490.504 I llama_context: kv_unified    = false
+0.07.490.506 I llama_context: freq_base     = 10000000.0
+0.07.490.506 I llama_context: freq_scale    = 1
+0.07.490.507 I llama_context: n_rs_seq      = 0
+0.07.490.507 I llama_context: n_outputs_max = 1
+0.07.490.508 I llama_context: n_ctx_seq (8192) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
+0.07.492.867 I llama_context: Vulkan_Host  output buffer size =     0.95 MiB
+0.07.505.172 I llama_kv_cache:    Vulkan0 KV buffer size =   512.00 MiB
+0.07.532.754 I llama_kv_cache: size =  512.00 MiB (  8192 cells,  16 layers,  1/1 seqs), K (f16):  256.00 MiB, V (f16):  256.00 MiB
+0.07.532.761 I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+0.07.532.762 I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+0.07.544.541 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.07.544.554 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.07.544.564 I sched_reserve: reserving ...
+0.07.581.111 I sched_reserve: Flash Attention was auto, set to enabled
+0.07.581.115 I sched_reserve: resolving fused Gated Delta Net support:
+0.07.584.402 I sched_reserve: fused Gated Delta Net (autoregressive) enabled
+0.07.587.615 I sched_reserve: fused Gated Delta Net (chunked) enabled
+0.07.633.673 I sched_reserve:    Vulkan0 compute buffer size =   568.18 MiB
+0.07.633.678 I sched_reserve: Vulkan_Host compute buffer size =   112.07 MiB
+0.07.633.678 I sched_reserve: graph nodes  = 3655
+0.07.633.679 I sched_reserve: graph splits = 2
+0.07.633.680 I sched_reserve: reserve took 89.11 ms, sched copies = 1
+0.07.633.797 I cmn  common_init_: warming up the model with an empty run - please wait ... (--no-warmup to disable)
+0.07.883.044 I cmn  common_conte: the context does not support partial sequence removal
+0.07.934.899 I srv    load_model: speculative decoding will use checkpoints
+0.07.934.902 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.07.934.910 I spec common_specu: no implementations specified for speculative decoding
+0.07.934.911 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 8192
+0.07.934.977 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.07.934.977 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.07.934.978 I srv    load_model: for more info see https://github.com/ggml-org/llama.cpp/pull/16391
+0.07.934.978 I srv    load_model: context checkpoints enabled, max = 32, min spacing = 8192
+0.07.934.995 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.07.955.869 I srv          init: init: chat template, example_format: '<|im_start|>system
+You are a helpful assistant<|im_end|>
+<|im_start|>user
+Hello<|im_end|>
+<|im_start|>assistant
+Hi there<|im_end|>
+<|im_start|>user
+How are you?<|im_end|>
+<|im_start|>assistant
+<think>
+'
+0.07.975.822 I srv          init: init: chat template, thinking = 1
+0.07.975.832 I srv          init: chat template supports preserving reasoning, consider enabling it via --reasoning-preserve
+0.07.975.867 I srv  llama_server: model loaded
+0.07.975.872 I srv  llama_server: listening on http://127.0.0.1:8448
+0.07.975.877 I srv  update_slots: all slots are idle
+0.09.518.727 I srv    operator(): chat format: peg-native
+0.09.518.993 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1
+0.09.519.000 I srv  get_availabl: updating prompt cache
+0.09.519.012 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.09.519.021 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.09.519.022 I srv  get_availabl: prompt cache update took 0.02 ms
+0.09.519.134 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.09.519.149 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.09.519.153 I slot launch_slot_: id  0 | task 0 | processing task, is_child = 0
+0.09.519.173 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1508
+0.09.519.178 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.09.547.665 I slot   operator(): id  0 | task 0 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.09.771.538 I slot create_check: id  0 | task 0 | created context checkpoint 1 of 32 (pos_min = 40, pos_max = 40, n_tokens = 41, size = 149.626 MiB)
+0.09.935.134 I slot   operator(): id  0 | task 0 | cached n_tokens = 1504, memory_seq_rm [1504, end)
+0.09.935.338 I slot init_sampler: id  0 | task 0 | init sampler, took 0.18 ms, tokens: text = 1508, total = 1508
+0.12.416.283 I slot print_timing: id  0 | task 0 | prompt eval time =    2432.14 ms /  1508 tokens (    1.61 ms per token,   620.03 tokens per second)
+0.12.416.289 I slot print_timing: id  0 | task 0 |        eval time =     464.95 ms /    16 tokens (   29.06 ms per token,    34.41 tokens per second)
+0.12.416.290 I slot print_timing: id  0 | task 0 |       total time =    2897.09 ms /  1524 tokens
+0.12.416.295 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.12.416.434 I slot      release: id  0 | task 0 | stop processing: n_tokens = 1523, truncated = 0
+0.12.416.446 I srv  update_slots: all slots are idle
+0.12.416.735 I srv  stream_sessi: conv_id= (empty=1)
+0.14.442.806 I srv    operator(): chat format: peg-native
+0.14.443.091 I slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.688 (> 0.100 thold), f_keep = 0.029
+0.14.443.102 I srv  get_availabl: updating prompt cache
+0.14.443.296 I srv   prompt_save:  - saving prompt with length 1523, total state size = 244.843 MiB (draft: 0.000 MiB)
+0.14.712.376 I srv          load:  - looking for better prompt, base f_keep = 0.029, sim = 0.688
+0.14.712.383 I srv        update:  - cache state: 1 prompts, 394.469 MiB (limits: 8192.000 MiB, 8192 tokens, 31628 est)
+0.14.712.385 I srv        update:    - prompt 0x57854ec41110:    1523 tokens, checkpoints:  1,   394.469 MiB
+0.14.712.387 I srv  get_availabl: prompt cache update took 269.28 ms
+0.14.712.494 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.14.712.502 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.14.712.505 I slot launch_slot_: id  0 | task 19 | processing task, is_child = 0
+0.14.712.514 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 64
+0.14.712.520 I slot   operator(): id  0 | task 19 | checking checkpoint with [40, 40] against 44...
+0.14.738.189 I slot   operator(): id  0 | task 19 | restored context checkpoint (pos_min = 40, pos_max = 40, n_tokens = 41, n_past = 41, size = 149.626 MiB)
+0.14.738.195 I slot   operator(): id  0 | task 19 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.14.843.743 I slot create_check: id  0 | task 19 | created context checkpoint 2 of 32 (pos_min = 40, pos_max = 40, n_tokens = 41, size = 149.626 MiB)
+0.14.852.857 I slot   operator(): id  0 | task 19 | cached n_tokens = 60, memory_seq_rm [60, end)
+0.14.852.884 I slot init_sampler: id  0 | task 19 | init sampler, took 0.01 ms, tokens: text = 64, total = 64
+0.16.079.893 I slot print_timing: id  0 | task 19 | prompt eval time =     595.87 ms /    23 tokens (   25.91 ms per token,    38.60 tokens per second)
+0.16.079.899 I slot print_timing: id  0 | task 19 |        eval time =     771.49 ms /    16 tokens (   48.22 ms per token,    20.74 tokens per second)
+0.16.079.900 I slot print_timing: id  0 | task 19 |       total time =    1367.36 ms /    39 tokens
+0.16.079.901 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.16.079.931 I slot      release: id  0 | task 19 | stop processing: n_tokens = 79, truncated = 0
+0.16.079.943 I srv  update_slots: all slots are idle
+0.16.080.210 I srv  stream_sessi: conv_id= (empty=1)
+0.18.110.770 I srv    operator(): chat format: peg-native
+0.18.111.077 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = 12758387466
+0.18.111.082 I srv  get_availabl: updating prompt cache
+0.18.111.126 I srv   prompt_save:  - saving prompt with length 79, total state size = 154.566 MiB (draft: 0.000 MiB)
+0.18.417.971 I srv          load:  - looking for better prompt, base f_keep = 0.557, sim = 0.029
+0.18.417.978 I srv          load:  - found better prompt with f_keep = 0.989, sim = 0.985
+0.18.480.559 I srv        update:  - cache state: 1 prompts, 453.818 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.18.480.563 I srv        update:    - prompt 0x57854ec67210:      79 tokens, checkpoints:  2,   453.818 MiB
+0.18.480.565 I srv  get_availabl: prompt cache update took 369.48 ms
+0.18.480.644 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.18.480.652 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.18.480.655 I slot launch_slot_: id  0 | task 37 | processing task, is_child = 0
+0.18.480.663 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1529
+0.18.480.669 I slot   operator(): id  0 | task 37 | checking checkpoint with [40, 40] against 1506...
+0.18.496.385 I slot   operator(): id  0 | task 37 | restored context checkpoint (pos_min = 40, pos_max = 40, n_tokens = 41, n_past = 41, size = 149.626 MiB)
+0.18.496.391 I slot   operator(): id  0 | task 37 | cached n_tokens = 41, memory_seq_rm [41, end)
+0.18.833.220 I slot   operator(): id  0 | task 37 | cached n_tokens = 1508, memory_seq_rm [1508, end)
+0.20.712.485 I slot create_check: id  0 | task 37 | created context checkpoint 2 of 32 (pos_min = 1507, pos_max = 1507, n_tokens = 1508, size = 149.626 MiB)
+0.20.721.033 I slot   operator(): id  0 | task 37 | cached n_tokens = 1525, memory_seq_rm [1525, end)
+0.20.721.219 I slot init_sampler: id  0 | task 37 | init sampler, took 0.17 ms, tokens: text = 1529, total = 1529
+0.21.364.223 I slot print_timing: id  0 | task 37 | prompt eval time =    2414.53 ms /  1488 tokens (    1.62 ms per token,   616.27 tokens per second)
+0.21.364.230 I slot print_timing: id  0 | task 37 |        eval time =     469.01 ms /    16 tokens (   29.31 ms per token,    34.11 tokens per second)
+0.21.364.231 I slot print_timing: id  0 | task 37 |       total time =    2883.55 ms /  1504 tokens
+0.21.364.233 I slot print_timing: id  0 | task 37 |    graphs reused =         42
+0.21.364.375 I slot      release: id  0 | task 37 | stop processing: n_tokens = 1544, truncated = 0
+0.21.364.388 I srv  update_slots: all slots are idle
+0.21.364.505 I srv  stream_sessi: conv_id= (empty=1)
+0.25.367.640 I srv    operator(): operator(): cleaning up before exit...
+0.25.376.230 I common_memory_breakdown_print: | memory breakdown [MiB] | total   free     self   model   context   compute    unaccounted |
+0.25.376.237 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 4217 + (18991 = 17761 +     661 +     568) +        1612 |
+0.25.376.237 I common_memory_breakdown_print: |   - Host               |                   945 =   833 +       0 +     112                |

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.cache-lines.txt
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.cache-lines.txt
@@ -1,0 +1,57 @@
+0.01.276.456 I load: 0 unused tokens
+0.01.339.800 I load: printing all EOG tokens:
+0.01.339.804 I load:   - 248044 ('<|endoftext|>')
+0.01.339.805 I load:   - 248046 ('<|im_end|>')
+0.01.339.806 I load:   - 248063 ('<|fim_pad|>')
+0.01.339.806 I load:   - 248064 ('<|repo_name|>')
+0.01.339.806 I load:   - 248065 ('<|file_sep|>')
+0.01.340.502 I load: special tokens cache size = 33
+0.01.438.250 I load: token to piece cache size = 1.7581 MB
+0.01.438.282 I print_info: n_swa                 = 0
+0.01.438.282 I print_info: is_swa_any            = 0
+0.21.368.106 I llama_context: n_seq_max     = 1
+0.21.368.109 I llama_context: kv_unified    = false
+0.21.396.688 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.21.396.696 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.21.574.389 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.21.574.497 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.21.574.499 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.21.574.527 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.23.148.857 I srv  get_availabl: updating prompt cache
+0.23.148.868 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.23.148.877 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.23.148.883 I srv  get_availabl: prompt cache update took 0.02 ms
+0.23.149.108 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1546
+0.23.149.115 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.23.205.188 I slot   operator(): id  0 | task 0 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.23.603.388 I slot   operator(): id  0 | task 0 | cached n_tokens = 1542, memory_seq_rm [1542, end)
+0.25.350.057 I slot print_timing: id  0 | task 0 | prompt eval time =    1750.80 ms /  1546 tokens (    1.13 ms per token,   883.03 tokens per second)
+0.25.350.062 I slot print_timing: id  0 | task 0 |        eval time =     450.14 ms /    16 tokens (   28.13 ms per token,    35.54 tokens per second)
+0.25.350.063 I slot print_timing: id  0 | task 0 |       total time =    2200.93 ms /  1562 tokens
+0.25.350.068 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.27.388.778 I srv  get_availabl: updating prompt cache
+0.27.388.916 I srv   prompt_save:  - saving prompt with length 1561, total state size = 247.219 MiB (draft: 0.000 MiB)
+0.27.661.045 I srv          load:  - looking for better prompt, base f_keep = 0.053, sim = 0.804
+0.27.661.062 I srv        update:  - cache state: 1 prompts, 396.845 MiB (limits: 8192.000 MiB, 8192 tokens, 32223 est)
+0.27.661.070 I srv  get_availabl: prompt cache update took 272.29 ms
+0.27.661.251 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 102
+0.27.686.989 I slot   operator(): id  0 | task 19 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.27.805.276 I slot   operator(): id  0 | task 19 | cached n_tokens = 98, memory_seq_rm [98, end)
+0.28.613.377 I slot print_timing: id  0 | task 19 | prompt eval time =     510.45 ms /    23 tokens (   22.19 ms per token,    45.06 tokens per second)
+0.28.613.382 I slot print_timing: id  0 | task 19 |        eval time =     441.66 ms /    16 tokens (   27.60 ms per token,    36.23 tokens per second)
+0.28.613.383 I slot print_timing: id  0 | task 19 |       total time =     952.11 ms /    39 tokens
+0.28.613.384 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.30.641.590 I srv  get_availabl: updating prompt cache
+0.30.641.632 I srv   prompt_save:  - saving prompt with length 117, total state size = 156.941 MiB (draft: 0.000 MiB)
+0.30.941.742 I srv          load:  - looking for better prompt, base f_keep = 0.701, sim = 0.052
+0.30.941.748 I srv          load:  - found better prompt with f_keep = 0.990, sim = 0.983
+0.31.004.978 I srv        update:  - cache state: 1 prompts, 456.193 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.31.004.984 I srv  get_availabl: prompt cache update took 363.39 ms
+0.31.005.080 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1571
+0.31.020.831 I slot   operator(): id  0 | task 37 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.31.293.577 I slot   operator(): id  0 | task 37 | cached n_tokens = 1550, memory_seq_rm [1550, end)
+0.32.564.367 I slot   operator(): id  0 | task 37 | cached n_tokens = 1567, memory_seq_rm [1567, end)
+0.33.148.790 I slot print_timing: id  0 | task 37 | prompt eval time =    1699.14 ms /  1492 tokens (    1.14 ms per token,   878.09 tokens per second)
+0.33.148.796 I slot print_timing: id  0 | task 37 |        eval time =     444.56 ms /    16 tokens (   27.78 ms per token,    35.99 tokens per second)
+0.33.148.796 I slot print_timing: id  0 | task 37 |       total time =    2143.70 ms /  1508 tokens
+0.33.148.798 I slot print_timing: id  0 | task 37 |    graphs reused =         43

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.json
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.json
@@ -1,0 +1,123 @@
+{
+  "model": "<drive>/models/chat/qwen3.8-27b-ud-q5km.gguf",
+  "bin": "<runtime>/llama-server",
+  "argv": [
+    "<runtime>/llama-server",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "8446",
+    "--model",
+    "<drive>/models/chat/qwen3.8-27b-ud-q5km.gguf",
+    "--ctx-size",
+    "8192",
+    "--threads",
+    "10",
+    "--batch-size",
+    "2048",
+    "--ubatch-size",
+    "2048",
+    "--jinja",
+    "--reasoning-format",
+    "deepseek",
+    "-lv",
+    "4",
+    "-np",
+    "1"
+  ],
+  "requests": [
+    {
+      "label": "R1 (conversation A, long)",
+      "http": 200,
+      "elapsedMs": 2247,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1546,
+        "total_tokens": 1562,
+        "prompt_tokens_details": {
+          "cached_tokens": 0
+        }
+      },
+      "timings": {
+        "cache_n": 0,
+        "prompt_n": 1546,
+        "prompt_ms": 1750.799,
+        "prompt_per_token_ms": 1.1324702457956015,
+        "prompt_per_second": 883.0254072569153,
+        "predicted_n": 16,
+        "predicted_ms": 450.136,
+        "predicted_per_token_ms": 28.1335,
+        "predicted_per_second": 35.544813123145005
+      },
+      "content": ""
+    },
+    {
+      "label": "R2 (conversation B, short)",
+      "http": 200,
+      "elapsedMs": 1258,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 102,
+        "total_tokens": 118,
+        "prompt_tokens_details": {
+          "cached_tokens": 79
+        }
+      },
+      "timings": {
+        "cache_n": 79,
+        "prompt_n": 23,
+        "prompt_ms": 510.453,
+        "prompt_per_token_ms": 22.193608695652173,
+        "prompt_per_second": 45.05801709461988,
+        "predicted_n": 16,
+        "predicted_ms": 441.656,
+        "predicted_per_token_ms": 27.6035,
+        "predicted_per_second": 36.22729001757023
+      },
+      "content": ""
+    },
+    {
+      "label": "R3 (back to conversation A)",
+      "http": 200,
+      "elapsedMs": 2534,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 1571,
+        "total_tokens": 1587,
+        "prompt_tokens_details": {
+          "cached_tokens": 79
+        }
+      },
+      "timings": {
+        "cache_n": 79,
+        "prompt_n": 1492,
+        "prompt_ms": 1699.141,
+        "prompt_per_token_ms": 1.1388344504021448,
+        "prompt_per_second": 878.090752915738,
+        "predicted_n": 16,
+        "predicted_ms": 444.555,
+        "predicted_per_token_ms": 27.7846875,
+        "predicted_per_second": 35.991047227002284
+      },
+      "content": ""
+    }
+  ],
+  "promptEvals": [
+    {
+      "task": 0,
+      "ms": 1750.8,
+      "tokens": 1546
+    },
+    {
+      "task": 19,
+      "ms": 510.45,
+      "tokens": 23
+    },
+    {
+      "task": 37,
+      "ms": 1699.14,
+      "tokens": 1492
+    }
+  ],
+  "stderrLines": 329
+}

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.run.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.run.log
@@ -1,0 +1,11 @@
+2026-09-10T07:58:45.728Z bin      <runtime>/llama-server
+2026-09-10T07:58:45.729Z model    <drive>/models/chat/qwen3.8-27b-ud-q5km.gguf
+2026-09-10T07:58:45.729Z ctx      8192  np 1  threads 10  extra []
+2026-09-10T07:58:45.729Z argv     <runtime>/llama-server --host 127.0.0.1 --port 8446 --model <drive>/models/chat/qwen3.8-27b-ud-q5km.gguf --ctx-size 8192 --threads 10 --batch-size 2048 --ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1
+2026-09-10T07:58:45.733Z waiting for /health ...
+2026-09-10T07:59:07.842Z server ready
+2026-09-10T07:59:11.090Z R1 (conversation A, long)  http=200  2247 ms  prompt_tokens=1546  completion_tokens=16  prompt_ms=1750.799  prompt_n=1546  cache_n=0
+2026-09-10T07:59:14.349Z R2 (conversation B, short)  http=200  1258 ms  prompt_tokens=102  completion_tokens=16  prompt_ms=510.453  prompt_n=23  cache_n=79
+2026-09-10T07:59:18.885Z R3 (back to conversation A)  http=200  2534 ms  prompt_tokens=1571  completion_tokens=16  prompt_ms=1699.141  prompt_n=1492  cache_n=79
+2026-09-10T07:59:22.887Z stopping server
+2026-09-10T07:59:23.501Z server exited code=0 signal=null

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.stderr.log
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-qwen3.8-27b-ud-q5km-control.stderr.log
@@ -1,0 +1,328 @@
+0.00.126.373 I cmn  common_param: common_params_print_info: build 9849 (799fcc04a) with GNU 11.4.0 for Linux x86_64
+0.00.126.380 I cmn  common_param: common_params_print_info: verbosity = 4 (adjust with the `-lv N` CLI arg)
+0.00.126.381 I cmn  common_param: device_info:
+0.00.130.745 I cmn  common_param:   - Vulkan0 : NVIDIA GeForce RTX 3090 (24822 MiB, 23719 MiB free)
+0.00.130.752 I cmn  common_param:   - CPU     : Intel(R) Core(TM) i9-9900X CPU @ 3.50GHz (128493 MiB, 128493 MiB free)
+0.00.130.786 I cmn  common_param: system_info: n_threads = 10 (n_threads_batch = 10) / 20 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
+0.00.131.044 I srv          init: running without SSL
+0.00.131.488 I srv          init: using 19 threads for HTTP server
+0.00.131.852 I srv         start: binding port with default address family
+0.00.133.151 I srv    load_model: loading model '<drive>/models/chat/qwen3.8-27b-ud-q5km.gguf'
+0.00.133.153 I srv    load_model: local path '<drive>/models/chat/qwen3.8-27b-ud-q5km.gguf'
+0.00.133.181 I cmn  common_init_: fitting params to device memory ...
+0.00.133.182 I cmn  common_init_: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
+0.00.133.193 I common_params_fit_impl: getting device memory data for initial parameters:
+0.00.890.438 I common_memory_breakdown_print: | memory breakdown [MiB] | total    free     self   model   context   compute    unaccounted |
+0.00.890.441 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 23239 + (19392 = 18163 +     661 +     568) +      -17809 |
+0.00.890.442 I common_memory_breakdown_print: |   - Host               |                    794 =   682 +       0 +     112                |
+0.00.967.316 I common_params_fit_impl: projected to use 19392 MiB of device memory vs. 23239 MiB of free device memory
+0.00.967.321 I common_params_fit_impl: will leave 3846 >= 1024 MiB of free device memory, no changes needed
+0.00.967.322 I common_fit_params: successfully fit params to free device memory
+0.00.967.326 I common_fit_params: fitting params to free memory took 0.83 seconds
+0.01.026.037 I llama_model_loader: loaded meta data with 50 key-value pairs and 866 tensors from <drive>/models/chat/qwen3.8-27b-ud-q5km.gguf (version GGUF V3 (latest))
+0.01.026.069 I llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+0.01.026.072 I llama_model_loader: - kv   0:                       general.architecture str              = qwen35
+0.01.026.073 I llama_model_loader: - kv   1:                               general.type str              = model
+0.01.026.075 I llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 20
+0.01.026.078 I llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+0.01.026.079 I llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+0.01.026.079 I llama_model_loader: - kv   5:                               general.name str              = Qwen3.8-27B
+0.01.026.080 I llama_model_loader: - kv   6:                           general.basename str              = Qwen3.8-27B
+0.01.026.081 I llama_model_loader: - kv   7:                        general.description str              = Renewal of the beloved Qwen model, de...
+0.01.026.082 I llama_model_loader: - kv   8:                       general.quantized_by str              = Unsloth
+0.01.026.083 I llama_model_loader: - kv   9:                         general.size_label str              = 27B
+0.01.026.083 I llama_model_loader: - kv  10:                            general.license str              = apache-2.0
+0.01.026.084 I llama_model_loader: - kv  11:                           general.repo_url str              = https://huggingface.co/unsloth
+0.01.026.085 I llama_model_loader: - kv  12:                   general.base_model.count u32              = 1
+0.01.026.085 I llama_model_loader: - kv  13:                  general.base_model.0.name str              = Qwen3.8 27B
+0.01.026.086 I llama_model_loader: - kv  14:          general.base_model.0.organization str              = Qwen
+0.01.026.087 I llama_model_loader: - kv  15:              general.base_model.0.repo_url str              = https://huggingface.co/Qwen/Qwen3.8-27B
+0.01.026.095 I llama_model_loader: - kv  16:                               general.tags arr[str,1]       = ["unsloth"]
+0.01.026.095 I llama_model_loader: - kv  17:                         qwen35.block_count u32              = 65
+0.01.026.096 I llama_model_loader: - kv  18:                      qwen35.context_length u32              = 262144
+0.01.026.097 I llama_model_loader: - kv  19:                    qwen35.embedding_length u32              = 5120
+0.01.026.097 I llama_model_loader: - kv  20:                 qwen35.feed_forward_length u32              = 17408
+0.01.026.098 I llama_model_loader: - kv  21:                qwen35.attention.head_count u32              = 24
+0.01.026.098 I llama_model_loader: - kv  22:             qwen35.attention.head_count_kv u32              = 4
+0.01.026.100 I llama_model_loader: - kv  23:             qwen35.rope.dimension_sections arr[i32,4]       = [11, 11, 10, 0]
+0.01.026.102 I llama_model_loader: - kv  24:                      qwen35.rope.freq_base f32              = 10000000.000000
+0.01.026.103 I llama_model_loader: - kv  25:    qwen35.attention.layer_norm_rms_epsilon f32              = 0.000001
+0.01.026.103 I llama_model_loader: - kv  26:                qwen35.attention.key_length u32              = 256
+0.01.026.104 I llama_model_loader: - kv  27:              qwen35.attention.value_length u32              = 256
+0.01.026.105 I llama_model_loader: - kv  28:                qwen35.nextn_predict_layers u32              = 1
+0.01.026.106 I llama_model_loader: - kv  29:                     qwen35.ssm.conv_kernel u32              = 4
+0.01.026.106 I llama_model_loader: - kv  30:                      qwen35.ssm.state_size u32              = 128
+0.01.026.107 I llama_model_loader: - kv  31:                     qwen35.ssm.group_count u32              = 16
+0.01.026.107 I llama_model_loader: - kv  32:                  qwen35.ssm.time_step_rank u32              = 48
+0.01.026.108 I llama_model_loader: - kv  33:                      qwen35.ssm.inner_size u32              = 6144
+0.01.026.108 I llama_model_loader: - kv  34:             qwen35.full_attention_interval u32              = 4
+0.01.026.109 I llama_model_loader: - kv  35:                qwen35.rope.dimension_count u32              = 64
+0.01.026.109 I llama_model_loader: - kv  36:                       tokenizer.ggml.model str              = gpt2
+0.01.026.110 I llama_model_loader: - kv  37:                         tokenizer.ggml.pre str              = qwen35
+0.01.054.008 I llama_model_loader: - kv  38:                      tokenizer.ggml.tokens arr[str,248320]  = ["!", "\"", "#", "$", "%", "&", "'", ...
+0.01.060.617 I llama_model_loader: - kv  39:                  tokenizer.ggml.token_type arr[i32,248320]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+0.01.088.753 I llama_model_loader: - kv  40:                      tokenizer.ggml.merges arr[str,247587]  = ["Ġ Ġ", "ĠĠ ĠĠ", "i n", "Ġ t",...
+0.01.088.759 I llama_model_loader: - kv  41:                tokenizer.ggml.eos_token_id u32              = 248046
+0.01.088.760 I llama_model_loader: - kv  42:            tokenizer.ggml.padding_token_id u32              = 248055
+0.01.088.761 I llama_model_loader: - kv  43:                tokenizer.ggml.bos_token_id u32              = 248044
+0.01.088.762 I llama_model_loader: - kv  44:               general.quantization_version u32              = 2
+0.01.088.762 I llama_model_loader: - kv  45:                          general.file_type u32              = 17
+0.01.088.764 I llama_model_loader: - kv  46:                      quantize.imatrix.file str              = Qwen3.8-27B-GGUF/imatrix_unsloth.gguf
+0.01.088.764 I llama_model_loader: - kv  47:             quantize.imatrix.entries_count u32              = 496
+0.01.088.765 I llama_model_loader: - kv  48:              quantize.imatrix.chunks_count u32              = 1251
+0.01.088.768 I llama_model_loader: - kv  49:                    tokenizer.chat_template str              = {%- set image_count = namespace(value...
+0.01.088.769 I llama_model_loader: - type  f32:  360 tensors
+0.01.088.770 I llama_model_loader: - type q8_0:  124 tensors
+0.01.088.770 I llama_model_loader: - type q4_K:   12 tensors
+0.01.088.771 I llama_model_loader: - type q5_K:  189 tensors
+0.01.088.771 I llama_model_loader: - type q6_K:  160 tensors
+0.01.088.771 I llama_model_loader: - type iq4_nl:    2 tensors
+0.01.088.772 I llama_model_loader: - type iq4_xs:   19 tensors
+0.01.088.774 I print_info: file format = GGUF V3 (latest)
+0.01.088.774 I print_info: file type   = Q5_K - Medium
+0.01.088.778 I print_info: file size   = 18.40 GiB (5.79 BPW) 
+0.01.097.135 I llama_prepare_model_devices: using device Vulkan0 (NVIDIA GeForce RTX 3090) (0000:c1:00.0) - 23695 MiB free
+0.01.276.456 I load: 0 unused tokens
+0.01.339.800 I load: printing all EOG tokens:
+0.01.339.804 I load:   - 248044 ('<|endoftext|>')
+0.01.339.805 I load:   - 248046 ('<|im_end|>')
+0.01.339.806 I load:   - 248063 ('<|fim_pad|>')
+0.01.339.806 I load:   - 248064 ('<|repo_name|>')
+0.01.339.806 I load:   - 248065 ('<|file_sep|>')
+0.01.340.502 I load: special tokens cache size = 33
+0.01.438.250 I load: token to piece cache size = 1.7581 MB
+0.01.438.267 I print_info: arch                  = qwen35
+0.01.438.268 I print_info: vocab_only            = 0
+0.01.438.268 I print_info: no_alloc              = 0
+0.01.438.268 I print_info: n_ctx_train           = 262144
+0.01.438.269 I print_info: n_embd_inp            = 5120
+0.01.438.269 I print_info: n_embd                = 5120
+0.01.438.270 I print_info: n_embd_out            = 5120
+0.01.438.270 I print_info: n_layer               = 64
+0.01.438.270 I print_info: n_layer_all           = 65
+0.01.438.280 I print_info: n_head                = 24
+0.01.438.281 I print_info: n_head_kv             = 4
+0.01.438.281 I print_info: n_rot                 = 64
+0.01.438.282 I print_info: n_swa                 = 0
+0.01.438.282 I print_info: is_swa_any            = 0
+0.01.438.282 I print_info: n_embd_head_k         = 256
+0.01.438.283 I print_info: n_embd_head_v         = 256
+0.01.438.284 I print_info: n_gqa                 = 6
+0.01.438.286 I print_info: n_embd_k_gqa          = 1024
+0.01.438.287 I print_info: n_embd_v_gqa          = 1024
+0.01.438.288 I print_info: f_norm_eps            = 0.0e+00
+0.01.438.289 I print_info: f_norm_rms_eps        = 1.0e-06
+0.01.438.290 I print_info: f_clamp_kqv           = 0.0e+00
+0.01.438.290 I print_info: f_max_alibi_bias      = 0.0e+00
+0.01.438.290 I print_info: f_logit_scale         = 0.0e+00
+0.01.438.291 I print_info: f_attn_scale          = 0.0e+00
+0.01.438.291 I print_info: f_attn_value_scale    = 0.0000
+0.01.438.292 I print_info: n_ff                  = 17408
+0.01.438.293 I print_info: n_expert              = 0
+0.01.438.293 I print_info: n_expert_used         = 0
+0.01.438.293 I print_info: n_expert_groups       = 0
+0.01.438.293 I print_info: n_group_used          = 0
+0.01.438.294 I print_info: causal attn           = 1
+0.01.438.294 I print_info: pooling type          = -1
+0.01.438.294 I print_info: rope type             = 40
+0.01.438.294 I print_info: rope scaling          = linear
+0.01.438.295 I print_info: freq_base_train       = 10000000.0
+0.01.438.296 I print_info: freq_scale_train      = 1
+0.01.438.296 I print_info: n_ctx_orig_yarn       = 262144
+0.01.438.297 I print_info: rope_yarn_log_mul     = 0.0000
+0.01.438.297 I print_info: rope_finetuned        = unknown
+0.01.438.297 I print_info: mrope sections        = [11, 11, 10, 0]
+0.01.438.298 I print_info: ssm_d_conv            = 4
+0.01.438.298 I print_info: ssm_d_inner           = 6144
+0.01.438.298 I print_info: ssm_d_state           = 128
+0.01.438.298 I print_info: ssm_dt_rank           = 48
+0.01.438.299 I print_info: ssm_n_group           = 16
+0.01.438.299 I print_info: ssm_dt_b_c_rms        = 0
+0.01.438.300 I print_info: model type            = 27B
+0.01.438.300 I print_info: model params          = 27.32 B
+0.01.438.301 I print_info: general.name          = Qwen3.8-27B
+0.01.438.302 I print_info: vocab type            = BPE
+0.01.438.302 I print_info: n_vocab               = 248320
+0.01.438.303 I print_info: n_merges              = 247587
+0.01.438.303 I print_info: BOS token             = 248044 '<|endoftext|>'
+0.01.438.303 I print_info: EOS token             = 248046 '<|im_end|>'
+0.01.438.303 I print_info: EOT token             = 248046 '<|im_end|>'
+0.01.438.304 I print_info: PAD token             = 248055 '<|vision_pad|>'
+0.01.438.304 I print_info: LF token              = 198 'Ċ'
+0.01.438.305 I print_info: FIM PRE token         = 248060 '<|fim_prefix|>'
+0.01.438.305 I print_info: FIM SUF token         = 248062 '<|fim_suffix|>'
+0.01.438.305 I print_info: FIM MID token         = 248061 '<|fim_middle|>'
+0.01.438.305 I print_info: FIM PAD token         = 248063 '<|fim_pad|>'
+0.01.438.306 I print_info: FIM REP token         = 248064 '<|repo_name|>'
+0.01.438.306 I print_info: FIM SEP token         = 248065 '<|file_sep|>'
+0.01.438.306 I print_info: EOG token             = 248044 '<|endoftext|>'
+0.01.438.307 I print_info: EOG token             = 248046 '<|im_end|>'
+0.01.438.307 I print_info: EOG token             = 248063 '<|fim_pad|>'
+0.01.438.307 I print_info: EOG token             = 248064 '<|repo_name|>'
+0.01.438.308 I print_info: EOG token             = 248065 '<|file_sep|>'
+0.01.438.308 I print_info: max token length      = 256
+0.01.438.309 I load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+0.17.025.509 I load_tensors: offloading output layer to GPU
+0.17.025.513 I load_tensors: offloading 64 repeating layers to GPU
+0.17.025.513 I load_tensors: offloaded 66/66 layers to GPU
+0.17.025.526 I load_tensors:   CPU_Mapped model buffer size =   682.03 MiB
+0.17.025.527 I load_tensors:      Vulkan0 model buffer size = 18163.06 MiB
+0.21.368.005 I cmn  common_init_: added <|endoftext|> logit bias = -inf
+0.21.368.017 I cmn  common_init_: added <|im_end|> logit bias = -inf
+0.21.368.018 I cmn  common_init_: added <|fim_pad|> logit bias = -inf
+0.21.368.018 I cmn  common_init_: added <|repo_name|> logit bias = -inf
+0.21.368.019 I cmn  common_init_: added <|file_sep|> logit bias = -inf
+0.21.368.104 I llama_context: constructing llama_context
+0.21.368.106 I llama_context: n_seq_max     = 1
+0.21.368.107 I llama_context: n_ctx         = 8192
+0.21.368.107 I llama_context: n_ctx_seq     = 8192
+0.21.368.107 I llama_context: n_batch       = 2048
+0.21.368.107 I llama_context: n_ubatch      = 2048
+0.21.368.108 I llama_context: causal_attn   = 1
+0.21.368.108 I llama_context: flash_attn    = auto
+0.21.368.109 I llama_context: kv_unified    = false
+0.21.368.111 I llama_context: freq_base     = 10000000.0
+0.21.368.111 I llama_context: freq_scale    = 1
+0.21.368.111 I llama_context: n_rs_seq      = 0
+0.21.368.112 I llama_context: n_outputs_max = 1
+0.21.368.112 I llama_context: n_ctx_seq (8192) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
+0.21.369.147 I llama_context: Vulkan_Host  output buffer size =     0.95 MiB
+0.21.378.494 I llama_kv_cache:    Vulkan0 KV buffer size =   512.00 MiB
+0.21.390.041 I llama_kv_cache: size =  512.00 MiB (  8192 cells,  16 layers,  1/1 seqs), K (f16):  256.00 MiB, V (f16):  256.00 MiB
+0.21.390.050 I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+0.21.390.051 I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+0.21.396.688 I llama_memory_recurrent:    Vulkan0 RS buffer size =   149.62 MiB
+0.21.396.696 I llama_memory_recurrent: size =  149.62 MiB (     1 cells,  64 layers,  1 seqs  0 rs_seq), R (f32):    5.62 MiB, S (f32):  144.00 MiB
+0.21.396.703 I sched_reserve: reserving ...
+0.21.432.047 I sched_reserve: Flash Attention was auto, set to enabled
+0.21.432.051 I sched_reserve: resolving fused Gated Delta Net support:
+0.21.435.300 I sched_reserve: fused Gated Delta Net (autoregressive) enabled
+0.21.438.475 I sched_reserve: fused Gated Delta Net (chunked) enabled
+0.21.477.990 I sched_reserve:    Vulkan0 compute buffer size =   568.18 MiB
+0.21.477.994 I sched_reserve: Vulkan_Host compute buffer size =   112.07 MiB
+0.21.477.995 I sched_reserve: graph nodes  = 3655
+0.21.477.995 I sched_reserve: graph splits = 2
+0.21.477.997 I sched_reserve: reserve took 81.29 ms, sched copies = 1
+0.21.478.097 I cmn  common_init_: warming up the model with an empty run - please wait ... (--no-warmup to disable)
+0.21.550.369 I cmn  common_conte: the context does not support partial sequence removal
+0.21.574.385 I srv    load_model: speculative decoding will use checkpoints
+0.21.574.389 I srv    load_model: initializing, n_slots = 1, n_ctx_slot = 8192, kv_unified = 'false'
+0.21.574.428 I spec common_specu: no implementations specified for speculative decoding
+0.21.574.429 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 8192
+0.21.574.497 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
+0.21.574.499 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
+0.21.574.499 I srv    load_model: for more info see https://github.com/ggml-org/llama.cpp/pull/16391
+0.21.574.499 I srv    load_model: context checkpoints enabled, max = 32, min spacing = 8192
+0.21.574.527 I srv          init: idle slots will be saved to prompt cache upon starting a new task
+0.21.601.692 I srv          init: init: chat template, example_format: '<|im_start|>system
+Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.
+
+You are a helpful assistant<|im_end|>
+<|im_start|>user
+Hello<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+Hi there<|im_end|>
+<|im_start|>user
+How are you?<|im_end|>
+<|im_start|>assistant
+<think>
+'
+0.21.622.949 I srv          init: init: chat template, thinking = 1
+0.21.622.960 I srv          init: chat template supports preserving reasoning, consider enabling it via --reasoning-preserve
+0.21.622.998 I srv  llama_server: model loaded
+0.21.623.003 I srv  llama_server: listening on http://127.0.0.1:8446
+0.21.623.019 I srv  update_slots: all slots are idle
+0.23.148.575 I srv    operator(): chat format: peg-native
+0.23.148.849 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1
+0.23.148.857 I srv  get_availabl: updating prompt cache
+0.23.148.868 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
+0.23.148.877 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 8192 tokens, 8589934592 est)
+0.23.148.883 I srv  get_availabl: prompt cache update took 0.02 ms
+0.23.149.047 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.23.149.074 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.23.149.083 I slot launch_slot_: id  0 | task 0 | processing task, is_child = 0
+0.23.149.108 I slot   operator(): id  0 | task 0 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1546
+0.23.149.115 I slot   operator(): id  0 | task 0 | cached n_tokens = 0, memory_seq_rm [0, end)
+0.23.205.188 I slot   operator(): id  0 | task 0 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.23.506.123 I slot create_check: id  0 | task 0 | created context checkpoint 1 of 32 (pos_min = 78, pos_max = 78, n_tokens = 79, size = 149.626 MiB)
+0.23.603.388 I slot   operator(): id  0 | task 0 | cached n_tokens = 1542, memory_seq_rm [1542, end)
+0.23.603.589 I slot init_sampler: id  0 | task 0 | init sampler, took 0.17 ms, tokens: text = 1546, total = 1546
+0.25.350.057 I slot print_timing: id  0 | task 0 | prompt eval time =    1750.80 ms /  1546 tokens (    1.13 ms per token,   883.03 tokens per second)
+0.25.350.062 I slot print_timing: id  0 | task 0 |        eval time =     450.14 ms /    16 tokens (   28.13 ms per token,    35.54 tokens per second)
+0.25.350.063 I slot print_timing: id  0 | task 0 |       total time =    2200.93 ms /  1562 tokens
+0.25.350.068 I slot print_timing: id  0 | task 0 |    graphs reused =         15
+0.25.350.164 I slot      release: id  0 | task 0 | stop processing: n_tokens = 1561, truncated = 0
+0.25.350.178 I srv  update_slots: all slots are idle
+0.25.350.452 I srv  stream_sessi: conv_id= (empty=1)
+0.27.388.551 I srv    operator(): chat format: peg-native
+0.27.388.773 I slot get_availabl: id  0 | task -1 | selected slot by LCP similarity, sim_best = 0.804 (> 0.100 thold), f_keep = 0.053
+0.27.388.778 I srv  get_availabl: updating prompt cache
+0.27.388.916 I srv   prompt_save:  - saving prompt with length 1561, total state size = 247.219 MiB (draft: 0.000 MiB)
+0.27.661.045 I srv          load:  - looking for better prompt, base f_keep = 0.053, sim = 0.804
+0.27.661.062 I srv        update:  - cache state: 1 prompts, 396.845 MiB (limits: 8192.000 MiB, 8192 tokens, 32223 est)
+0.27.661.067 I srv        update:    - prompt 0x59693df4c6d0:    1561 tokens, checkpoints:  1,   396.845 MiB
+0.27.661.070 I srv  get_availabl: prompt cache update took 272.29 ms
+0.27.661.209 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.27.661.231 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.27.661.237 I slot launch_slot_: id  0 | task 19 | processing task, is_child = 0
+0.27.661.251 I slot   operator(): id  0 | task 19 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 102
+0.27.661.258 I slot   operator(): id  0 | task 19 | checking checkpoint with [78, 78] against 82...
+0.27.686.984 I slot   operator(): id  0 | task 19 | restored context checkpoint (pos_min = 78, pos_max = 78, n_tokens = 79, n_past = 79, size = 149.626 MiB)
+0.27.686.989 I slot   operator(): id  0 | task 19 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.27.791.946 I slot create_check: id  0 | task 19 | created context checkpoint 2 of 32 (pos_min = 78, pos_max = 78, n_tokens = 79, size = 149.626 MiB)
+0.27.805.276 I slot   operator(): id  0 | task 19 | cached n_tokens = 98, memory_seq_rm [98, end)
+0.27.805.325 I slot init_sampler: id  0 | task 19 | init sampler, took 0.03 ms, tokens: text = 102, total = 102
+0.28.613.377 I slot print_timing: id  0 | task 19 | prompt eval time =     510.45 ms /    23 tokens (   22.19 ms per token,    45.06 tokens per second)
+0.28.613.382 I slot print_timing: id  0 | task 19 |        eval time =     441.66 ms /    16 tokens (   27.60 ms per token,    36.23 tokens per second)
+0.28.613.383 I slot print_timing: id  0 | task 19 |       total time =     952.11 ms /    39 tokens
+0.28.613.384 I slot print_timing: id  0 | task 19 |    graphs reused =         29
+0.28.613.419 I slot      release: id  0 | task 19 | stop processing: n_tokens = 117, truncated = 0
+0.28.613.433 I srv  update_slots: all slots are idle
+0.28.613.563 I srv  stream_sessi: conv_id= (empty=1)
+0.30.641.416 I srv    operator(): chat format: peg-native
+0.30.641.586 I slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = 9363036903
+0.30.641.590 I srv  get_availabl: updating prompt cache
+0.30.641.632 I srv   prompt_save:  - saving prompt with length 117, total state size = 156.941 MiB (draft: 0.000 MiB)
+0.30.941.742 I srv          load:  - looking for better prompt, base f_keep = 0.701, sim = 0.052
+0.30.941.748 I srv          load:  - found better prompt with f_keep = 0.990, sim = 0.983
+0.31.004.978 I srv        update:  - cache state: 1 prompts, 456.193 MiB (limits: 8192.000 MiB, 8192 tokens, 8192 est)
+0.31.004.983 I srv        update:    - prompt 0x59693dde9cd0:     117 tokens, checkpoints:  2,   456.193 MiB
+0.31.004.984 I srv  get_availabl: prompt cache update took 363.39 ms
+0.31.005.062 I slot launch_slot_: id  0 | task -1 | sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
+0.31.005.069 I slot launch_slot_: id  0 | task -1 | sampler params: 
+	repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
+	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 8192
+	top_k = 20, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
+	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
+0.31.005.072 I slot launch_slot_: id  0 | task 37 | processing task, is_child = 0
+0.31.005.080 I slot   operator(): id  0 | task 37 | new prompt, n_ctx_slot = 8192, n_keep = 0, task.n_tokens = 1571
+0.31.005.085 I slot   operator(): id  0 | task 37 | checking checkpoint with [78, 78] against 1545...
+0.31.020.827 I slot   operator(): id  0 | task 37 | restored context checkpoint (pos_min = 78, pos_max = 78, n_tokens = 79, n_past = 79, size = 149.626 MiB)
+0.31.020.831 I slot   operator(): id  0 | task 37 | cached n_tokens = 79, memory_seq_rm [79, end)
+0.31.293.577 I slot   operator(): id  0 | task 37 | cached n_tokens = 1550, memory_seq_rm [1550, end)
+0.32.555.859 I slot create_check: id  0 | task 37 | created context checkpoint 2 of 32 (pos_min = 1549, pos_max = 1549, n_tokens = 1550, size = 149.626 MiB)
+0.32.564.367 I slot   operator(): id  0 | task 37 | cached n_tokens = 1567, memory_seq_rm [1567, end)
+0.32.564.671 I slot init_sampler: id  0 | task 37 | init sampler, took 0.28 ms, tokens: text = 1571, total = 1571
+0.33.148.790 I slot print_timing: id  0 | task 37 | prompt eval time =    1699.14 ms /  1492 tokens (    1.14 ms per token,   878.09 tokens per second)
+0.33.148.796 I slot print_timing: id  0 | task 37 |        eval time =     444.56 ms /    16 tokens (   27.78 ms per token,    35.99 tokens per second)
+0.33.148.796 I slot print_timing: id  0 | task 37 |       total time =    2143.70 ms /  1508 tokens
+0.33.148.798 I slot print_timing: id  0 | task 37 |    graphs reused =         43
+0.33.148.885 I slot      release: id  0 | task 37 | stop processing: n_tokens = 1586, truncated = 0
+0.33.148.896 I srv  update_slots: all slots are idle
+0.33.149.092 I srv  stream_sessi: conv_id= (empty=1)
+0.37.151.980 I srv    operator(): operator(): cleaning up before exit...
+0.37.165.131 I common_memory_breakdown_print: | memory breakdown [MiB] | total   free     self   model   context   compute    unaccounted |
+0.37.165.133 I common_memory_breakdown_print: |   - Vulkan0 (RTX 3090) | 24822 = 3715 + (19392 = 18163 +     661 +     568) +        1714 |
+0.37.165.134 I common_memory_breakdown_print: |   - Host               |                   794 =   682 +       0 +     112                |

--- a/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep.comment.md
+++ b/eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep.comment.md
@@ -1,0 +1,95 @@
+### Issue #446 — the three chat entries the #399 sweep could not start
+
+The leg-A protocol of #399, re-run unchanged against the three catalog entries that were never in
+that sweep. Same driver (`issue399-arch-sweep.mjs`, unmodified — its prompts are byte-stable, so
+these rows are directly comparable to the fourteen in `issue399-arch-sweep.comment.md`), same
+argv shape, same pinned binary, same machine, **no MTP flags**.
+
+1. **Runtime:** the same pinned `version: 9849 (799fcc04a)` b9849 Ubuntu Vulkan build (GNU 11.4.0)
+   at `<runtime>/llama-server` that the `issue399-*` captures used.
+2. **Argv (every model):**
+   `llama-server --host 127.0.0.1 --port <n> --model <drive>/models/chat/<id>.gguf --ctx-size 8192
+   --threads 10 --batch-size 2048 --ubatch-size 2048 --jinja --reasoning-format deepseek -lv 4 -np 1`
+3. **Machine:** Ubuntu 22.04.5 LTS, kernel 6.8.0-138-generic, RTX 3090 24,576 MiB, NVIDIA
+   595.91.07. **All four starts below offloaded FULLY** (the `layers` column), so no verdict rests
+   on a partial offload. Every one reports `n_slots = 1`, `n_ctx_slot = 8192`, `kv_unified = false`,
+   `n_seq_max = 1`.
+4. **The three requests** are #399's: **R1** conversation A (shared ~40-token system message + a
+   fixed synthetic ~1,450-token user message), **R2** conversation B (same system message, a short
+   unrelated question) takes the slot, **R3** back to A with one new short turn.
+
+#### Getting the weights (this was the blocker)
+
+`qwen3.6-27b-q4` and `qwen3.6-27b-q5` were broken symlinks into `<home>/llama.cpp/models/`, the eval
+drive deleted on 2026-09-04 — the directory still exists and is empty. Both were re-fetched from the
+manifest's `download.url`, and `granite-4.1-8b-q4` was fetched for the first time. **Each was
+verified against its manifest `sha256` AND its `size_bytes` before it was measured**, because a
+truncated GGUF would have produced a verdict rather than an error:
+
+| model | bytes | sha256 (manifest = fetched) |
+|---|---|---|
+| `qwen3.6-27b-q4` | 16,817,244,384 | `5ed60d0a…638392a0` ✓ |
+| `qwen3.6-27b-q5` | 19,509,790,944 | `cfecab16…316ccbde` ✓ |
+| `granite-4.1-8b-q4` | 5,347,914,400 | `ed902ac9…fac5309e` ✓ |
+
+#### The table
+
+`prefilled` is `prompt eval time = … / N tokens`; `of` is the request's whole `prompt_tokens`;
+`kept` is the `cached n_tokens` R3 started from.
+
+| model | arch | n_swa | recurrent state | layers | R1 prefilled | R2 prefilled | R3 prefilled | kept | verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| `qwen3.6-27b-q4` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | 1508 of 1508 | 23 of 64 | **1488 of 1529** | 41 | **RE-PREFILLED** |
+| `qwen3.6-27b-q5` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | 1508 of 1508 | 23 of 64 | **1488 of 1529** | 41 | **RE-PREFILLED** |
+| `granite-4.1-8b-q4` | granite | 0 | none | 41/41 | 1377 of 1377 | 18 of 62 | **22 of 1414** | 1392 | **RESTORED** |
+| `qwen3.8-27b-ud-q5km` (control) | qwen35 | 0 | 149.62 MiB (64 layers) | 66/66 | 1546 of 1546 | 23 of 102 | **1492 of 1571** | 79 | **RE-PREFILLED** |
+
+**The control reproduced the #399 sweep token for token** — 1,492 of 1,571 with 79 kept, the same
+149.62 MiB recurrent state over 64 layers, the same 66/66 offload. So the setup is the sweep's, and
+the three new rows sit in the same table as the fourteen old ones.
+
+#### What it answers
+
+**`qwen3.6` is AFFECTED, and for the measured reason, not the expected one.** Both quants report
+arch **`qwen35`** — the same architecture as the `qwen3.5` line and the `qwen3.8` 27Bs — with a
+149.62 MiB `llama_memory_recurrent` state over 64 layers. They land on exactly the `qwen3.5` row's
+numbers (1,488 of 1,529, 41 kept), not the `qwen3.8` 27B's (1,492 of 1,571, 79 kept), because the
+system prefix tokenises the same way for them. The two quants are identical in every column, which
+is what a family-level rule expects. → `qwen3.6` joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES`.
+
+**`granite` RESTORES, which is the result nobody predicted.** Arch `granite`, `n_swa` 0, no
+`llama_memory_recurrent` line at all: R3 re-prefilled **22 tokens of 1,414** and started from A's
+whole 1,392-token prefix. The 217.517 MiB it saved on the hand-back was actually read back. It is a
+fourth positive control alongside `qwen3`, `qwen3moe` and `mistral3` — and the reason the
+conservative cache-ON default was worth having. → `granite` stays off the list, now for a measured
+reason instead of an absent one.
+
+That closes the last two families in the catalog with no verdict. Every `family:` a manifest
+declares is now on one side of the architecture split.
+
+#### The trap, reproduced a fourth time
+
+`forcing full prompt re-processing due to lack of cache data` appears **0 times** in all four
+stderr captures — including in the two `qwen3.6` runs that demonstrably re-prefilled 1,488 tokens.
+What the server logged instead, on both affected models, was
+`load: - found better prompt with f_keep = 0.989, sim = 0.985`: it FOUND A's cached prompt, reported
+a 98.9 % keep fraction, and then prefilled the whole thing anyway. Granite logged the same
+reassuring shape (`f_keep = 1.000, sim = 0.984`) and actually restored. **The log line does not
+distinguish the two cases; only the token count does.**
+
+#### Cost side-observation
+
+Per eviction of a ~1,500-token conversation: `qwen3.6-27b-q4` and `-q5` both save 244.843 MiB for A
+plus 154.566 MiB for B and read neither back — that is the waste `--cache-ram 0` now stops.
+`granite-4.1-8b-q4` saves 217.517 MiB and 11.252 MiB, and uses them.
+
+#### What this run could not measure
+
+- Nothing here was run above `--ctx-size 8192`, and nothing with MTP — deliberate, so the argv
+  stays identical to the fourteen rows this extends.
+- The remaining broken symlinks on this rig are untouched: `gemma-4-26b-q4`, `gemma4-coding-q8`,
+  `qwen3.5-0.8b-q6`, `qwen3.5-9b-q8`. All four are additional weights of families that already have
+  a measured verdict (`gemma4`, `qwen3.5`), so they cannot change the rule, only add rows.
+- **R1/R3 timings are not a speed result.** The card idles at a 405 MHz memory clock on this rig and
+  does not always reach P0, so the tok/s implied here is not comparable to a clean benchmark run.
+  No verdict in the table depends on a timing — every one is a token count.


### PR DESCRIPTION
Closes #446.

#399 measured which chat models lose llama-server's host-RAM prompt-cache restore after an eviction, and shipped `--cache-ram 0` for the families measured to be affected. Three catalog entries were never in that sweep — not because anyone judged them, but because `qwen3.6-27b-q4` / `-q5` were **broken symlinks** into the eval drive deleted 2026-09-04 and `granite-4.1-8b-q4` was not on the rig. Under the conservative D5 default all three were treated as unaffected. Safe, but it left the saving unclaimed and, worse, left "never tested" one careless reading away from "measured and fine".

All three now have a verdict.

## What was run

The **unchanged** leg-A driver (`issue399-arch-sweep.mjs`) on the same machine, the same pinned b9849 (`799fcc04a`), the app's argv shape at `--ctx-size 8192 -np 1`, **no MTP flags**, three requests per start (long conversation A → a short unrelated B takes the slot → back to A). Its prompts are byte-stable, so these rows sit in the same table as the fourteen.

Weights were fetched from the manifests' own `download.url` and verified against **both** the manifest `sha256` and its `size_bytes` before measuring — a truncated GGUF would have produced a verdict rather than an error. No weights are committed.

## The numbers

`prefilled` is R3's `prompt eval time = … / N tokens`; `kept` is the `cached n_tokens` it started from.

| model | arch | n_swa | recurrent state | layers | R3 prefilled | kept | verdict |
|---|---|---|---|---|---|---|---|
| `qwen3.6-27b-q4` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | **1488 of 1529** | 41 | **RE-PREFILLED** |
| `qwen3.6-27b-q5` | qwen35 | 0 | 149.62 MiB (64 layers) | 65/65 | **1488 of 1529** | 41 | **RE-PREFILLED** |
| `granite-4.1-8b-q4` | granite | 0 | none | 41/41 | **22 of 1414** | 1392 | **RESTORED** |
| `qwen3.8-27b-ud-q5km` (control) | qwen35 | 0 | 149.62 MiB (64 layers) | 66/66 | **1492 of 1571** | 79 | **RE-PREFILLED** |

**The control reproduced the #399 sweep token for token** — 1,492 of 1,571 with 79 kept, same recurrent state, same 66/66 offload — so the setup is the sweep's and the new rows are comparable. Every start above offloaded fully; no verdict rests on a partial offload.

## What it means

**`qwen3.6` is affected — but the architecture decided it, not the lineage.** Both quants report arch **`qwen35`** with a 149.62 MiB `llama_memory_recurrent` state over 64 layers. The expectation from its lineage happened to be right; the `arch` line and the token count are why it is on the list. Both quants are identical in every column, which is what a family-level rule expects. `qwen3.6` therefore joins `PROMPT_CACHE_RESTORE_BROKEN_FAMILIES`, making the affected set **13 of 17 measured models**.

**`granite` restores, and that is the more useful result.** No sliding window, no recurrent state, 22 of 1,414 tokens re-prefilled — and the 217.517 MiB it saved on the hand-back was actually read back. It becomes the fourth positive control beside `qwen3`, `qwen3moe` and `mistral3`. It is also the concrete justification for the cache-ON default: the family everyone expected to be affected was, and the one nobody had an opinion about would have lost real restores had we generalised.

Every `family:` in the catalog now has a verdict. The default still governs the family added *next*.

## The trap, a fourth time

`forcing full prompt re-processing due to lack of cache data` appears **0 times** in all four stderr captures — including in the two `qwen3.6` runs that demonstrably re-prefilled 1,488 tokens. Both instead logged a confident `load: - found better prompt with f_keep = 0.989, sim = 0.985` and then re-prefilled anyway. Granite logged the same reassuring shape (`f_keep = 1.000`) and actually restored. The log line does not distinguish the two cases; only the token count does.

## Tests that changed deliberately

- `prompt-cache-rules.test.ts` — "the exported list is exactly the three measured families" is the guard against quietly widening the rule, so its expectation went to four **and** its comment now says what a fourth entry has to be backed by.
- The same file's unmeasured-family test used `'qwen3.6'` and `'granite'` as examples. Both are now measured, so they would have stopped testing the default they exist to protect: swapped for `llama9` / `phi-next` / `qwen4` / `gemma5`, families the catalog does not have. The comment says why.
- `llama-runtime.test.ts` used `'qwen3.6'` the same way — now `'qwen3'`, `'granite'`, `'llama9'`, `undefined`.
- Added a `qwen3.65` case to the no-prefix-creep test.

## Not changed

**CHANGELOG.** The D5 switch is still in `[Unreleased]`, and its entry ("Less RAM held for nothing while you chat") is written family-agnostically — "on the model families where the local engine cannot reuse a saved conversation anyway". Adding `qwen3.6` to that set before the release ships does not change what the entry says, so a second entry would be noise.

## Local test note

`npm run typecheck` and `npm run build` are green. `npm test` is green except for two assertions in `tests/integration/evidence-pack-pdf-smoke.test.ts`, which fail **identically on master before this branch** (verified) — a local Electron `printToPDF` + pdfjs artefact where the extracted text splits an `fi` ligature ("identi fi zieren"). That file skips where the Electron binary/display is absent, i.e. on CI. Untouched here.

Evidence: `eval/results/hardware/i9-9900x-rtx-3090-24gb-128gb/issue446-arch-sweep-*` (the driver's four outputs per model, plus `issue446-arch-sweep.comment.md`), matching the committed `issue399-*` file set. Synthetic prompts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F4z4eUscYBzLyrGejWGKj
