### PR TITLE
test(467): the 8 MiB zim-client fixture leaves the close to the client

### DIFF
--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -28,6 +28,13 @@
 > entries were true when written but are snapshots — as of 2026-07-10 `master` is pushed (in sync
 > with origin through `ac4f315`) and the 2026-06-30 audit branch stack is merged. Only the branches
 > named in §5's branch analysis still carry unmerged work.
+_2026-09-13 — **#467 fixed — the `zim-client` 8 MiB `read ECONNRESET` was the FIXTURE's server-side close, not a slow transfer**
+(`fix/467-zim-client-reset`; record `rag-design.md` §17 D-Z22 "Also absorbed"). Reproduced outside vitest (14 of 30, idle-priority load): the
+client asks `Connection: close`, the fixture closed ~1 ms after its last write, and a CPU-starved Windows reader then never gets the queued
+tail — it stops ~0.4 % short and the OS resets at **~19 s, every time** (the 2026-09-05 15 s timeout and ~19 s reset were this). From 256 KB
+up; 4–64 KB 0 of 80; client-closes-first 0 of 50. Fix: the ceiling answers are keep-alive with `keepAliveTimeout` 0, `retry: 2` dropped, plus an
+assert the server never closed first (FAILS on an idle box with the line removed). Under load after: 26 of 26 ceiling legs, ≤ 111 ms. Production
+`/raw` absorbs it (1 s idle + resume, 24/24 starved 1 MiB reads at ~1.1 s); kiwix-serve's own close is unmeasured._
 _2026-09-13 — **#460 fixed (acceptance: the CI legs print `1 deferred root`) — the harness closes the sqlite handles test files leave open**
 (`fix/460-sqlite-handles`; record `packaging.md` "Continuous integration (CI)", design in `tests/helpers/sqlite-handles.ts`). Counted at runtime,
 not by grep: **120 files** leave **1,709 of 2,306** handles open (the issue's static 99 missed the vault-opened ones). `tests/setup-temp-roots.ts`
@@ -135,22 +142,6 @@ slow reply, once. Follow-ups **#446** (`qwen3.6-27b` ×2 + `granite-4.1-8b` neve
 and **#447** (the ZIM query expander is bounded by inference, not measurement). Trap for reproducers: `forcing full
 prompt re-processing` appears only on MTP starts — the token count is the only honest read._
 
-_2026-09-09 — **#331 CLOSED — the four blocked HW3 acceptance legs performed** (`docs/331-hardware-acceptance-legs`;
-record `benchmark.md` §2 row HW3 + §4 HW3; evidence `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md`).
-A workspace created on a SECOND computer with the 14B active made leg 2 a real moved-drive `new-machine` run behind a 66 s model
-start — the review box's ~120 ms first run reproduced here first, and a FRESH workspace would not have helped either
-(`activeModelId` starts null, so nothing precedes the check). **Passed:** the moved-drive check observed window-open → completion
-(13.7 s), transitioning with no navigation; a foreground chat inside a benchmark span (both M1 halves — a chat never masquerades as
-a span nor hides one; the ~130–270 ms overlap is structural, `modelBusy` is re-checked inside the speed leg); a model load
-(120.3 MB/s) and a full file verification (85.5 s forced re-hash, 242 s cold `#382`/`#420` pass) each refreshing rows and tiles in
-place, matching what persisted. **Three defects filed:** under Narrator — against a positive control proving live regions DO work in
-the app's window — NEITHER live region is announced. **#436** is the serious one: `ErrorBanner`'s always-mounted `role="alert"` is
-defeated by the `Banner` nested inside it, whose `role="status"` is itself a live region mounted WITH its text (M-U1 one level
-down), affecting 11 screens + the gate's #145 wrong-password banner; a control fixed the remedy — inner `aria-live="off"` does NOT
-work, the inner role must go. **#437** the step region (inserted with content AND progress carried only by a CSS class +
-`aria-hidden` icon). **#438** an automatic run's step list never advances (progress is addressed to the invoking window; the screen
-renders the list for any held span, correct per M1). Lesson to keep: `role="status"` and `role="alert"` are both live regions —
-nesting one inside the other silences the outer. Docs: `benchmark.md`, `known-limitations.md` (Performance + Accessibility)._
 _2026-09-09 — **Knowledge packs get a public face (`docs/knowledge-packs.md` + README section; docs-only,
 `docs/knowledge-packs-readme-and-page`):** the feature shipped but the repo did not say so — one README bullet (#5 of 10,
 linking nowhere) and user-guide §7b, reachable only through "walkthrough of every screen". New canonical page
