### PR TITLE
test(460): the harness closes the sqlite handles a test file leaves open

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,15 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-13 — **#460 fixed (acceptance: the CI legs print `1 deferred root`) — the harness closes the sqlite handles test files leave open**
+(`fix/460-sqlite-handles`; record `packaging.md` "Continuous integration (CI)", design in `tests/helpers/sqlite-handles.ts`). Counted at runtime,
+not by grep: **120 files** leave **1,709 of 2,306** handles open (the issue's static 99 missed the vault-opened ones). `tests/setup-temp-roots.ts`
+now replaces `DatabaseSync` on the `node:sqlite` CJS module object with a recording subclass — `db.ts` and every raw-handle test read it off that
+object, so one property catches every handle — and closes them in its `afterAll` BEFORE root removal. Full suite on Windows: **deferred roots
+1,515 → 1** (that 1 is `temp-roots.test.ts` exercising the deferral), zero `database is not open`, no new failure. The order holds only under
+vitest's default `sequence.hooks: 'stack'`, pinned by a guard verified to FAIL under `'list'`. Loading `node:sqlite` in every fork added ~180
+ExperimentalWarning lines (268 → 449), so that one warning is swallowed during the harness's own load (now 0). Hygiene, not speed (#458).
+Not this change: the known `zim-client` 8 MiB `read ECONNRESET` load flake failed all 3 attempts in 2 of 3 local full runs (3/3 alone)._
 _2026-09-12 — **#458 (3 of 3 done, acceptance pending) — the windows CI legs: budgets, sharding, timing asserts** (`fix/458-ci-hook-timeout` PR #461;
 `fix/458-shard-windows-legs` PR #462; record `packaging.md` "Continuous integration (CI)"; decision + full evidence in the issue comment).
 Investigated: **five** windows flakes, not three, and #457 did not end them; windows 22.x carried 4 of 5. **(1)** `testTimeout` widened to 60 s
@@ -153,18 +162,6 @@ repo About text + `zim`/`kiwix`/`wikipedia`/`offline` topics, a v0.1.60 release 
 `[Unreleased]`; v0.1.59 predates the wave), a first screenshot, the org profile README. The follow-up PR #441 adds the repo's
 first `.github/ISSUE_TEMPLATE/`: a knowledge-pack report form asking for the facts that decide those reports, and a `config.yml`
 that keeps blank issues one click away and routes vulnerabilities to the private advisory channel._
