### PR TITLE
fix(458): the root test script must forward flags, or --shard is a no-op

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,16 @@ jobs:
         run: npm run build
 
       # `matrix.shard` is `--shard=i/2` on the windows legs and UNSET (empty) on the ubuntu
-      # ones, which run the whole suite. `npm test --` with nothing after it forwards nothing,
-      # so one step serves both shapes.
+      # ones, which run the whole suite. An empty expansion contributes NO argv element, so one
+      # step serves both shapes — verified, because an empty string WOULD have read as a path
+      # filter and silently switched the collection guard off on the ubuntu legs.
+      #
+      # This must stay `npm test`, and the root `test` script must keep its trailing `--`.
+      # THE FIRST SHARDED RUN SILENTLY DID NOTHING because of that: the root script forwards to
+      # the workspace (`npm run test --workspace apps/desktop`), and without a `--` the inner
+      # `npm run` ate `--shard=1/2` as an npm config ("npm warn Unknown cli config"), so all six
+      # legs ran the whole 449-file suite and merely looked slow. A POSITIONAL survives two npm
+      # layers; a FLAG does not. Run 34660709148 is the evidence — every leg reported "(449)".
       #
       # The suite's anti-false-green reporter is shard-aware (tests/full-suite-guard.ts): it
       # narrows to the shard's expected subset by reproducing vitest's own split, so a dropped

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -29,17 +29,18 @@
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
 _2026-09-12 — **#458 OPEN (2 of 3 done) — the windows CI legs: CI-aware `hookTimeout`, then sharded** (`fix/458-ci-hook-timeout` PR #461;
