### PR TITLE
fix(test): T15's deadline case asserts the bound, not how far the work got

### DIFF
--- a/apps/desktop/tests/integration/zim-regressions.test.ts
+++ b/apps/desktop/tests/integration/zim-regressions.test.ts
@@ -1921,7 +1921,15 @@ describe('T15 — fair allocation, bounded concurrency, the selection cap, the d
         expect(timedOut.every((o) => o.status === 'failed')).toBe(true)
         expect(notStarted).toHaveLength(3)
         expect(notStarted.every((o) => o.status === 'skipped')).toBe(true)
-        expect(new Set(t15Searches).size).toBe(2) // only the two in-flight packs were asked
+        // Only the in-flight packs were asked — at most `concurrency`, and never one the
+        // deadline skipped. NOT `toBe(2)`: that assumed both in-flight searches had also
+        // REACHED the fixture inside the 150 ms budget, which is a property of the runner,
+        // not of the code. On a loaded CI worker (windows-latest 22.x, 2026-09-10) the
+        // deadline fired before either request went out and the case failed at 0, while every
+        // outcome above was correct. The guarantee is the bound and the exclusion.
+        const timedOutIds = new Set(timedOut.map((o) => o.packId))
+        expect(new Set(t15Searches).size).toBeLessThanOrEqual(2)
+        for (const asked of new Set(t15Searches)) expect(timedOutIds.has(asked)).toBe(true)
         t15Hold = null
       } finally {
         await h.close()


### PR DESCRIPTION
One assertion in `zim-regressions.test.ts` T15 sub-case (5) pinned a property of the CI runner rather than of the code, and it failed a required check on an unrelated PR.

## The defect

Sub-case (5) gives the archive arm a **150 ms** per-ask deadline with every search parked forever, then asserts what the truncation did:

```ts
expect(timedOut).toHaveLength(2)                     // in flight when it fired
expect(notStarted).toHaveLength(3)                   // never started
expect(new Set(t15Searches).size).toBe(2)            // ← this one
```

The last line assumes the two in-flight packs also got their `/search` request **out to the fixture** within those 150 ms. Nothing in the code promises that. On `windows-latest, 22.x` (run `34512403336`, opened on PR #454, a data-only PR) the fake sidecar spawn plus health probe ran long enough that the deadline fired with zero requests sent: `expected +0 to be 2`. Every assertion above it passed — the outcomes were all correct — so the truncation behaviour under test was fine and only the incidental assumption broke.

## The fix

```ts
const timedOutIds = new Set(timedOut.map((o) => o.packId))
expect(new Set(t15Searches).size).toBeLessThanOrEqual(2)
for (const asked of new Set(t15Searches)) expect(timedOutIds.has(asked)).toBe(true)
```

The bound (never more than `concurrency` asked) and the exclusion (no pack the deadline skipped was ever searched) are what the deadline actually guarantees. This still fails if work leaks out after the deadline, if concurrency breaks, or if a skipped pack is asked — it no longer fails because a loaded runner was slow. Everything else in the block is untouched, including the five outcome assertions that are the point of the case.

## Verification

- `zim-regressions.test.ts` run 3× locally: 15/15 each time, T15 in ~1.3 s.
- `npm run typecheck` clean.

## Scope

This is the narrow half of the CI-flake problem. The broader one — both Windows legs running at their time budget, which produced three re-run cycles in two days on three different test files — is filed separately; this PR is referenced from it. Same fragility class as #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
