### PR TITLE
test(458): CI-aware hang detectors, and a probe seam for the arm (3 of 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,16 @@ jobs:
         # which a noisy neighbour can hit. Runner minutes are free on a public repo, so the
         # extra jobs cost nothing but queue time. See docs/packaging.md, the CI section.
         #
-        # Sharding halves EXPOSURE, not crowding: each shard still runs `availableParallelism()
-        # - 1` forks on a 4-core runner. Widening the vitest budgets (step 1, `hookTimeout` /
-        # `testTimeout`) is what buys tolerance; these two changes address different halves.
+        # MEASURED, once the shard flag actually reached vitest (run 34662589439): the windows
+        # Test step fell from 483–542 s to 221–239 s and the job from 10–13 min to 5.3–5.7 min,
+        # so windows is no longer the critical path (ubuntu: 4.9–5.3 min). The gain BEATS a
+        # halving because per-file overheads drop too: per-file test cost went 2.22 s → 1.65/
+        # 1.99 s, and both shards together cost LESS total test time than the one unsharded run
+        # (816 s vs 997 s). So sharding does not only halve exposure — pressure per runner
+        # genuinely eases (plausibly the #460 handle/temp-root accumulation, halved per runner;
+        # correlation, not proven cause). Widening the vitest budgets (step 1, `hookTimeout` /
+        # `testTimeout`) is still what buys TOLERANCE against a starved fork; each shard runs
+        # the same `availableParallelism() - 1` forks.
         #
         # WHY UBUNTU STAYS WHOLE — not just cost. One leg per node version still runs all 449
         # files in a SINGLE vitest process, so cross-file interference (shared module state, a

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,7 +28,7 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
-_2026-09-12 — **#458 OPEN (2 of 3 done) — the windows CI legs: CI-aware `hookTimeout`, then sharded** (`fix/458-ci-hook-timeout` PR #461;
+_2026-09-12 — **#458 (3 of 3 done, acceptance pending) — the windows CI legs: budgets, sharding, timing asserts** (`fix/458-ci-hook-timeout` PR #461;
 `fix/458-shard-windows-legs` PR #462; record `packaging.md` "Continuous integration (CI)"; decision + full evidence in the issue comment).
 Investigated: **five** windows flakes, not three, and #457 did not end them; windows 22.x carried 4 of 5. **(1)** `testTimeout` widened to 60 s
 on CI long ago but `hookTimeout` never did (vitest's 10 s default, 6× tighter) and **2 of the 5 were hook timeouts** — structural, not slow
@@ -41,10 +41,13 @@ and all six legs ran 449 files, merely looking slow (run 34660709148). Both now 
 suites never close). **Measured once the flag really landed (run 34662589439): windows Test step 483–542 s → 221–239 s, job 10–13 min → 5.3–5.7,
 critical path 13.3 → 5.7 min — windows is no longer the long pole.** It BEATS a halving (per-file cost 2.22 → 1.65/1.99 s; both shards together
 816 s vs 997 s), so "halves exposure, not crowding" was too strong — pressure per runner eases too, plausibly #460's accumulation halved. A
-SIXTH flake appeared on master post-(1) — `zim-arm.test.ts` `collectPackCandidates` asserting the exact list AND ORDER of concurrent suggest
-requests (run 34659678616): not a timeout, squarely (3)'s class. Next: **(3)** the **29 hand-rolled `Date.now()` poll bounds across 16 files** +
-`zim-arm.test.ts:672` and that ordering assert. Acceptance ("green on a first push over a week") is judged from real traffic._
-_2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
+SIXTH flake appeared on master post-(1) — `zim-arm.test.ts` `collectPackCandidates` L3-b (run 34659678616): NOT the assertion's fault, the arm's
+own 3 s `DF_PROBE_TIMEOUT_MS` lost its race on a starved runner so the list article was never read. **(3) DONE**: the **29 hand-rolled
+`Date.now()` bounds across 16 files** + both fixture `waitFor` defaults now go through `tests/helpers/hang-budget.ts` (4× on CI — the
+`testTimeout` ratio — capped at 45 s so a detector still fires inside the 60 s budget); and a `probeTimeoutMs` SEAM (mirroring
+`articleTimeoutMs`) stops the expansion cases racing that 3 s timer, verified by setting it to 1 ms and watching exactly those 6 cases fail.
+Timing PROOFS are deliberately excluded from the helper (`fts-rowid-sync` 500 ms #84; `zim-arm:672`, which exists to exclude the 15 s default).
+Acceptance ("green on a first push over a week") is judged from real traffic._
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._
 _2026-09-10 — **#446 CLOSED — the three untested chat entries measured; `qwen3.6` joins the rule, `granite` does not**

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -38,9 +38,12 @@ DISABLE it instead. TWO silent failures found by MEASURING, not reasoning: the s
 with pathe), so a native-`resolve` reproduction agreed with a real run on 109 of 225 files (chance) while every property test passed; and the
 first sharded CI run **did nothing at all** — the root `test` script forwarded to the workspace without a `--`, so npm ate `--shard` as a config
 and all six legs ran 449 files, merely looking slow (run 34660709148). Both now pinned (sha1 vectors; the trailing `--`). Rejected: dropping a
-node version (22.x is the `engines` floor AND carried 4 of 5); temp-root churn on measurement (~1.5 s/run — **#460**, 99/129 `openDatabase()`
-suites never close). Sharding halves EXPOSURE, not crowding — the budgets buy tolerance. Next: **(3)** the **29 hand-rolled `Date.now()` poll
-bounds across 16 files** + `zim-arm.test.ts:672`. Acceptance ("green on a first push over a week") is judged from real traffic after (2)._
+suites never close). **Measured once the flag really landed (run 34662589439): windows Test step 483–542 s → 221–239 s, job 10–13 min → 5.3–5.7,
+critical path 13.3 → 5.7 min — windows is no longer the long pole.** It BEATS a halving (per-file cost 2.22 → 1.65/1.99 s; both shards together
+816 s vs 997 s), so "halves exposure, not crowding" was too strong — pressure per runner eases too, plausibly #460's accumulation halved. A
+SIXTH flake appeared on master post-(1) — `zim-arm.test.ts` `collectPackCandidates` asserting the exact list AND ORDER of concurrent suggest
+requests (run 34659678616): not a timeout, squarely (3)'s class. Next: **(3)** the **29 hand-rolled `Date.now()` poll bounds across 16 files** +
+`zim-arm.test.ts:672` and that ordering assert. Acceptance ("green on a first push over a week") is judged from real traffic._
 _2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._