-`fix/458-shard-windows-legs`; record `packaging.md` "Continuous integration (CI)"; decision + full evidence in the issue comment).
+`fix/458-shard-windows-legs` PR #462; record `packaging.md` "Continuous integration (CI)"; decision + full evidence in the issue comment).
 Investigated: **five** windows flakes, not three, and #457 did not end them; windows 22.x carried 4 of 5. **(1)** `testTimeout` widened to 60 s
 on CI long ago but `hookTimeout` never did (vitest's 10 s default, 6× tighter) and **2 of the 5 were hook timeouts** — structural, not slow
 setup: 3 forks + main fill a 4-core runner. **(2)** Each windows leg is now two `--shard` jobs (6 legs; ubuntu stays WHOLE so one leg per node
 version still sees cross-file interference). `FullSuiteGuard` is shard-aware or it fails every sharded run — and a folder split would silently
-DISABLE it instead. The split is hashed over `/` + the **posix** path (vitest resolves with pathe): a native-`resolve` reproduction agreed with a
-real run on 109 of 225 files, i.e. chance — caught by running the shards, now pinned with sha1 vectors. Rejected: dropping a node version (22.x
-is the `engines` floor AND carried 4 of 5); temp-root churn on measurement (~1.5 s/run — refiled as **#460**, 99/129 `openDatabase()` suites
-never close). Sharding halves EXPOSURE, not crowding — the budgets buy tolerance. Next: **(3)** the **29 hand-rolled `Date.now()` poll bounds
-across 16 files** + `zim-arm.test.ts:672`; a hand-rolled bound never widens with the vitest budget. Acceptance ("green on a first push, sampled
-over a week") is judged after (2) lands, not from one green run._
+DISABLE it instead. TWO silent failures found by MEASURING, not reasoning: the split is hashed over `/` + the **posix** path (vitest resolves
+with pathe), so a native-`resolve` reproduction agreed with a real run on 109 of 225 files (chance) while every property test passed; and the
+first sharded CI run **did nothing at all** — the root `test` script forwarded to the workspace without a `--`, so npm ate `--shard` as a config
+and all six legs ran 449 files, merely looking slow (run 34660709148). Both now pinned (sha1 vectors; the trailing `--`). Rejected: dropping a
+node version (22.x is the `engines` floor AND carried 4 of 5); temp-root churn on measurement (~1.5 s/run — **#460**, 99/129 `openDatabase()`
+suites never close). Sharding halves EXPOSURE, not crowding — the budgets buy tolerance. Next: **(3)** the **29 hand-rolled `Date.now()` poll
+bounds across 16 files** + `zim-arm.test.ts:672`. Acceptance ("green on a first push over a week") is judged from real traffic after (2)._
 _2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -586,6 +586,17 @@ traps, both already paid for:
   Fixed sha1 vectors in `tests/unit/full-suite-guard.test.ts` pin the hashed string so the
   mistake cannot return unnoticed on a machine where `sep === '/'`.
 
+**Passing a flag through `npm test` needs the root script's trailing `--` (#458).** The root
+`test` script forwards to the workspace — `npm run test --workspace apps/desktop --` — and that
+trailing `--` is load-bearing. A **positional** survives two npm layers (`npm test -- tests/unit`
+has always worked), but a **flag** does not: without the `--`, the inner `npm run` swallows
+`--shard=1/2` as an npm config and only prints `npm warn Unknown cli config "--shard"`. The first
+sharded CI run hit exactly this and **silently did nothing** — all six legs ran the whole 449-file
+suite and merely looked slow (run `34660709148`; every leg reported `(449)`). Nothing failed,
+because the guard was correctly enforcing all 449 and all 449 had run. When adding a CI leg that
+passes vitest a flag, check the leg's `Test Files` line really shows the reduced count, and treat
+an `Unknown cli config` warning in a run log as an error.
+
 **Why both Node majors, and why the explicit pinned-npm install (AUD-26).** The two versions are the
 two ends of what the repo *claims*, and each was previously an unexercised claim: `22.x` is the
 `engines.node >= 22.12` floor the app promises to run on (raised from 22.5 by Electron 43 — wave

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "npm run dev --workspace apps/desktop",
     "build": "npm run build --workspace apps/desktop",
     "typecheck": "npm run typecheck --workspace apps/desktop",
-    "test": "npm run test --workspace apps/desktop",
+    "test": "npm run test --workspace apps/desktop --",
     "test:coverage": "npm run test:coverage --workspace apps/desktop",
     "package": "npm run package --workspace apps/desktop",
     "package:win": "npm run package:win --workspace apps/desktop"


### PR DESCRIPTION
**Urgent follow-up to #462 — master is currently worse off than before it merged.**

#462 was merged at `6dcc8bac`, which is the commit *before* the forwarding fix I pushed to that branch (`66674f2e`). Its merge parents are `5de7f5f7` + `6dcc8bac`, so master got the six-leg sharded matrix **without** the one-line change that makes the shard flag actually reach vitest. This PR cherry-picks that commit onto master. My fault for not flagging the timing loudly enough before the merge.

## What is wrong on master right now

The root script is `npm run test --workspace apps/desktop`, so the workflow's `npm test -- --shard=1/2` expands to `npm run test --workspace apps/desktop --shard=1/2`, and the **inner** `npm run` eats the flag as an npm config — it only prints `npm warn Unknown cli config "--shard"`. A *positional* survives two npm layers (`npm test -- tests/unit` has always worked); a *flag* does not.

So every one of the six legs runs the whole 449-file suite:

- **Before #462:** 4 legs, 2 of them full Windows suites. Critical path ~10–11 min.
- **On master now:** 6 legs, **4** of them full Windows suites. Critical path 13.3 min (measured, run `34660709148`), and ~50% more runner time for zero benefit.

Nothing fails, which is why it merged clean: the guard was correctly enforcing all 449 and all 449 had run.

## The fix

The root `test` script ends with `--`. `package-lock.json` untouched (issue #49).

Verified **through the real CI path** on master's tree — my earlier check ran `npx vitest run --shard=1/2` inside the workspace, which is not what CI does, and that is exactly what let this through:

```
> npm run test --workspace apps/desktop -- --shard=1/2 --reporter=dot
> vitest run --shard=1/2
  Test Files  213 passed | 11 skipped (225)
```

**225 files, not 449**, and no npm warning. Bare `npm test` still resolves to a clean `vitest run` with no stray `--` (449 files, 7,157 passed / 85 skipped, verified before the previous push).

Also carried in this cherry-pick: the write-ups in `packaging.md` and above the workflow's Test step — check a sharded leg's `Test Files` line really shows the reduced count, and treat an `Unknown cli config` warning in a run log as an error — plus the updated `#458` BUILD_STATE entry.

## One local failure, disclosed and not caused by this

`tests/unit/zim-client.test.ts` (the 8 MiB body ceiling cases) failed with `read ECONNRESET` in my local sharded runs. It passes **63/63 alone**, passed in both full unsharded local runs, and has passed on every CI leg. An 8 MiB localhost transfer on a box that has been running back-to-back full suites is the likely cause. Flagging it because it flaked twice under `--shard` and never unsharded, so it is not fully explained — but it is not introduced here, and CI is the check that matters.

## Separately: a sixth flake, and it is step 3's class

Master's own post-#461 run (`34659678616`, windows 24.x) failed on something new — **not** a timeout, so step 1 would not have caught it and did not regress it:

```
FAIL tests/integration/zim-arm.test.ts > collectPackCandidates …
AssertionError: expected [ 'Kohlekraftwerk', 'Kohleausstieg' ] to deeply equal [ … ]
  expect(suggestRequests.map((r) => r.term)).toEqual(['Liste der grö…'])
```

That asserts the exact list *and order* of concurrent suggest requests — the #457/#389 fragility class squarely. It means `zim-arm.test.ts` has at least two members of it (this and the `elapsedMs < 10_000` bound at :672), and it is direct evidence that step 3 is the right next move rather than optional polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