@@ -189,7 +180,8 @@ hardware session) on 2026-09-12 (preamble budget, making room for the #458 CI en
 closed 2026-09-07 models/runtime entries (#372, and the #310/#312/#313/#314/#315 wave of PR #371 —
 its residuals stay live in §5 item 23) on 2026-09-12 (preamble budget, making room for the #438
 entry), and the #339 Range-first article-reads entry on 2026-09-13 (preamble budget, making room for
-the #460 test-harness entry) —
+the #460 test-harness entry), and the closed #331 HW3-acceptance entry on 2026-09-13 (preamble budget,
+making room for the #467 test-fixture entry) —
 citations of the form "BUILD_STATE <date> entry" / "BUILD_STATE V1" /
 "Skills — Sn handoff" resolve there._
 

--- a/apps/desktop/tests/unit/zim-client.test.ts
+++ b/apps/desktop/tests/unit/zim-client.test.ts
@@ -66,6 +66,9 @@ const SUGGEST_FIXTURES: Record<string, { status: number; body: string } | 'park'
 }
 /** Mirrors client.ts MAX_BODY_BYTES (8 MiB) — kept literal here so the test pins the shipped ceiling. */
 const CEILING_BYTES = 8 * 1024 * 1024
+/** One entry per finished body-ceiling response: had the SERVER already begun closing the
+ *  connection when its response finished? Must be false — see the fixture (#467). */
+const ceilingServerClosedFirst: Array<Promise<boolean>> = []
 /** Every request the fixture server received — used to prove the L5 contract rejects a
  *  hazardous key BEFORE any HTTP request (#301 P5, finding L5). */
 let requestCount = 0
