### PR TITLE
ci(458): shard the windows legs, and make the guard shard-aware (2 of 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,20 +49,52 @@ env:
 
 jobs:
   build-and-test:
-    name: build-and-test
+    # Explicit per-leg name, because the legs are no longer a plain OS x node cross-product
+    # (see the matrix below) and the auto-generated names would read
+    # "(windows-latest, 22.x, --shard=1/2)".
+    name: build-and-test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     strategy:
       # Report every leg even if one fails — the ci-success gate below aggregates them
       # (a matrix job's `result` is success only when ALL legs succeeded).
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        # BOTH ends of the supported range, because both were previously untested claims
-        # (AUD-26): 22.x is the `engines.node >=22.12` floor the app promises to run on
-        # (raised from 22.5 by Electron 43, wave DEP-4), 24.x is what every release leg builds
-        # AND runs the full suite under. CI gating only one of them leaves the other a
-        # declaration nothing exercises.
-        node: ['22.x', '24.x']
+        # Spelled out with `include` only, because the legs are deliberately ASYMMETRIC: the
+        # windows legs are SHARDED, the ubuntu ones are not (#458 step 2).
+        #
+        # BOTH ends of the supported range are gated on both platforms, because both were
+        # previously untested claims (AUD-26): 22.x is the `engines.node >=22.12` floor the app
+        # promises to run on (raised from 22.5 by Electron 43, wave DEP-4), 24.x is what every
+        # release leg builds AND runs the full suite under. CI gating only one of them leaves
+        # the other a declaration nothing exercises.
+        #
+        # WHY THE WINDOWS LEGS ARE SPLIT (#458). The `npm test` step was 483–542 s of a 10–14
+        # min windows leg while the ubuntu legs finished in ~5 min with room to spare, so the
+        # windows legs ran AT their time budget: the same suite on one tree measured 486 s green
+        # and 694/802 s on the runs that failed, and whichever file was unlucky on a starved
+        # worker failed a run no code change could have broken (five flakes in two days, each
+        # costing a full re-run). Two shards halve the wall clock, and with it the window in
+        # which a noisy neighbour can hit. Runner minutes are free on a public repo, so the
+        # extra jobs cost nothing but queue time. See docs/packaging.md, the CI section.
+        #
+        # Sharding halves EXPOSURE, not crowding: each shard still runs `availableParallelism()
+        # - 1` forks on a 4-core runner. Widening the vitest budgets (step 1, `hookTimeout` /
+        # `testTimeout`) is what buys tolerance; these two changes address different halves.
+        #
+        # WHY UBUNTU STAYS WHOLE — not just cost. One leg per node version still runs all 449
+        # files in a SINGLE vitest process, so cross-file interference (shared module state, a
+        # leaked global, an ordering dependency) keeps a leg that can see it. A fully sharded
+        # matrix would partition that surface away on every leg at once.
+        #
+        # Adding or renaming a leg is safe: `ci-success` below is the only required check and
+        # aggregates whatever legs exist. NEVER mark a leg's own name required.
+        include:
+          - { label: 'ubuntu 22.x',           os: ubuntu-latest,  node: '22.x' }
+          - { label: 'ubuntu 24.x',           os: ubuntu-latest,  node: '24.x' }
+          - { label: 'windows 22.x, 1 of 2',  os: windows-latest, node: '22.x', shard: '--shard=1/2' }
+          - { label: 'windows 22.x, 2 of 2',  os: windows-latest, node: '22.x', shard: '--shard=2/2' }
+          - { label: 'windows 24.x, 1 of 2',  os: windows-latest, node: '24.x', shard: '--shard=1/2' }
+          - { label: 'windows 24.x, 2 of 2',  os: windows-latest, node: '24.x', shard: '--shard=2/2' }
 
     steps:
       - name: Checkout
@@ -97,13 +129,23 @@ jobs:
       - name: Build
         run: npm run build
 
+      # `matrix.shard` is `--shard=i/2` on the windows legs and UNSET (empty) on the ubuntu
+      # ones, which run the whole suite. `npm test --` with nothing after it forwards nothing,
+      # so one step serves both shapes.
+      #
+      # The suite's anti-false-green reporter is shard-aware (tests/full-suite-guard.ts): it
+      # narrows to the shard's expected subset by reproducing vitest's own split, so a dropped
+      # file still hard-fails whichever shard owned it. Do NOT "shard" by passing a path
+      # (`npm test -- tests/unit`) — a positional reads as a filter and switches that guard
+      # off silently, which is the one failure mode it exists to prevent.
       - name: Test
-        run: npm test
+        run: npm test -- ${{ matrix.shard }}
 
   # Single stable gate to mark as the branch-protection required status check. The matrix legs
-  # publish as "build-and-test (ubuntu-latest, 22.x)" / "(windows-latest, 24.x)" / … — names that
-  # shift whenever the OS labels or the Node list change; "ci-success" does not, so it stays
-  # matched in branch protection. Never add a leg's own name as a required check.
+  # publish as "build-and-test (ubuntu 22.x)" / "(windows 24.x, 1 of 2)" / … — names that shift
+  # whenever the OS labels, the Node list or the SHARD COUNT change (#458 step 2 renamed all six
+  # of them); "ci-success" does not, so it stays matched in branch protection. Never add a leg's
+  # own name as a required check.
   ci-success:
     name: ci-success
     runs-on: ubuntu-latest

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,12 +28,18 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
-_2026-09-12 — **#458 OPEN (1 of 3) — windows CI: `hookTimeout` is now CI-aware** (`fix/458-ci-hook-timeout`; record `packaging.md` "Continuous
-integration (CI)"; decision + full evidence in the issue comment). **Five** windows flakes, not three, and #457 did not end them; `testTimeout`
-widened to 60 s on CI long ago but `hookTimeout` never did (vitest's 10 s default, 6× tighter) and **2 of the 5 were hook timeouts** — structural,
-not slow setup: 3 forks + main fill a 4-core runner. Decision = **shard the windows legs**; dropping a node version rejected (22.x is the `engines`
-floor AND carries 4 of 5), temp-root churn rejected on measurement (~1.5 s/run; refiled as hygiene — 99/129 `openDatabase()` suites never close).
-Next: (2) shard 2× + **shard-aware `FullSuiteGuard`** (`--shard` leaves `isFullRun` true → it fails every sharded run; a folder split silently DISABLES it). (3) the **29 hand-rolled `Date.now()` poll bounds across 16 files** + `zim-arm.test.ts:672` — never widen with the vitest budget._
+_2026-09-12 — **#458 OPEN (2 of 3 done) — the windows CI legs: CI-aware `hookTimeout`, then sharded** (`fix/458-ci-hook-timeout` PR #461;
+`fix/458-shard-windows-legs`; record `packaging.md` "Continuous integration (CI)"; decision + full evidence in the issue comment).
+Investigated: **five** windows flakes, not three, and #457 did not end them; windows 22.x carried 4 of 5. **(1)** `testTimeout` widened to 60 s
+on CI long ago but `hookTimeout` never did (vitest's 10 s default, 6× tighter) and **2 of the 5 were hook timeouts** — structural, not slow
+setup: 3 forks + main fill a 4-core runner. **(2)** Each windows leg is now two `--shard` jobs (6 legs; ubuntu stays WHOLE so one leg per node
+version still sees cross-file interference). `FullSuiteGuard` is shard-aware or it fails every sharded run — and a folder split would silently
+DISABLE it instead. The split is hashed over `/` + the **posix** path (vitest resolves with pathe): a native-`resolve` reproduction agreed with a
+real run on 109 of 225 files, i.e. chance — caught by running the shards, now pinned with sha1 vectors. Rejected: dropping a node version (22.x
+is the `engines` floor AND carried 4 of 5); temp-root churn on measurement (~1.5 s/run — refiled as **#460**, 99/129 `openDatabase()` suites
+never close). Sharding halves EXPOSURE, not crowding — the budgets buy tolerance. Next: **(3)** the **29 hand-rolled `Date.now()` poll bounds
+across 16 files** + `zim-arm.test.ts:672`; a hand-rolled bound never widens with the vitest budget. Acceptance ("green on a first push, sampled
+over a week") is judged after (2) lands, not from one green run._
 _2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._
@@ -130,15 +136,6 @@ repo About text + `zim`/`kiwix`/`wikipedia`/`offline` topics, a v0.1.60 release 
 `[Unreleased]`; v0.1.59 predates the wave), a first screenshot, the org profile README. The follow-up PR #441 adds the repo's
 first `.github/ISSUE_TEMPLATE/`: a knowledge-pack report form asking for the facts that decide those reports, and a `config.yml`
 that keeps blank issues one click away and routes vulnerabilities to the private advisory channel._
-_2026-09-09 — **#333 CLOSED — measured, no cache** (instrumented on `perf/333-manifest-read-instrumentation`, PR #431; record
-`benchmark.md` §4 **I5** + Perf marks "`discover_manifests` / `performance_get` — the #333 pair"; evidence
-`eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-333-measurement.txt`): on the drive, cold (eject/replug ×3:
-90.3 / 75.6 / 92.2 ms) and end to end through the app (20 reads: median **27 ms**, scan 18 of it, ~9 ms settings + detectSystem).
-Owner decision: acceptable as measured. A cache saves 18 ms on a pushed screen, would not have touched the 116 ms tail (that read's
-scan was 15 ms — the rest was the settings read contending with the benchmark's drive probe), and the screen is a minority caller
-(66 scans vs 20 reads). Corrections on record: the old ~100 ms was the INTERNAL disk while the launchers point
-`HILBERTRAUM_MANIFESTS_DIR` at the drive's copy; the cost is CPU (82 % parse+validate) not media; and the app has ONE window, so the
-per-chat-answer exposure is smaller than the pre-measurement analysis claimed. Instrumentation kept._
 _2026-09-08 — **#339 Range-first article reads (`fix/339-range-first-article-read`), record `rag-design.md` §17 **D-Z22**:**
 every `/raw` article request (and the redirect hop) now carries `Range: bytes=0-`, which libkiwix serves through its 16 KiB
 callback reader instead of the one-buffer path that carries the win-x86_64 cut-short defect — so the app stops TRIGGERING an
@@ -151,11 +148,6 @@ so 1,000 ms stands, not 1,500; 60 real article opens through the shipped client 
 0 + 0 at 19.9 ms/open**. Suite 423 files / 7,065 (+14 legs). Evidence: `ai_drive-archive/zim-wave-2026-09/evidence/range-fix-2026-09-08/`.
 The three closed ZIM wave entries (#301 / the follow-up wave / the open-issues wave) are retired verbatim to `docs/build-log.md`
 "2026-09-08 — the three closed ZIM knowledge-pack wave entries"; §5 item 21 holds what is still open (all of it the owner's)._
-_2026-09-07 — **#318 hardware session CLOSED (`docs/318-hardware-verification`):** six machines, legs 1–5 + 7 with
-the app's own argv; every §6.6 verdict held (8 GB: 9B 31/33 → 4B ★; 12 GB: Gemma 49/49; sub-gate 6 GB laptop: E2B 36/36
-on the card anyway; 24 GB: Q4 66/66, Q5 62/66 under rung 1a yet 66/66 with `-np 1` or MTP off). Leg 6 (20 GB) and an
-Intel-first hybrid do not exist in the project → predicted by inference. Record + six findings: `model-benchmarks.md`
-§6.6 "Hardware verification"; evidence `eval/results/hardware/<slug>/`; routed to #319/#320/#321/#329/#332; §5 item 22 (e)–(k)._
 _2026-09-07 — **#372 (the #312 follow-up; `fix/372-model-load-latch`):** a model the ladder blamed is latched for the session
 (`factory.ts` module state beside the #182 latch): its next start spawns no rung, re-fires the model-named notice and lands on the
 mock at once — no repeated 180 s health timeouts. With acceleration off / auto-disabled (no GPU rung to compare against) every rung
@@ -193,7 +185,8 @@ budget), and the Phase 9b close-out (PR #282), Model library UX (PR #302) and #2
 entries on 2026-09-09 (preamble budget, making room for the knowledge-packs docs and #331
 HW3-acceptance entries), and the three closed 2026-09-06 entries (the #303 follow-up wave, the PR #308
 audit remediation, the PR #303 audit remediation) on 2026-09-10 (preamble budget, making room for the
-#436/#437 accessibility entry) —
+#436/#437 accessibility entry), and the two oldest closed entries (#333 manifest-read cost, #318
+hardware session) on 2026-09-12 (preamble budget, making room for the #458 CI entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/apps/desktop/tests/full-suite-guard.ts
+++ b/apps/desktop/tests/full-suite-guard.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readdirSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import type { File, Reporter } from 'vitest'
@@ -47,4 +48,81 @@ export class FullSuiteGuard implements Reporter {
     // A throw from onFinished is the only mechanism that reliably forces a non-zero exit.
     throw new Error(msg)
   }
+}
+
+// ---- Sharding (#458 step 2) ---------------------------------------------------------------
+//
+// The windows legs run at their time budget, so CI splits each of them into `--shard` jobs.
+// That breaks the gate above unless the guard knows about it: `--shard=1/2` is a FLAG, so
+// `isFullRun` in vitest.config.ts stays true and the guard would demand all 449 files from a
+// job that legitimately collected half — a hard failure on EVERY sharded run.
+//
+// Note the alternative is worse, which is why this code exists rather than a folder split:
+// `vitest run tests/unit` passes a POSITIONAL, so `isFullRun` goes false and the guard
+// silently NO-OPS. Splitting the suite that way would quietly retire the very false-green
+// protection this file exists for, with no signal. Shard; never split by path.
+//
+// So reproduce vitest's own split and assert the shard's expected SUBSET. The union of the
+// shards is still every file, so nothing is given up: a dropped file fails whichever shard
+// owned it. Kept deliberately faithful to vitest 3.2.6 `BaseSequencer.shard`:
+//
+//   const shardSize = Math.ceil(files.length / count)
+//   files.map((spec) => ({ spec, hash: hash('sha1', specPath, 'hex') }))
+//        .sort(byHashAscending)
+//        .slice(shardSize * (index - 1), shardSize * index)
+//
+// The one detail that matters, and that cost a wrong first implementation here: `specPath` is
+//
+//   pathe.resolve(slash(config.root), slash(spec.moduleId)).slice(config.root.length)
+//
+// and vitest's `resolve` is **pathe**, which always returns POSIX paths — while vite has
+// already normalised `config.root` to POSIX too. So the hashed string is simply the
+// root-relative path with forward slashes and a leading one, `/tests/unit/x.test.ts`, on
+// EVERY platform, and the split is therefore platform-independent. Reproducing it with
+// node's native `path.resolve` looks equivalent and is not: on windows it hashes
+// `\tests\unit\x.test.ts` and assigns a completely different half (verified — it agreed with
+// vitest on 109 of 225 files, i.e. chance). `hash()` itself is `crypto.hash ?? createHash`,
+// both plain sha1-hex.
+//
+// Verified against a real `vitest run --shard=1/2` on windows: this helper's shard 1 contains
+// all 213 files that run actually executed (`shard-split` cases below pin the properties).
+// If a vitest upgrade changes the algorithm the sharded legs fail loudly and together — the
+// guard over-reporting missing files, never a false green.
+
+export interface Shard {
+  index: number
+  count: number
+}
+
+/**
+ * `--shard=1/2`, `--shard 1/2` or `--shard=2` → `{ index, count }`; `null` when absent or not
+ * parseable. A malformed value returns null so the guard falls back to whole-suite enforcement
+ * (fail safe: over-strict, never silently off) and vitest reports the bad flag itself.
+ */
+export function parseShard(argv: readonly string[]): Shard | null {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg !== '--shard' && !arg.startsWith('--shard=')) continue
+    const raw = arg.startsWith('--shard=') ? arg.slice('--shard='.length) : (argv[i + 1] ?? '')
+    const m = /^(\d+)(?:\/(\d+))?$/.exec(raw.trim())
+    if (!m) return null
+    const index = Number(m[1])
+    const count = m[2] === undefined ? 1 : Number(m[2])
+    if (count < 1 || index < 1 || index > count) return null
+    return { index, count }
+  }
+  return null
+}
+
+/**
+ * The subset of `files` — posix-relative paths as `listTestFiles` returns them — that vitest's
+ * sequencer assigns to `shard`. Order is vitest's (hash-ascending), not the input order.
+ */
+export function shardTestFiles(files: readonly string[], shard: Shard): string[] {
+  const shardSize = Math.ceil(files.length / shard.count)
+  return [...files]
+    .map((file) => ({ file, hash: createHash('sha1').update(`/${file}`).digest('hex') }))
+    .sort((a, b) => (a.hash < b.hash ? -1 : a.hash > b.hash ? 1 : 0))
+    .slice(shardSize * (shard.index - 1), shardSize * shard.index)
+    .map(({ file }) => file)
 }

--- a/apps/desktop/tests/unit/full-suite-guard.test.ts
+++ b/apps/desktop/tests/unit/full-suite-guard.test.ts
@@ -1,7 +1,11 @@
+import { createHash } from 'node:crypto'
 import { resolve } from 'node:path'
 import type { File } from 'vitest'
 import { describe, expect, it } from 'vitest'
-import { FullSuiteGuard, listTestFiles } from '../full-suite-guard'
+import { FullSuiteGuard, listTestFiles, parseShard, shardTestFiles } from '../full-suite-guard'
+
+/** A literal backslash, spelled without one so no codegen pass can mangle it. */
+const BACKSLASH = String.fromCharCode(92)
 
 const file = (name: string): File => ({ name }) as File
 
@@ -40,5 +44,101 @@ describe('FullSuiteGuard', () => {
   it('no-ops on a filtered/subset run (expected = null), never false-failing', () => {
     const guard = new FullSuiteGuard(null)
     expect(() => guard.onFinished([])).not.toThrow()
+  })
+})
+
+// ---- Sharding (#458 step 2) ----------------------------------------------------------------
+
+describe('parseShard', () => {
+  it('reads the `=` form CI uses, and the space form', () => {
+    expect(parseShard(['--shard=1/2'])).toEqual({ index: 1, count: 2 })
+    expect(parseShard(['--shard', '2/2'])).toEqual({ index: 2, count: 2 })
+    expect(parseShard(['--reporter=dot', '--shard=3/4', '--bail=1'])).toEqual({ index: 3, count: 4 })
+  })
+
+  it('treats a bare count as 1/1 (vitest accepts `--shard=1`)', () => {
+    expect(parseShard(['--shard=1'])).toEqual({ index: 1, count: 1 })
+  })
+
+  it('is null when absent, so the guard enforces the whole suite', () => {
+    expect(parseShard([])).toBeNull()
+    expect(parseShard(['--reporter=dot'])).toBeNull()
+  })
+
+  // Fail SAFE: an unparseable shard must not narrow the expected set to a lucky subset —
+  // null means "enforce everything", which over-reports rather than passing a dropped file.
+  it('is null for a malformed or out-of-range value (over-strict, never silently off)', () => {
+    for (const bad of ['--shard=0/2', '--shard=3/2', '--shard=2/0', '--shard=a/b', '--shard=/2', '--shard=1/2/3', '--shard=-1/2']) {
+      expect(parseShard([bad]), bad).toBeNull()
+    }
+    expect(parseShard(['--shard'])).toBeNull() // flag with no value
+  })
+})
+
+describe('shardTestFiles — reproduces vitest 3.2.6 BaseSequencer.shard', () => {
+  const root = resolve(__dirname, '..', '..')
+  const files = listTestFiles(root, resolve(root, 'tests'))
+
+  it('splits the real suite into a complete, disjoint cover', () => {
+    for (const count of [2, 3, 4]) {
+      const shards = Array.from({ length: count }, (_, i) => shardTestFiles(files, { index: i + 1, count }))
+      expect(new Set(shards.flat()).size, `count=${count} union`).toBe(files.length)
+      expect(shards.reduce((n, s) => n + s.length, 0), `count=${count} no overlap`).toBe(files.length)
+      // vitest's `ceil` slice: every shard is full except possibly the last.
+      expect(shards.slice(0, -1).every((s) => s.length === Math.ceil(files.length / count)), `count=${count} sizes`).toBe(true)
+    }
+  })
+
+  it('a single shard is the whole suite', () => {
+    expect(shardTestFiles(files, { index: 1, count: 1 }).sort()).toEqual([...files].sort())
+  })
+
+  it('returns input (posix) paths, so the result compares to what the reporter collects', () => {
+    const shard = shardTestFiles(files, { index: 1, count: 2 })
+    expect(shard.every((f) => !f.includes(BACKSLASH))).toBe(true)
+    expect(shard.every((f) => files.includes(f))).toBe(true)
+  })
+
+  it('is stable: the same shard twice is the same list', () => {
+    expect(shardTestFiles(files, { index: 2, count: 3 })).toEqual(shardTestFiles(files, { index: 2, count: 3 }))
+  })
+
+  // THE regression test for this helper. vitest hashes `/` + the POSIX root-relative path
+  // (its `resolve` is pathe, which normalises away from `\` on windows), so the split is the
+  // same on every platform. A native-separator implementation type-checks, looks equivalent,
+  // and silently assigns a different half — it agreed with a real `--shard=1/2` run on only
+  // 109 of 225 files, i.e. chance. These fixed vectors pin the exact hashed string, so that
+  // mistake cannot come back unnoticed on a machine where `sep === '/'`.
+  it('hashes `/` + the posix path — pinned against sha1 vectors, platform-independent', () => {
+    const sha1 = (s: string): string => createHash('sha1').update(s).digest('hex')
+    // Two files whose relative order under the real algorithm is fixed by these digests.
+    const sample = ['tests/unit/a.test.ts', 'tests/unit/b.test.ts']
+    const byHash = [...sample].sort((x, y) => (sha1(`/${x}`) < sha1(`/${y}`) ? -1 : 1))
+    expect(shardTestFiles(sample, { index: 1, count: 2 })).toEqual([byHash[0]])
+    expect(shardTestFiles(sample, { index: 2, count: 2 })).toEqual([byHash[1]])
+    // And NOT the native-separator variant, on any platform.
+    const nat = (f: string): string => BACKSLASH + f.split('/').join(BACKSLASH)
+    const byNativeHash = [...sample].sort((x, y) => (sha1(nat(x)) < sha1(nat(y)) ? -1 : 1))
+    if (byNativeHash[0] !== byHash[0]) {
+      expect(shardTestFiles(sample, { index: 1, count: 2 })).not.toEqual([byNativeHash[0]])
+    }
+  })
+})
+
+describe('FullSuiteGuard under sharding', () => {
+  const root = resolve(__dirname, '..', '..')
+  const files = listTestFiles(root, resolve(root, 'tests'))
+
+  it('passes when a shard collected exactly its own subset, and fails when that shard drops one', () => {
+    const mine = shardTestFiles(files, { index: 1, count: 2 })
+    expect(() => new FullSuiteGuard(mine).onFinished(mine.map(file))).not.toThrow()
+    expect(() => new FullSuiteGuard(mine).onFinished(mine.slice(1).map(file))).toThrow(/were dropped/)
+  })
+
+  // The failure this whole section exists to prevent: enforcing the WHOLE suite against a
+  // shard. Pinned so nobody "simplifies" the config back to passing `allTestFiles`.
+  it('would fail every sharded run if handed the whole suite instead of the shard', () => {
+    const mine = shardTestFiles(files, { index: 1, count: 2 })
+    expect(() => new FullSuiteGuard(files).onFinished(mine.map(file))).toThrow(/were dropped/)
   })
 })

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
-import { FullSuiteGuard, listTestFiles } from './tests/full-suite-guard'
+import { FullSuiteGuard, listTestFiles, parseShard, shardTestFiles } from './tests/full-suite-guard'
 
 // Default environment is node (the bulk of the suite tests main-process services). Renderer
 // component tests opt into jsdom per-file with a `// @vitest-environment jsdom` docblock and
@@ -10,9 +10,21 @@ import { FullSuiteGuard, listTestFiles } from './tests/full-suite-guard'
 // run: vitest's argv after the `run` subcommand is flags-only for a full run, so any positional
 // (a path/name filter via `npm test -- tests/unit`) means "subset" and disables the guard. The
 // gate fails safe — an unrecognised invocation disables the guard rather than false-failing.
+//
+// A SHARDED run (#458 step 2: the windows legs are split) is still a full run, just divided,
+// so the guard stays on and narrows to the shard's expected subset — `shardTestFiles`
+// reproduces vitest's own split. Without that it would demand all 449 files from a job that
+// correctly collected half, failing every sharded run.
+//
+// `--shard 1/2` (space form) puts its VALUE in argv looking exactly like a path filter, which
+// would switch the guard off instead of narrowing it — silently, the one failure mode this
+// file cannot tolerate. So the positional check skips a `--shard` value. CI uses the `=` form.
 const runArgs = process.argv.slice(process.argv.indexOf('run') + 1)
-const isFullRun = process.argv.includes('run') && !runArgs.some((a) => !a.startsWith('-'))
-const expectedFiles = isFullRun ? listTestFiles(__dirname, resolve(__dirname, 'tests')) : null
+const shard = parseShard(runArgs)
+const positionals = runArgs.filter((a, i) => !a.startsWith('-') && runArgs[i - 1] !== '--shard')
+const isFullRun = process.argv.includes('run') && positionals.length === 0
+const allTestFiles = isFullRun ? listTestFiles(__dirname, resolve(__dirname, 'tests')) : null
+const expectedFiles = allTestFiles && shard ? shardTestFiles(allTestFiles, shard) : allTestFiles
 
 export default defineConfig({
   resolve: {

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,29 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-12 — the two oldest closed dated entries retired verbatim (#333, #318 — preamble budget)
+
+Retired from `BUILD_STATE.md` on 2026-09-12 to make room for the #458 CI entries (the preamble was
+at its 200-line budget; the retention rule is "MOVE, don't raise"). Both rounds are CLOSED and their
+durable records live on: #333 in `benchmark.md` §4 **I5**, #318 in `model-benchmarks.md` §6.6
+"Hardware verification". Citations of the form "BUILD_STATE 2026-09-09 entry" / "2026-09-07 entry"
+for these two resolve here. Text below is byte-identical to what was removed.
+
+_2026-09-09 — **#333 CLOSED — measured, no cache** (instrumented on `perf/333-manifest-read-instrumentation`, PR #431; record
+`benchmark.md` §4 **I5** + Perf marks "`discover_manifests` / `performance_get` — the #333 pair"; evidence
+`eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/manifest-read-333-measurement.txt`): on the drive, cold (eject/replug ×3:
+90.3 / 75.6 / 92.2 ms) and end to end through the app (20 reads: median **27 ms**, scan 18 of it, ~9 ms settings + detectSystem).
+Owner decision: acceptable as measured. A cache saves 18 ms on a pushed screen, would not have touched the 116 ms tail (that read's
+scan was 15 ms — the rest was the settings read contending with the benchmark's drive probe), and the screen is a minority caller
+(66 scans vs 20 reads). Corrections on record: the old ~100 ms was the INTERNAL disk while the launchers point
+`HILBERTRAUM_MANIFESTS_DIR` at the drive's copy; the cost is CPU (82 % parse+validate) not media; and the app has ONE window, so the
+per-chat-answer exposure is smaller than the pre-measurement analysis claimed. Instrumentation kept._
+_2026-09-07 — **#318 hardware session CLOSED (`docs/318-hardware-verification`):** six machines, legs 1–5 + 7 with
+the app's own argv; every §6.6 verdict held (8 GB: 9B 31/33 → 4B ★; 12 GB: Gemma 49/49; sub-gate 6 GB laptop: E2B 36/36
+on the card anyway; 24 GB: Q4 66/66, Q5 62/66 under rung 1a yet 66/66 with `-np 1` or MTP off). Leg 6 (20 GB) and an
+Intel-first hybrid do not exist in the project → predicted by inference. Record + six findings: `model-benchmarks.md`
+§6.6 "Hardware verification"; evidence `eval/results/hardware/<slug>/`; routed to #319/#320/#321/#329/#332; §5 item 22 (e)–(k)._
+
 ## 2026-09-10 — the three 2026-09-06 entries retired verbatim (preamble budget)
 
 _Moved out of `BUILD_STATE.md` while making room for the #436/#437 accessibility entry. All three

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -541,15 +541,50 @@ second-laptop continuity check.
 
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs the **exact pre-release command
 chain** — `npm ci` → `npm run typecheck` → `npm run build` → `npm test` — on every pull request
-and on pushes to `master`, across a matrix of **`ubuntu-latest` and `windows-latest`** (Windows is
+and on pushes to `master`, on **`ubuntu-latest` and `windows-latest`** (Windows is
 first-class for this project) × **Node `22.x` and `24.x`**. It is the machine
 backstop the audit asked for (TEST-N1): before CI, the suite was green only by author discipline,
 and the repo's own anti-false-green check ([`tests/full-suite-guard.ts`](../apps/desktop/tests/full-suite-guard.ts))
-only mattered if something ran it. CI runs the four matrix legs (`build-and-test
-(ubuntu-latest, 22.x)` / `(windows-latest, 24.x)` / …) plus a tiny **`ci-success`** aggregate job
-that passes only when **every** leg passes — mark **`ci-success`** the **required status check** on
-`master`. Its name is stable even if the matrix labels change later, so branch protection never
-silently stops matching; never mark an individual leg required.
+only mattered if something ran it. The legs are **deliberately asymmetric since #458**: each
+windows leg is **split into two `--shard` jobs**, the ubuntu legs run the whole suite. So six legs
+(`build-and-test (ubuntu 22.x)` / `(windows 24.x, 1 of 2)` / …) plus a tiny **`ci-success`**
+aggregate job that passes only when **every** leg passes — mark **`ci-success`** the **required
+status check** on `master`. Its name is stable even when the matrix labels, the Node list or the
+shard count change (#458 renamed all six legs), so branch protection never silently stops
+matching; never mark an individual leg required.
+
+**Why the windows legs are sharded and the ubuntu ones are not (#458).** The `npm test` step was
+483–542 s of a 10–14 min windows leg against ~5 min for a whole ubuntu leg, so the windows legs ran
+*at* their budget and any unlucky file failed a run no code change could have broken — five such
+flakes in two days, each costing a full re-run. Two shards halve the wall clock and with it the
+window a noisy neighbour can hit; runner minutes are free on a public repo, so the extra jobs cost
+only queue time. Note what sharding does **not** do: it halves *exposure*, not *crowding* — each
+shard still runs `availableParallelism() - 1` forks on a 4-core runner, so the CI-aware
+`testTimeout`/`hookTimeout` above remain what buys *tolerance*. The two changes address different
+halves of the same problem. **Ubuntu stays whole for a reason beyond cost:** one leg per Node
+version still runs all 449 files in a *single* vitest process, so cross-file interference (shared
+module state, a leaked global, an ordering dependency) keeps a leg that can still see it; a fully
+sharded matrix would partition that surface away everywhere at once.
+
+**The collection guard is shard-aware — and must stay that way.** `tests/full-suite-guard.ts`
+asserts vitest actually collected every file it should, which is what makes a silently dropped
+suite fail instead of passing by not running. A shard legitimately collects half, so the guard
+reproduces **vitest's own split** (`shardTestFiles`) and asserts the shard's expected subset; the
+union of the shards is still every file, so a dropped file fails whichever shard owned it. Two
+traps, both already paid for:
+
+- **Never "shard" by passing a path** (`npm test -- tests/unit`). A positional argument reads as a
+  filter, so the guard switches itself **off silently** — retiring the exact protection it exists
+  for, with no signal. `--shard` is a flag, so the guard stays on and merely narrows. The space
+  form `--shard 1/2` puts its value in argv looking like a path, which the config now skips
+  explicitly; CI uses `--shard=1/2`.
+- **The split is hashed over `/` + the POSIX root-relative path** — vitest resolves paths with
+  `pathe`, which normalises away from `\`, so the assignment is identical on every platform.
+  Reproducing it with node's native `path.resolve` type-checks and looks equivalent but hashes
+  `\tests\unit\x.test.ts` on Windows and assigns a different half: the first implementation here
+  did exactly that and agreed with a real `--shard=1/2` run on 109 of 225 files, i.e. chance.
+  Fixed sha1 vectors in `tests/unit/full-suite-guard.test.ts` pin the hashed string so the
+  mistake cannot return unnoticed on a machine where `sep === '/'`.
 
 **Why both Node majors, and why the explicit pinned-npm install (AUD-26).** The two versions are the
 two ends of what the repo *claims*, and each was previously an unexercised claim: `22.x` is the
@@ -606,22 +641,15 @@ a compromised action repo inject code into CI; full-audit 2026-07-10 SC-1). This
 telemetry/analytics, and performs no network egress beyond the registry install (the "no cloud /
 no telemetry" hard rule governs the shipped app at runtime).
 
-**The windows legs run at their time budget, and the vitest budgets are CI-aware because of it
-(#458).** On the same commit the ubuntu legs finish in ~5 min and the windows legs in 10–14; the
-`npm test` step is 483–542 s of that, while install + typecheck + build is only ~90 s, so the test
-step *is* the leg. The excess is concentrated in the tests themselves (2.2× ubuntu, measured
-per-phase), not in collection or setup (1.05–1.35×): vitest runs `availableParallelism() - 1`
-forks, so on a 4-core runner three forks plus the main process fill the machine before Defender
-and the runner agent take their share, and Windows file operations cost more per call. Run-to-run
-variance on a shared runner then decides the outcome — the same suite measured 486 s green and
-694/802 s on the runs that failed. Any fork can be descheduled for 10+ seconds, and whichever
-file is unlucky fails a run that no code change could have broken.
-Both vitest budgets therefore widen on CI (`vitest.config.ts`, GitHub Actions sets `CI=true`):
-`testTimeout` 15 s → 60 s, and since #458 `hookTimeout` likewise — before that it sat on vitest's
-10 s default, six times tighter than the tests, and two of the five windows flakes investigated in
-#458 were hook timeouts rather than test timeouts. Neither widening loosens any evidence: timing
-PROOFS live in explicit assertions (the FTS 500 ms bound, #84), never in a vitest budget, and a
-hook is setup. Locally both stay at 15 s so a real hang still fails fast at the desk.
+**Both vitest budgets are CI-aware, for the starvation described above (#458).** A fork on a
+saturated runner can be descheduled for 10+ seconds, so whichever file is unlucky fails a run no
+code change could have broken. The budgets therefore widen on CI (`vitest.config.ts`; GitHub
+Actions sets `CI=true`): `testTimeout` 15 s → 60 s, and since #458 `hookTimeout` likewise — before
+that it sat on vitest's 10 s default, six times tighter than the tests, and two of the five windows
+flakes investigated in #458 were hook timeouts rather than test timeouts. Neither widening loosens
+any evidence: timing PROOFS live in explicit assertions (the FTS 500 ms bound, #84), never in a
+vitest budget, and a hook is setup, not proof. Locally both stay at 15 s so a real hang still
+fails fast at the desk.
 **A hand-rolled wall-clock bound does NOT widen with them** — a `Date.now() - start > N` poll
 guard, a fixture's own `waitFor` default, or a child-process `timeout` is invisible to vitest's
 config, so each one needs its own CI headroom (`doctasks-translation.test.ts` says so at its


### PR DESCRIPTION
Step **2 of 3** for #458, the one the decision in [this comment](https://github.com/HilbertraumAI/HilbertRaum/issues/458#issuecomment-5641761307) actually turns on. Follows #461 (step 1, CI-aware `hookTimeout`).

## What changes

**Each windows leg becomes two `--shard` jobs; the ubuntu legs stay whole.** Six legs instead of four, named `build-and-test (ubuntu 22.x)` / `(windows 24.x, 1 of 2)` / … The matrix is spelled out with `include` only, because the legs are now deliberately asymmetric.

**`FullSuiteGuard` becomes shard-aware** — without this the change cannot ship at all (see below).

## Why sharding, and what it does *not* buy

The `npm test` step was 483–542 s of a 10–14 min windows leg against ~5 min for a whole ubuntu leg, so the windows legs ran *at* their budget and any unlucky file failed a run no code change could have broken. Two shards halve the wall clock and with it the window a noisy neighbour can hit. Runner minutes are free on a public repo, so the extra jobs cost only queue time.

Being explicit about the limit: **sharding halves *exposure*, not *crowding*.** Each shard still runs `availableParallelism() - 1` forks on a 4-core runner, so a test is just as likely to be starved at any instant — there are simply half as many instants. Step 1's widened budgets are what buy *tolerance*. The two changes address different halves of the same problem, and neither replaces the other.

**Ubuntu stays whole for a reason beyond cost.** One leg per Node version still runs all 449 files in a *single* vitest process, so cross-file interference (shared module state, a leaked global, an ordering dependency) keeps a leg that can still see it. A fully sharded matrix would partition that surface away everywhere at once.

## The guard, and the two traps

`tests/full-suite-guard.ts` is what makes a silently dropped suite fail instead of passing by not running. Sharding collides with it head-on:

- **`--shard=1/2` is a flag**, so `isFullRun` stays true and the guard would demand all **449** files from a job that correctly collected **225** — a hard failure on *every* sharded run. So the guard now reproduces vitest's split and asserts the shard's expected subset. The union of the shards is still every file, so a dropped file fails whichever shard owned it; nothing is given up.
- **Splitting by folder instead would have been worse.** `npm test -- tests/unit` passes a positional, which reads as a filter and switches the guard **off silently** — retiring the exact protection it exists for, with no signal. Documented in the workflow and the docs so nobody "simplifies" it that way later.

Also fixed a latent hole found on the way: the space form `--shard 1/2` put its value in argv looking exactly like a path filter, so it too would have silently disabled the guard. The positional check now skips a `--shard` value.

## The bug this nearly shipped with

My first implementation reproduced vitest's `specPath` with node's native `path.resolve`. It type-checked, the unit tests I wrote for it passed, and the complete/disjoint-cover property held — **and it was wrong.** Running the real shards caught it:

```
Full-suite collection guard FAILED: vitest collected 225 of 225 test files.
116 were dropped
```

Same *size*, different *members*. vitest resolves paths with `pathe`, which always normalises to POSIX, so the hashed string is `/tests/unit/x.test.ts` on every platform; the native version hashed `\tests\unit\x.test.ts` on Windows and assigned a different half — it agreed with the real run on 109 of 225 files, i.e. chance. Fitting candidate formulas against the 213 files that run actually executed identified the right one at 213/213.

Two lessons are now encoded rather than remembered: fixed sha1 vectors pin the exact hashed string (so the mistake cannot return unnoticed on a machine where `sep === '/'`), and the failure mode is written up in `packaging.md` and above the helper. Note the property tests alone would *not* have caught it — only running the shards did.

## Verification

- `npm run typecheck` green.
- `npx vitest run --shard=1/2` → **exit 0**, 225 files (214 passed, 11 skipped), 3,585 tests, guard satisfied.
- `npx vitest run --shard=2/2` → **exit 0**, 224 files (211 passed, 13 skipped), 3,658 tests, guard satisfied.
- 225 + 224 = **449**, no overlap. Test totals reconcile with the unsharded run exactly: +11 over the previous full run, which is precisely the 11 new guard cases.
- Unsharded `npm test` green (the gate change affects that path too).
- 16 cases in `tests/unit/full-suite-guard.test.ts`, including the sha1 vectors and a test asserting the guard *would* fail if handed the whole suite instead of the shard.
- Gate behaviour checked across all six invocation shapes: bare run and `--reporter=dot` enforce all 449; both `--shard` forms narrow; a path filter (with or without `--shard`) disables.

## Docs / BUILD_STATE

- `docs/packaging.md` — the CI section rewritten for the asymmetric matrix, plus a subsection on the shard-aware guard and both traps.
- `BUILD_STATE.md` — the #458 entry updated to cover steps 1–2 as one wave rather than adding a second entry.
- **Judgment call to flag:** the preamble was at its 200-line budget, so, per the retention rule's "MOVE, don't raise", I retired the two oldest explicitly-CLOSED entries (**#333** manifest-read cost, **#318** hardware session) verbatim to `docs/build-log.md`. I deliberately avoided the two 2026-09-07 entries (#372 and the #310–#315 wave) because the in-flight #438 branch retires those. Preamble is now 193/200, leaving room for step 3. Happy to swap which entries went if you'd rather keep those two live.

## Still open

Step **3**: the 29 hand-rolled `Date.now()` poll bounds across 16 files, plus `zim-arm.test.ts:672`. And the acceptance criterion ("green on a first push, sampled over a week") should be judged from a week of real PRs after this lands — not from this PR's own green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
