### PR TITLE
fix(performance): an automatic check says so instead of a frozen step list (#438)

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -48,6 +48,16 @@ own 3 s `DF_PROBE_TIMEOUT_MS` lost its race on a starved runner so the list arti
 `articleTimeoutMs`) stops the expansion cases racing that 3 s timer, verified by setting it to 1 ms and watching exactly those 6 cases fail.
 Timing PROOFS are deliberately excluded from the helper (`fts-rowid-sync` 500 ms #84; `zim-arm:672`, which exists to exclude the 15 s default).
 Acceptance ("green on a first push over a week") is judged from real traffic._
+_2026-09-12 — **#438 CLOSED — the automatic check's frozen step list; owner call taken on option 2**
+(`fix/438-automatic-check-step-list`; record `benchmark.md` "An automatic run's step list", which carries the three options and
+the reasoning). Two CORRECT decisions multiplied: progress is addressed to the window that invoked `benchmark:run` (the automatic
+scheduler passes none) while the screen drew the list for any held BACKEND span (audit M1) — so #331 leg 2's moved-drive check sat
+frozen on step 1 for 13.7 s. The list now belongs to a run THIS window started; every other span renders one line,
+`perf.running.background`, **inside the same live region**, so an automatic check is announced rather than silent (an empty region
+would have regressed #437). Option 1 (broadcast) was rejected as a HALF-fix — the common path is the user arriving MID-RUN, and a
+late-joining window has already missed the one-shot steps. IPC contract UNCHANGED. Residuals: no per-step detail for an automatic
+run (option 3, the steps carried in `PerformanceSnapshot`, stays available), and the by-ear leg #436/#437 owe now has this line._
+_2026-09-11 — **#413 CLOSED — `USABLE_VRAM_MB` stays 5,120, decided without a 4 GB measurement** (`docs/413-keep-usable-vram-floor`; record
 `model-benchmarks.md` §6.6 N8 "Decided 2026-09-11", §5 item 22 (e)(1)). The project owns no 4 GB card and will not buy one. Keeping the floor
 self-corrects (placement ignores it; a crawl on the RAM pick steps the ★ down, §6.5); lowering it would pin the E2B with no step back up. Docs only._
 _2026-09-10 — **#446 CLOSED — the three untested chat entries measured; `qwen3.6` joins the rule, `granite` does not**
@@ -155,21 +165,6 @@ so 1,000 ms stands, not 1,500; 60 real article opens through the shipped client 
 0 + 0 at 19.9 ms/open**. Suite 423 files / 7,065 (+14 legs). Evidence: `ai_drive-archive/zim-wave-2026-09/evidence/range-fix-2026-09-08/`.
 The three closed ZIM wave entries (#301 / the follow-up wave / the open-issues wave) are retired verbatim to `docs/build-log.md`
 "2026-09-08 — the three closed ZIM knowledge-pack wave entries"; §5 item 21 holds what is still open (all of it the owner's)._
-_2026-09-07 — **#372 (the #312 follow-up; `fix/372-model-load-latch`):** a model the ladder blamed is latched for the session
-(`factory.ts` module state beside the #182 latch): its next start spawns no rung, re-fires the model-named notice and lands on the
-mock at once — no repeated 180 s health timeouts. With acceleration off / auto-disabled (no GPU rung to compare against) every rung
-failing now names the model too; `gpuAutoDisabled` is never written on that path. Only a `failureSignature` class latches (never a
-bind race or an unrecognised shape). Clearing rule: "Verify checksum" on the model, a completed download of it, a chat-engine install
-(every latch), an app restart — not "Try GPU again". Record: GPU record §5.2 "#372" paragraph + §5.4 table; user-guide, known-limitations,
-CHANGELOG. Tests: `runtime-ladder.test.ts` "#372" (16 cases + the `ctx.onModelInstalled` source pin), `core-model-ipc`, `engine-consent-ipc`, `gpu-ipc`._
-_2026-09-07 — **Models/runtime fix wave (#310, #312, #313, #314, #315; `fix/310-315-models-runtime-wave`, one PR):**
-#310 a manifest declares every required weight file (`files:`, validator fail-closed incl. shard-set completeness; one enumeration
-`manifestFiles()` feeds install state, verify, byte totals, prefetch, planner, both verify/fetch scripts; sidecar roles need every
-file present); #312 the ladder holds a rung-1 failure until a forced-CPU rung answers — same failure class on every rung blames the
-MODEL (nothing persisted, `runtime:notice` names it), a CPU rung starting persists as before (GPU record §5.2); #313 family options
-follow view + task, a kept selection is marked, family-only reset; #314 `downloads:list`/`downloads:dismiss` re-attach a download after
-a renderer reload, dismissal lives in main memory; #315 findBy assertions, baseline staleness test, 17 dead keys deleted. Owner rulings
-taken on the plan defaults (PR body). Suite: master 421 files / 6,815 tests → 422 / 6,930 (85 skipped); typecheck + build green; the zim-packs T14 case flaked once under full load (green alone, untouched here). Residuals: §5 item 23._
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -193,7 +188,10 @@ entries on 2026-09-09 (preamble budget, making room for the knowledge-packs docs
 HW3-acceptance entries), and the three closed 2026-09-06 entries (the #303 follow-up wave, the PR #308
 audit remediation, the PR #303 audit remediation) on 2026-09-10 (preamble budget, making room for the
 #436/#437 accessibility entry), and the two oldest closed entries (#333 manifest-read cost, #318
-hardware session) on 2026-09-12 (preamble budget, making room for the #458 CI entry) —
+hardware session) on 2026-09-12 (preamble budget, making room for the #458 CI entry), and the two
+closed 2026-09-07 models/runtime entries (#372, and the #310/#312/#313/#314/#315 wave of PR #371 —
+its residuals stay live in §5 item 23) on 2026-09-12 (preamble budget, making room for the #438
+entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,14 @@ from its first public `1.0.0` release onward.
 
 ### Fixed
 
+- **A check that starts on its own now says so, instead of showing a progress list that never
+  moves.** The app checks what your computer can do by itself the first time, and again whenever
+  the drive is plugged into a different computer. On the Performance screen that check used to
+  appear as the same three-step list you get from a check you start yourself — except that it
+  never advanced: it sat on the first step for the whole check (about fourteen seconds on a real
+  drive) and then vanished. The screen now says "Checking this computer in the background." for a
+  check it did not start, and a screen reader reads that out. A check you start yourself still
+  shows each step as it completes.
 - **List questions against knowledge packs now work on slower computers too.** When you ask a
   pack something like "which countries emit the most CO2", the app first asks your local model
   what a list article about it would be called. That step was given six seconds, which turned out

--- a/apps/desktop/src/renderer/screens/PerformanceScreen.tsx
+++ b/apps/desktop/src/renderer/screens/PerformanceScreen.tsx
@@ -29,8 +29,11 @@ import type {
 // "Performance screen"). Four cards — "This computer", "Observed while you worked", "Models on
 // this computer", "Other computers":
 //   1. "This computer": the hardware check's answer as a verdict line + four tiles (speed,
-//      memory, graphics memory, drive) and the one action, "Check again". While a check runs, the steps show
-//      as they land (EVENTS.benchmarkProgress) instead of an opaque "Running…" button. The model
+//      memory, graphics memory, drive) and the one action, "Check again". While a check THIS
+//      window started runs, the steps show as they land (EVENTS.benchmarkProgress) instead of an
+//      opaque "Running…" button; a check the window did not start says so in one line instead
+//      (#438 — main addresses the steps to the window that asked, so there are none to drive a
+//      list with, and a list that cannot advance is worse than no list). The model
 //      the verdict and the "Start … and measure" offer name is `snapshot.recommendation` — the
 //      LIVE pick the AI Model screen stars; the result's saved pick is history, labelled
 //      "Recommended at the time of the check" where it differs.
@@ -398,9 +401,11 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
     // run as readily as into one.
     setSnap(next)
     // A run this window did not start has no steps here (main sends `benchmark:progress` to the
-    // requesting window only), so it shows the running state with none ticked rather than
-    // inventing them. Our own run cleared them at the click and its first step can land before
-    // this snapshot does — re-clearing under our own run would un-tick it.
+    // requesting window only), so the card shows the one-line background state instead of a step
+    // list nothing can advance (#438). Clearing on the edge still matters: it is what makes
+    // `doneSteps` a reliable "these steps are MINE" marker for the render below. Our own run
+    // cleared them at the click and its first step can land before this snapshot does —
+    // re-clearing under our own run would un-tick it.
     if (next.running && !backendRunningRef.current && !ownActionRef.current) setDoneSteps([])
     backendRunningRef.current = next.running
   }, [])
@@ -563,6 +568,19 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
   const backendRunning = snap?.running ?? false
   /** What the card shows as busy: a run anywhere on this machine, or this window's own action. */
   const busy = backendRunning || ownActionInFlight
+  /**
+   * Whether the step list is OURS to drive (#438). Progress is addressed to the window that
+   * invoked `benchmark:run`, so only a run this window started ever produces steps; for every
+   * other run — the first-run path, the moved-drive check, another window — the list could never
+   * advance, and one was observed frozen on step 1 for a whole 13.7 s check (#331 leg 2).
+   *
+   * `doneSteps.length > 0` is the second term rather than `ownActionInFlight` alone because the
+   * flag is cleared in the action's `finally`, one snapshot read BEFORE `backendRunning` catches
+   * up — without it the list would blink to the background line at the tail of our own run. A
+   * foreign run cannot fake the term: it delivers no steps, and `applySnapshot` clears whatever
+   * an earlier own run left as the span is taken.
+   */
+  const showOwnSteps = ownActionInFlight || doneSteps.length > 0
 
   // Keyboard focus across the busy swap (HW3; design-guidelines §6). The busy branch renders a
   // DIFFERENT subtree — the steps list plus a disabled "Running…" button — so the action button
@@ -945,10 +963,11 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
 
   /**
    * The progress-step ITEMS. The <ul> that holds them is mounted unconditionally below — this
-   * returns only what goes inside it while a check runs (#437 cause 1: the region used to be
-   * created together with its <li>s, i.e. inserted already containing its content, which is the
-   * M-U1 anti-pattern every other live region in the renderer avoids; Narrator heard nothing
-   * across two real 14-second runs).
+   * returns only what goes inside it while a check THIS WINDOW STARTED runs (#437 cause 1: the
+   * region used to be created together with its <li>s, i.e. inserted already containing its
+   * content, which is the M-U1 anti-pattern every other live region in the renderer avoids;
+   * Narrator heard nothing across two real 14-second runs). A run this window did not start gets
+   * the single background line instead — see `showOwnSteps` (#438).
    */
   function stepItems(): JSX.Element[] {
     // The speed step only exists when a runtime is up; a run with no model shows it skipped.
@@ -1007,8 +1026,16 @@ export function PerformanceScreen({ onNavigate }: PerformanceScreenProps): JSX.E
         {/* The live region is mounted at all times — empty while idle (`.perf-steps:empty`
             collapses it, so the idle layout is unchanged) and filled while a check runs, so the
             steps arrive as a text change INSIDE a region that was already there (#437). Nothing
-            in here may carry a live-region role of its own — see #436. */}
-        <ul className="perf-steps" aria-live="polite">{busy ? stepItems() : null}</ul>
+            in here may carry a live-region role of its own — see #436.
+
+            Two fillings, never both (#438). Our own run gets the advancing step list. Any other
+            run — first-run, moved-drive, another window — gets ONE line saying a check is under
+            way: it is the honest thing to show for a run whose progress this window is never
+            sent, and it keeps the automatic check announced rather than silent, which an empty
+            region would have made it. */}
+        <ul className="perf-steps" aria-live="polite">
+          {showOwnSteps ? stepItems() : busy ? <li className="perf-step">{t('perf.running.background')}</li> : null}
+        </ul>
         {busy ? (
           <>
             <div className="actions perf-actions">

--- a/apps/desktop/src/shared/i18n/de.ts
+++ b/apps/desktop/src/shared/i18n/de.ts
@@ -1999,6 +1999,9 @@ export const de: Record<keyof typeof en, string> = {
   'perf.step.speed': 'Generierungsgeschwindigkeit mit {model}',
   'perf.step.speedSkipped': 'Generierungsgeschwindigkeit (kein Modell läuft, übersprungen)',
   'perf.step.hint': 'Etwa eine halbe Minute. Du kannst die App weiter benutzen.',
+  // #438: eine von der App selbst gestartete Prüfung sendet ihre Schritte an niemanden — statt
+  // einer auf Schritt 1 eingefrorenen Liste diese eine Zeile, in derselben Live-Region.
+  'perf.running.background': 'Dieser Computer wird im Hintergrund geprüft.',
   // #437: der Schrittzustand steckt jetzt im Text, nicht nur in der CSS-Klasse.
   'perf.step.state.done': '{step}: fertig',
   'perf.step.state.active': '{step}: läuft',

--- a/apps/desktop/src/shared/i18n/en.ts
+++ b/apps/desktop/src/shared/i18n/en.ts
@@ -2000,6 +2000,11 @@ export const en = {
   'perf.step.speed': 'Generation speed with {model}',
   'perf.step.speedSkipped': 'Generation speed (no model running, skipped)',
   'perf.step.hint': 'About half a minute. You can keep using the app.',
+  // #438: a check the app started by itself (first run, or this drive arriving on a different
+  // computer) sends its steps to nobody, so the screen cannot show them advancing. It says this
+  // instead of a step list frozen on step 1 — and because it lands in the same live region the
+  // steps use, an automatic check is still ANNOUNCED rather than silently under way.
+  'perf.running.background': 'Checking this computer in the background.',
   // #437: a step's progress used to live ONLY in a CSS class and an aria-hidden icon, so the
   // live region's text never changed as the check advanced and a screen reader heard nothing
   // after the list appeared. Each step now carries its state IN ITS TEXT — the whole line is

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -2351,7 +2351,10 @@ export const MAX_BENCHMARK_HISTORY = 8
 /**
  * The step the running benchmark is on (`EVENTS.benchmarkProgress`): the Performance screen
  * shows the steps as they complete instead of one opaque "Running…" button. 'speed' is
- * skipped entirely (no event) when no runtime is up.
+ * skipped entirely (no event) when no runtime is up. Addressed to the window that invoked
+ * `benchmark:run`, so a run started anywhere else (first-run, moved-drive, another window)
+ * produces none — the screen shows one background line for those rather than a list it could
+ * never advance (#438).
  */
 export type BenchmarkProgressStep = 'system' | 'drive' | 'speed' | 'done'
 

--- a/apps/desktop/tests/renderer/PerformanceScreen.test.tsx
+++ b/apps/desktop/tests/renderer/PerformanceScreen.test.tsx
@@ -973,7 +973,7 @@ describe('PerformanceScreen: the pushed refresh', () => {
     expect(screen.getByText(/Runs Qwen3\.5 9B/)).toBeInTheDocument()
   })
 
-  it('M1: an external run shows as running with no steps ticked, never the last run’s', async () => {
+  it('M1 + #438: an external run shows as running with the background line, never the last run’s steps', async () => {
     let resolveRun: (r: BenchmarkResult) => void = () => {}
     const { api, progress, pushes } = install(snapshot(), {
       runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
@@ -986,11 +986,46 @@ describe('PerformanceScreen: the pushed refresh', () => {
       resolveRun(result())
     })
     await screen.findByRole('button', { name: 'Check again' })
-    // Someone else takes the lane: this window gets no steps for that run, so it shows none.
+    // Someone else takes the lane. Main addresses progress to the window that invoked the run, so
+    // this window is never sent that run's steps and a step list could only sit frozen on step 1
+    // (#438, measured at 13.7 s on a real moved-drive check). The region carries one honest line
+    // instead — and nothing of our own finished run survives into it.
     api.getPerformance.mockResolvedValue(snapshot({ running: true }))
     await pushChanged(pushes)
     expect(await screen.findByRole('button', { name: 'Running…' })).toBeDisabled()
-    expect(screen.getByText('Hardware detected').closest('li')?.className).not.toContain('perf-step-done')
+    expect(screen.getByText('Checking this computer in the background.')).toBeInTheDocument()
+    expect(screen.queryByText('Hardware detected')).not.toBeInTheDocument()
+  })
+
+  it('#438: the background line sits IN the step region, so an automatic check is still announced', async () => {
+    install(snapshot({ running: true }))
+    renderScreen()
+    // The region is the always-mounted <ul> of #437: the line arrives as a text change inside a
+    // region that was already there, which is what makes it audible. An empty region would have
+    // left the automatic check silent — the cost this option would otherwise have carried.
+    const region = (await screen.findByText('Checking this computer in the background.')).closest('ul')
+    expect(region).toHaveClass('perf-steps')
+    expect(region).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('#438: at the tail of our own run the list stays ours, never blinking to the background line', async () => {
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    const { api, progress, pushes } = install(snapshot(), {
+      runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r)))
+    })
+    mountScreen()
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    act(() => progress.forEach((cb) => cb('system')))
+    // The backend still holds the span when the invoke resolves and `ownActionInFlight` drops —
+    // exactly the window in which that flag ALONE would have handed the region to the background
+    // line for a run the user is watching their own steps on.
+    api.getPerformance.mockResolvedValue(snapshot({ running: true }))
+    await pushChanged(pushes)
+    await act(async () => {
+      resolveRun(result())
+    })
+    expect(screen.queryByText('Checking this computer in the background.')).not.toBeInTheDocument()
+    expect(screen.getByText('Hardware detected').closest('li')?.className).toContain('perf-step-done')
   })
 
   it('the push announcing our OWN run does not un-tick the steps it already reported', async () => {
@@ -1519,10 +1554,17 @@ describe('PerformanceScreen: labels that match what is measured', () => {
   })
 
   it('N5: the drive step is "Drive speed", not "Drive write speed" beside a tile reading MB/s read', async () => {
-    install(snapshot({ running: true }))
+    let resolveRun: (r: BenchmarkResult) => void = () => {}
+    install(snapshot(), { runBenchmark: vi.fn(() => new Promise<BenchmarkResult>((r) => (resolveRun = r))) })
     renderScreen()
-    expect(await screen.findByText('Drive speed')).toBeInTheDocument()
+    // The step list belongs to a run THIS window started (#438), so press the button rather than
+    // borrowing a foreign `running: true` span — that now shows the one-line background state.
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }))
+    expect(screen.getByText('Drive speed')).toBeInTheDocument()
     expect(screen.queryByText(/write speed/i)).not.toBeInTheDocument()
+    await act(async () => {
+      resolveRun(result())
+    })
   })
 })
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1037,10 +1037,69 @@ a probe that FAILED while something was busy (the stop that killed the stream) r
 the PROBES are complete: it precedes the persist and the occupancy release, so it is not the
 idle signal — the terminal `performance:changed` after both is. The IPC handler forwards the
 steps to the requesting window only, as `benchmark:progress`, and the screen shows a step
-list instead of an opaque "Running…" button. The first-run path passes no callback. The drive
+list instead of an opaque "Running…" button. The first-run path passes no callback — so the
+step list is shown for a run THIS window started, and any other run (first-run, moved-drive,
+another window) gets a single "Checking this computer in the background." line in the same live
+region instead of a list nothing could advance (#438; see "An automatic run's step list" below).
+The drive
 step is labelled **"Drive speed"**, not "Drive write speed" (PR #303 audit N5): the step's write
 probe is one input, and the tile the user reads next to it reports MB/s *read* — naming the step
 after the write leg contradicted the figure it leads to.
+
+### An automatic run's step list (#438, owner decision 2026-09-12)
+
+Found by #331 leg 2 on the E: stick: a moved-drive check ran for 13.7 s with the Performance
+screen mounted, the step list frozen on step 1 for the whole run, then gone. A manual "Erneut
+prüfen" advanced normally in the same session — the contrast case.
+
+**Cause: two correct decisions multiplying.** Progress is emitted only from the `benchmark:run`
+IPC handler and addressed to `event.sender`, the window that invoked it; the automatic scheduler
+calls `runAndPersistBenchmark(ctx)` with no callback at all. The screen meanwhile renders the list
+on `busy`, which follows the BACKEND span (`snap.running`), not "a run this window started" —
+deliberately so, per audit **M1**: merging the two locked the screen into "Running…" for a foreign
+run and never let it out. So the list was shown for a run whose progress can never arrive.
+
+**Options weighed.** (1) Broadcast the steps to every window and have the scheduler pass a
+callback. (2) Show the steps only for an own action, and give any other run one honest line.
+(3) Carry the completed steps in `PerformanceSnapshot`, so the screen reconstructs them on any
+mount.
+
+**Decided: (2).** (1) was rejected as a HALF-fix, on a fact the issue's own framing missed: the
+automatic check fires about a minute after unlock, once the model start settles, so the common
+path is the user arriving on Performance **mid-run** — and a late-joining window has already
+missed the earlier one-shot messages. It would render "Hardware detected: in progress · Drive
+speed: waiting · Generation speed: done", which is worse than frozen. The cheap patch — a step
+marks every earlier one done — is barred by the **L3** honesty rule: a step is reported only when
+it SUCCEEDED, so back-filling would claim a skipped drive probe had passed. (3) fixes the
+late-join case properly and stays the option if per-step detail for automatic runs is ever
+wanted; it was not worth a shared-shape change plus a push per step for a case nobody reported.
+
+**As built.** `showOwnSteps = ownActionInFlight || doneSteps.length > 0` gates the items; any
+other held span renders one `<li>` carrying `perf.running.background` ("Checking this computer in
+the background." / "Dieser Computer wird im Hintergrund geprüft."). Three things that look
+incidental and are not:
+
+- The line goes **inside** the always-mounted `.perf-steps` live region of #437, not beside it.
+  An empty region would have left the automatic check silent to a screen reader — a regression
+  against #437 rather than a neutral subtraction. Inside it, the line is a text change in a region
+  that was already there, which is what makes it audible. It carries no live-region role of its
+  own (#436).
+- `doneSteps.length > 0` is the second term because `ownActionInFlight` is cleared in the action's
+  `finally`, one snapshot read BEFORE `backendRunning` catches up; on the flag alone the region
+  would blink to the background line at the tail of the user's own run.
+- A foreign run cannot fake that term: it delivers no steps, and `applySnapshot` clears whatever
+  an earlier own run left as the span is taken — which is what makes `doneSteps` a sound "these
+  steps are MINE" marker.
+
+**The IPC contract is unchanged** — steps still go to the requesting window only. This is a
+renderer-side decision about what to DRAW for a run that has none. Pinned by
+`PerformanceScreen.test.tsx` "M1 + #438: an external run shows as running with the background
+line, never the last run's steps", "#438: the background line sits IN the step region, so an
+automatic check is still announced" and "#438: at the tail of our own run the list stays ours,
+never blinking to the background line".
+
+**Residual:** an automatic check reports no per-step detail, and the outstanding by-ear leg now
+has this line to hear as well.
 
 ### The Diagnostics benchmark card — a support artifact (§5 item 22 (b), owner decision 2026-09-08)
 
@@ -1259,7 +1318,7 @@ guess.
 | TH2 | fixed P8 `4baec2be` | `closePerformanceFixture()` tears down every DB/root/observer the performance test helper registered; a leak check showed zero growth across a targeted run. The other suites' ~2,500 leaked roots per full run (#335, 2026-09-06) are now recorded and removed by the harness itself — `tests/setup-temp-roots.ts` per file, `tests/global-temp-roots.ts` after the forks exit; design in `tests/helpers/temp-roots.ts`, rule in CONTRIBUTING.md. | `tests/helpers/performance-fixture.ts`; `tests/unit/temp-roots.test.ts` |
 | HW1 | verified 2026-09-07 (issue #330) | Physical encrypted-drive A→B→A move on two real computers (i9-14900K / RTX 3080 Ti and i7-8700 / GTX 1070 Ti, one exFAT SSD) for a fresh workspace AND an upgraded one created by 0.1.57 (keyed `lastBenchmark`, no history): new-computer background run on B, instant restore on A, the outgoing result backfilled, later samples update the headline and the matching entry only. Side findings are not persistence defects (§4). | `eval/results/hardware/330-round-trip-20260907/` (`00-protocol.md` + every report and log) |
 | HW2 | CLOSED 2026-09-08 (#329) | Same gap as T9, closed by the same capture: real partial-offload load logs from the pinned build now exist (20/33 and 18/33 on a hybrid laptop, 62/66 on an RTX 3090) and are committed as fixtures. | `apps/desktop/tests/fixtures/placement-b9849-*.txt`; `eval/results/hardware/` |
-| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the four blocked legs CLOSED 2026-09-09 (issue #331) | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). The four legs not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms) were performed 2026-09-09 on the E: stick with a moved-drive workspace and a real 14B: **chat-during-a-span and mounted-screen refresh PASSED; both live regions were SILENT under a screen reader (#436, #437 — code fixed 2026-09-10, by-ear re-verification still outstanding) and an automatic run's step list never advances (#438, open owner call)**. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run"; `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md` |
+| HW3 | performed P10 (live, CDP-driven, at `07dd9085`); the four blocked legs CLOSED 2026-09-09 (issue #331) | Passed in the dev app: EN/DE layout at 880/1024/1280 px in both themes with no horizontal overflow, the German rail label at font weight 600 on one line, the keyboard focus order (a real Tab walk in visual order, no trap) and Enter activation. The one failure it found — focus lost after an own run — is the HW3-focus row below (fixed P10). The four legs not exercisable on the review box (no screen reader, no runtime, a first run that finishes in ~120 ms) were performed 2026-09-09 on the E: stick with a moved-drive workspace and a real 14B: **chat-during-a-span and mounted-screen refresh PASSED; both live regions were SILENT under a screen reader (#436, #437 — code fixed 2026-09-10, by-ear re-verification still outstanding) and an automatic run's step list never advances (#438 — decided and fixed 2026-09-12, owner call for option 2: the step list belongs to a run this window started, any other run gets one announced background line; record "An automatic run's step list" above)**. | `GermanSmoke.test.tsx` "PerformanceScreen renders German (PR #303 audit T6)"; `rail-labels.test.ts`; `PerformanceScreen.test.tsx` describe "PerformanceScreen: focus survives the run"; `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md` |
 | HW4 | follow-up issue #332 | Hybrid `[iGPU, dGPU]` Vulkan order and Apple Silicon unified memory: synthetic fixtures only. | — |
 | DR1 | fixed P5 `be177a34` | Chat/translation "on the card" rows now respect `gpuMode`, `gpuAutoDisabled` and the matching observed backend, not the hardware class alone. | `performance-gpu.test.ts` "gpuMode 'off': both rows say cpu, the verdict is the processor estimate against RAM, bothOnCard is false — the hardware class is untouched"; "a matching start OBSERVED on the CPU backend puts the chat row on the processor and judges it against RAM" |
 | DR2 | fixed P5 `be177a34` | `ModelPlacement.devices` keeps every GPU row of the `device_info` block; `attributedGpuFigures` matches by device name, never the first row's. | `placement-parser.test.ts` "keeps every GPU row of a hybrid device_info block with its own compute buffer, by label (DR2)"; `performance-gpu.test.ts` "a hybrid log: the figures are the selected dGPU's, by name — never the first row's" |
@@ -1427,9 +1486,12 @@ commit references, and added the changelog entry.
   fails on any live-region role nested inside another; it flags all three pre-fix sites.
   **The acceptance is not complete:** both issues require re-verification BY EAR (a real failure
   and a wrong-password unlock for #436; a real multi-second check for #437), and that needs a
-  screen reader on this box. What is pinned so far is the DOM, not the sound. #438 remains an
-  open owner call on the same subtree; the #437 fix is forward-compatible with either of its
-  options (under option 2 the items render on `ownActionInFlight` rather than `busy`).
+  screen reader on this box. What is pinned so far is the DOM, not the sound.
+
+  **#438 decided and fixed 2026-09-12 (owner call, option 2).** Design record: "An automatic run's
+  step list" under "Performance screen" above. It lands on the same subtree, so its by-ear leg
+  folds into the one session #436/#437 still owe — the automatic check now SAYS something where it
+  previously said nothing, and that line is what the session has to hear.
 - **HW3-focus**: the keyboard-focus-after-a-run fix (`PerformanceScreen.test.tsx` "PerformanceScreen:
   focus survives the run") is pinned in jsdom and was re-verified live at P11 in the dev app
   built from `ab01e14b`: with "Check again" focused, a real Enter press ran the check (the

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -50,6 +50,29 @@ on the card anyway; 24 GB: Q4 66/66, Q5 62/66 under rung 1a yet 66/66 with `-np 
 Intel-first hybrid do not exist in the project → predicted by inference. Record + six findings: `model-benchmarks.md`
 §6.6 "Hardware verification"; evidence `eval/results/hardware/<slug>/`; routed to #319/#320/#321/#329/#332; §5 item 22 (e)–(k)._
 
+## 2026-09-12 — the two 2026-09-07 models/runtime entries retired verbatim (preamble budget)
+
+_Moved out of `BUILD_STATE.md` while making room for the #438 entry. Both waves are closed: the
+#372 model-load latch and the #310/#312/#313/#314/#315 models-runtime fix wave (PR #371). The
+wave's still-open residuals stay live in `BUILD_STATE.md` §5 item 23; the durable records are the
+GPU record §5.2/§5.4 in `docs/architecture.md`._
+
+_2026-09-07 — **#372 (the #312 follow-up; `fix/372-model-load-latch`):** a model the ladder blamed is latched for the session
+(`factory.ts` module state beside the #182 latch): its next start spawns no rung, re-fires the model-named notice and lands on the
+mock at once — no repeated 180 s health timeouts. With acceleration off / auto-disabled (no GPU rung to compare against) every rung
+failing now names the model too; `gpuAutoDisabled` is never written on that path. Only a `failureSignature` class latches (never a
+bind race or an unrecognised shape). Clearing rule: "Verify checksum" on the model, a completed download of it, a chat-engine install
+(every latch), an app restart — not "Try GPU again". Record: GPU record §5.2 "#372" paragraph + §5.4 table; user-guide, known-limitations,
+CHANGELOG. Tests: `runtime-ladder.test.ts` "#372" (16 cases + the `ctx.onModelInstalled` source pin), `core-model-ipc`, `engine-consent-ipc`, `gpu-ipc`._
+_2026-09-07 — **Models/runtime fix wave (#310, #312, #313, #314, #315; `fix/310-315-models-runtime-wave`, one PR):**
+#310 a manifest declares every required weight file (`files:`, validator fail-closed incl. shard-set completeness; one enumeration
+`manifestFiles()` feeds install state, verify, byte totals, prefetch, planner, both verify/fetch scripts; sidecar roles need every
+file present); #312 the ladder holds a rung-1 failure until a forced-CPU rung answers — same failure class on every rung blames the
+MODEL (nothing persisted, `runtime:notice` names it), a CPU rung starting persists as before (GPU record §5.2); #313 family options
+follow view + task, a kept selection is marked, family-only reset; #314 `downloads:list`/`downloads:dismiss` re-attach a download after
+a renderer reload, dismissal lives in main memory; #315 findBy assertions, baseline staleness test, 17 dead keys deleted. Owner rulings
+taken on the plan defaults (PR body). Suite: master 421 files / 6,815 tests → 422 / 6,930 (85 skipped); typecheck + build green; the zim-packs T14 case flaked once under full load (green alone, untouched here). Residuals: §5 item 23._
+
 ## 2026-09-10 — the three 2026-09-06 entries retired verbatim (preamble budget)
 
 _Moved out of `BUILD_STATE.md` while making room for the #436/#437 accessibility entry. All three

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -717,7 +717,9 @@ head's own weights + KV.
   the injected `effectiveRead`.
 - **`ipc/registerBenchmarkIpc.ts`** — `runBenchmark()` (`benchmark:run`); runs it, persists to
   `settings.lastBenchmark` + `settings.benchmarkHistory`, returns the result, and streams
-  `benchmark:progress` (`BenchmarkProgressStep`) to the requesting window — a step only when it
+  `benchmark:progress` (`BenchmarkProgressStep`) to the requesting window (so the Performance
+  screen draws a step list only for a run IT started; any other held span gets one announced
+  background line instead — #438, `benchmark.md` "An automatic run's step list") — a step only when it
   succeeded (`'drive'` only on a successful probe, `'speed'` only on an obtained reading,
   `'done'` always, and `'done'` PRECEDES the persist and the occupancy release). `performance:get`
   returns the `PerformanceSnapshot` the Performance screen renders (`current`,

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -2486,11 +2486,22 @@ All of these are decided scope, not oversights; the design record's §7 carries 
   "the step list is announceable (#437)". **What is pinned is the DOM, not the sound:** both
   issues ask for re-verification by ear during a real multi-second check, and that still needs a
   screen reader on the hardware box.
-- **An automatic check shows a step list that never advances.** A first-run or moved-drive check
-  is run by the main process, and progress steps are addressed only to the window that pressed
-  the button — but the screen renders the list whenever the backend span is held (correct per
-  audit M1). So a moved-drive check sits frozen on step 1 for its whole duration (measured:
-  13.7 s) and then disappears. A manual check does advance. Tracked as #438.
+- **An automatic check reports itself in one line, not as steps — FIXED 2026-09-12 (#438).** A
+  first-run or moved-drive check is run by the main process, and progress steps are addressed only
+  to the window that invoked `benchmark:run` — but the screen used to render the step list
+  whenever the backend span was held (correct per audit M1), so a moved-drive check sat frozen on
+  step 1 for its whole duration (measured: 13.7 s) and then disappeared. Both halves were
+  deliberate; the frozen list was their product. The step list now belongs to a run THIS window
+  started; any other run — first-run, moved-drive, another window — gets one line, "Checking this
+  computer in the background.", in the same live region, so it is still announced rather than
+  silent. **The residual, accepted:** an automatic check reports no per-step detail at all. The
+  alternative (broadcasting the steps) was rejected as a half-fix — the common path for a
+  moved-drive check is the user arriving on the screen mid-run, and a late-joining window has
+  missed the earlier one-shot messages, so it would show "Hardware detected: in progress" beside
+  "Generation speed: done". Back-filling the earlier steps was refused outright: the L3 rule is
+  that a step is reported only when it SUCCEEDED, so it would claim a skipped drive probe had
+  passed. Carrying the steps in `PerformanceSnapshot` would fix the late-join case properly and
+  stays the option if per-step detail is ever wanted for automatic runs.
 - **Remaining hardware acceptance not yet performed:** the hybrid iGPU+dGPU device-order check
   and Apple Silicon unified-memory behaviour. Two items left this list: the two-computer round
   trip on an encrypted drive, including an upgraded workspace with no history yet, was verified


### PR DESCRIPTION
Closes #438.

## The defect

Two **correct** decisions multiplying. Progress is emitted only from the `benchmark:run` IPC
handler and addressed to `event.sender` — the window that invoked it — and the automatic scheduler
calls `runAndPersistBenchmark(ctx)` with no callback at all. The screen meanwhile rendered the
step list on `busy`, which follows the **backend span**, not "a run this window started"; that
split is audit **M1**, and merging the two is what used to lock the screen into "Running…" for a
foreign run.

So the list was drawn for a run whose progress can never arrive. On the E: stick (#331 leg 2) a
moved-drive check sat frozen on step 1 for its whole **13.7 s** and then vanished.

## The call: option 2

The step list belongs to a run **this window started**; every other held span renders one line —
`perf.running.background`, "Checking this computer in the background." / "Dieser Computer wird im
Hintergrund geprüft."

**Option 1 (broadcast the steps) was rejected as a half-fix**, on a fact the issue's own framing
missed: the automatic check fires about a minute after unlock, once the model start settles, so
the common path is the user arriving on Performance **mid-run** — and a late-joining window has
already missed the earlier one-shot messages. It would render *"Hardware detected: in progress ·
Drive speed: waiting · Generation speed: done"*, which is worse than frozen. The cheap patch (a
step marks every earlier one done) is barred by the **L3** honesty rule: a step is reported only
when it SUCCEEDED, so back-filling would claim a skipped drive probe had passed.

**Option 3** — the steps carried in `PerformanceSnapshot`, so the screen reconstructs them on any
mount — fixes the late-join case properly and stays available if per-step detail for automatic
runs is ever wanted. It was not worth a shared-shape change plus a push per step for a case nobody
has reported.

## Three things that look incidental and are not

- **The line goes INSIDE the always-mounted `.perf-steps` live region of #437, not beside it.** An
  empty region would have left the automatic check silent to a screen reader — a regression
  against #437 rather than a neutral subtraction. Inside it, the line is a text change in a region
  that was already there, which is what makes it audible. It carries no live-region role of its
  own (#436).
- **`showOwnSteps = ownActionInFlight || doneSteps.length > 0`.** The second term is there because
  `ownActionInFlight` is cleared in the action's `finally`, one snapshot read *before*
  `backendRunning` catches up; on the flag alone the region would blink to the background line at
  the tail of the user's own run.
- **A foreign run cannot fake that term**: it delivers no steps, and `applySnapshot` clears
  whatever an earlier own run left as the span is taken — which is what makes `doneSteps` a sound
  "these steps are MINE" marker.

**The IPC contract is unchanged.** Steps still go to the requesting window only; this is a
renderer decision about what to draw for a run that has none.

## Acceptance (from the issue)

- [x] An automatic first-run/moved-drive check shows no step list at all — one announced line
      instead.
- [x] The M1 split is preserved: `busy` is untouched, so a foreign run still shows as running and
      still releases the screen the moment the backend is idle.
- [x] Covered by a test — **renderer-seam, not IPC**, stated plainly because the IPC side does not
      change: `PerformanceScreen.test.tsx` "M1 + #438: an external run shows as running with the
      background line, never the last run's steps", "#438: the background line sits IN the step
      region, so an automatic check is still announced", "#438: at the tail of our own run the
      list stays ours, never blinking to the background line". The N5 label test now starts its
      own run instead of borrowing a foreign `running: true` span.

## Residuals

- An automatic check reports no per-step detail (option 3 above remains the answer if that is
  ever wanted).
- **The by-ear leg #436/#437 still owe now has this line to hear too.** It lands on the same
  subtree, so it should fold into that one Narrator session rather than booking a second trip —
  the automatic check now *says* something where it previously said nothing.

## Verification

Re-verified on the current master base (after the whole #458 CI wave landed): `npm run typecheck`
clean, `npm test` **7,159 passed** / 85 skipped / 0 failed (425 files), `npm run build` green.

BUILD_STATE budgets green — the preamble needed a retirement pass, and master had meanwhile
retired a *different* pair for the #458 entry, so **both** retirements now apply: #333/#318 (from
master) and #372 + the #310–#315 wave (this branch, moved **verbatim** to `docs/build-log.md`;
that wave's open residuals stay live in §5 item 23). §5 untouched. Preamble 198/200.

Docs: `benchmark.md` gains the design record "An automatic run's step list" plus the "Progress"
paragraph and the HW3 row; `known-limitations.md`, `data-contracts.md`, `types.ts`, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