--- a/apps/desktop/src/main/services/zim/arm.ts
+++ b/apps/desktop/src/main/services/zim/arm.ts
@@ -110,6 +110,19 @@ export interface CollectPackCandidatesOptions {
    */
   articleTimeoutMs?: number
   /**
+   * The budget for the small JSON probes — the document-frequency `/search` totals and the
+   * `/suggest` title lookup (`DF_PROBE_TIMEOUT_MS`, 3 s). Test seam only; production never
+   * sets it.
+   *
+   * #458 step 3: without this the expansion tests raced a REAL 3 s timer against a local stub.
+   * On a starved windows CI runner that timer won — the title lookup was abandoned, the list
+   * article was never read, and `rawReads` came back holding only the plain reads while the
+   * assertion expected the expansion's too (run 34659678616, `collectPackCandidates` L3-b).
+   * The assertions there are about WHICH articles get read, not about latency, so the honest
+   * fix is to stop making them depend on a wall-clock race they never meant to test.
+   */
+  probeTimeoutMs?: number
+  /**
    * #340 L3-b (D-Z20): the ask's query expander — ONE local-model call per ask, before any pack
    * is searched; its concepts feed one extra `/search` and its list title one `/suggest` per
    * pack, whose articles are fetched in ADDITION to the plain search's. Absent or resolving null
@@ -282,7 +295,7 @@ export async function collectPackCandidates(
       try {
         // A title lookup is one small JSON: it gets the probe budget (`DF_PROBE_TIMEOUT_MS`), not
         // the client's 15 s default — the same argument as the #353 probes.
-        const lookup = { timeoutMs: DF_PROBE_TIMEOUT_MS }
+        const lookup = { timeoutMs: opts.probeTimeoutMs ?? DF_PROBE_TIMEOUT_MS }
         let rows = await suggestTitles(port, servedName, expansion.listTitle, EXPANSION_TITLE_ROWS, signal, lookup)
         // The title index is PREFIX-only (R-6): a model title one word too long or inflected at
         // its end ("… nach CO2-Emissionen" against "… nach CO2-Emission pro Kopf", measured
@@ -346,7 +359,7 @@ export async function collectPackCandidates(
         try {
           for (const term of probeTerms) {
             const total = await searchPackTotal(port, pack.id, term, signal, {
-              timeoutMs: DF_PROBE_TIMEOUT_MS
+              timeoutMs: opts.probeTimeoutMs ?? DF_PROBE_TIMEOUT_MS
             })
             if (total !== null) df.set(term, total)
           }

--- a/apps/desktop/tests/helpers/hang-budget.ts
+++ b/apps/desktop/tests/helpers/hang-budget.ts
@@ -40,3 +40,18 @@ export function hangBudgetMs(localMs: number): number {
   if (!process.env.CI) return localMs
   return Math.min(localMs * CI_FACTOR, CI_CEILING_MS)
 }
+
+/**
+ * The same widening for a poll loop bounded by ITERATION COUNT rather than wall clock —
+ * `for (let i = 0; i < hangPolls(200); i++)`. Pass the loop's own sleep so the 45 s cap still
+ * lands on real time: 200 polls of 5 ms is a 1 s detector, and on CI becomes a 4 s one.
+ *
+ * This shape is the NASTIER of the two and was missed by the first sweep of #458 step 3 —
+ * CI found it (`vision-security.test.ts`, run 34664328086). A counted loop does not merely
+ * stay narrow on CI, it **falls through silently**: no named error, just the next assertion
+ * failing with something opaque like `expected [] to have a length of 1`. Prefer failing
+ * loudly after the loop where the surrounding test makes that practical.
+ */
+export function hangPolls(iterations: number, stepMs: number): number {
+  return Math.max(1, Math.round(hangBudgetMs(iterations * stepMs) / stepMs))
+}

--- a/apps/desktop/tests/helpers/hang-budget.ts
+++ b/apps/desktop/tests/helpers/hang-budget.ts
@@ -1,0 +1,42 @@
+// CI-aware budgets for test-side HANG DETECTORS (#458 step 3).
+//
+// Roughly thirty poll loops across the suite carry a hand-rolled bound —
+// `if (Date.now() - start > 5_000) throw new Error('task never finished')` — and a few
+// fixtures carry their own `waitFor(..., ms)` default. Every one of them exists to turn a
+// hang into a NAMED failure instead of a bare vitest timeout. None is a timing proof.
+//
+// The trap they all shared: `vitest.config.ts` widens `testTimeout`/`hookTimeout` to 60 s on
+// CI because the windows runners are starved (#458, #101), but **a hand-rolled bound is
+// invisible to that config and does not widen with it**. So the suite's own hang detectors
+// stayed at their desk-tight values on the one platform that needed slack, and fired on work
+// that was merely slow. `doctasks-translation.test.ts` documented this at its 30 s detector
+// after it flaked 3 of 4 runs; this module generalises the fix instead of waiting for each
+// bound to be bitten in turn.
+//
+// Deliberately NOT for timing PROOFS. If a test asserts that something completed *within* a
+// budget as evidence about the code (the FTS 500 ms bound, #84; the `elapsedMs >=
+// DF_PROBE_TIMEOUT_MS` lower bound in `zim-arm`), that assertion is the point and must not be
+// silently relaxed here. Use this only where exceeding the bound means "it hung", never "it
+// was too slow".
+
+/** Multiplier applied on CI. 4x is exactly the ratio `testTimeout` already uses: 15 s -> 60 s. */
+const CI_FACTOR = 4
+
+/**
+ * Ceiling for a widened budget. A hang detector is only useful if it fires BEFORE the test
+ * budget around it — otherwise the named error is replaced by a bare `Test timed out in
+ * 60000ms` and the diagnosis is lost. 45 s keeps every widened bound comfortably inside the
+ * 60 s CI `testTimeout`. A file that deliberately raises its own per-test budget (e.g.
+ * `vi.setConfig`) and needs a longer detector should pass the value it wants directly.
+ */
+const CI_CEILING_MS = 45_000
+
+/**
+ * The wall-clock budget a test-side hang detector should use, given the value that is right at
+ * a developer's desk. Unchanged locally (a real hang still fails fast); widened on CI, where
+ * GitHub Actions sets `CI=true` and a starved fork can be descheduled for 10+ seconds.
+ */
+export function hangBudgetMs(localMs: number): number {
+  if (!process.env.CI) return localMs
+  return Math.min(localMs * CI_FACTOR, CI_CEILING_MS)
+}

--- a/apps/desktop/tests/integration/audit-ipc.test.ts
+++ b/apps/desktop/tests/integration/audit-ipc.test.ts
@@ -74,6 +74,7 @@ import type {
   WorkspaceActionResult
 } from '../../src/shared/types'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -244,7 +245,7 @@ function eventTypes(db: Db): string[] {
 async function pollUntil(check: () => Promise<boolean>, what: string): Promise<void> {
   const start = Date.now()
   while (!(await check())) {
-    if (Date.now() - start > 5000) throw new Error(`timed out waiting for ${what}`)
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error(`timed out waiting for ${what}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/collections-ipc.test.ts
+++ b/apps/desktop/tests/integration/collections-ipc.test.ts
@@ -34,6 +34,7 @@ import type { AppContext } from '../../src/main/services/context'
 import type { Collection, Conversation, DocumentInfo, ImportJob, ImportJobStatus, Message } from '../../src/shared/types'
 import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
 import { inFlightStreams } from '../../src/main/ipc/inflight'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -102,7 +103,7 @@ async function importIndexed(ctx: AppContext, filePath: string): Promise<string>
   while (true) {
     const { result: s } = await invoke(handlers, IPC.getImportJob, job.jobId)
     if ((s as ImportJobStatus).done) break
-    if (Date.now() - start > 5000) throw new Error('import timed out')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('import timed out')
     await new Promise((r) => setTimeout(r, 10))
   }
   return job.documentIds[0]

--- a/apps/desktop/tests/integration/docs-ipc.test.ts
+++ b/apps/desktop/tests/integration/docs-ipc.test.ts
@@ -141,6 +141,7 @@ import type { OcrEngine } from '../../src/main/services/ocr'
 import type { RasterizePdf } from '../../src/main/services/ocr/rasterizer'
 import { makeScanOnlyPdf } from '../helpers/fixtures'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -1636,7 +1637,7 @@ describe('doc-task admission vs. in-flight ingestion (BE-1)', () => {
     for (;;) {
       const s = manager.getDocTask(jobId)
       if (['done', 'failed', 'cancelled'].includes(s.state)) return s.state
-      if (Date.now() - start > 30_000) throw new Error(`task never finished: ${s.state}`)
+      if (Date.now() - start > hangBudgetMs(30_000)) throw new Error(`task never finished: ${s.state}`)
       await new Promise((r) => setTimeout(r, 10))
     }
   }

--- a/apps/desktop/tests/integration/docs-ipc.test.ts
+++ b/apps/desktop/tests/integration/docs-ipc.test.ts
@@ -141,7 +141,7 @@ import type { OcrEngine } from '../../src/main/services/ocr'
 import type { RasterizePdf } from '../../src/main/services/ocr/rasterizer'
 import { makeScanOnlyPdf } from '../helpers/fixtures'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
-import { hangBudgetMs } from '../helpers/hang-budget'
+import { hangBudgetMs, hangPolls } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -190,7 +190,7 @@ async function runImport(paths: string[], options?: ImportOptions): Promise<Impo
   // T-7 (Chat & Documents audit 2026-07-07): a generous non-racy ceiling (was 200×5ms ≈ 1s) —
   // the loop settles well before this; the higher bound only removes headroom flakiness on a
   // busy CI box, it never gates a passing run.
-  for (let i = 0; i < 400; i++) {
+  for (let i = 0; i < hangPolls(400, 5); i++) {
     const { result: s } = await invoke(handlers, IPC.getImportJob, job.jobId)
     if ((s as ImportJobStatus).done) break
     await new Promise((r) => setTimeout(r, 5))
@@ -591,7 +591,7 @@ describe('registerDocsIpc', () => {
     const { result: imp } = await invoke(handlers, IPC.importDocuments, [file])
     const jobId = (imp as ImportJob).jobId
     let status: ImportJobStatus | undefined
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < hangPolls(200, 5); i++) {
       status = (await invoke(handlers, IPC.getImportJob, jobId)).result as ImportJobStatus
       if (status.done) break
       await new Promise((r) => setTimeout(r, 5))
@@ -1293,7 +1293,7 @@ describe('registerDocsIpc — Session 6 backend performance (DB-4…DB-7)', () =
     expect(count).toBe(6)
 
     // Drive to completion so the lease/loop unwind cleanly, then confirm every row indexed.
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < hangPolls(200, 5); i++) {
       const { result: s } = await invoke(handlers, IPC.getImportJob, job.jobId)
       if ((s as ImportJobStatus).done) break
       await new Promise((r) => setTimeout(r, 5))
@@ -1398,7 +1398,7 @@ describe('registerDocsIpc — Session 6 backend performance (DB-4…DB-7)', () =
     // gated one → it is evicted → getImportJob returns synthetic done:true → this reddens.
 
     release() // let the gated embed resolve, then drain so the loop/lease unwind cleanly
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < hangPolls(200, 5); i++) {
       const s = (await invoke(handlers, IPC.getImportJob, gated.jobId)).result as ImportJobStatus
       if (s.done) break
       await new Promise((r) => setTimeout(r, 5))
@@ -1472,7 +1472,7 @@ describe('registerDocsIpc — Session 7 guard preconditions & lock-mid-job (T-3/
 
     // Release + drain so the loop/lease unwind cleanly (no leak into the next test).
     release()
-    for (let i = 0; i < 400; i++) {
+    for (let i = 0; i < hangPolls(400, 5); i++) {
       const s = (await invoke(handlers, IPC.getImportJob, gated.jobId)).result as ImportJobStatus
       if (s.done) break
       await new Promise((r) => setTimeout(r, 5))
@@ -1584,7 +1584,7 @@ describe('registerDocsIpc — Session 7 guard preconditions & lock-mid-job (T-3/
     // Drive to done via getImportJob (it needs NO unlock, unlike listDocuments) since the workspace
     // locks itself mid-job.
     let status: ImportJobStatus = { jobId: job.jobId, total: 2, completed: 0, failed: 0, done: false }
-    for (let i = 0; i < 400; i++) {
+    for (let i = 0; i < hangPolls(400, 5); i++) {
       status = (await invoke(handlers, IPC.getImportJob, job.jobId)).result as ImportJobStatus
       if (status.done) break
       await new Promise((r) => setTimeout(r, 5))
@@ -1914,7 +1914,7 @@ describe('registerDocsIpc — #90 export original (docs:exportOriginal)', () => 
     )
 
     release()
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < hangPolls(200, 5); i++) {
       const s = (await invoke(handlers, IPC.getImportJob, gated.jobId)).result as ImportJobStatus
       if (s.done) break
       await new Promise((r) => setTimeout(r, 5))

--- a/apps/desktop/tests/integration/doctasks-categorize.test.ts
+++ b/apps/desktop/tests/integration/doctasks-categorize.test.ts
@@ -9,6 +9,7 @@ import { BANK_EXTRACTOR_VERSION } from '../../src/main/services/skills/tools/ban
 import { buildToolRunner, toSkillToolAudit } from '../../src/main/services/skills/tool-runs'
 import { DocTaskManager, type DocTaskDeps } from '../../src/main/services/doctasks'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // Phase 33 — the `categorize` document task (the bank-statement LLM categorizer's lane). CI posture:
 // zero model, zero network — a scripted runtime (or none, for the deterministic fallback). Covers:
@@ -94,7 +95,7 @@ async function waitTerminal(mgr: DocTaskManager, jobId: string): Promise<ReturnT
   for (;;) {
     const s = mgr.getDocTask(jobId)
     if (s.state === 'done' || s.state === 'failed' || s.state === 'cancelled') return s
-    if (Date.now() - start > 10_000) throw new Error(`task ${jobId} never finished: ${s.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task ${jobId} never finished: ${s.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/doctasks-compare.test.ts
+++ b/apps/desktop/tests/integration/doctasks-compare.test.ts
@@ -31,6 +31,7 @@ import { recordEvent, listAuditEvents } from '../../src/main/services/audit'
 import type { AuditEventType } from '../../src/shared/types'
 import { createMockEmbedder } from '../../src/main/services/embeddings/mock'
 import type { Embedder } from '../../src/main/services/embeddings'
+import { hangBudgetMs } from '../helpers/hang-budget'
 import type {
   ChatMessage,
   ModelRuntime,
@@ -168,7 +169,7 @@ async function waitTerminal(
     if (status.state === 'done' || status.state === 'failed' || status.state === 'cancelled') {
       return status
     }
-    if (Date.now() - start > 10_000) throw new Error(`task ${jobId} never finished: ${status.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task ${jobId} never finished: ${status.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }
@@ -525,7 +526,7 @@ describe('cancellation persists nothing', () => {
     const { jobId } = manager.startDocTask({ kind: 'compare', documentIds: [a, b] })
     const start = Date.now()
     while (manager.getDocTask(jobId).state !== 'running' || runtime.calls.length === 0) {
-      if (Date.now() - start > 5000) throw new Error('task never started')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('task never started')
       await new Promise((r) => setTimeout(r, 5))
     }
     manager.cancelDocTask(jobId)

--- a/apps/desktop/tests/integration/doctasks-ipc.test.ts
+++ b/apps/desktop/tests/integration/doctasks-ipc.test.ts
@@ -37,6 +37,7 @@ import { inFlightStreams } from '../../src/main/ipc/inflight'
 import type { AppContext } from '../../src/main/services/context'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -126,7 +127,7 @@ async function pollTerminal(jobId: string): Promise<DocTaskStatus> {
     if (status.state === 'done' || status.state === 'failed' || status.state === 'cancelled') {
       return status
     }
-    if (Date.now() - start > 5000) throw new Error('task never finished')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('task never finished')
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/doctasks-translation.test.ts
+++ b/apps/desktop/tests/integration/doctasks-translation.test.ts
@@ -52,6 +52,7 @@ import type { ModelRuntime } from '../../src/main/services/runtime'
 import type { OcrEngine } from '../../src/main/services/ocr'
 import { applyUiLanguageSetting } from '../../src/main/services/i18n'
 import { t } from '../../src/shared/i18n'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // Phase 34 — the translation document task (wave-3 plan §7, decisions D27 + D36), REROUTED at
 // TG-3 (translategemma plan §2 D3/D9): translation runs on the TranslateGemma SIDECAR (a
@@ -209,7 +210,7 @@ async function waitTerminal(
     // failed 3 of 4 runs at ~10.16 s with "never finished: running" — the foreign task was
     // still legitimately translating. Same class as #84/#97/#101 and the local-api wave fix:
     // vitest's CI testTimeout budget does NOT widen a hand-rolled poll bound like this one.
-    if (Date.now() - start > 30_000) throw new Error(`task ${jobId} never finished: ${status.state}`)
+    if (Date.now() - start > hangBudgetMs(30_000)) throw new Error(`task ${jobId} never finished: ${status.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }
@@ -867,7 +868,7 @@ describe('cancellation persists nothing', () => {
     // Wait until it is actually translating, then cancel.
     const start = Date.now()
     while (manager.getDocTask(jobId).state !== 'running' || translator.calls.length === 0) {
-      if (Date.now() - start > 5000) throw new Error('task never started')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('task never started')
       await new Promise((r) => setTimeout(r, 5))
     }
     manager.cancelDocTask(jobId)
@@ -899,7 +900,7 @@ describe('lifecycle flush (TA-1: lock/quit cancel the running task AND the queue
     // Wait until A is actually running and B is still queued behind it.
     const start = Date.now()
     while (manager.getDocTask(first.jobId).state !== 'running' || translator.calls.length === 0) {
-      if (Date.now() - start > 5000) throw new Error('task A never started')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('task A never started')
       await new Promise((r) => setTimeout(r, 5))
     }
     expect(manager.getDocTask(second.jobId).state).toBe('queued')
@@ -946,7 +947,7 @@ describe('targeted cancel + active-task read (FA-3: F-6 stale cancel, F-3 reload
     const start = Date.now()
     const before = translator.calls.length
     while (manager.getDocTask(jobId).state !== 'running' || translator.calls.length === before) {
-      if (Date.now() - start > 5000) throw new Error(`task ${jobId} never started running`)
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error(`task ${jobId} never started running`)
       await new Promise((r) => setTimeout(r, 5))
     }
   }
@@ -1194,7 +1195,7 @@ describe('busy-document guard covers the freshly created output document', () =>
     const start = Date.now()
     let outputId: string | null = null
     while (!outputId) {
-      if (Date.now() - start > 5000) throw new Error('output document never appeared')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('output document never appeared')
       outputId = listDocuments(db).find((d) => d.id !== docId)?.id ?? null
       if (!outputId) await new Promise((r) => setTimeout(r, 5))
     }

--- a/apps/desktop/tests/integration/doctasks.test.ts
+++ b/apps/desktop/tests/integration/doctasks.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/main/services/doctasks'
 import { recordEvent, listAuditEvents } from '../../src/main/services/audit'
 import type { AuditEventType } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 import type {
   ChatMessage,
   ModelRuntime,
@@ -147,7 +148,7 @@ async function waitTerminal(manager: DocTaskManager, jobId: string): Promise<Ret
     if (status.state === 'done' || status.state === 'failed' || status.state === 'cancelled') {
       return status
     }
-    if (Date.now() - start > 10_000) throw new Error(`task ${jobId} never finished: ${status.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task ${jobId} never finished: ${status.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/download-fsync-durability.test.ts
+++ b/apps/desktop/tests/integration/download-fsync-durability.test.ts
@@ -33,6 +33,7 @@ const { validateManifest } = await import('../../src/shared/manifest')
 import type { FetchFn } from '../../src/main/services/assets'
 import type { ModelManifest } from '../../src/shared/manifest'
 import type { DownloadJob } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const spies = {
   openSync: vi.mocked(openSync),
@@ -88,7 +89,7 @@ async function waitForTerminal(mgr: InstanceType<typeof DownloadManager>, jobId:
   for (;;) {
     const job = mgr.get(jobId)
     if (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled') return job
-    if (Date.now() - start > 5000) throw new Error('download never finished')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('download never finished')
     await new Promise((r) => setTimeout(r, 5))
   }
 }

--- a/apps/desktop/tests/integration/download-ipc.test.ts
+++ b/apps/desktop/tests/integration/download-ipc.test.ts
@@ -27,6 +27,7 @@ import { seedSettings, updateSettings } from '../../src/main/services/settings'
 import type { DownloadJob } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
 import { ANY_SENDER, invoke, type IpcHandlers } from '../helpers/ipc'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -122,7 +123,7 @@ async function waitForTerminal(jobId: string): Promise<DownloadJob> {
     const { result } = await invoke(handlers, IPC.getDownloadJob, jobId)
     const job = result as DownloadJob
     if (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled') return job
-    if (Date.now() - start > 5000) throw new Error('download job never finished')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('download job never finished')
     await new Promise((r) => setTimeout(r, 10))
   }
 }
@@ -237,7 +238,7 @@ describe('downloads:list / downloads:dismiss (renderer-reload recovery, #314)', 
     for (;;) {
       const job = manager.get(jobId)
       if (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled') return job
-      if (Date.now() - start > 5000) throw new Error('download job never finished')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('download job never finished')
       await new Promise((r) => setTimeout(r, 5))
     }
   }

--- a/apps/desktop/tests/integration/downloads.test.ts
+++ b/apps/desktop/tests/integration/downloads.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../src/main/services/read-speed'
 import { validateManifest, type ModelManifest } from '../../src/shared/manifest'
 import type { DownloadJob } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // Phase 18 — the in-app model downloader (architecture.md "In-app model downloader"). Everything
 // runs through the INJECTED fake fetch: the suite makes zero real network calls, and the
@@ -161,7 +162,7 @@ function routedFetch(routes: Record<string, string>): { fetch: FetchFn; urls: st
 async function waitFor(cond: () => boolean, ms = 5000): Promise<void> {
   const start = Date.now()
   while (!cond()) {
-    if (Date.now() - start > ms) throw new Error('waitFor timed out')
+    if (Date.now() - start > hangBudgetMs(ms)) throw new Error('waitFor timed out')
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/engine-download.test.ts
+++ b/apps/desktop/tests/integration/engine-download.test.ts
@@ -44,6 +44,7 @@ import {
 import { chatEngineInUse, llamaSidecarInUse, whisperSidecarInUse } from '../../src/main/ipc/registerEngineIpc'
 import type { RuntimeManager } from '../../src/main/services/runtime'
 import type { EngineDownloadJob } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // In-app engine (llama.cpp sidecar) downloader: the gates (a closed gate never reaches the
 // network seam), the verify-before-trust flow (placeholder honesty, mismatch discard), the
@@ -132,7 +133,7 @@ async function runToEnd(mgr: EngineDownloadManager, jobId: string): Promise<Engi
   for (;;) {
     const job = mgr.get(jobId)
     if (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled') return job
-    if (Date.now() - start > 5000) throw new Error('engine job never finished')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('engine job never finished')
     await new Promise((r) => setTimeout(r, 5))
   }
 }
@@ -345,7 +346,7 @@ describe('cancel during verify/extract + upgrade-while-running (full-audit 2026-
   ): Promise<void> {
     const start = Date.now()
     while (mgr.get(jobId).status !== status) {
-      if (Date.now() - start > 5000) throw new Error(`job never reached ${status}`)
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error(`job never reached ${status}`)
       await new Promise((r) => setTimeout(r, 2))
     }
   }
@@ -459,7 +460,7 @@ describe('extraction bounds + concurrency (F-33)', () => {
   ): Promise<void> {
     const start = Date.now()
     while (mgr.get(jobId).status !== status) {
-      if (Date.now() - start > 5000) throw new Error(`job never reached ${status}`)
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error(`job never reached ${status}`)
       await new Promise((r) => setTimeout(r, 2))
     }
   }
@@ -483,7 +484,7 @@ describe('extraction bounds + concurrency (F-33)', () => {
     // gate). TS-1 rule: gate on the observable state the assertion needs.
     const entered = Date.now()
     while (sawSignal === undefined) {
-      if (Date.now() - entered > 5000) throw new Error('extractor never entered')
+      if (Date.now() - entered > hangBudgetMs(5000)) throw new Error('extractor never entered')
       await new Promise((r) => setTimeout(r, 2))
     }
     expect(sawSignal).toBeDefined() // the extractor received the job's abort signal…
@@ -515,7 +516,7 @@ describe('extraction bounds + concurrency (F-33)', () => {
     releaseExtract()
     const freeBy = Date.now()
     while (mgr.activeJob() !== null) {
-      if (Date.now() - freeBy > 5000) throw new Error('slot never freed after run() settled')
+      if (Date.now() - freeBy > hangBudgetMs(5000)) throw new Error('slot never freed after run() settled')
       await new Promise((r) => setTimeout(r, 5))
     }
     expect(mgr.get(started.jobId).status).toBe('cancelled')
@@ -776,7 +777,7 @@ describe('kiwix_tools — the optional two-executable family (#339 P8-1, T20-a)'
     const started = await mgr.start({ rootPath, manifestsDir, gates: ALLOW, families: ['kiwix_tools'] })
     const start = Date.now()
     while (mgr.get(started.jobId).status !== 'extracting') {
-      if (Date.now() - start > 5000) throw new Error('never extracting')
+      if (Date.now() - start > hangBudgetMs(5000)) throw new Error('never extracting')
       await new Promise((r) => setTimeout(r, 2))
     }
     mgr.cancel(started.jobId)
@@ -789,7 +790,7 @@ describe('kiwix_tools — the optional two-executable family (#339 P8-1, T20-a)'
     // The master CI run after the merge caught exactly that race on ubuntu-22.x.
     const settleStart = Date.now()
     while (mgr.activeJob() !== null) {
-      if (Date.now() - settleStart > 5000) throw new Error('the cancelled run never settled')
+      if (Date.now() - settleStart > hangBudgetMs(5000)) throw new Error('the cancelled run never settled')
       await new Promise((r) => setTimeout(r, 2))
     }
     expect(existsSync(runtimeMarkerPath(KIWIX_DIR(rootPath)))).toBe(false)

--- a/apps/desktop/tests/integration/engine-extract-containment.test.ts
+++ b/apps/desktop/tests/integration/engine-extract-containment.test.ts
@@ -20,6 +20,7 @@ import {
 import { llamaServerBinaryName } from '../../src/main/services/runtime/sidecar'
 import { runtimeMarkerPath, type FetchFn } from '../../src/main/services/assets'
 import type { EngineDownloadJob } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // SEC-2 (full-audit 2026-07-12): the in-app engine extractor relies on the OS tar's implicit
 // refusal of `..` members; its residual soft spot was a SYMLINK member resolving outside the
@@ -188,7 +189,7 @@ async function runToEnd(mgr: EngineDownloadManager, jobId: string): Promise<Engi
   for (;;) {
     const job = mgr.get(jobId)
     if (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled') return job
-    if (Date.now() - start > 5000) throw new Error('engine job never finished')
+    if (Date.now() - start > hangBudgetMs(5000)) throw new Error('engine job never finished')
     await new Promise((r) => setTimeout(r, 5))
   }
 }

--- a/apps/desktop/tests/integration/images-ipc.test.ts
+++ b/apps/desktop/tests/integration/images-ipc.test.ts
@@ -55,6 +55,7 @@ import type { AppContext } from '../../src/main/services/context'
 import { openDatabase, type Db } from '../../src/main/services/db'
 import { encryptFile, decryptFile, encryptFileAsync, decryptFileAsync } from '../../src/main/services/workspace-vault'
 import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
+import { hangPolls } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -130,7 +131,7 @@ const goodReq = (): ImageAnalyzeRequest => ({
 })
 
 async function waitForTerminal(jobId: string): Promise<ImageJob> {
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < hangPolls(200, 5); i++) {
     const { result } = await invoke(handlers, IPC.imageGetJob, jobId)
     const job = result as ImageJob
     if (job.state === 'done' || job.state === 'failed' || job.state === 'cancelled') return job
@@ -145,7 +146,7 @@ async function waitForTerminal(jobId: string): Promise<ImageJob> {
 // session/turn/stored image exist. Wait for the streamed terminal (imgDone/imgError) — the renderer's
 // real signal — which guarantees persistence is done. Returns the streamed job payload.
 async function waitForImgSend(event: FakeIpcEvent, jobId: string): Promise<ImageJob> {
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < hangPolls(200, 5); i++) {
     const call = event.sender.send.mock.calls.find(
       (c: unknown[]) => c[0] === STREAM.imgDone(jobId) || c[0] === STREAM.imgError(jobId)
     )

--- a/apps/desktop/tests/integration/local-api-lifecycle.test.ts
+++ b/apps/desktop/tests/integration/local-api-lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   maybeStartLocalApi
 } from '../../src/main/services/local-api/lifecycle'
 import type { AppContext } from '../../src/main/services/context'
+import { hangPolls } from '../helpers/hang-budget'
 
 // Local-API lifecycle pins (local-api wave P3): DEFAULT OFF means a fresh workspace opens
 // ZERO listeners (the outbound-only test gap — the policy suite pins outbound calls, this
@@ -58,7 +59,7 @@ function makeCtx(opts?: { unlocked?: boolean; policyJson?: string; isDev?: boole
 
 async function settle(): Promise<void> {
   // maybeStartLocalApi is fire-and-forget; give its start() a few ticks to bind.
-  for (let i = 0; i < 20; i++) await new Promise((r) => setTimeout(r, 5))
+  for (let i = 0; i < hangPolls(20, 5); i++) await new Promise((r) => setTimeout(r, 5))
 }
 
 describe('local API lifecycle (P3 wiring)', () => {

--- a/apps/desktop/tests/integration/local-api-server.test.ts
+++ b/apps/desktop/tests/integration/local-api-server.test.ts
@@ -3,6 +3,7 @@ import net from 'node:net'
 import { RuntimeManager, type RuntimeChatOptions } from '../../src/main/services/runtime'
 import { LocalApiServer, PortInUseError } from '../../src/main/services/local-api/server'
 import { manualSource, type ManualSource } from '../helpers/manual-stream'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // LocalApiServer integration pins (local-api wave P3): a REAL listener on an ephemeral
 // port, driven over real HTTP, against a real RuntimeManager (gated mock runtimes). The
@@ -632,7 +633,7 @@ describe('LocalApiServer — completions contract (client-dev 1/2/5/7)', () => {
 async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<void> {
   const start = Date.now()
   while (!check()) {
-    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out')
+    if (Date.now() - start > hangBudgetMs(timeoutMs)) throw new Error('waitFor timed out')
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/ocr-task.test.ts
+++ b/apps/desktop/tests/integration/ocr-task.test.ts
@@ -29,6 +29,7 @@ import { recordEvent, listAuditEvents } from '../../src/main/services/audit'
 import type { AuditEventType } from '../../src/shared/types'
 import { makeScanOnlyPdf, TINY_PNG } from '../helpers/fixtures'
 import { PDF_SCAN_DETECTED_MESSAGE } from '../../src/main/services/ingestion/parsers/pdf'
+import { hangBudgetMs } from '../helpers/hang-budget'
 import {
   IMAGE_NEEDS_OCR_MESSAGE,
   IMAGE_OCR_UNAVAILABLE_MESSAGE
@@ -120,7 +121,7 @@ async function waitTerminal(manager: DocTaskManager, jobId: string) {
   for (;;) {
     const status = manager.getDocTask(jobId)
     if (['done', 'failed', 'cancelled'].includes(status.state)) return status
-    if (Date.now() - start > 10_000) throw new Error(`task never finished: ${status.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task never finished: ${status.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/placement-wiring.test.ts
+++ b/apps/desktop/tests/integration/placement-wiring.test.ts
@@ -57,6 +57,7 @@ import { getSettings } from '../../src/main/services/settings'
 import type { ModelPrefetch, PrefetchOutcome } from '../../src/main/services/runtime/prefetch'
 import type { ModelRuntime, RuntimeStartOptions } from '../../src/main/services/runtime'
 import type { GpuDevice, ModelPlacement } from '../../src/shared/types'
+import { hangPolls } from '../helpers/hang-budget'
 import {
   closePerformanceFixture,
   ctxWith,
@@ -190,7 +191,7 @@ function ladderHarness(config: {
 
 /** Resolve once `cond` holds — polled on observable state, never a fixed sleep. */
 async function until(cond: () => boolean): Promise<void> {
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < hangPolls(500, 1); i++) {
     if (cond()) return
     await new Promise((r) => setTimeout(r, 1))
   }

--- a/apps/desktop/tests/integration/translate-ipc.test.ts
+++ b/apps/desktop/tests/integration/translate-ipc.test.ts
@@ -25,6 +25,7 @@ import { TRANSLATE_MAX_TEXT_CHARS } from '../../src/shared/types'
 import type { TranslateJob, TranslateRequest } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
 import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type FakeIpcEvent, type IpcHandlers } from '../helpers/ipc'
+import { hangPolls } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -104,7 +105,7 @@ function service(deps: {
 }
 
 async function waitForTerminal(event: FakeIpcEvent, jobId: string): Promise<TranslateJob> {
-  for (let i = 0; i < 300; i++) {
+  for (let i = 0; i < hangPolls(300, 5); i++) {
     const done = event.sender.send.mock.calls.find((c: unknown[]) => c[0] === STREAM.trDone(jobId))
     const err = event.sender.send.mock.calls.find((c: unknown[]) => c[0] === STREAM.trError(jobId))
     if (done) return done[1] as TranslateJob

--- a/apps/desktop/tests/integration/vision-security.test.ts
+++ b/apps/desktop/tests/integration/vision-security.test.ts
@@ -33,6 +33,7 @@ import { IPC, STREAM } from '../../src/shared/ipc'
 import type { ImageAnalyzeRequest, ImageJob, VisionStatus } from '../../src/shared/types'
 import type { AppContext } from '../../src/main/services/context'
 import { ANY_SENDER, invoke, invokeWithEvent, makeEvent, type IpcHandlers } from '../helpers/ipc'
+import { hangPolls } from '../helpers/hang-budget'
 
 const handlers = ipcState.handlers as unknown as IpcHandlers
 
@@ -116,13 +117,29 @@ const sentinelReq = (): ImageAnalyzeRequest => ({
 })
 
 async function waitForTerminal(jobId: string): Promise<ImageJob> {
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < hangPolls(200, 5); i++) {
     const { result } = await invoke(handlers, IPC.imageGetJob, jobId)
     const job = result as ImageJob
     if (job.state === 'done' || job.state === 'failed' || job.state === 'cancelled') return job
     await new Promise((r) => setTimeout(r, 5))
   }
   throw new Error('vision job never reached a terminal state')
+}
+
+/**
+ * Persistence is async: wait for the streamed done event before inspecting the rows.
+ *
+ * Throws BY NAME rather than falling through. The counted loop this replaces did the latter,
+ * so when it ran out on a starved CI worker the next assertion failed with an opaque
+ * `expected [] to have a length of 1` instead of saying what had not happened (#458, run
+ * 34664328086). Its budget is `hangPolls`, so it widens on CI like every other detector.
+ */
+async function waitForDoneEvent(event: { sender: { send: { mock: { calls: unknown[][] } } } }, jobId: string): Promise<void> {
+  for (let i = 0; i < hangPolls(200, 5); i++) {
+    if (event.sender.send.mock.calls.some((c: unknown[]) => c[0] === STREAM.imgDone(jobId))) return
+    await new Promise((r) => setTimeout(r, 5))
+  }
+  throw new Error(`vision-security: the streamed done event for ${jobId} never arrived`)
 }
 
 let logCalls: string[]
@@ -356,10 +373,7 @@ describe('vision security sentinel', () => {
     expect(done.state).toBe('done')
     // F-12 (audit 2026-07-16): the encrypted store is async, so the .enc sidecar (and the shred of the
     // plaintext temp) land only after the streamed done EVENT fires — wait for it before the disk check.
-    for (let i = 0; i < 200; i++) {
-      if (event.sender.send.mock.calls.some((c: unknown[]) => c[0] === STREAM.imgDone(initial.jobId))) break
-      await new Promise((r) => setTimeout(r, 5))
-    }
+    await waitForDoneEvent(event, initial.jobId)
 
     expect(ocrSpy).not.toHaveBeenCalled() // no OCR engine ever built on the vision path
     expect(existsSync(join(root, 'documents'))).toBe(false) // never the documents pipeline
@@ -470,10 +484,7 @@ describe('vision security sentinel', () => {
     const done = await waitForTerminal(initial.jobId)
     expect(done.state).toBe('done')
     // Persistence is async — wait for the streamed done event before inspecting the rows.
-    for (let i = 0; i < 200; i++) {
-      if (event.sender.send.mock.calls.some((c: unknown[]) => c[0] === STREAM.imgDone(initial.jobId))) break
-      await new Promise((r) => setTimeout(r, 5))
-    }
+    await waitForDoneEvent(event, initial.jobId)
 
     const list = (await invoke(handlers, IPC.imageListSessions)).result as Array<{
       id: string

--- a/apps/desktop/tests/integration/whole-doc-analysis.test.ts
+++ b/apps/desktop/tests/integration/whole-doc-analysis.test.ts
@@ -29,6 +29,7 @@ import {
   reachableLeafChunkIds
 } from '../../src/main/services/analysis/coverage'
 import { t } from '../../src/shared/i18n'
+import { hangBudgetMs } from '../helpers/hang-budget'
 import type {
   ChatMessage,
   ModelRuntime,
@@ -170,14 +171,14 @@ async function waitTerminal(m: DocTaskManager, jobId: string): Promise<AnyStatus
   for (;;) {
     const s = m.getDocTask(jobId)
     if (s.state === 'done' || s.state === 'failed' || s.state === 'cancelled') return s
-    if (Date.now() - start > 10_000) throw new Error(`task never finished: ${s.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task never finished: ${s.state}`)
     await new Promise((r) => setTimeout(r, 5))
   }
 }
 async function waitFor(pred: () => boolean, label = 'condition'): Promise<void> {
   const start = Date.now()
   while (!pred()) {
-    if (Date.now() - start > 10_000) throw new Error(`timed out waiting for ${label}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`timed out waiting for ${label}`)
     await new Promise((r) => setTimeout(r, 5))
   }
 }

--- a/apps/desktop/tests/integration/whole-doc-compare.test.ts
+++ b/apps/desktop/tests/integration/whole-doc-compare.test.ts
@@ -23,6 +23,7 @@ import type {
   RuntimeChatOptions
 } from '../../src/main/services/runtime'
 import { readStoredDocumentText } from '../../src/main/services/ingestion'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 // Phase 4 (whole-document-analysis plan §4.3, H4/H5/H8, L6) — the SYMMETRIC both-trees
 // compare and lazy node embeddings. CI posture: mock runtime + mock embedder, zero network.
@@ -127,7 +128,7 @@ async function waitTerminal(manager: DocTaskManager, jobId: string): Promise<str
   for (;;) {
     const s = manager.getDocTask(jobId)
     if (s.state === 'done' || s.state === 'failed' || s.state === 'cancelled') return s.state
-    if (Date.now() - start > 15_000) throw new Error(`task ${jobId} never finished: ${s.state}`)
+    if (Date.now() - start > hangBudgetMs(15_000)) throw new Error(`task ${jobId} never finished: ${s.state}`)
     await new Promise((r) => setTimeout(r, 10))
   }
 }

--- a/apps/desktop/tests/integration/whole-doc-extract.test.ts
+++ b/apps/desktop/tests/integration/whole-doc-extract.test.ts
@@ -22,6 +22,7 @@ import { ModelSlotArbiter } from '../../src/main/services/analysis/model-slot-ar
 import { t, type MessageKey, type MessageParams } from '../../src/shared/i18n'
 import type { ChatMessage, ModelRuntime, RuntimeChatOptions } from '../../src/main/services/runtime'
 import { EXTRACT_RECORD_TYPES, type RetrievalScope } from '../../src/shared/types'
+import { hangBudgetMs } from '../helpers/hang-budget'
 
 const tr = (key: MessageKey, params?: MessageParams): string => t('en', key, params)
 
@@ -125,7 +126,7 @@ async function waitTerminal(m: DocTaskManager, jobId: string): Promise<AnyStatus
   for (;;) {
     const s = m.getDocTask(jobId)
     if (s.state === 'done' || s.state === 'failed' || s.state === 'cancelled') return s
-    if (Date.now() - start > 10_000) throw new Error(`task never finished: ${s.state}`)
+    if (Date.now() - start > hangBudgetMs(10_000)) throw new Error(`task never finished: ${s.state}`)
     await new Promise((r) => setTimeout(r, 5))
   }
 }

--- a/apps/desktop/tests/integration/zim-arm.test.ts
+++ b/apps/desktop/tests/integration/zim-arm.test.ts
@@ -666,8 +666,12 @@ describe('collectPackCandidates', () => {
       reason: null,
       found: 0
     })
-    // Comfortably above DF_PROBE_TIMEOUT_MS (scheduling slack) and comfortably below the
-    // client's old 15 s default — proves the SHORT budget fired, not the long one.
+    // A TIMING PROOF — deliberately NOT widened by `hangBudgetMs` (#458 step 3). Its whole job
+    // is to exclude the client's 15 s default (`DEFAULT_TIMEOUT_MS`, zim/client.ts), so a wider
+    // bound would stop discriminating and a CI-scaled one would mean nothing. The margin is
+    // 3 s (the probe) → 10 s (here) → 15 s (the default). If this ever flakes on a starved
+    // runner, the fix is to SHRINK what is measured — pass a short `probeTimeoutMs`, the seam
+    // the expansion cases now use — never to raise this number toward 15 s.
     expect(elapsedMs).toBeGreaterThanOrEqual(DF_PROBE_TIMEOUT_MS)
     expect(elapsedMs).toBeLessThan(10_000)
   }, 15_000)
@@ -1017,6 +1021,12 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
     expandSearches.length = 0
     suggestRequests.length = 0
   }
+  // The expansion cases assert WHICH articles get read, never latency — so they must not race
+  // the real 3 s `DF_PROBE_TIMEOUT_MS` against a local stub. On a starved windows runner that
+  // timer won and the list article was simply never read (#458, run 34659678616). The #353
+  // cases that PROVE the short budget fires deliberately do NOT pass this and keep the default.
+  const PROBE_BUDGET_MS = 30_000
+
   const plainReads = ['Kohlekraftwerk', 'Kohleausstieg']
 
   it('#340 L3-b: the expansion runs ONCE per ask; its title-index and concept articles are fetched FIRST and in addition to the plain hits; a duplicate is fetched once; a list article keeps more chunks', async () => {
@@ -1027,7 +1037,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
       expect(q).toBe(QUESTION)
       return EXPANSION
     }
-    const { candidates, outcomes } = await collectPackCandidates(port, packs, QUESTION, undefined, names, { expand })
+    const { candidates, outcomes } = await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS, expand })
     expect(calls).toBe(1)
     expect(suggestRequests).toEqual([{ content: 'book-pack-expand', term: 'Liste der größten Kohlekraftwerke' }])
     expect(expandSearches).toEqual(['größten Kohlekraftwerke Welt', 'Konzept Suche'])
@@ -1052,12 +1062,12 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
     expect(suggestRequests).toEqual([])
     expect(expandSearches).toEqual(['größten Kohlekraftwerke Welt'])
     reset()
-    const nulled = await collectPackCandidates(port, packs, QUESTION, undefined, names, { expand: async () => null })
+    const nulled = await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS, expand: async () => null })
     expect(rawReads).toEqual(plainReads)
     expect(suggestRequests).toEqual([])
     expect(nulled).toEqual(none)
     reset()
-    const threw = await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+    const threw = await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => {
         throw new Error('runtime exploded')
       }
@@ -1077,7 +1087,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
       throw err
     }
     await expect(
-      collectPackCandidates(port, packs, QUESTION, ctrl.signal, names, { expand })
+      collectPackCandidates(port, packs, QUESTION, ctrl.signal, names, { probeTimeoutMs: PROBE_BUDGET_MS, expand })
     ).rejects.toMatchObject({ name: 'AbortError' })
     expect(expandSearches).toEqual([])
     expect(rawReads).toEqual([])
@@ -1085,7 +1095,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
 
   it('#340 L3-b: a list title the prefix index does not know is retried once, one word shorter', async () => {
     reset()
-    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => ({ concepts: [], listTitle: 'Liste der größten Kohlekraftwerke Welt' })
     })
     expect(suggestRequests).toEqual([
@@ -1097,7 +1107,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
 
   it('#340 L3-b: the shorter fallback prefix is broader — its rows are ranked by the dropped word, the right list article first', async () => {
     reset()
-    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => ({ concepts: [], listTitle: 'Liste der größten Kohlekraftwerke der Erde' })
     })
     expect(suggestRequests.map((r) => r.term)).toEqual(['Liste der größten Kohlekraftwerke der Erde', 'Liste der größten Kohlekraftwerke der'])
@@ -1107,7 +1117,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
 
   it('#340 L3-b: a failing title index costs only the title hit — the concept hit and the plain hits still arrive', async () => {
     reset()
-    const { candidates } = await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+    const { candidates } = await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => ({ concepts: ['Konzept', 'Suche'], listTitle: 'Liste kaputt' })
     })
     expect(suggestRequests).toEqual([{ content: 'book-pack-expand', term: 'Liste kaputt' }])
@@ -1117,7 +1127,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
 
   it('#340 L3-b: the expansion adds at most EXPANSION_ARTICLES_PER_PACK articles, the plain ARTICLES_PER_PACK bound is untouched, and without a served name the title index is not asked', async () => {
     reset()
-    await collectPackCandidates(port, packs, QUESTION, undefined, names, {
+    await collectPackCandidates(port, packs, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => ({ concepts: ['Drei', 'Treffer'], listTitle: 'Liste der größten Kohlekraftwerke' })
     })
     // list article + 'Kraftwerk A' = the two expansion fetches; B and C are never read; the
@@ -1127,7 +1137,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
     reset()
     // No served-name map (a caller without the published library): the title index needs the
     // served name, so only the concept query runs.
-    await collectPackCandidates(port, packs, QUESTION, undefined, undefined, { expand: async () => EXPANSION })
+    await collectPackCandidates(port, packs, QUESTION, undefined, undefined, { probeTimeoutMs: PROBE_BUDGET_MS, expand: async () => EXPANSION })
     expect(suggestRequests).toEqual([])
     expect(rawReads).toEqual(['Kraftwerk Tuoketuo', ...plainReads])
   })
@@ -1149,7 +1159,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
       QUESTION,
       deadline.signal,
       names,
-      { expand, askSignal: ask.signal }
+      { probeTimeoutMs: PROBE_BUDGET_MS, expand, askSignal: ask.signal }
     )
     expect(candidates).toEqual([])
     expect(outcomes.map((o) => [o.packId, o.status, o.reason])).toEqual([
@@ -1163,7 +1173,7 @@ describe('collectPackCandidates — #340 L3-b query expansion (D-Z20)', () => {
   it('#340 L3-b: on a three-pack ask the expansion takes at most half the pack quota, so the plain hits are still read', async () => {
     reset()
     const three = [...packs, { id: 'pack-climate', title: 'Klimawandel' }, { id: 'pack-mixed', title: 'Gemischt' }]
-    const { candidates, outcomes } = await collectPackCandidates(port, three, QUESTION, undefined, names, {
+    const { candidates, outcomes } = await collectPackCandidates(port, three, QUESTION, undefined, names, { probeTimeoutMs: PROBE_BUDGET_MS,
       expand: async () => EXPANSION
     })
     // quota per pack = floor(24 / 3) = 8 → the expansion may hold 4 of it: the list article is

--- a/apps/desktop/tests/unit/runtime-ladder.test.ts
+++ b/apps/desktop/tests/unit/runtime-ladder.test.ts
@@ -32,6 +32,7 @@ import { RuntimeManager } from '../../src/main/services/runtime'
 import type { ModelRuntime, RuntimeStartOptions } from '../../src/main/services/runtime'
 import type { UnexpectedExitInfo } from '../../src/main/services/runtime/sidecar'
 import type { GpuDevice } from '../../src/shared/types'
+import { hangPolls } from '../helpers/hang-budget'
 
 // Phase 15 start ladder (architecture.md GPU record §5.2). Zero binaries, zero GPUs:
 // everything runs through the injected makeLlama/makeMock/probe seams.
@@ -247,7 +248,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 
 /** Resolve once `cond` holds (micro/macro-task polling; injected budgets keep this fast). */
 async function until(cond: () => boolean): Promise<void> {
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < hangPolls(200, 1); i++) {
     if (cond()) return
     await new Promise((r) => setTimeout(r, 1))
   }

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -709,6 +709,19 @@ read*, not latency, so the fix was a `probeTimeoutMs` test seam (mirroring the e
 budget fires keep the real default. Verified by setting the seam to 1 ms: exactly those six
 expansion cases fail, which is what makes the seam's wiring provable rather than assumed.
 
+**There are TWO shapes of hand-rolled bound, and the counted one is nastier.** The first sweep
+caught only `Date.now() - start > N`. CI then failed `vision-security.test.ts` (run
+`34664328086`) on the other shape — a loop bounded by ITERATION COUNT:
+`for (let i = 0; i < 200; i++) { if (cond) break; await sleep(5) }`. That is a 1 s detector
+hard-coded in disguise, and worse than the wall-clock form in two ways: it does not widen on CI
+**and it falls through silently**, leaving the next assertion to fail with something opaque —
+here `expected [] to have a length of 1`, which says nothing about the event that never arrived.
+The suite's **16** counted loops across 7 files now use `hangPolls(n, stepMs)`, which applies the
+same 4×/45 s contract in steps. Where a counted loop can fall through, prefer failing by name
+after it (`vision-security`'s `waitForDoneEvent` is the pattern); `waitForTerminal` in the same
+file already did. **When adding a poll loop, bound it in wall-clock terms through one of these
+two helpers and make its exhaustion an error, never a `break` into the next assertion.**
+
 **What CI does NOT cover — the manual `HILBERTRAUM_*` matrix stays a separate human gate.** A green
 CI run says **nothing** about the real-`spawn` / real-binary / real-weights surface: that is the
 `HILBERTRAUM_*` manual harness matrix below (audit M-A5), which is env-gated and skips in CI. CI is

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -684,6 +684,31 @@ config, so each one needs its own CI headroom (`doctasks-translation.test.ts` sa
 far concurrent work got inside it; the latter is a property of the runner, not of the code (#457,
 #389).
 
+**Hand-rolled wall-clock bounds are CI-aware via one helper (#458 step 3).** The paragraph above
+warned that a `Date.now() - start > N` guard does not widen with `testTimeout`; the suite's
+**29** such bounds across 16 files, plus the two fixture `waitFor` defaults, now all go through
+[`tests/helpers/hang-budget.ts`](../apps/desktop/tests/helpers/hang-budget.ts):
+`hangBudgetMs(5_000)` stays 5 s at a desk and becomes 20 s on CI. The multiplier is 4× — exactly
+the ratio `testTimeout` already uses (15 s → 60 s) — capped at 45 s so a widened detector still
+fires *inside* the 60 s CI test budget and you keep its named error instead of a bare
+`Test timed out`. Every one of those bounds is a **hang detector**, not a measurement: exceeding
+it means "it never finished", never "it was slow".
+
+**What must NOT go through it:** a bound that is itself the evidence. `fts-rowid-sync`'s 500 ms
+(#84) and `zim-arm`'s `elapsedMs < 10_000` are timing PROOFS — the second exists to exclude the
+client's 15 s default, so widening it would stop it discriminating. Those are marked as
+deliberate exceptions in place.
+
+**When a test depends on a budget inside the PRODUCT, add a seam instead of loosening the
+assertion.** The sixth flake of this wave was `zim-arm`'s `collectPackCandidates` L3-b case (run
+`34659678616`): the arm's title lookup and document-frequency probes ran against a real 3 s
+`DF_PROBE_TIMEOUT_MS`, and on a starved runner that timer won — the list article was never read,
+so `rawReads` came back holding only the plain reads. The assertion was about *which articles get
+read*, not latency, so the fix was a `probeTimeoutMs` test seam (mirroring the existing
+`articleTimeoutMs`) that the expansion cases pass, while the #353 cases that *prove* the short
+budget fires keep the real default. Verified by setting the seam to 1 ms: exactly those six
+expansion cases fail, which is what makes the seam's wiring provable rather than assumed.
+
 **What CI does NOT cover — the manual `HILBERTRAUM_*` matrix stays a separate human gate.** A green
 CI run says **nothing** about the real-`spawn` / real-binary / real-weights surface: that is the
 `HILBERTRAUM_*` manual harness matrix below (audit M-A5), which is env-gated and skips in CI. CI is

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -558,10 +558,26 @@ matching; never mark an individual leg required.
 *at* their budget and any unlucky file failed a run no code change could have broken — five such
 flakes in two days, each costing a full re-run. Two shards halve the wall clock and with it the
 window a noisy neighbour can hit; runner minutes are free on a public repo, so the extra jobs cost
-only queue time. Note what sharding does **not** do: it halves *exposure*, not *crowding* — each
-shard still runs `availableParallelism() - 1` forks on a 4-core runner, so the CI-aware
-`testTimeout`/`hookTimeout` above remain what buys *tolerance*. The two changes address different
-halves of the same problem. **Ubuntu stays whole for a reason beyond cost:** one leg per Node
+only queue time.
+
+**What it actually bought, measured** (run `34662589439` — the first run in which the shard flag
+really reached vitest; see the forwarding note below for why the earlier ones did not):
+
+| | before | after |
+| --- | --- | --- |
+| windows `Test` step | 483–542 s | **221–239 s** |
+| windows job | 10–13 min | **5.3–5.7 min** |
+| critical path | windows, 13.3 min | **5.7 min** — windows is no longer the long pole (ubuntu 4.9–5.3 min) |
+
+The gain **beats** a halving, because per-file overheads fall too: per-file test cost went
+2.22 s → 1.65/1.99 s, and the two shards together spend *less* total test time than the single
+unsharded run (816 s vs 997 s). So the earlier framing here — "sharding halves *exposure*, not
+*crowding*" — was too strong: pressure per runner genuinely eases, plausibly because each runner
+now accumulates only half the leaked sqlite handles and locked temp roots of #460 (correlation,
+not a proven cause). What remains true is that each shard runs the same
+`availableParallelism() - 1` forks, so the CI-aware `testTimeout`/`hookTimeout` above are still
+what buy *tolerance* when a fork is starved; the two changes address different halves of the
+problem. **Ubuntu stays whole for a reason beyond cost:** one leg per Node
 version still runs all 449 files in a *single* vitest process, so cross-file interference (shared
 module state, a leaked global, an ordering dependency) keeps a leg that can still see it; a fully
 sharded matrix would partition that surface away everywhere at once.


### PR DESCRIPTION
Step **3 of 3** for #458 — the last acceptance item: *"any remaining assertion that pins progress-within-a-deadline is restated as a bound, or given an explicit CI-aware budget."*

Also carries `24d27d57`, the measurement/correction commit that #463 merged one commit short of (docs only — the measured sharding figures and a correction to an overclaim I made in #462).

## 1. Hand-rolled bounds are now CI-aware

`vitest.config.ts` widens `testTimeout`/`hookTimeout` to 60 s on CI because the windows runners are starved — but **a hand-rolled `Date.now() - start > N` guard is invisible to that config and does not widen with it.** The suite carried **29** such bounds across **16** files, plus two fixture `waitFor` defaults, all pinned at desk-tight values on the one platform that needed slack.

They now route through the new `tests/helpers/hang-budget.ts`:

- **4× on CI** — exactly the ratio `testTimeout` already uses (15 s → 60 s), so the constant is one the repo has already blessed rather than a new invention.
- **Capped at 45 s**, so a widened detector still fires *inside* the 60 s CI budget. Otherwise its named error (`task never finished: running`) is replaced by a bare `Test timed out in 60000ms` and the diagnosis is lost.
- **Unchanged locally**, so a real hang still fails fast at a desk.

`doctasks-translation.test.ts` had already documented this exact trap at its own 30 s detector, after it flaked 3 of 4 runs. This generalises that one-off fix instead of waiting for each bound to be bitten in turn.

The two fixture `waitFor` helpers are widened **at the comparison**, not at the default, so callers that pass an explicit budget benefit too.

## 2. What deliberately does NOT go through it

A bound that is itself the evidence must not be silently relaxed. Marked as exceptions in place:

- `fts-rowid-sync`'s `elapsed <= 500` (#84) — a scan-regression guard, already twinned by an EXPLAIN-QUERY-PLAN structural test.
- `zim-arm`'s `elapsedMs < 10_000` — its whole job is to exclude the client's 15 s default, so a wider bound stops discriminating and a CI-scaled one would mean nothing. Its comment now says that if it ever flakes, the fix is to **shrink what is measured** via the new seam below — never to raise the number toward 15 s.

## 3. The sixth flake was not the assertion's fault

I previously called run `34659678616` a #457/#389-class assertion problem. Reading the failure properly, it is not. The received value was `plainReads` alone — `rawReads` was **missing the list-article reads**:

```
FAIL tests/integration/zim-arm.test.ts > collectPackCandidates … L3-b
expected [ 'Kohlekraftwerk', 'Kohleausstieg' ] to deeply equal [ … ]
```

The cause is in the product, not the test. `articleTimeoutMs` was already an injectable test seam, but `DF_PROBE_TIMEOUT_MS` (3 s) was hardcoded — so the title lookup and document-frequency probes raced a **real 3 s timer against a local stub**. On a starved runner the timer won, the lookup was abandoned, and the list article was never read.

Those assertions are about *which articles get read*, not latency, so the honest fix is a seam, not a restated assertion: `probeTimeoutMs`, mirroring `articleTimeoutMs`. The expansion cases pass a generous value; the #353 cases that *prove* the short budget fires keep the real default. Production sets neither — the diff is one optional field and two `??` defaults.

**Verified the seam is wired rather than assumed:** set it to `1` and exactly the six expansion cases fail; at `30_000` all 30 pass. That is the check that would have caught it had it been wrong.

## Verification

- `npm run typecheck` green.
- `npm test` green: **449 files, 7,157 passed / 85 skipped**.
- `zim-arm`, `doctasks-translation`, `downloads`, `local-api-server` run individually: green.
- The seam falsification test above.

## Disclosed: one pre-existing flake, not from this change

An earlier full run here failed `zim-client.test.ts`'s two 8 MiB loopback legs with `read ECONNRESET`; the re-run was green. It is **not** caused by this branch, and not merely by absence of edits — `CI` is unset locally, so `hangBudgetMs` returns its input unchanged and the whole diff is a behavioural no-op at a desk; `zim-client.test.ts` is untouched and imports nothing new.

Worth recording on #458 rather than burying, because it sits **outside this wave's three levers**: the test already carries a 60 s budget *and* two retries, and its own comment documents the same signature from 2026-09-05. A *reset* connection is not a *slow* one, so no `testTimeout`, `hookTimeout` or `hangBudgetMs` value can fix it. If the "green on a first push over a week" criterion ends up with a floor, this is the likeliest cause — and it wants its own issue rather than more budget.

## Note for the next entry

`BUILD_STATE.md`'s preamble is at **200/200** again, so the next entry needs a closed one retired to `docs/build-log.md` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
