### PR TITLE
fix(ci): hooks get the same CI budget as tests (#458, 1 of 3)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,12 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-12 — **#458 OPEN (1 of 3) — windows CI: `hookTimeout` is now CI-aware** (`fix/458-ci-hook-timeout`; record `packaging.md` "Continuous
+integration (CI)"; decision + full evidence in the issue comment). **Five** windows flakes, not three, and #457 did not end them; `testTimeout`
+widened to 60 s on CI long ago but `hookTimeout` never did (vitest's 10 s default, 6× tighter) and **2 of the 5 were hook timeouts** — structural,
+not slow setup: 3 forks + main fill a 4-core runner. Decision = **shard the windows legs**; dropping a node version rejected (22.x is the `engines`
+floor AND carries 4 of 5), temp-root churn rejected on measurement (~1.5 s/run; refiled as hygiene — 99/129 `openDatabase()` suites never close).
+Next: (2) shard 2× + **shard-aware `FullSuiteGuard`** (`--shard` leaves `isFullRun` true → it fails every sharded run; a folder split silently DISABLES it). (3) the **29 hand-rolled `Date.now()` poll bounds across 16 files** + `zim-arm.test.ts:672` — never widen with the vitest budget._
 _2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -63,6 +63,29 @@ export default defineConfig({
     // This loosens no evidence: timing PROOFS in this suite live in explicit
     // assertions (e.g. the FTS 500 ms bound, #84), never in the vitest budget.
     // Locally the tight 15 s stays, catching real hangs fast at the desk.
-    testTimeout: process.env.CI ? 60_000 : 15_000
+    testTimeout: process.env.CI ? 60_000 : 15_000,
+    // Hooks get the SAME budget as tests, for the same reason and on the same evidence.
+    // Until #458 this line did not exist, so `beforeEach`/`afterEach`/`beforeAll` ran on
+    // vitest's 10 s default — SIX TIMES LESS headroom than the tests above, on the one
+    // platform the comment above says is starved. Two of the five windows flakes in #458 were
+    // hook timeouts, not test timeouts: `performance-gpu` (run 34655007954) and
+    // `doctasks-translation` (run 34543501694), both `Hook timed out in 10000ms`.
+    //
+    // Those hooks are not slow. `performance-gpu`'s is five synchronous resets; 10 s on that is
+    // a fork that got no CPU, which no amount of hook optimisation fixes: vitest runs
+    // `availableParallelism() - 1` forks, so on a 4-core runner three forks plus the main
+    // process fill the machine before Defender and the runner agent take their share.
+    //
+    // The 10 s default was already known to be too tight here and patched ONE hook at a time —
+    // `tests/setup-temp-roots.ts` carries its own `TEARDOWN_TIMEOUT_MS` (120 s) citing run
+    // 34033122353. This generalises that fix instead of waiting for each hook to be bitten;
+    // 129 suites open a sqlite DB (99 of them never close it, #460) and many do that plus
+    // `mkdtempSync` inside a hook, as do the fixture teardowns that close DBs and remove roots.
+    //
+    // This loosens no evidence, exactly as for `testTimeout`: a hook is SETUP, never a timing
+    // proof — the suite's timing proofs live in explicit assertions (the FTS 500 ms bound, #84),
+    // and nothing asserts a hook timeout. Locally the tight 15 s stays, so a real hang at the
+    // desk still fails fast.
+    hookTimeout: process.env.CI ? 60_000 : 15_000
   }
 })

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -606,6 +606,29 @@ a compromised action repo inject code into CI; full-audit 2026-07-10 SC-1). This
 telemetry/analytics, and performs no network egress beyond the registry install (the "no cloud /
 no telemetry" hard rule governs the shipped app at runtime).
 
+**The windows legs run at their time budget, and the vitest budgets are CI-aware because of it
+(#458).** On the same commit the ubuntu legs finish in ~5 min and the windows legs in 10–14; the
+`npm test` step is 483–542 s of that, while install + typecheck + build is only ~90 s, so the test
+step *is* the leg. The excess is concentrated in the tests themselves (2.2× ubuntu, measured
+per-phase), not in collection or setup (1.05–1.35×): vitest runs `availableParallelism() - 1`
+forks, so on a 4-core runner three forks plus the main process fill the machine before Defender
+and the runner agent take their share, and Windows file operations cost more per call. Run-to-run
+variance on a shared runner then decides the outcome — the same suite measured 486 s green and
+694/802 s on the runs that failed. Any fork can be descheduled for 10+ seconds, and whichever
+file is unlucky fails a run that no code change could have broken.
+Both vitest budgets therefore widen on CI (`vitest.config.ts`, GitHub Actions sets `CI=true`):
+`testTimeout` 15 s → 60 s, and since #458 `hookTimeout` likewise — before that it sat on vitest's
+10 s default, six times tighter than the tests, and two of the five windows flakes investigated in
+#458 were hook timeouts rather than test timeouts. Neither widening loosens any evidence: timing
+PROOFS live in explicit assertions (the FTS 500 ms bound, #84), never in a vitest budget, and a
+hook is setup. Locally both stay at 15 s so a real hang still fails fast at the desk.
+**A hand-rolled wall-clock bound does NOT widen with them** — a `Date.now() - start > N` poll
+guard, a fixture's own `waitFor` default, or a child-process `timeout` is invisible to vitest's
+config, so each one needs its own CI headroom (`doctasks-translation.test.ts` says so at its
+30 s hang detector). Prefer asserting what a deadline GUARANTEES (a bound, an exclusion) over how
+far concurrent work got inside it; the latter is a property of the runner, not of the code (#457,
+#389).
+
 **What CI does NOT cover — the manual `HILBERTRAUM_*` matrix stays a separate human gate.** A green
 CI run says **nothing** about the real-`spawn` / real-binary / real-weights surface: that is the
 `HILBERTRAUM_*` manual harness matrix below (audit M-A5), which is env-gated and skips in CI. CI is


### PR DESCRIPTION
Step **1 of 3** for #458. The decision record for the whole wave is [this comment on #458](https://github.com/HilbertraumAI/HilbertRaum/issues/458#issuecomment-5641761307).

## What this changes

One config property: `hookTimeout: process.env.CI ? 60_000 : 15_000` in `apps/desktop/vitest.config.ts`, mirroring the `testTimeout` line directly above it.

## Why

`testTimeout` has widened to 60 s on CI for a while, behind a long comment about endemic starvation on the windows runners. `hookTimeout` was never set, so **hooks ran on vitest's 10 s default — six times tighter than the tests — on exactly the platform that comment is about.**

Investigating #458 turned up **five** windows flakes rather than the three in the issue, and **two of the five were hook timeouts, not test timeouts**:

| run | leg | failure |
|---|---|---|
| `34655007954` | windows 22.x | `performance-gpu.test.ts` — `Hook timed out in 10000ms` (**after #457 merged**) |
| `34543501694` | windows 24.x | `doctasks-translation.test.ts` — `Hook timed out in 10000ms` |
| `34540466043` | windows 22.x | model-verify `cancellable verification (#420)` — `Test timed out in 60000ms` |

The hooks are not slow. `performance-gpu`'s `beforeEach` is five synchronous resets — 10 s on that is a fork that got no CPU, which no amount of hook optimisation fixes. vitest runs `availableParallelism() - 1` forks (`createForksPool`, 3.2.6), so on a 4-core runner three forks plus the main process fill the machine before Defender and the runner agent take their share.

This was already known in-tree and patched one hook at a time: `tests/setup-temp-roots.ts` carries its own `TEARDOWN_TIMEOUT_MS = 120_000`, citing run `34033122353` as the starved-windows hook that tripped the 10 s budget. This generalises that fix rather than waiting for each hook to be bitten.

## Why this is not "hiding the problem"

The objection raised on the issue was that raising timeouts hides starvation and that slow hooks are usually real setup cost. Neither applies:

- **It loosens no evidence.** A hook is setup, never a timing proof. Every timing proof in this suite lives in an explicit assertion (the FTS 500 ms bound, #84), and nothing anywhere asserts a hook timeout — checked: no assertions on it, and no hook carries its own budget except the 120 s one above.
- **Locally nothing relaxes.** The desk value is 15 s, matching `testTimeout`, so a genuine hang still fails fast. Only CI widens.
- **It is not the whole fix, and does not claim to be.** Step 2 (sharding + a shard-aware `FullSuiteGuard`) addresses exposure; step 3 sweeps the hand-rolled bounds. This step removes the single most common observed failure mode.

The only cost: a genuinely hung hook now takes 60 s to fail on CI instead of 10 s.

## Docs

- `docs/packaging.md` — the CI section gains a paragraph on the leg budget with the measured per-phase numbers, both CI-aware vitest budgets and why, and the warning that **a hand-rolled wall-clock bound does not widen with them** (a `Date.now()` poll guard, a fixture `waitFor` default, a child-process `timeout`).
- `BUILD_STATE.md` — dated entry, `#458 OPEN (1 of 3)`, with the decision and the rejected options.

## Note for whoever takes step 2

- The `BUILD_STATE.md` preamble is now **exactly at its 200-line budget**. The next entry needs a closed one retired to `docs/build-log.md` first — the retention rule's "MOVE, don't raise".
- `--shard` will fail the `FullSuiteGuard` on **every** run (`isFullRun` stays true, so it demands all 449 files), and splitting by folder instead **silently disables** the guard. Fix the guard in the same PR; vitest's split reproduces exactly (225 + 224 = 449, no overlap).

Split out of this wave: **#460** (99 of 129 `openDatabase()` suites never close the handle — hygiene, measured at ~1.5 s/run, explicitly *not* a CI-time lever).

## Verification

- `npm run typecheck` green.
- `npm test` green locally (449 files).
- CI is the real test of the change, since the new value only takes effect when `CI=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