-_2026-09-08 — **#339 Range-first article reads (`fix/339-range-first-article-read`), record `rag-design.md` §17 **D-Z22**:**
-every `/raw` article request (and the redirect hop) now carries `Range: bytes=0-`, which libkiwix serves through its 16 KiB
-callback reader instead of the one-buffer path that carries the win-x86_64 cut-short defect — so the app stops TRIGGERING an
-upstream bug it cannot fix. `kiwixGet` gained a `headers` option, a bytes-level core and an inter-chunk idle timer
-(`ARTICLE_READ_IDLE_MS` = 1,000, `KiwixTimeoutError.kind`); a stall that left a prefix is RESUMED with `Range: bytes=<received>-`,
-accepted only against an exact `Content-Range`, joined as bytes before the UTF-8 decode, never chained. The 4 s × 3 retry stays as
-the safety net; `MAX_SELECTED_PACKS`, the ask deadline, the arm, the viewer and the other routes are untouched. **Measured on the
-K: Kit drive (USB), pinned 3.8.1:** 880 Range reads 0 bad vs 70/600 plain short; max inter-chunk gap **17.8 ms** (24.6 on NVMe) —
-so 1,000 ms stands, not 1,500; 60 real article opens through the shipped client **13 retries + 1 article lost at 953.8 ms/open →
-0 + 0 at 19.9 ms/open**. Suite 423 files / 7,065 (+14 legs). Evidence: `ai_drive-archive/zim-wave-2026-09/evidence/range-fix-2026-09-08/`.
-The three closed ZIM wave entries (#301 / the follow-up wave / the open-issues wave) are retired verbatim to `docs/build-log.md`
-"2026-09-08 — the three closed ZIM knowledge-pack wave entries"; §5 item 21 holds what is still open (all of it the owner's)._
 _Older dated entries (the closed waves through 2026-08-22) and the Skills S2–S12 handoff sections were
 moved **verbatim** to [`docs/build-log.md`](docs/build-log.md) — 2026-07-09-and-earlier plus the
 Skills handoffs on 2026-07-12, the 2026-07-10 block on 2026-08-09 (images-wave close-out, for the
@@ -191,7 +188,8 @@ audit remediation, the PR #303 audit remediation) on 2026-09-10 (preamble budget
 hardware session) on 2026-09-12 (preamble budget, making room for the #458 CI entry), and the two
 closed 2026-09-07 models/runtime entries (#372, and the #310/#312/#313/#314/#315 wave of PR #371 —
 its residuals stay live in §5 item 23) on 2026-09-12 (preamble budget, making room for the #438
-entry) —
+entry), and the #339 Range-first article-reads entry on 2026-09-13 (preamble budget, making room for
+the #460 test-harness entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/apps/desktop/tests/global-temp-roots.ts
+++ b/apps/desktop/tests/global-temp-roots.ts
@@ -1,9 +1,12 @@
 // Vitest global setup (issue #335): the post-run half of the temp-root hygiene — see
 // `tests/helpers/temp-roots.ts`. Runs in the main vitest process. `setup` mints the run's
 // deferred-list file and hands its path to the forks through the environment (child processes
-// inherit it); `teardown` runs after every fork has exited — so a sqlite handle a suite never
-// closed no longer locks its files — and sweeps the roots the per-file teardown could not
-// remove. One summary line; never throws.
+// inherit it); `teardown` runs after every fork has exited — so no handle a fork held locks its
+// files any more — and sweeps the roots the per-file teardown could not remove. Since #460 that
+// teardown closes the sqlite handles first, so this sweep is the RARE path again: ~1,500 roots
+// per windows run before, 1 after — and that one is `tests/unit/temp-roots.test.ts` exercising
+// the deferral on purpose. A count above 1 is a new leak worth a look. One summary line; never
+// throws.
 import { writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/apps/desktop/tests/helpers/sqlite-handles.ts
+++ b/apps/desktop/tests/helpers/sqlite-handles.ts
@@ -1,0 +1,126 @@
+import { createRequire } from 'node:module'
+
+// Test sqlite-handle hygiene (issue #460). Measured 2026-09-13 on a full run: 120 test files leave
+// 1,709 of the 2,306 `node:sqlite` handles the run constructs open until their fork exits — opened
+// through `openDatabase`, a raw `new DatabaseSync`, or production code under test (the vault). On
+// Linux that is invisible. On Windows an open handle locks its file, so the #335 per-file teardown
+// (`tests/setup-temp-roots.ts`) could not remove the root the DB lives in and deferred ~1,500 roots
+// per run to the post-run sweep: the fallback had become the normal path, and a root nothing could
+// ever clean looked exactly like the routine ones.
+//
+// The fix applies the Performance fixture's pattern (`performance-fixture.ts`, TH2: register every
+// DB at creation, close them in one teardown) once, in the harness, instead of by hand in 120 files:
+// `tests/setup-temp-roots.ts` replaces `DatabaseSync` on the `node:sqlite` module object with a
+// subclass that records every instance, and closes what was recorded in its `afterAll` BEFORE it
+// removes the roots. Same box, same tree, full suite: deferred roots 1,515 → 1, no test newly failing.
+//
+// Why the MODULE and not `openDatabase`: `db.ts` — and every test that opens a raw handle (e.g.
+// `chat-compaction.test.ts`) — reads `DatabaseSync` off the CommonJS module object
+// (`createRequire(process.execPath)('node:sqlite')`; a bare `import 'node:sqlite'` does not resolve
+// under Vite), and does so after the setup file has run. Replacing that one property therefore
+// catches every handle, including the ones no test file opens itself, which a wrapper around
+// `openDatabase` would miss. The setup file also re-syncs the builtin's ESM exports, so an ESM
+// importer would see the same class.
+//
+// This module holds the pure pieces so they can be unit-tested (`tests/unit/sqlite-handles.test.ts`).
+// Nothing here touches production code.
+
+/** What the tracker needs from a handle. */
+export interface ClosableHandle {
+  close(): void
+}
+
+// A class extended by a mixin must have a single `...args: any[]` constructor (TS2545).
+type HandleConstructor = new (...args: any[]) => ClosableHandle
+
+/** The slice of `node:sqlite` the tracker patches (an injectable stand-in in the unit test). */
+export interface SqliteModuleLike {
+  DatabaseSync: HandleConstructor
+}
+
+// The registry lives ON the patched module object, not in this module's scope: the builtin is one
+// object per process, so every copy of this helper that module isolation may load shares one list.
+const TRACKED = Symbol.for('hilbertraum.trackedSqliteHandles')
+type Tracked = SqliteModuleLike & { [TRACKED]?: ClosableHandle[] }
+
+/**
+ * `node:sqlite`, loaded the way `db.ts` loads it; `null` on a runtime without it.
+ *
+ * Node prints "SQLite is an experimental feature" as an ExperimentalWarning the first time a process
+ * loads the module. The harness now loads it in EVERY fork, including the renderer and pure-logic
+ * files that never open a DB, so loading it loudly added ~180 lines of noise to a full run (measured:
+ * 268 → 449). That one warning — and only it — is swallowed while this call loads the module, and
+ * `process.emitWarning` is restored before returning. Node emits it once per process, so a fork that
+ * does use sqlite no longer prints it either; it tells a test run nothing (`db.ts` documents it).
+ */
+export function nodeSqlite(): SqliteModuleLike | null {
+  const emitWarning = process.emitWarning
+  process.emitWarning = function (warning: string | Error, ...rest: unknown[]): void {
+    const type = typeof rest[0] === 'string' ? rest[0] : (rest[0] as { type?: string } | undefined)?.type
+    const message = typeof warning === 'string' ? warning : warning.message
+    if (type === 'ExperimentalWarning' && /SQLite/.test(message)) return
+    ;(emitWarning as (...args: unknown[]) => void).call(process, warning, ...rest)
+  } as typeof process.emitWarning
+  try {
+    return createRequire(process.execPath)('node:sqlite') as SqliteModuleLike
+  } catch {
+    return null
+  } finally {
+    process.emitWarning = emitWarning
+  }
+}
+
+/**
+ * Replace `sqlite.DatabaseSync` with a subclass that records every instance it constructs. A
+ * constructor that throws records nothing, and `instanceof` the original class still holds.
+ * Idempotent: returns `false`, changing nothing, when the module is already patched.
+ */
+export function installSqliteHandleTracking(sqlite: SqliteModuleLike): boolean {
+  const mod = sqlite as Tracked
+  if (mod[TRACKED]) return false
+  const handles: ClosableHandle[] = []
+  mod[TRACKED] = handles
+  const Real = mod.DatabaseSync
+  class TrackedDatabaseSync extends Real {
+    constructor(...args: any[]) {
+      super(...args)
+      handles.push(this)
+    }
+  }
+  // The name a stack trace or a log line shows stays the real one.
+  Object.defineProperty(TrackedDatabaseSync, 'name', { value: Real.name })
+  mod.DatabaseSync = TrackedDatabaseSync
+  return true
+}
+
+/** The handles recorded so far and not yet taken by {@link closeTrackedHandles}. */
+export function trackedHandles(sqlite: SqliteModuleLike): readonly ClosableHandle[] {
+  return (sqlite as Tracked)[TRACKED] ?? []
+}
+
+export interface CloseResult {
+  /** Handles this call closed. */
+  closed: number
+  /** Handles whose `close()` threw — in practice ones the suite already closed. */
+  alreadyClosed: number
+}
+
+/**
+ * Close every recorded handle and empty the registry. Never throws: `close()` on a handle the
+ * suite already closed throws `ERR_INVALID_STATE` ("database is not open"), which is counted.
+ * (`isOpen` would say so without the throw, but it is newer than the engines floor, Node 22.12.)
+ */
+export function closeTrackedHandles(sqlite: SqliteModuleLike): CloseResult {
+  const result: CloseResult = { closed: 0, alreadyClosed: 0 }
+  const handles = (sqlite as Tracked)[TRACKED]
+  if (!handles) return result
+  for (const handle of handles.splice(0, handles.length)) {
+    try {
+      handle.close()
+      result.closed += 1
+    } catch {
+      result.alreadyClosed += 1
+    }
+  }
+  return result
+}

--- a/apps/desktop/tests/helpers/temp-roots.ts
+++ b/apps/desktop/tests/helpers/temp-roots.ts
@@ -12,10 +12,11 @@ import { basename, dirname, resolve } from 'node:path'
 //   tests/setup-temp-roots.ts   (vitest `setupFiles`, runs inside every test file's fork) wraps
 //                               the `mkdtemp` family, records every root minted directly under
 //                               `os.tmpdir()` with a test prefix, and removes them in `afterAll`
-//                               (ONE attempt each, under the hook's own long timeout); a root
-//                               that cannot be removed — on Windows a sqlite handle the suite
-//                               never closed keeps the file locked until the fork exits — goes
-//                               onto the run's deferred list instead of failing the suite.
+//                               (ONE attempt each, under the hook's own long timeout) — after
+//                               closing every sqlite handle the file left open, which on Windows
+//                               locks its root (#460, `tests/helpers/sqlite-handles.ts`); a root
+//                               that still cannot be removed goes onto the run's deferred list
+//                               instead of failing the suite.
 //   tests/global-temp-roots.ts  (vitest `globalSetup`, main process) mints the deferred list and
 //                               sweeps it in its teardown, which runs after every fork has exited
 //                               and released its handles.

--- a/apps/desktop/tests/setup-temp-roots.ts
+++ b/apps/desktop/tests/setup-temp-roots.ts
@@ -1,6 +1,8 @@
 // Vitest setup (issue #335), applied to every test file after `tests/setup.ts`: the temp-root
 // hygiene the Performance fixture does for its own suites (`performance-fixture.ts`, TH2),
 // applied by the harness to every file — see `tests/helpers/temp-roots.ts` for the design.
+// Issue #460 extends it to the sqlite handles those roots hold — see
+// `tests/helpers/sqlite-handles.ts`.
 //
 // The `mkdtemp` family is wrapped on the CommonJS `fs` object and the ESM live bindings are
 // re-synced (`syncBuiltinESMExports`), so a test file's `import { mkdtempSync } from 'node:fs'`
@@ -10,6 +12,7 @@
 import fs from 'node:fs'
 import { syncBuiltinESMExports } from 'node:module'
 import { afterAll } from 'vitest'
+import { closeTrackedHandles, installSqliteHandleTracking, nodeSqlite } from './helpers/sqlite-handles'
 import { cleanupRecordedRoots, recordTempRoot } from './helpers/temp-roots'
 
 type MkdtempSync = typeof fs.mkdtempSync
@@ -51,16 +54,33 @@ if (!marker[PATCHED]) {
   syncBuiltinESMExports()
 }
 
-// One teardown per file: remove what this file minted; what cannot be removed (an open sqlite
-// handle on Windows) is deferred to the post-run sweep in `tests/global-temp-roots.ts`. Never
-// throws, never fails a green suite.
+// Issue #460: record every `DatabaseSync` this fork constructs — a test's own `openDatabase` or
+// `new DatabaseSync`, a helper's, and the ones production code opens under test (the vault's) —
+// so the teardown below can close what the file left open. `db.ts` and the tests read the class
+// off the CommonJS module object this replaces (the helper says why that catches every handle);
+// the re-sync covers an ESM importer too.
+const sqlite = nodeSqlite()
+if (sqlite && installSqliteHandleTracking(sqlite)) syncBuiltinESMExports()
+
+// One teardown per file. It first CLOSES every sqlite handle the file left open (#460): on
+// Windows an open handle locks its file, so before this almost every root failed to be removed
+// here — ~1,500 per run went to the deferred list, and a root that genuinely could not be
+// cleaned was indistinguishable from the routine case. Then it removes what this file minted;
+// what still cannot be removed is deferred to the post-run sweep in `tests/global-temp-roots.ts`.
+// Never throws, never fails a green suite.
 //
-// ONE attempt per root here, no in-hook retry: a handle the suite never closed does not clear
-// in 25 ms, and a second recursive delete of a locked root only doubles the cost — on a starved
-// windows CI runner that tripped vitest's 10 s hook budget (run 34033122353, a suite holding a
-// sqlite handle per test). The sweep after the forks exit is the retry. The hook also carries
-// its own generous timeout: cleanup may be slow, it must never fail a green suite.
+// It never closes a DB a suite's own teardown still needs: vitest's default `sequence.hooks`
+// ('stack') runs after-hooks in REVERSE registration order and this setup file registers first,
+// so a test file's own `afterAll` runs before this one (`tests/unit/sqlite-handles.test.ts` pins
+// that order).
+//
+// ONE attempt per root here, no in-hook retry: a locked root does not clear in 25 ms, and a
+// second recursive delete of it only doubles the cost — on a starved windows CI runner that
+// tripped vitest's 10 s hook budget (run 34033122353, a suite holding a sqlite handle per test).
+// The sweep after the forks exit is the retry. The hook also carries its own generous timeout:
+// cleanup may be slow, it must never fail a green suite.
 const TEARDOWN_TIMEOUT_MS = 120_000
 afterAll(async () => {
+  if (sqlite) closeTrackedHandles(sqlite)
   await cleanupRecordedRoots({ attempts: 1 })
 }, TEARDOWN_TIMEOUT_MS)

--- a/apps/desktop/tests/unit/sqlite-handles.test.ts
+++ b/apps/desktop/tests/unit/sqlite-handles.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { openDatabase } from '../../src/main/services/db'
+import {
+  closeTrackedHandles,
+  installSqliteHandleTracking,
+  nodeSqlite,
+  trackedHandles,
+  type SqliteModuleLike
+} from '../helpers/sqlite-handles'
+
+// Issue #460: the harness closes the sqlite handles a test file leaves open, before its temp roots
+// are removed (tests/helpers/sqlite-handles.ts, tests/setup-temp-roots.ts). Before it, ~1,500 roots
+// per windows run could not be removed by the per-file teardown and went to the post-run sweep.
+
+/** A stand-in for `node:sqlite`'s class: throws like a non-database file, and like a double close. */
+class FakeDb {
+  open = true
+  constructor(readonly path: string) {
+    if (path === 'not-a-database') throw new Error('file is not a database')
+  }
+  close(): void {
+    if (!this.open) throw Object.assign(new Error('database is not open'), { code: 'ERR_INVALID_STATE' })
+    this.open = false
+  }
+}
+
+const fakeModule = (): SqliteModuleLike => ({ DatabaseSync: FakeDb })
+const construct = (mod: SqliteModuleLike, path: string): FakeDb => new mod.DatabaseSync(path) as FakeDb
+
+describe('sqlite handles: the patched class records what it constructs', () => {
+  it('records every instance, which is still an instance of the real class under its real name', () => {
+    const mod = fakeModule()
+    expect(installSqliteHandleTracking(mod)).toBe(true)
+    const a = construct(mod, 'a')
+    const b = construct(mod, 'b')
+    expect(a).toBeInstanceOf(FakeDb)
+    expect(a.path).toBe('a')
+    expect(mod.DatabaseSync.name).toBe('FakeDb')
+    expect(trackedHandles(mod)).toHaveLength(2)
+    expect(trackedHandles(mod)[0]).toBe(a)
+    expect(trackedHandles(mod)[1]).toBe(b)
+  })
+
+  it('a constructor that throws records nothing (openDatabase closes that handle itself, #208)', () => {
+    const mod = fakeModule()
+    installSqliteHandleTracking(mod)
+    expect(() => construct(mod, 'not-a-database')).toThrow('file is not a database')
+    expect(trackedHandles(mod)).toEqual([])
+  })
+
+  it('installing twice patches once — no double wrap, no double record', () => {
+    const mod = fakeModule()
+    installSqliteHandleTracking(mod)
+    const patched = mod.DatabaseSync
+    expect(installSqliteHandleTracking(mod)).toBe(false)
+    expect(mod.DatabaseSync).toBe(patched)
+    construct(mod, 'a')
+    expect(trackedHandles(mod)).toHaveLength(1)
+  })
+})
+
+describe('sqlite handles: closing never fails a suite', () => {
+  it('closes the open handles, counts the ones the suite already closed, and empties the registry', () => {
+    const mod = fakeModule()
+    installSqliteHandleTracking(mod)
+    const leftOpen = construct(mod, 'left-open')
+    const closedBySuite = construct(mod, 'closed-by-suite')
+    closedBySuite.close()
+
+    expect(closeTrackedHandles(mod)).toEqual({ closed: 1, alreadyClosed: 1 })
+    expect(leftOpen.open).toBe(false)
+    expect(trackedHandles(mod)).toEqual([])
+    // A second teardown finds nothing to do.
+    expect(closeTrackedHandles(mod)).toEqual({ closed: 0, alreadyClosed: 0 })
+  })
+
+  it('a module that was never patched: nothing tracked, closing is a no-op', () => {
+    const mod = fakeModule()
+    expect(trackedHandles(mod)).toEqual([])
+    expect(closeTrackedHandles(mod)).toEqual({ closed: 0, alreadyClosed: 0 })
+  })
+})
+
+// ORDER GUARD. This DB stays open for the whole file and this file's own `afterAll` uses it. The
+// harness's teardown closes every tracked handle, so it must run AFTER this hook — which holds only
+// while vitest's `sequence.hooks` is 'stack' (after-hooks in reverse registration order; the setup
+// file registers first). If that ever changes, this hook throws "database is not open" and fails.
+const leftOpenForTheHarness = openDatabase(join(mkdtempSync(join(tmpdir(), 'hilbertraum-sqlite-handles-order-')), 'test.sqlite'))
+afterAll(() => {
+  expect(leftOpenForTheHarness.prepare('SELECT 1 AS one').get()).toEqual({ one: 1 })
+})
+
+describe('sqlite handles: the harness tracks real node:sqlite handles (tests/setup-temp-roots.ts)', () => {
+  it('a DB opened through openDatabase — the production seam — is tracked', () => {
+    const sqlite = nodeSqlite()
+    expect(sqlite).not.toBeNull()
+    expect(trackedHandles(sqlite!)).toContain(leftOpenForTheHarness)
+
+    const db = openDatabase(join(mkdtempSync(join(tmpdir(), 'hilbertraum-sqlite-handles-seam-')), 'test.sqlite'))
+    expect(trackedHandles(sqlite!)).toContain(db)
+    db.close()
+  })
+
+  it('loading the module leaves process.emitWarning exactly as it found it', () => {
+    // The load swallows Node's one-time SQLite ExperimentalWarning; a wrapper left behind would
+    // silently swallow warnings for the rest of the fork.
+    const before = process.emitWarning
+    expect(nodeSqlite()).not.toBeNull()
+    expect(process.emitWarning).toBe(before)
+  })
+
+  it('closing a tracked real handle releases its root — the property the teardown depends on', () => {
+    // A registry of its own, layered on the harness's patched class, so this closes only its own
+    // handle and not the order guard's. The harness still records the handle and later finds it closed.
+    const scoped: SqliteModuleLike = { DatabaseSync: nodeSqlite()!.DatabaseSync }
+    installSqliteHandleTracking(scoped)
+    const root = mkdtempSync(join(tmpdir(), 'hilbertraum-sqlite-handles-rm-'))
+    const db = new scoped.DatabaseSync(join(root, 'test.sqlite')) as unknown as { exec(sql: string): void }
+    // WAL mode leaves -wal/-shm sidecars open next to the file, as openDatabase does.
+    db.exec('PRAGMA journal_mode = WAL; CREATE TABLE t (x); INSERT INTO t VALUES (1);')
+
+    expect(closeTrackedHandles(scoped)).toEqual({ closed: 1, alreadyClosed: 0 })
+    rmSync(root, { recursive: true, force: true })
+    expect(existsSync(root)).toBe(false)
+  })
+})

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -42,9 +42,11 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.{ts,tsx}'],
     // Issue #335: `setup-temp-roots.ts` records every `hilbertraum-*` / `hr-*` root a file mints
-    // under the OS temp dir and removes them in that file's `afterAll`; `global-temp-roots.ts`
-    // sweeps, after the forks exit, the roots an open sqlite handle kept locked on Windows.
-    // See tests/helpers/temp-roots.ts. Before this, a full run leaked ~2,500 roots.
+    // under the OS temp dir and removes them in that file's `afterAll` — after closing the sqlite
+    // handles the file left open, which lock their roots on Windows (#460); `global-temp-roots.ts`
+    // sweeps, after the forks exit, whatever still could not be removed. See
+    // tests/helpers/temp-roots.ts and tests/helpers/sqlite-handles.ts. Before #335 a full run leaked
+    // ~2,500 roots; before #460 ~1,500 of them per windows run reached the sweep.
     setupFiles: ['./tests/setup.ts', './tests/setup-temp-roots.ts'],
     globalSetup: ['./tests/global-temp-roots.ts'],
     globals: true,
@@ -91,8 +93,8 @@ export default defineConfig({
     // The 10 s default was already known to be too tight here and patched ONE hook at a time —
     // `tests/setup-temp-roots.ts` carries its own `TEARDOWN_TIMEOUT_MS` (120 s) citing run
     // 34033122353. This generalises that fix instead of waiting for each hook to be bitten;
-    // 129 suites open a sqlite DB (99 of them never close it, #460) and many do that plus
-    // `mkdtempSync` inside a hook, as do the fixture teardowns that close DBs and remove roots.
+    // 129 suites open a sqlite DB (most leave it for the harness to close, #460) and many do that
+    // plus `mkdtempSync` inside a hook, as do the fixture teardowns that close DBs and remove roots.
     //
     // This loosens no evidence, exactly as for `testTimeout`: a hook is SETUP, never a timing
     // proof — the suite's timing proofs live in explicit assertions (the FTS 500 ms bound, #84),

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,27 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-13 — the oldest closed dated entry retired verbatim (#339 — preamble budget)
+
+Retired from `BUILD_STATE.md` on 2026-09-13 to make room for the #460 test-harness entry (the
+preamble was at 198 of its 200-line budget; the retention rule is "MOVE, don't raise"). The work is
+shipped and its durable record lives on in `rag-design.md` §17 **D-Z22**; what is still open from the
+ZIM wave is `BUILD_STATE.md` §5 item 21. Citations of the form "BUILD_STATE 2026-09-08 entry" for the
+Range-first article reads resolve here. Text below is byte-identical to what was removed.
+
+_2026-09-08 — **#339 Range-first article reads (`fix/339-range-first-article-read`), record `rag-design.md` §17 **D-Z22**:**
+every `/raw` article request (and the redirect hop) now carries `Range: bytes=0-`, which libkiwix serves through its 16 KiB
+callback reader instead of the one-buffer path that carries the win-x86_64 cut-short defect — so the app stops TRIGGERING an
+upstream bug it cannot fix. `kiwixGet` gained a `headers` option, a bytes-level core and an inter-chunk idle timer
+(`ARTICLE_READ_IDLE_MS` = 1,000, `KiwixTimeoutError.kind`); a stall that left a prefix is RESUMED with `Range: bytes=<received>-`,
+accepted only against an exact `Content-Range`, joined as bytes before the UTF-8 decode, never chained. The 4 s × 3 retry stays as
+the safety net; `MAX_SELECTED_PACKS`, the ask deadline, the arm, the viewer and the other routes are untouched. **Measured on the
+K: Kit drive (USB), pinned 3.8.1:** 880 Range reads 0 bad vs 70/600 plain short; max inter-chunk gap **17.8 ms** (24.6 on NVMe) —
+so 1,000 ms stands, not 1,500; 60 real article opens through the shipped client **13 retries + 1 article lost at 953.8 ms/open →
+0 + 0 at 19.9 ms/open**. Suite 423 files / 7,065 (+14 legs). Evidence: `ai_drive-archive/zim-wave-2026-09/evidence/range-fix-2026-09-08/`.
+The three closed ZIM wave entries (#301 / the follow-up wave / the open-issues wave) are retired verbatim to `docs/build-log.md`
+"2026-09-08 — the three closed ZIM knowledge-pack wave entries"; §5 item 21 holds what is still open (all of it the owner's)._
+
 ## 2026-09-12 — the two oldest closed dated entries retired verbatim (#333, #318 — preamble budget)
 
 Retired from `BUILD_STATE.md` on 2026-09-12 to make room for the #458 CI entries (the preamble was

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -582,6 +582,17 @@ version still runs all 449 files in a *single* vitest process, so cross-file int
 module state, a leaked global, an ordering dependency) keeps a leg that can still see it; a fully
 sharded matrix would partition that surface away everywhere at once.
 
+**#460 has since been fixed (2026-09-13): the leaked handles and locked roots above no longer
+accumulate.** The per-file test teardown (`tests/setup-temp-roots.ts`) now closes every
+`node:sqlite` handle a test file left open — 1,709 of the 2,306 a full run opens, across 120 files
+— *before* it removes that file's temp roots, so on Windows the post-run sweep went from ~1,500
+roots per run to **1**, and that one is the harness's own `temp-roots.test.ts` exercising the
+deferral on purpose (design: `tests/helpers/sqlite-handles.ts`). Locally it bought no speed worth
+quoting (201 → 189 s, within noise), as #458 predicted: this is hygiene, not a CI-budget lever.
+**What to look for on a run:** the `temp roots: N deferred root(s)` line at the end of the `Test`
+step reads `1` on the ubuntu legs and on whichever windows shard owns `temp-roots.test.ts`, and is
+absent on the other shard. A higher count is a new leak — worth a look, not a re-run.
+
 **The collection guard is shard-aware — and must stay that way.** `tests/full-suite-guard.ts`
 asserts vitest actually collected every file it should, which is what makes a silently dropped
 suite fail instead of passing by not running. A shard legitimately collects half, so the guard


### PR DESCRIPTION
Fixes #460.

## What

120 test files leave **1,709 of the 2,306** `node:sqlite` handles a full run opens until their fork exits (counted at runtime; the issue's static count of 99 missed the handles the vault opens under test). On Windows an open handle locks its file, so the #335 per-file teardown could not remove the temp root around it, and ~1,500 roots per run fell through to the post-run sweep.

## How

`tests/setup-temp-roots.ts` now replaces `DatabaseSync` on the `node:sqlite` CommonJS module object with a subclass that records every instance, and closes them in its existing `afterAll` **before** removing roots. Pure pieces live in `tests/helpers/sqlite-handles.ts`.

Why the module and not `openDatabase` (the issue's suggested shape): `db.ts` and every raw-handle test read the class off that one CJS object, so replacing one property catches every handle, including the vault's. **No production code changes.**

- **Ordering:** the close has to run after a test file's own `afterAll`. That holds under vitest's default `sequence.hooks: 'stack'`. A guard in `tests/unit/sqlite-handles.test.ts` pins it, and I checked that it fails with `database is not open` under `--sequence.hooks=list`.
- **Log noise:** loading `node:sqlite` in every fork (including renderer files) added ~180 `ExperimentalWarning` lines per run (268 → 449). That one warning is swallowed during the harness's own load and `process.emitWarning` is restored, so the count is now 0. A unit test pins the restore.

## Measured (full suite, Windows, this branch vs master)

| | master | this branch |
|---|---|---|
| deferred temp roots | 1,515 | **1** |
| `database is not open` errors | — | 0 |
| ExperimentalWarning lines | 268 | 0 |
| duration | 201 s | 189 s (noise; this is hygiene, not speed — #458) |

The remaining deferred root is `temp-roots.test.ts` testing the deferral path on purpose.

**What CI should show:** `temp roots: 1 deferred root(s)` at the end of the `Test` step on both ubuntu legs and on whichever windows shard owns `temp-roots.test.ts`; no line at all on the other shard.

**Known, unrelated flake:** `zim-client.test.ts`'s 8 MiB tests failed with `read ECONNRESET` (all 3 attempts) in 2 of 3 local full runs, once on master before this change. This machine was also running a benchmark queue at the time. The file passes 3/3 on its own, never touches sqlite, and its comment already documents this failure mode.

## Docs

- `docs/packaging.md` CI section: records the fix and what the log line should read.
- `BUILD_STATE.md`: new dated entry.
- `docs/build-log.md`: the closed #339 entry, moved there verbatim to stay within the preamble's line budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