@@ -200,8 +203,20 @@ beforeAll(async () => {
     // Body-ceiling fixtures (PR #294 review INFO / plan T01): kiwixGet rejects a body of
     // MORE than 8 MiB and accepts one of exactly 8 MiB. Streamed in 1 MiB writes so the
     // ceiling is hit mid-stream, the way a pathological entry would arrive.
+    //
+    // #467: the CLIENT closes these connections, never the server. The client asks for
+    // `Connection: close`, so a default answer closes the server's socket the moment its last
+    // write is handed to the kernel. Under CPU starvation on Windows the tail of a body queued
+    // behind a lagging reader is then never delivered — the read stops ~0.4 % short and Windows
+    // resets the connection ~19 s later (`read ECONNRESET`). Measured from 256 KB up; 64 KB and
+    // below never did. Answering keep-alive (with no keep-alive timer) leaves the close to the
+    // client, which only closes once it has read what it wanted — 0 of 30 under the same load.
     if (req.url?.startsWith('/big') || req.url?.startsWith('/atceiling')) {
       const total = CEILING_BYTES + (req.url.startsWith('/big') ? 1 : 0)
+      res.shouldKeepAlive = true
+      ceilingServerClosedFirst.push(
+        new Promise((resolve) => res.once('finish', () => resolve(req.socket.writableEnded)))
+      )
       res.writeHead(200, { 'content-type': 'text/html' })
       const piece = Buffer.alloc(1024 * 1024, 0x78)
       let sent = 0
@@ -322,6 +337,9 @@ beforeAll(async () => {
     res.writeHead(200)
     res.end('ok')
   })
+  // Only the body-ceiling answers are keep-alive (#467); 0 disables the idle timer that would
+  // otherwise close their socket server-side after 5 s — the very close the fixture avoids.
+  server.keepAliveTimeout = 0
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
   port = (server.address() as AddressInfo).port
   // A real ephemeral port that is then CLOSED: a connection to it is refused by the OS, which
@@ -398,25 +416,26 @@ describe('kiwixGet', () => {
     await expect(pending).rejects.toThrow()
   })
 
-  // The two 8 MiB legs move real bytes over loopback: ~0.2 s alone, but under a full-suite fork
-  // load on Windows they have failed on their own in otherwise green runs (2026-09-05: one
-  // 15 s timeout, then one `read ECONNRESET` at ~19 s on the at-ceiling leg while the build
-  // and typecheck ran alongside; both pass 10/10 alone every time). The loopback transfer
-  // itself is what the environment starves, so they carry a generous budget AND one retry —
-  // the assertions are unchanged and a genuine ceiling regression fails every attempt.
+  // The two 8 MiB legs move real bytes over loopback: well under a second even under load, so
+  // the budget is headroom for a starved fork, not a rescue. They used to carry `retry: 2` too,
+  // for a `read ECONNRESET` blamed on the transfer being slow; it was the fixture's server-side
+  // close instead (#467, see the fixture), so there is nothing left for a retry to absorb.
   const BIG_BODY_BUDGET_MS = 60_000
-  const BIG_BODY_TEST = { timeout: BIG_BODY_BUDGET_MS, retry: 2 }
   it('rejects a body over the 8 MiB ceiling mid-stream (T01, review INFO)', async () => {
     await expect(kiwixGet(port, '/big', { timeoutMs: BIG_BODY_BUDGET_MS })).rejects.toThrow(
       /exceeded 8388608 bytes/
     )
-  }, BIG_BODY_TEST)
+  }, BIG_BODY_BUDGET_MS)
 
   it('accepts a body of exactly 8 MiB (the ceiling is strict-greater)', async () => {
+    ceilingServerClosedFirst.length = 0
     const res = await kiwixGet(port, '/atceiling', { timeoutMs: BIG_BODY_BUDGET_MS })
     expect(res.status).toBe(200)
     expect(res.body.length).toBe(CEILING_BYTES)
-  }, BIG_BODY_TEST)
+    // The fixture's precondition (#467), checked on every run rather than only under load: had
+    // the server closed first, this leg would pass on an idle box and reset on a busy one.
+    expect(await Promise.all(ceilingServerClosedFirst)).toEqual([false])
+  }, BIG_BODY_BUDGET_MS)
 })
 
 describe('parseSearchXml / searchPack', () => {

--- a/docs/build-log.md
+++ b/docs/build-log.md
@@ -27,6 +27,33 @@
 > text kept, wrapper dropped, prose otherwise byte-identical. The archive is frozen in CONTENT; a
 > pointer that resolves in neither direction is a defect of the move, not a fact of the record.
 
+## 2026-09-13 — a closed dated entry retired verbatim (#331 — preamble budget)
+
+Retired from `BUILD_STATE.md` on 2026-09-13 to make room for the #467 test-fixture entry (the
+preamble was at 196 of its 200-line budget; the retention rule is "MOVE, don't raise"). Not the oldest
+entry: the 2026-09-09 knowledge-packs entry below it still carries owner-side items it says are
+tracked nowhere else, so it stays. #331 is closed, the three defects it filed (#436, #437, #438) are
+closed, and its durable record lives on in `benchmark.md` §2 row HW3 + §4 HW3. Citations of the form
+"BUILD_STATE 2026-09-09 entry" for the HW3 acceptance legs resolve here. Text below is byte-identical
+to what was removed.
+
+_2026-09-09 — **#331 CLOSED — the four blocked HW3 acceptance legs performed** (`docs/331-hardware-acceptance-legs`;
+record `benchmark.md` §2 row HW3 + §4 HW3; evidence `eval/results/hardware/i7-8700-gtx-1070-ti-8gb-32gb/331-hw3-acceptance-legs.md`).
+A workspace created on a SECOND computer with the 14B active made leg 2 a real moved-drive `new-machine` run behind a 66 s model
+start — the review box's ~120 ms first run reproduced here first, and a FRESH workspace would not have helped either
+(`activeModelId` starts null, so nothing precedes the check). **Passed:** the moved-drive check observed window-open → completion
+(13.7 s), transitioning with no navigation; a foreground chat inside a benchmark span (both M1 halves — a chat never masquerades as
+a span nor hides one; the ~130–270 ms overlap is structural, `modelBusy` is re-checked inside the speed leg); a model load
+(120.3 MB/s) and a full file verification (85.5 s forced re-hash, 242 s cold `#382`/`#420` pass) each refreshing rows and tiles in
+place, matching what persisted. **Three defects filed:** under Narrator — against a positive control proving live regions DO work in
+the app's window — NEITHER live region is announced. **#436** is the serious one: `ErrorBanner`'s always-mounted `role="alert"` is
+defeated by the `Banner` nested inside it, whose `role="status"` is itself a live region mounted WITH its text (M-U1 one level
+down), affecting 11 screens + the gate's #145 wrong-password banner; a control fixed the remedy — inner `aria-live="off"` does NOT
+work, the inner role must go. **#437** the step region (inserted with content AND progress carried only by a CSS class +
+`aria-hidden` icon). **#438** an automatic run's step list never advances (progress is addressed to the invoking window; the screen
+renders the list for any held span, correct per M1). Lesson to keep: `role="status"` and `role="alert"` are both live regions —
+nesting one inside the other silences the outer. Docs: `benchmark.md`, `known-limitations.md` (Performance + Accessibility)._
+
 ## 2026-09-13 — the oldest closed dated entry retired verbatim (#339 — preamble budget)
 
 Retired from `BUILD_STATE.md` on 2026-09-13 to make room for the #460 test-harness entry (the

--- a/docs/rag-design.md
+++ b/docs/rag-design.md
@@ -3081,7 +3081,17 @@ offline article viewer. Files are registered in place, never copied.
   untouched, so the safety net stays. **What did NOT change:** `MAX_SELECTED_PACKS`, the ask
   deadline, `ARTICLE_READ_TIMEOUT_MS`, `ARTICLE_READ_ATTEMPTS`, the arm's chunking, the viewer,
   the request guard, `probeSearchable`, and the `/search` / `/suggest` / health-probe routes —
-  which still send no `Range` header at all (pinned by a test leg). The log line
+  which still send no `Range` header at all (pinned by a test leg). **Also absorbed — measured
+  2026-09-13 (#467), and not kiwix-serve's defect:** on Windows, when a loopback server closes
+  right after its last write while the READER is CPU-starved, the tail queued behind the reader is
+  never delivered — the read stops ~0.4 % short and Windows resets the connection ~19 s later
+  (`read ECONNRESET`). Measured with a node:http server, in-process and as its own normal-priority
+  process, under one idle-priority busy loop per CPU: 256 KB–8 MiB bodies failed 25–70 % of reads,
+  4–64 KB bodies 0 of 80, and with the CLIENT closing the connection instead 0 of 50. Through
+  `fetchArticleHtml` it is only a stall: the idle timer fires after 1 s and the resume fetches the
+  tail — 24 of 24 starved 1 MiB reads recovered at ~1.1 s each, while a plain `kiwixGet` failed 8 of
+  8. NOT measured: whether kiwix-serve's own close triggers it. The `/search`, `/suggest` and
+  health-probe answers are normally a few KB, below every size that failed. The log line
   `kiwix-serve cut a knowledge-pack article read short — retrying` gained `kind` and `resume` and
   still carries no path and no serving name (finding L1). Tests: the `zim-client.test.ts` describe
   "fetchArticleHtml reads /raw Range-first and resumes a stall (#339, rag-design §17 D-Z22)" —


### PR DESCRIPTION
Fixes #467.

## Root cause

The `read ECONNRESET` on the two body-ceiling legs was **not** a slow loopback transfer — it was the fixture server closing the connection first.

- `kiwixGet` sends `Connection: close`, so the fixture closed its socket ~1 ms after handing its last write to the kernel.
- On Windows, when the **reader** is CPU-starved, the tail queued behind it is never delivered: the read stops ~0.4 % short (8,355,634 of 8,388,608 bytes) and the OS resets the connection **~19 s later, every time** (18.96–18.99 s). The 2026-09-05 "15 s timeout" and "reset at ~19 s" in the test comment were this one mechanism.
- Retries in the same process fail too because the load outlasts all three attempts.

Measured outside vitest (standalone node:http server + client, one busy loop per logical CPU, everything at idle priority so a normal-priority benchmark on the box was not disturbed):

| configuration (reader starved) | failed |
|---|---|
| in-process server closes first, 8 MiB | 14 of 30, 5 of 10 |
| **client closes first** (keep-alive, `keepAliveTimeout 0`), 8 MiB / 1 MiB | **0 of 30 / 0 of 20** |
| server as its own normal-priority process, 8 MiB / 1 MiB | 6 of 12 / 5 of 20 |
| server closes first, 1 MiB / 256 KB | 14 of 20 / 10 of 20 |
| server closes first, 4 KB / 16 KB / 64 KB | 0 of 80 total |

## Change (test fixture only)

- The `/big` and `/atceiling` answers are keep-alive, and the fixture server's `keepAliveTimeout` is 0, so the **client** always closes.
- `retry: 2` dropped — nothing left for it to absorb.
- The at-ceiling leg asserts the server had not begun closing when its response finished. **Verified by mutation:** with `res.shouldKeepAlive = true` removed, it fails on an idle box in 66 ms (`expected [ true ] to deeply equal [ false ]`) — so the precondition is checked every run, not only under load.

## Blast radius

- **Tests:** only these two legs move bodies in the affected size range.
- **CI:** no `ECONNRESET` in the failed-step logs of 73 failed runs since 2026-09-01 — but a retried-then-passed attempt prints nothing, so silent absorption can't be ruled out.
- **Production:** the `/raw` article path already absorbs this signature — the 1 s idle timer fires, then the Range resume fetches the tail: 24 of 24 starved 1 MiB reads through `fetchArticleHtml` recovered at ~1.1 s each, while a plain `kiwixGet` failed 8 of 8. `/search`, `/suggest` and the health probe are normally a few KB, below every size that failed. **Not measured:** whether kiwix-serve's own close triggers it (no binary on the measurement box). Recorded in `rag-design.md` §17 D-Z22.

## Verification

- `zim-client.test.ts` under idle-priority load after the fix: 13 runs, **26 of 26 ceiling legs green, ≤ 111 ms**. One run had a failure in a *different* test in the file that did not recur in 8 further runs and was not captured — reported, not attributed.
- Unloaded: `zim-client.test.ts` 63/63, `repo-hygiene.test.ts` green, `npm run typecheck` clean. Full suite: left to CI.

## Docs

- `BUILD_STATE.md`: #467 entry; the closed #331 entry retired **verbatim** (16 lines, 0 differing) to `docs/build-log.md` for the preamble budget. The older 2026-09-09 knowledge-packs entry was kept because it still carries owner-side items tracked nowhere else.
- `docs/rag-design.md` §17 D-Z22: "Also absorbed" paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
